### PR TITLE
release: 1.4.2 — dogfood polish round

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-06-17
+
 ### Fixed
 - **`kit <command> --help` shows help instead of running the command.** A `--help`/`-h` after any top-level command fell through to the dispatch and *executed* the command — harmless for read-only ones, but `kit agent-config --help` would inject its rules block, and `fix` / `secrets` / `hooks add --help` would run their side effects. The main dispatch now intercepts `--help`/`-h` for any command and prints that command's help (generalizes the 1.4.0 fix that only covered `kit memory <sub> --help`).
+- **Informational services are a warning, not a failure, in `check` / `ci` / `escalate`.** A service whose login is `#`-documented (no CLI — e.g. resend "set `RESEND_API_KEY`", sentry "get DSN") was reported as `✗ fail`, dragged down the overall gate, and `escalate` printed a nonsensical `Run: # resend …`. It now shows as a `warn` / "manual setup (no CLI login)", does not fail the gate, and `escalate` shows the documentation message. (Extends the 1.4.1 `manual` login state to the check/ci/escalate paths.)
+- **`kit security scan-build` no longer false-positives on framework manifests.** Terraform/tfstate finding labels (`tfstate-value`, `terraform-sensitive`) are filtered out of build-artifact scanning, so a Next.js `routes-manifest.json` `"value":"…"` route entry is no longer reported as a potential secret. Real inlined credentials (Stripe/JWT/AWS/…) are still caught.
+- **`kit memory status` now aliases `kit memory stats`** (was "unknown subcommand").
+- **`kit review`, `kit design`, and `kit baseline` now have help text** (`kit <cmd> --help` / `kit help`).
 
 ### Security
 - **Encrypted backup passes an explicit `authTagLength` (16) to `createCipheriv`/`createDecipheriv`.** The GCM auth tag was already fixed at 16 bytes (`setAuthTag` + `final()`), so this is a hardening assertion that also clears the Semgrep `gcm-no-tag-length` finding that was blocking the "Security — Full App Scan" workflow.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -197,7 +197,9 @@ async function cmdCheck(): Promise<boolean> {
       const lockOk = lockResults.every((l) => l.inSync);
       const allOk =
         toolResults.every((t) => t.ok) &&
-        serviceResults.every((s) => s.authenticated) &&
+        // Informational services (no CLI login — `#`-documented, e.g. resend
+        // env keys) are manual setup, not a failed gate. They surface as warns.
+        serviceResults.every((s) => s.authenticated || s.informational) &&
         secretResults.keys.every((s) => s.available) &&
         skillResults.filter((s) => s.required).every((s) => s.installed) &&
         hookResults.every((h) => h.installed && h.upToDate) &&
@@ -215,8 +217,10 @@ async function cmdCheck(): Promise<boolean> {
           })),
           ...serviceResults.map((s) => ({
             name: s.name,
-            status: (s.authenticated ? "pass" : "fail") as JsonCheck["status"],
-            detail: s.output ?? (s.authenticated ? "authenticated" : "not authenticated"),
+            status: (s.authenticated ? "pass" : s.informational ? "warn" : "fail") as JsonCheck["status"],
+            detail: s.informational
+              ? (s.output || "manual setup (no CLI login)")
+              : (s.output ?? (s.authenticated ? "authenticated" : "not authenticated")),
             category: "services",
           })),
           ...secretResults.keys.map((s) => ({
@@ -2295,8 +2299,12 @@ async function cmdCi(): Promise<boolean> {
         })),
         ...serviceResults.map((s) => ({
           name: s.name,
-          status: (s.authenticated ? "pass" : "fail") as JsonCheck["status"],
-          detail: s.output ?? (s.authenticated ? "authenticated" : "not authenticated"),
+          // Informational services (no CLI login) are a manual-setup warning,
+          // not a CI failure.
+          status: (s.authenticated ? "pass" : s.informational ? "warn" : "fail") as JsonCheck["status"],
+          detail: s.informational
+            ? (s.output || "manual setup (no CLI login)")
+            : (s.output ?? (s.authenticated ? "authenticated" : "not authenticated")),
           category: "services",
         })),
         ...secretResults.keys.map((s) => ({
@@ -3648,6 +3656,9 @@ function cmdVersion(): boolean {
 const COMMAND_HELP: Record<string, string> = {
   status:         "Adoption checklist — what's set up across kit + the next step for each gap",
   check:          "Check status of all tools, services, secrets, and lock files",
+  review:         "Full repo audit — runs check + design in one gate (for agents / PR checks)",
+  design:         "Check design quality (a11y, design tokens) against the baseline",
+  baseline:       "Freeze current warnings into .kit-baseline.json so future runs gate only net-new findings",
   memory:         "Local conversation memory — index transcripts + show stats",
   "memory index": "Index ~/.claude transcripts into the SQLite memory store",
   "memory search": "Full-text search memory (current project; --global for all)",

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -54,6 +54,7 @@ export async function cmdMemory(): Promise<boolean> {
     index: memIndex,
     merge: memMerge,
     stats: memStats,
+    status: memStats, // common typo/alias for `stats`
     suggest: memSuggest,
     search: memSearch,
     hook: memHook,

--- a/src/escalate.test.ts
+++ b/src/escalate.test.ts
@@ -44,6 +44,24 @@ describe("collectEscalations", () => {
     assert.equal(items[0].name, "github");
   });
 
+  it("renders an informational service as manual setup, not a `Run: #` command", () => {
+    const services: ServiceStatus[] = [
+      {
+        name: "resend",
+        checkCommand: "# resend — check RESEND_API_KEY is set",
+        authenticated: false,
+        output: "resend — check RESEND_API_KEY is set",
+        informational: true,
+      },
+    ];
+
+    const items = collectEscalations([], services, []);
+    assert.equal(items.length, 1);
+    assert.equal(items[0].issue, "Manual setup (no CLI login)");
+    assert.ok(!items[0].action.startsWith("Run:"), `action should not be a Run: command, got: ${items[0].action}`);
+    assert.ok(items[0].action.includes("RESEND_API_KEY"));
+  });
+
   it("collects missing secrets with source-specific actions", () => {
     const secrets: SecretStatus[] = [
       { name: "DB_URL", source: "1password", available: false, detail: "op read failed" },

--- a/src/escalate.ts
+++ b/src/escalate.ts
@@ -31,12 +31,24 @@ export function collectEscalations(
 
   for (const s of services) {
     if (!s.authenticated) {
-      items.push({
-        category: "service",
-        name: s.name,
-        issue: "Not authenticated",
-        action: `Run: ${s.checkCommand.replace(/\bstatus\b|whoami|--list/g, "login").trim()}`,
-      });
+      // An informational service (no CLI login — `#`-documented, e.g. set an
+      // env var) is manual setup, not a failed login. Surface the
+      // documentation message verbatim instead of a bogus `Run: # …`.
+      if (s.informational) {
+        items.push({
+          category: "service",
+          name: s.name,
+          issue: "Manual setup (no CLI login)",
+          action: s.output,
+        });
+      } else {
+        items.push({
+          category: "service",
+          name: s.name,
+          issue: "Not authenticated",
+          action: `Run: ${s.checkCommand.replace(/\bstatus\b|whoami|--list/g, "login").trim()}`,
+        });
+      }
     }
   }
 

--- a/src/scan-build.test.ts
+++ b/src/scan-build.test.ts
@@ -69,6 +69,44 @@ describe("scanBuildArtifacts", () => {
     }
   });
 
+  it("does not flag a framework manifest's `value` fields (tfstate FP filter)", async () => {
+    const dir = makeRepo();
+    try {
+      mkdirSync(join(dir, ".next"), { recursive: true });
+      // Next.js routes-manifest.json carries `"value":"…"` header/redirect
+      // entries that match the tfstate `"value"` rule but are not secrets.
+      writeFileSync(
+        join(dir, ".next", "routes-manifest.json"),
+        JSON.stringify({
+          headers: [
+            { source: "/", headers: [{ key: "x-mw", value: "twenty-plus-character-route-value-login" }] },
+          ],
+        }),
+      );
+      const hits = await scanBuildArtifacts(dir);
+      assert.equal(hits.length, 0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("still flags a real inlined credential alongside a manifest", async () => {
+    const dir = makeRepo();
+    try {
+      mkdirSync(join(dir, ".next"), { recursive: true });
+      writeFileSync(
+        join(dir, ".next", "routes-manifest.json"),
+        JSON.stringify({ headers: [{ value: "another-twenty-plus-character-value" }] }),
+      );
+      writeFileSync(join(dir, ".next", "leak.js"), "sk_" + "live_AaBbCcDdEeFfGgHhIiJjKkLl\n");
+      const hits = await scanBuildArtifacts(dir);
+      assert.equal(hits.length, 1);
+      assert.ok(hits[0].file.includes("leak.js"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("respects customDirs override", async () => {
     const dir = makeRepo();
     try {

--- a/src/scan-build.ts
+++ b/src/scan-build.ts
@@ -56,6 +56,13 @@ const SKIP_DIRS = new Set([
 
 const MAX_BYTES = 5 * 1024 * 1024; // 5 MiB
 
+// Terraform / tfstate finding labels do not apply to build artifacts and
+// false-positive on framework manifests — e.g. Next.js `routes-manifest.json`
+// has many `"value":"…"` route entries that match the tfstate `"value"` rule.
+// A build-artifact leak is an inlined CREDENTIAL (sk_/JWT/AWS/…), not an HCL or
+// state construct, so these labels are filtered out here.
+const BUILD_IRRELEVANT_LABELS = new Set(["tfstate-value", "terraform-sensitive"]);
+
 async function walk(
   dir: string,
   out: string[],
@@ -112,7 +119,9 @@ export async function scanBuildArtifacts(
     } catch {
       continue;
     }
-    const findings = findSecrets(content);
+    const findings = findSecrets(content).filter(
+      (f) => !BUILD_IRRELEVANT_LABELS.has(f.label),
+    );
     if (findings.length > 0) {
       // Strip leading cwd from path for readable reporting.
       const rel = path.startsWith(cwd) ? path.slice(cwd.length + 1) : path;


### PR DESCRIPTION
Polish round from a full read-only command sweep on a real repo. All verified live + unit-tested; full suite green.

### Fixed
- **Informational services warn, not fail** (`check`/`ci`/`escalate`) — a `#`-documented no-CLI login (resend `set RESEND_API_KEY`, sentry DSN) was a `✗ fail` that dragged the gate down; `escalate` even printed `Run: # resend …`. Now a `warn` / "manual setup", and escalate shows the doc message. (Extends 1.4.1's `manual` login state.)
- **`scan-build` false positive** on Next.js `routes-manifest.json` — Terraform/tfstate finding labels are filtered out of build-artifact scanning (real credentials still caught).
- **`kit memory status`** aliases `stats`.
- **`review` / `design` / `baseline`** gained help text.

(Also includes the already-merged `--help`-no-exec and GCM `authTagLength` fixes carried in `[Unreleased]`.)

Cuts **1.4.2** (version + CHANGELOG bumped). After merge, tag `v1.4.2` to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)