### PR TITLE
feat(security): kit security semgrep — cited Semgrep findings (1.5.0 2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **`kit security semgrep` — cited Semgrep findings (1.5.0 consolidation, first step).** Runs Semgrep when installed, parses its JSON, and lists each finding normalized into kit's finding + citation shape: `file:line`, severity, and a `[CWE-…]`/`[OWASP-…]` tag derived from Semgrep's own rule metadata. `--json` for machine output. kit wraps scanners, it does not rebuild SAST; folding these into `kit review` (single-run consolidation) follows.
+
 ## [1.4.0] - 2026-06-17
 
 ### Added

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2667,6 +2667,42 @@ async function cmdSecurityPrescanDiff(): Promise<boolean> {
   return diff.added.length === 0;
 }
 
+async function cmdSecuritySemgrep(): Promise<boolean> {
+  const jsonMode = hasFlag(process.argv, "--json");
+  const { runSemgrep } = await import("./semgrep-ingest.js");
+  const { available, findings } = await runSemgrep();
+
+  if (jsonMode) {
+    console.log(JSON.stringify({ available, findings }, null, 2));
+    return !findings.some((f) => f.severity === "error");
+  }
+  if (!available) {
+    console.log(`${c.dim}semgrep not installed — brew install semgrep (or pipx install semgrep)${c.reset}`);
+    return true;
+  }
+  if (findings.length === 0) {
+    console.log(`${c.green}✓${c.reset} semgrep: no findings`);
+    return true;
+  }
+  console.log(`${c.bold}Semgrep${c.reset}  ${c.dim}${findings.length} finding(s)${c.reset}\n`);
+  for (const f of findings) {
+    const icon =
+      f.severity === "error"
+        ? `${c.red}✗${c.reset}`
+        : f.severity === "warning"
+          ? `${c.yellow}!${c.reset}`
+          : `${c.dim}·${c.reset}`;
+    const loc = f.file ? `${f.file}${f.line ? `:${f.line}` : ""}` : "(unknown location)";
+    const tag = f.rule ? ` ${c.dim}[${f.rule.id}]${c.reset}` : "";
+    console.log(`  ${icon} ${loc}${tag}`);
+    if (f.message) console.log(`      ${c.dim}${f.message.split("\n")[0].slice(0, 120)}${c.reset}`);
+    console.log(`      ${c.dim}${f.ruleId}${c.reset}`);
+  }
+  const errors = findings.filter((f) => f.severity === "error").length;
+  if (errors > 0) console.log(`\n${c.red}${errors} error-severity finding(s).${c.reset}`);
+  return errors === 0;
+}
+
 async function cmdSecurity(): Promise<boolean> {
   // Subcommand routing
   const sub = process.argv[3];
@@ -2705,6 +2741,10 @@ async function cmdSecurity(): Promise<boolean> {
 
   if (sub === "prescan-diff") {
     return cmdSecurityPrescanDiff();
+  }
+
+  if (sub === "semgrep") {
+    return cmdSecuritySemgrep();
   }
 
   if (sub !== "policy") {

--- a/src/semgrep-ingest.test.ts
+++ b/src/semgrep-ingest.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseSemgrepResults, citationFromMetadata } from "./semgrep-ingest.js";
+
+describe("semgrep ingest", () => {
+  it("parses results into normalized, cited findings (CWE)", () => {
+    const json = {
+      results: [
+        {
+          check_id: "javascript.lang.security.audit.xss.template-string",
+          path: "src/app.ts",
+          start: { line: 42 },
+          extra: {
+            message: "Potential XSS via template string.",
+            severity: "ERROR",
+            metadata: {
+              cwe: ["CWE-79: Improper Neutralization of Input During Web Page Generation"],
+              owasp: ["A03:2021 - Injection"],
+            },
+          },
+        },
+      ],
+    };
+    const f = parseSemgrepResults(json);
+    assert.equal(f.length, 1);
+    assert.equal(f[0]?.severity, "error");
+    assert.equal(f[0]?.file, "src/app.ts");
+    assert.equal(f[0]?.line, 42);
+    assert.equal(f[0]?.ruleId, "javascript.lang.security.audit.xss.template-string");
+    assert.equal(f[0]?.rule?.id, "CWE-79");
+    assert.equal(f[0]?.rule?.source, "cwe");
+  });
+
+  it("falls back to OWASP when no CWE is present", () => {
+    const r = citationFromMetadata({ owasp: ["A01:2021 - Broken Access Control"] });
+    assert.equal(r?.id, "OWASP-A01");
+    assert.equal(r?.source, "owasp");
+  });
+
+  it("returns no citation when metadata has neither CWE nor OWASP", () => {
+    assert.equal(citationFromMetadata({ references: ["x"] }), null);
+    assert.equal(citationFromMetadata(null), null);
+  });
+
+  it("handles malformed or empty input safely", () => {
+    assert.deepEqual(parseSemgrepResults(null), []);
+    assert.deepEqual(parseSemgrepResults({}), []);
+    assert.deepEqual(parseSemgrepResults({ results: "nope" }), []);
+    // an entry without a check_id is skipped
+    assert.deepEqual(parseSemgrepResults({ results: [{ path: "x" }] }), []);
+  });
+
+  it("normalizes WARNING/INFO severities", () => {
+    const f = parseSemgrepResults({
+      results: [
+        { check_id: "a", path: "x", extra: { severity: "WARNING" } },
+        { check_id: "b", path: "y", extra: { severity: "INFO" } },
+      ],
+    });
+    assert.equal(f[0]?.severity, "warning");
+    assert.equal(f[1]?.severity, "info");
+  });
+});

--- a/src/semgrep-ingest.ts
+++ b/src/semgrep-ingest.ts
@@ -1,0 +1,126 @@
+/**
+ * Semgrep ingestion — wrap, don't rebuild.
+ *
+ * kit does not implement SAST; Semgrep (and Snyk, etc.) do that well. This module
+ * runs Semgrep when it is present, parses its JSON output, and normalizes each
+ * finding into kit's finding + citation shape so `kit security semgrep` (and, later,
+ * `kit review`) can show one consolidated, cited, fix-oriented report. Semgrep
+ * findings already carry a rule id and CWE/OWASP metadata, so the citation comes
+ * almost for free.
+ */
+import { execFileNoThrow } from "./utils/execFileNoThrow.js";
+import type { RuleRef } from "./rules/catalog.js";
+
+export interface SemgrepFinding {
+  ruleId: string;
+  message: string;
+  file: string;
+  line: number | null;
+  severity: "error" | "warning" | "info";
+  /** Citation derived from Semgrep's own metadata (CWE preferred, else OWASP). */
+  rule: RuleRef | null;
+}
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return v && typeof v === "object" ? (v as Record<string, unknown>) : null;
+}
+
+function firstString(v: unknown): string | null {
+  if (typeof v === "string") return v;
+  if (Array.isArray(v) && typeof v[0] === "string") return v[0];
+  return null;
+}
+
+/** Build a RuleRef from a Semgrep `extra.metadata` block (cwe / owasp). PURE. */
+export function citationFromMetadata(metadata: unknown): RuleRef | null {
+  const meta = asRecord(metadata);
+  if (!meta) return null;
+
+  const cwe = firstString(meta.cwe);
+  if (cwe) {
+    const m = cwe.match(/CWE-(\d+)/i);
+    if (m) {
+      return {
+        id: `CWE-${m[1]}`,
+        source: "cwe",
+        ref: `https://cwe.mitre.org/data/definitions/${m[1]}.html`,
+        title: cwe.replace(/^CWE-\d+:?\s*/i, "").trim() || `CWE-${m[1]}`,
+      };
+    }
+  }
+
+  const owasp = firstString(meta.owasp);
+  if (owasp) {
+    const m = owasp.match(/A(\d+)/i);
+    if (m) {
+      return {
+        id: `OWASP-A${m[1].padStart(2, "0")}`,
+        source: "owasp",
+        ref: "https://owasp.org/www-project-top-ten/",
+        title: owasp.trim(),
+      };
+    }
+  }
+
+  return null;
+}
+
+function normalizeSeverity(v: unknown): SemgrepFinding["severity"] {
+  switch (String(v ?? "").toUpperCase()) {
+    case "ERROR":
+      return "error";
+    case "WARNING":
+      return "warning";
+    default:
+      return "info";
+  }
+}
+
+/** Parse Semgrep `--json` output into normalized, cited findings. PURE (no I/O). */
+export function parseSemgrepResults(json: unknown): SemgrepFinding[] {
+  const root = asRecord(json);
+  const results = root?.results;
+  if (!Array.isArray(results)) return [];
+
+  const out: SemgrepFinding[] = [];
+  for (const entry of results) {
+    const r = asRecord(entry);
+    if (!r) continue;
+    const ruleId = typeof r.check_id === "string" ? r.check_id : null;
+    if (!ruleId) continue;
+    const extra = asRecord(r.extra) ?? {};
+    const start = asRecord(r.start);
+    const line = typeof start?.line === "number" ? start.line : null;
+    out.push({
+      ruleId,
+      message: typeof extra.message === "string" ? extra.message.trim() : "",
+      file: typeof r.path === "string" ? r.path : "",
+      line,
+      severity: normalizeSeverity(extra.severity),
+      rule: citationFromMetadata(extra.metadata),
+    });
+  }
+  return out;
+}
+
+export interface SemgrepRunResult {
+  available: boolean;
+  findings: SemgrepFinding[];
+}
+
+/** Run Semgrep once (if installed) and return parsed findings. Never throws. */
+export async function runSemgrep(): Promise<SemgrepRunResult> {
+  const version = await execFileNoThrow("semgrep", ["--version"], { timeout: 5_000 });
+  if (!version.ok) return { available: false, findings: [] };
+
+  const result = await execFileNoThrow(
+    "semgrep",
+    ["scan", "--config", "auto", "--json", "--quiet", "--no-rewrite-rule-ids"],
+    { timeout: 120_000 },
+  );
+  try {
+    return { available: true, findings: parseSemgrepResults(JSON.parse(result.stdout || result.stderr)) };
+  } catch {
+    return { available: true, findings: [] };
+  }
+}


### PR DESCRIPTION
First step of the 1.5.0 consolidation layer: kit **wraps** Semgrep, it does not rebuild SAST.

`kit security semgrep` runs Semgrep (when installed), parses its JSON, and lists each finding normalized into kit's finding + citation shape: `file:line`, severity, and a `[CWE-…]`/`[OWASP-…]` tag built from Semgrep's own rule metadata. `--json` for machine output; exits non-zero on error-severity findings so it can gate. Graceful no-op when semgrep is absent.

- Pure `parseSemgrepResults` / `citationFromMetadata` (unit-tested incl. malformed input).
- Self-contained surface (no double-run): folding these findings into `kit review` as a single consolidated pass is the next step.

tsc + build clean, full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)