### PR TITLE
fix(security): explicit GCM authTagLength in backup (clears Semgrep gate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Security
+- **Encrypted backup passes an explicit `authTagLength` (16) to `createCipheriv`/`createDecipheriv`.** The GCM auth tag was already fixed at 16 bytes (`setAuthTag` + `final()`), so this is a hardening assertion that also clears the Semgrep `gcm-no-tag-length` finding that was blocking the "Security — Full App Scan" workflow.
+
 ## [1.4.1] - 2026-06-17
 
 ### Added

--- a/src/memory/backup.ts
+++ b/src/memory/backup.ts
@@ -69,7 +69,9 @@ export function backupEncrypted(
   const data = readFileSync(srcPath);
   const salt = randomBytes(SALT_LEN);
   const iv = randomBytes(IV_LEN);
-  const cipher = createCipheriv("aes-256-gcm", deriveKey(passphrase, salt), iv);
+  const cipher = createCipheriv("aes-256-gcm", deriveKey(passphrase, salt), iv, {
+    authTagLength: TAG_LEN,
+  });
   const ciphertext = Buffer.concat([cipher.update(data), cipher.final()]);
   const tag = cipher.getAuthTag();
   writeFileSync(outPath, Buffer.concat([MAGIC, salt, iv, tag, ciphertext]));
@@ -86,7 +88,9 @@ export function restoreEncrypted(passphrase: string, inPath: string, destPath: s
   const iv = blob.subarray(off, (off += IV_LEN));
   const tag = blob.subarray(off, (off += TAG_LEN));
   const ciphertext = blob.subarray(off);
-  const decipher = createDecipheriv("aes-256-gcm", deriveKey(passphrase, salt), iv);
+  const decipher = createDecipheriv("aes-256-gcm", deriveKey(passphrase, salt), iv, {
+    authTagLength: TAG_LEN,
+  });
   decipher.setAuthTag(tag);
   const data = Buffer.concat([decipher.update(ciphertext), decipher.final()]); // throws if wrong key
   writeFileSync(destPath, data);


### PR DESCRIPTION
The **Security — Full App Scan** workflow was red on a single Semgrep blocking finding (`javascript.node-crypto.security.gcm-no-tag-length`) at `src/memory/backup.ts:89` — `createDecipheriv("aes-256-gcm", …)` had no `authTagLength`.

It was effectively a false positive: the auth tag is already pinned to 16 bytes (`TAG_LEN`) via `setAuthTag(tag)` + `final()` (which throws on a wrong key/tampered blob). But passing `{ authTagLength: TAG_LEN }` to **both** `createCipheriv` and `createDecipheriv` is a real hardening assertion (not a `// nosemgrep` mute) and clears the gate. Backup round-trip tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)