### PR TITLE
docs(agent-config): teach agents about kit memory + README memory summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **`kit agent-config` now teaches agents about memory.** The managed "use kit" block injected into CLAUDE.md / AGENTS.md / .cursorrules / .clinerules gains a bullet: recall prior decisions with `kit memory search "<query>"` (cross-session, cross-agent) and keep the store current with `kit memory index`. Previously the block covered check/triage/secrets/elevate but never mentioned the memory store, so agents in a kit repo had no pointer to it. Also refreshed the README's memory command summary (was missing `stats`, `merge`, `save`/`threads`).
+
 ## [1.4.2] - 2026-06-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Complete reference: [`docs/COMMANDS.md`](./docs/COMMANDS.md). The shortlist:
 - `kit fix`: Auto-remediate gaps (tools, gitignore, hooks, .env.template)
 - `kit login --plan`: Show the resolved auth strategy (vault/capture/interactive) per service without logging in
 - `kit secrets {set,migrate,rotate,propagate,onecli,validate}`: Secret lifecycle
-- `kit memory {index,search,suggest,pal,share,backup}`: Local-first second brain + pending-action ledger
+- `kit memory {index,search,stats,suggest,merge,save,threads,share,backup}`: Local-first, cross-harness second brain (per-harness `stats`, project recall, saved copilots) + `kit memory pal` pending-action ledger
 - `kit auth {elevate,setup-totp,status,revoke}`: Elevation gate + TOTP
 - `kit mcp {list,auth,set-token,clear}`: MCP-server orchestrator
 - `kit env {list,switch,current,diff}`: Environment routing + drift detection

--- a/src/agent-config.ts
+++ b/src/agent-config.ts
@@ -26,6 +26,7 @@ export const KIT_INSTRUCTION = `## kit
 This project uses [kit](https://github.com/sandstream/kit) to manage tools, secrets, and environment setup. As the agent working here:
 
 - Run \`kit check\` before starting; if it reports \`fail\`, run \`kit fix\` then re-check.
+- Recall prior decisions with \`kit memory search "<query>"\` (cross-session, cross-agent); keep the local store current with \`kit memory index\`.
 - Before installing ANY dependency, run \`kit triage npm|pip|docker|repo <target>\` and only install if it passes.
 - Never write secrets to \`.env*\` in plaintext — resolve them with \`kit secrets\` (vault-backed).
 - After a batch of edits, run \`kit check --category security\`; halt and surface findings on \`fail\`.


### PR DESCRIPTION
Dogfooding surfaced that the `kit agent-config` managed block (the "use kit" instructions injected into CLAUDE.md / AGENTS.md / .cursorrules / .clinerules) covered check / triage / secrets / elevate but **never mentioned the memory store** — so an agent working in a kit repo had no pointer to `kit memory` at all.

- Added a recall bullet to the template: `kit memory search "<query>"` (cross-session, cross-agent) + `kit memory index`.
- Refreshed the README's one-line memory command summary, which was stale (missing `stats` — the per-harness portability proof — plus `merge`, `save`/`threads`).

agent-config + full suite green (2253).

🤖 Generated with [Claude Code](https://claude.com/claude-code)