### PR TITLE
fix(cli): --help never executes a command (incl. side-effectful ones)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- **`kit <command> --help` shows help instead of running the command.** A `--help`/`-h` after any top-level command fell through to the dispatch and *executed* the command — harmless for read-only ones, but `kit agent-config --help` would inject its rules block, and `fix` / `secrets` / `hooks add --help` would run their side effects. The main dispatch now intercepts `--help`/`-h` for any command and prints that command's help (generalizes the 1.4.0 fix that only covered `kit memory <sub> --help`).
+
 ### Security
 - **Encrypted backup passes an explicit `authTagLength` (16) to `createCipheriv`/`createDecipheriv`.** The GCM auth tag was already fixed at 16 bytes (`setAuthTag` + `final()`), so this is a hardening assertion that also clears the Semgrep `gcm-no-tag-length` finding that was blocking the "Security — Full App Scan" workflow.
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -145,6 +145,43 @@ describe("CLI error handling", () => {
 });
 
 // ---------------------------------------------------------------------------
+// --help never executes a command (esp. side-effectful ones)
+// ---------------------------------------------------------------------------
+
+describe("kit <command> --help", () => {
+  let tempDir: string;
+
+  before(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "kit-integ-help-"));
+    await writeFile(join(tempDir, ".gitignore"), GITIGNORE_CONTENT, "utf-8");
+    await writeFile(join(tempDir, ".kit.toml"), FIXTURE_EMPTY, "utf-8");
+  });
+
+  after(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  const exists = (p: string) => access(p).then(() => true, () => false);
+
+  it("agent-config --help prints help and does NOT inject a rules block", async () => {
+    const result = await runCli(["agent-config", "--help"], tempDir);
+    assert.equal(result.exitCode, 0);
+    assert.ok(/agent-config/.test(result.stdout), `expected help; got: ${result.stdout}`);
+    // The side effect (writing CLAUDE.md / AGENTS.md) must not have happened.
+    assert.equal(await exists(join(tempDir, "CLAUDE.md")), false, "must not create CLAUDE.md");
+    assert.equal(await exists(join(tempDir, "AGENTS.md")), false, "must not create AGENTS.md");
+  });
+
+  it("status --help prints help, not the adoption checklist", async () => {
+    const result = await runCli(["status", "--help"], tempDir);
+    assert.equal(result.exitCode, 0);
+    assert.ok(/status/.test(result.stdout), `expected help; got: ${result.stdout}`);
+    // The checklist run uses ✓ / ○ status markers; the help line has none.
+    assert.ok(!/[✓○]/.test(result.stdout), "should show help, not run the status checklist");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // kit check
 // ---------------------------------------------------------------------------
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4256,6 +4256,16 @@ async function main(): Promise<void> {
       process.exitCode = 0;
       return;
     }
+    // A `--help`/`-h` anywhere after the command means "show that command's
+    // help" — NEVER execute the command. Critical for side-effectful commands
+    // (agent-config, fix, secrets, hooks add): `kit <cmd> --help` previously
+    // fell through to the dispatch and ran <cmd>. (Generalizes the 1.4.0 fix
+    // that only covered `kit memory <sub> --help`.)
+    if (command && command !== "help" && (hasFlag(args, "--help") || hasFlag(args, "-h"))) {
+      cmdHelp(command);
+      process.exitCode = 0;
+      return;
+    }
 
     // version/help/completions need bespoke handling; everything else is a flat
     // command->fn dispatch (was a ~40-case switch — the main complexity driver).


### PR DESCRIPTION
Dogfooding surfaced that `kit <command> --help` **executed the command** instead of showing help. Harmless for read-only commands, but:
- `kit agent-config --help` injected its managed rules block into CLAUDE.md/AGENTS.md,
- `kit fix --help` / `secrets` / `hooks add --help` would run their side effects.

The main dispatch only intercepted `kit --help` (no command). It now intercepts `--help`/`-h` after **any** command and prints that command's help — generalizing the 1.4.0 fix that only covered `kit memory <sub> --help`.

Integration tests: `agent-config --help` exits 0, prints help, and writes **no** CLAUDE.md/AGENTS.md; `status --help` shows help (no `✓`/`○` checklist markers). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)