### PR TITLE
feat(review): cite the rule each security check enforces (Increment 1)

### DIFF
--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -3,6 +3,7 @@ import { promisify } from "node:util";
 import { readFile, access } from "node:fs/promises";
 import { resolve } from "node:path";
 import { execFileNoThrow } from "./utils/execFileNoThrow.js";
+import { ruleForCheck, type RuleRef } from "./rules/catalog.js";
 import {
   ensureBumblebee,
   runScan,
@@ -51,6 +52,7 @@ export interface SecurityCheckResult {
   severity?: "critical" | "high" | "medium" | "low";
   files?: string[]; // Files with issues (for secrets scan)
   suggestion?: string; // Installation or remediation instructions
+  rule?: RuleRef; // citation for the rule this check enforces (CWE/OWASP), if mapped
 }
 
 /**
@@ -1005,7 +1007,13 @@ export async function checkSecurity(): Promise<SecurityCheckResult[]> {
   const exposureResults = await checkServiceExposure();
   results.push(...exposureResults);
 
-  return results;
+  // Attach a rule citation (CWE/OWASP) to each finding whose check is mapped in
+  // the local rules catalog. Deterministic lookup, no network. Unmapped checks
+  // pass through unchanged.
+  return results.map((r) => {
+    const rule = ruleForCheck(r.name);
+    return rule ? { ...r, rule } : r;
+  });
 }
 
 /**

--- a/src/output.ts
+++ b/src/output.ts
@@ -264,7 +264,9 @@ export function printSkillsTable(skills: SkillCheckResult[]): void {
         ? `${c.dim}[${result.severity}]${c.reset}`
         : "";
 
-      console.log(`  ${icon} ${name} ${statusColor}${result.status}${c.reset}  ${detail} ${severity}`);
+      const ruleTag = result.rule ? ` ${c.dim}[${result.rule.id}]${c.reset}` : "";
+
+      console.log(`  ${icon} ${name} ${statusColor}${result.status}${c.reset}  ${detail} ${severity}${ruleTag}`);
       
       // Show affected files if available (limit to first 5)
       if (result.files && result.files.length > 0) {

--- a/src/rules/catalog.test.ts
+++ b/src/rules/catalog.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { SECURITY_RULES, ruleForCheck } from "./catalog.js";
+
+describe("rules catalog", () => {
+  const sources = new Set(["cwe", "owasp", "asvs", "kit"]);
+
+  it("every entry is well-formed", () => {
+    for (const [name, rule] of Object.entries(SECURITY_RULES)) {
+      assert.ok(name.length > 0, "check name is non-empty");
+      assert.ok(rule.id.length > 0, `${name}: id non-empty`);
+      assert.ok(sources.has(rule.source), `${name}: known source (${rule.source})`);
+      assert.ok(rule.ref.startsWith("https://"), `${name}: ref is an https URL`);
+      assert.ok(rule.title.length > 0, `${name}: title non-empty`);
+    }
+  });
+
+  it("looks up a mapped check", () => {
+    const env = ruleForCheck(".env gitignored");
+    assert.equal(env?.id, "CWE-538");
+    assert.equal(env?.source, "cwe");
+
+    const audit = ruleForCheck("npm audit");
+    assert.equal(audit?.id, "OWASP-A06");
+
+    const secrets = ruleForCheck("secrets scan");
+    assert.equal(secrets?.id, "CWE-798");
+  });
+
+  it("returns undefined for an unmapped or unknown check", () => {
+    assert.equal(ruleForCheck("license check"), undefined); // intentionally unmapped
+    assert.equal(ruleForCheck("does not exist"), undefined);
+  });
+});

--- a/src/rules/catalog.ts
+++ b/src/rules/catalog.ts
@@ -1,0 +1,61 @@
+/**
+ * Rule citations for kit's deterministic checks.
+ *
+ * Each finding can carry a `RuleRef` pointing at the rule it enforces (CWE,
+ * OWASP Top 10, or a kit-native rule). This is a LOCAL, deterministic lookup
+ * with no network access. kit only maps the checks it actually implements, so
+ * the catalog stays bounded to the number of checks, not the full CWE/OWASP
+ * corpus. A check without a clear, defensible anchor carries no rule (the field
+ * is optional; a forced weak mapping is worse than none).
+ *
+ * Maintenance: this map is co-located with the checks it describes. When you add
+ * a security check, add its mapping here in the same change. Framework IDs (CWE,
+ * OWASP Top 10) are low-churn and pinned by ID, so the catalog does not rot.
+ */
+
+export interface RuleRef {
+  /** Short display id, e.g. "CWE-798" or "OWASP-A06". */
+  id: string;
+  source: "cwe" | "owasp" | "asvs" | "kit";
+  /** Canonical reference URL. */
+  ref: string;
+  title: string;
+}
+
+const cwe = (n: number, title: string): RuleRef => ({
+  id: `CWE-${n}`,
+  source: "cwe",
+  ref: `https://cwe.mitre.org/data/definitions/${n}.html`,
+  title,
+});
+
+const owasp = (num: string, slug: string, title: string): RuleRef => ({
+  id: `OWASP-${num}`,
+  source: "owasp",
+  ref: `https://owasp.org/Top10/${slug}/`,
+  title,
+});
+
+/**
+ * Security check `name` (from check-security.ts `SecurityCheckResult.name`) to
+ * the rule it enforces. Intentionally unmapped (no single defensible anchor):
+ * "license check", "semgrep SAST" (an engine; its own findings carry their own
+ * citations), "requirements.txt" (presence, not a weakness).
+ */
+export const SECURITY_RULES: Record<string, RuleRef> = {
+  ".env gitignored": cwe(538, "Insertion of Sensitive Information into Externally-Accessible File or Directory"),
+  "secrets scan": cwe(798, "Use of Hard-coded Credentials"),
+  "npm audit": owasp("A06", "A06_2021-Vulnerable_and_Outdated_Components", "A06:2021 Vulnerable and Outdated Components"),
+  "pip-audit": owasp("A06", "A06_2021-Vulnerable_and_Outdated_Components", "A06:2021 Vulnerable and Outdated Components"),
+  "trivy container scan": owasp("A06", "A06_2021-Vulnerable_and_Outdated_Components", "A06:2021 Vulnerable and Outdated Components"),
+  "pinned versions": cwe(1104, "Use of Unmaintained Third Party Components"),
+  "package-lock.json": owasp("A08", "A08_2021-Software_and_Data_Integrity_Failures", "A08:2021 Software and Data Integrity Failures"),
+  "socket scan": owasp("A08", "A08_2021-Software_and_Data_Integrity_Failures", "A08:2021 Software and Data Integrity Failures"),
+  Ollama: cwe(668, "Exposure of Resource to Wrong Sphere"),
+  "Remote API": cwe(668, "Exposure of Resource to Wrong Sphere"),
+};
+
+/** Look up the rule a security check enforces, or undefined if unmapped. */
+export function ruleForCheck(name: string): RuleRef | undefined {
+  return SECURITY_RULES[name];
+}


### PR DESCRIPTION
## What
Foundation for the consolidation/citation layer discussed for `kit review`.

- Adds optional `rule?: RuleRef` to `SecurityCheckResult`.
- New local, deterministic rules catalog `src/rules/catalog.ts` mapping each kit security check to the rule it enforces (CWE / OWASP Top 10). No network.
- `checkSecurity()` decorates findings by name; the citation flows into the `kit check` JSON automatically (agent-facing) and renders as a `[CWE-xxx]` tag in the text table (`output.ts`).
- Tests for catalog well-formedness + lookup.

## Why this is non-duplicative (not a SAST)
This cites kit's OWN deterministic checks (gitignore, secrets, dep-pinning, lockfiles, service exposure), which no SAST covers. kit does not compete with Semgrep/Snyk; it orchestrates them. Checks without a defensible anchor (license, the semgrep engine itself, requirements presence) carry no rule rather than a forced weak mapping.

## Maintenance
The catalog is co-located with the checks (add a check, add its mapping). Framework IDs (CWE, OWASP Top 10) are low-churn and pinned by ID. No live lookup, so it does not rot.

## Next (separate PRs, as plugins)
- Wrap Semgrep ASVS rule-packs + a coverage/gap view.
- Team rule-packs (e.g. a `dev-standard` plugin) pinned per-project.

Gates: tsc clean, build clean, full suite 2218 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)