### PR TITLE
fix(setup): clear mise-missing message + Quick start onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **Quick start + Prerequisites** in the README and `kit --help`. Lists Node 22+, git, and [mise](https://mise.jdx.dev) (used to install the tools in `[tools]`), the npx vs global-install paths (incl. the user-prefix fix for `npm -g` permission errors), and the first-run command sequence (`init → check → setup → context check`). `kit --help` now leads with a "Get going" line.
+
+### Fixed
+- **Clear message when mise is missing.** `kit setup` / `kit install` now says "mise is not installed — install with `brew install mise` (or `curl https://mise.run | sh`)" instead of surfacing a raw `spawn mise ENOENT`. kit uses mise to install and pin tool versions; if it is absent, the failure is now actionable.
+
 ## [1.4.0] - 2026-06-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 - **Clear message when mise is missing.** `kit setup` / `kit install` now says "mise is not installed — install with `brew install mise` (or `curl https://mise.run | sh`)" instead of surfacing a raw `spawn mise ENOENT`. kit uses mise to install and pin tool versions; if it is absent, the failure is now actionable.
+- **Surface mise's real error instead of "Command failed".** When `mise install` fails, kit now reads mise's stderr and shows the concrete `mise ERROR …` line. It specifically detects an untrusted `.mise.toml` (mise refuses to run until `mise trust`) and tells you to review the file and run `mise trust` — previously this surfaced only as an opaque `Command failed: mise install …`.
 
 ## [1.4.0] - 2026-06-17
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,28 @@ For AI agents and humans. Manages tools, auth, secrets, and project setup. Zero 
 
 🌐 [sandstre.am/kit](https://sandstre.am/kit)
 
+## Quick start
+
+**Prerequisites:** Node.js 22+, git, and [mise](https://mise.jdx.dev) for installing tools (`brew install mise`, or `curl https://mise.run | sh`).
+
 ```bash
+# zero install (also sidesteps npm -g permission issues):
 npx sandstream-kit setup
+
+# or install globally:
+npm i -g sandstream-kit
+# if npm -g is permission-blocked, use a user-owned prefix instead of sudo:
+#   npm config set prefix ~/.npm-global
+#   echo 'export PATH="$HOME/.npm-global/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc
+```
+
+Then, in a repo:
+
+```bash
+kit init           # detect the stack → generate .kit.toml
+kit check          # what's set up vs missing (tools, services, secrets, hooks, security)
+kit setup          # install tools (via mise), git hooks, logins, secrets
+kit context check  # lock each CLI to the declared account + project (no wrong-org pushes)
 ```
 
 ## Problem

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4004,6 +4004,8 @@ function cmdHelp(subcommand?: string): boolean {
   const bold = c.bold, cyan = c.cyan, dim = c.dim, reset = c.reset, green = c.green;
 
   console.log(`${bold}kit${reset} ${dim}v${KIT_VERSION}${reset} — developer environment manager\n`);
+  console.log(`${bold}Get going:${reset}  ${dim}npx sandstream-kit setup${reset}  ${dim}or${reset}  ${green}kit init${reset} ${dim}→${reset} ${green}kit check${reset} ${dim}→${reset} ${green}kit setup${reset}`);
+  console.log(`${dim}Prereqs: Node 22+, git, and mise (brew install mise) for installing tools.${reset}\n`);
   console.log(`${bold}Usage:${reset}  kit ${cyan}<command>${reset} ${dim}[options]${reset}\n`);
   console.log(`${bold}Commands:${reset}`);
 

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { installTools, type InstallDeps } from "./install.js";
+import { installTools, miseErrorDetail, type InstallDeps } from "./install.js";
 
 function makeDeps(overrides: Partial<InstallDeps> = {}): InstallDeps {
   return {
@@ -114,5 +114,17 @@ describe("installTools", () => {
     assert.equal(results.length, 2);
     assert.equal(results[0].action, "already_ok");
     assert.equal(results[1].action, "installed");
+  });
+});
+
+describe("miseErrorDetail", () => {
+  it("turns a missing-mise spawn error into an actionable message", () => {
+    const detail = miseErrorDetail("spawn mise ENOENT");
+    assert.ok(/mise is not installed/i.test(detail));
+    assert.ok(/brew install mise|mise\.run/i.test(detail));
+  });
+
+  it("passes other errors through (first line only)", () => {
+    assert.equal(miseErrorDetail("mise: plugin not found\nmore noise"), "mise: plugin not found");
   });
 });

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -127,4 +127,18 @@ describe("miseErrorDetail", () => {
   it("passes other errors through (first line only)", () => {
     assert.equal(miseErrorDetail("mise: plugin not found\nmore noise"), "mise: plugin not found");
   });
+
+  it("detects an untrusted .mise.toml from stderr and points at mise trust", () => {
+    const stderr =
+      "mise ERROR Config files in ~/repo/.mise.toml are not trusted.\nmise ERROR Trust them with `mise trust`.";
+    const detail = miseErrorDetail("Command failed: mise install node@24", stderr);
+    assert.ok(/not trusted/i.test(detail));
+    assert.ok(/mise trust/.test(detail));
+  });
+
+  it("surfaces the real mise ERROR line instead of the generic Command failed", () => {
+    const stderr = "mise ERROR error parsing config file: ~/repo/.mise.toml\nmise ERROR Version: 2026.6.11";
+    const detail = miseErrorDetail("Command failed: mise install node@24", stderr);
+    assert.equal(detail, "error parsing config file: ~/repo/.mise.toml");
+  });
 });

--- a/src/install.ts
+++ b/src/install.ts
@@ -9,6 +9,19 @@ export interface InstallResult {
   detail: string;
 }
 
+/**
+ * Turn a mise exec failure into an actionable message. The common case is mise
+ * not being installed at all (`spawn mise ENOENT`), which otherwise surfaces as
+ * a cryptic spawn error. PURE so it can be unit-tested.
+ */
+export function miseErrorDetail(message: string): string {
+  const first = message.split("\n")[0];
+  if (/ENOENT/.test(first)) {
+    return "mise is not installed — kit installs and pins tool versions with it. Install mise (brew install mise, or: curl https://mise.run | sh) and re-run, or install the tool yourself.";
+  }
+  return first;
+}
+
 async function miseInstall(
   tool: string,
   version: string,
@@ -27,7 +40,7 @@ async function miseInstall(
     return { ok: true, detail: `Installed ${tool}@${versionArg} via mise` };
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    return { ok: false, detail: message.split("\n")[0] };
+    return { ok: false, detail: miseErrorDetail(message) };
   }
 }
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -10,16 +10,32 @@ export interface InstallResult {
 }
 
 /**
- * Turn a mise exec failure into an actionable message. The common case is mise
- * not being installed at all (`spawn mise ENOENT`), which otherwise surfaces as
- * a cryptic spawn error. PURE so it can be unit-tested.
+ * Turn a mise exec failure into an actionable message. PURE so it can be
+ * unit-tested. `message` is the error's `.message` (often just the generic
+ * "Command failed: mise install node@24"); `stderr` is mise's real output,
+ * which carries the actionable cause. Common cases:
+ *   - mise not installed at all (`spawn mise ENOENT`)
+ *   - the repo's .mise.toml is untrusted (mise refuses to run until `mise trust`)
+ * Otherwise prefer the real `mise ERROR` line from stderr over "Command failed".
  */
-export function miseErrorDetail(message: string): string {
-  const first = message.split("\n")[0];
-  if (/ENOENT/.test(first)) {
+export function miseErrorDetail(message: string, stderr = ""): string {
+  const firstMsg = message.split("\n")[0];
+  if (/ENOENT/.test(firstMsg)) {
     return "mise is not installed — kit installs and pins tool versions with it. Install mise (brew install mise, or: curl https://mise.run | sh) and re-run, or install the tool yourself.";
   }
-  return first;
+  const combined = `${message}\n${stderr}`;
+  if (/not trusted|mise trust/i.test(combined)) {
+    return "mise refused this repo's .mise.toml because it is not trusted. Review the file, then run `mise trust` here and re-run kit setup.";
+  }
+  // Prefer a concrete `mise ERROR ...` line over the generic "Command failed".
+  const miseErr = stderr
+    .split("\n")
+    .map((l) => l.trim())
+    .find((l) => /^mise ERROR/.test(l));
+  if (miseErr) return miseErr.replace(/^mise ERROR\s*/, "");
+  const firstStderr = stderr.trim().split("\n")[0];
+  if (firstStderr) return firstStderr;
+  return firstMsg;
 }
 
 async function miseInstall(
@@ -40,7 +56,11 @@ async function miseInstall(
     return { ok: true, detail: `Installed ${tool}@${versionArg} via mise` };
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    return { ok: false, detail: miseErrorDetail(message) };
+    const stderr =
+      typeof (err as { stderr?: unknown } | null)?.stderr === "string"
+        ? (err as { stderr: string }).stderr
+        : "";
+    return { ok: false, detail: miseErrorDetail(message, stderr) };
   }
 }
 


### PR DESCRIPTION
Dogfooding kit on a fresh repo surfaced onboarding friction:

1. **Cryptic mise error** — `kit setup`/`install` showed a raw `spawn mise ENOENT` when mise wasn't installed. `miseErrorDetail` (pure, unit-tested) now turns it into: "mise is not installed — install with brew install mise (or curl https://mise.run | sh)".
2. **mise wasn't a documented prerequisite** — added a **Quick start + Prerequisites** section to the README (Node 22+, git, mise; npx vs global incl. the user-prefix fix for `npm -g` EACCES; and the `init → check → setup → context check` first-run sequence). `kit --help` now leads with a "Get going" line + prereqs.

tsc + build clean, full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)