### PR TITLE
fix(memory): --help must not run a side-effectful subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- **A `--help`/`-h` flag never executes a side-effectful subcommand.** `kit memory <subcommand> --help` (e.g. `kit memory install --help`) previously ran the subcommand instead of printing help, so `kit memory install --help` would actually install the hooks. It now shows help and does nothing else.
+
 ## [1.3.1] - 2026-06-17
 
 ### Security

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -43,6 +43,9 @@ import {
 export async function cmdMemory(): Promise<boolean> {
   const subcommand = process.argv[3];
   if (!subcommand || subcommand === "--help" || subcommand === "-h") return memHelp();
+  // A --help/-h flag after a subcommand means "show help", never run a
+  // side-effectful subcommand (e.g. `kit memory install --help` must not install).
+  if (hasFlag(process.argv, "--help") || hasFlag(process.argv, "-h")) return memHelp();
 
   // One handler per subcommand — keeps this dispatcher flat (was a complexity-132
   // if-chain). Each handler reads process.argv itself, so no args thread through.


### PR DESCRIPTION
`kit memory <subcommand> --help` (e.g. `kit memory install --help`) executed the subcommand instead of printing help — so asking for help on `install` actually installed the memory hooks into `~/.claude/settings.json`. A help flag should never have a side effect.

`cmdMemory` now treats a `--help`/`-h` flag anywhere in the args as "show help" before dispatching to a subcommand handler. Verified via smoke: `kit memory install --help` and `kit memory index --help` print help and do nothing else. Build clean.

Follow-up worth auditing: confirm no other top-level command runs on `--help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)