### PR TITLE
fix(memory): install hooks with an absolute path (silent-failure bug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- **`kit memory install` writes hooks that actually run.** Hooks were written as a bare `kit memory hook …`, but Claude Code runs hooks in a non-login `/bin/sh` whose PATH usually does **not** include the npm global bin (`~/.npm-global/bin`, nvm/volta/pnpm shims, …). So the hook failed with `kit: command not found` and **silently broke memory capture** — the store looked installed but recorded nothing live. Install now pins an absolute `<node> <cli.js>` invocation resolved from the running process, matches existing hooks by suffix (so re-install dedupes and uninstall cleans up legacy bare entries), and **warns loudly** if it cannot resolve an absolute path instead of failing silently.
+
 ### Added
 - **`kit agent-config` now teaches agents about memory.** The managed "use kit" block injected into CLAUDE.md / AGENTS.md / .cursorrules / .clinerules gains a bullet: recall prior decisions with `kit memory search "<query>"` (cross-session, cross-agent) and keep the store current with `kit memory index`. Previously the block covered check/triage/secrets/elevate but never mentioned the memory store, so agents in a kit repo had no pointer to it. Also refreshed the README's memory command summary (was missing `stats`, `merge`, `save`/`threads`).
 

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -358,10 +358,17 @@ async function memHook(): Promise<boolean> {
 }
 
 async function memInstall(): Promise<boolean> {
-    const { added, alreadyPresent } = installMemoryHooks();
+    const { added, alreadyPresent, resolved } = installMemoryHooks();
     for (const e of added) console.log(`${c.green}✓${c.reset} installed ${e} hook`);
     for (const e of alreadyPresent) console.log(`${c.dim}• ${e} hook already present${c.reset}`);
     console.log(`${c.dim}settings: ${getClaudeSettingsPath()}${c.reset}`);
+    if (!resolved) {
+      console.log(
+        `${c.yellow}!${c.reset} Could not resolve kit's absolute path — hooks use a bare \`kit\`, ` +
+          `which only fires if kit is on the hook shell's PATH (often not the case). ` +
+          `Reinstall kit globally and re-run, or edit the commands in ${getClaudeSettingsPath()} to an absolute path.`,
+      );
+    }
     return true;
 }
 

--- a/src/memory/install.test.ts
+++ b/src/memory/install.test.ts
@@ -42,15 +42,19 @@ describe("memory hook installer", () => {
       g.hooks.map((h) => h.command),
     );
     assert.ok(ups.includes("some-other-tool"), "preserves the pre-existing hook");
-    assert.ok(ups.includes("kit memory hook user-prompt-submit"));
+    const upsHook = ups.find((c: string) => c.endsWith("memory hook user-prompt-submit"));
+    assert.ok(upsHook, "wires the user-prompt-submit hook");
+    // Must be an ABSOLUTE invocation (node + cli.js), not a bare `kit` that the
+    // hook shell's PATH can't resolve.
+    assert.ok(upsHook.includes("/"), `hook command must be absolute, got: ${upsHook}`);
     assert.ok(
       s.hooks.SessionEnd.some((g: { hooks: { command: string }[] }) =>
-        g.hooks.some((h) => h.command === "kit memory hook session-end"),
+        g.hooks.some((h) => h.command.endsWith("memory hook session-end")),
       ),
     );
     assert.ok(
       s.hooks.SessionStart.some((g: { hooks: { command: string }[] }) =>
-        g.hooks.some((h) => h.command === "kit memory hook session-start"),
+        g.hooks.some((h) => h.command.endsWith("memory hook session-start")),
       ),
     );
   });
@@ -62,9 +66,36 @@ describe("memory hook installer", () => {
     assert.deepEqual(res2.alreadyPresent.sort(), ["SessionEnd", "SessionStart", "UserPromptSubmit"]);
     const s = JSON.parse(readFileSync(settingsPath, "utf8"));
     const ours = s.hooks.UserPromptSubmit.filter((g: { hooks: { command: string }[] }) =>
-      g.hooks.some((h) => h.command === "kit memory hook user-prompt-submit"),
+      g.hooks.some((h) => h.command.endsWith("memory hook user-prompt-submit")),
     );
     assert.equal(ours.length, 1);
+  });
+
+  it("recognizes a legacy bare-`kit` hook and neither duplicates nor leaves it on uninstall", () => {
+    // Simulate a settings file written by an older kit (bare command).
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [{ hooks: [{ type: "command", command: "kit memory hook user-prompt-submit" }] }],
+        },
+      }),
+    );
+    // Re-install must treat the legacy entry as already present (no duplicate).
+    const res = installMemoryHooks();
+    assert.ok(!res.added.includes("UserPromptSubmit"), "must not add a second UPS hook");
+    const s = JSON.parse(readFileSync(settingsPath, "utf8"));
+    const ours = s.hooks.UserPromptSubmit.filter((g: { hooks: { command: string }[] }) =>
+      g.hooks.some((h) => h.command.endsWith("memory hook user-prompt-submit")),
+    );
+    assert.equal(ours.length, 1, "no duplicate UPS hook");
+    // Uninstall removes the legacy bare entry too (suffix match).
+    uninstallMemoryHooks();
+    const s2 = JSON.parse(readFileSync(settingsPath, "utf8"));
+    const left = (s2.hooks.UserPromptSubmit ?? []).filter((g: { hooks: { command: string }[] }) =>
+      g.hooks?.some((h) => h.command.endsWith("memory hook user-prompt-submit")),
+    );
+    assert.equal(left.length, 0, "legacy hook removed");
   });
 
   it("uninstall removes only our hooks, leaving others intact", () => {

--- a/src/memory/install.ts
+++ b/src/memory/install.ts
@@ -7,12 +7,30 @@
  */
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, dirname } from "node:path";
+import { join, dirname, resolve } from "node:path";
 
-const MEMORY_HOOKS: { event: string; command: string }[] = [
-  { event: "UserPromptSubmit", command: "kit memory hook user-prompt-submit" },
-  { event: "SessionEnd", command: "kit memory hook session-end" },
-  { event: "SessionStart", command: "kit memory hook session-start" },
+/**
+ * Absolute invocation of kit for use inside a Claude Code hook. Hooks run in a
+ * non-login `/bin/sh` whose PATH usually does NOT include the npm global bin
+ * (`~/.npm-global/bin`, nvm/volta/pnpm shims, etc.). A bare `kit` there fails
+ * with "command not found" and SILENTLY breaks memory capture — the worst
+ * failure mode, because the store looks installed but records nothing. So we
+ * pin an absolute `<node> <cli.js>` resolved from the running process.
+ */
+function kitHookInvocation(): string {
+  const entry = process.argv[1];
+  if (entry) return `${process.execPath} ${resolve(entry)}`;
+  return "kit"; // last resort — relies on PATH (and will warn at the call site)
+}
+
+/** A kit memory hook is identified by this stable suffix, regardless of how
+ *  kit was invoked — lets us dedupe + clean up old bare-`kit` entries. */
+const hookSuffix = (sub: string): string => `memory hook ${sub}`;
+
+const MEMORY_HOOKS: { event: string; sub: string }[] = [
+  { event: "UserPromptSubmit", sub: "user-prompt-submit" },
+  { event: "SessionEnd", sub: "session-end" },
+  { event: "SessionStart", sub: "session-start" },
 ];
 
 export function getClaudeSettingsPath(): string {
@@ -46,28 +64,33 @@ function writeSettings(path: string, s: Settings): void {
   writeFileSync(path, JSON.stringify(s, null, 2) + "\n");
 }
 
-function groupsHaveCommand(groups: HookGroup[], command: string): boolean {
-  return groups.some((g) => g.hooks?.some((h) => h.command === command));
+/** True if any hook command in these groups is a kit memory hook for `sub`
+ *  (matches by suffix, so a bare-`kit` or absolute-path entry both count). */
+function groupsHaveHook(groups: HookGroup[], sub: string): boolean {
+  const suffix = hookSuffix(sub);
+  return groups.some((g) => g.hooks?.some((h) => h.command.endsWith(suffix)));
 }
 
 export function installMemoryHooks(
   path: string = getClaudeSettingsPath(),
-): { added: string[]; alreadyPresent: string[] } {
+): { added: string[]; alreadyPresent: string[]; resolved: boolean } {
   const s = readSettings(path);
   const hooks = (s.hooks ??= {});
+  const prefix = kitHookInvocation();
+  const resolved = prefix !== "kit";
   const added: string[] = [];
   const alreadyPresent: string[] = [];
-  for (const { event, command } of MEMORY_HOOKS) {
+  for (const { event, sub } of MEMORY_HOOKS) {
     const groups = (hooks[event] ??= []);
-    if (groupsHaveCommand(groups, command)) {
+    if (groupsHaveHook(groups, sub)) {
       alreadyPresent.push(event);
       continue;
     }
-    groups.push({ hooks: [{ type: "command", command }] });
+    groups.push({ hooks: [{ type: "command", command: `${prefix} ${hookSuffix(sub)}` }] });
     added.push(event);
   }
   if (added.length) writeSettings(path, s);
-  return { added, alreadyPresent };
+  return { added, alreadyPresent, resolved };
 }
 
 export function uninstallMemoryHooks(
@@ -76,10 +99,11 @@ export function uninstallMemoryHooks(
   const s = readSettings(path);
   if (!s.hooks) return { removed: [] };
   const removed: string[] = [];
-  for (const { event, command } of MEMORY_HOOKS) {
+  for (const { event, sub } of MEMORY_HOOKS) {
     const groups = s.hooks[event];
     if (!Array.isArray(groups)) continue;
-    const filtered = groups.filter((g) => !g.hooks?.some((h) => h.command === command));
+    const suffix = hookSuffix(sub);
+    const filtered = groups.filter((g) => !g.hooks?.some((h) => h.command.endsWith(suffix)));
     if (filtered.length !== groups.length) {
       s.hooks[event] = filtered;
       removed.push(event);


### PR DESCRIPTION
Dogfooding caught the memory store's auto-capture **silently broken**: `kit memory install` wrote hooks as bare `kit memory hook …`, but Claude Code runs hooks in a non-login `/bin/sh` whose PATH usually does **not** include the npm global bin (`~/.npm-global/bin`, nvm/volta/pnpm shims). The hook failed with `kit: command not found` every prompt — and hook errors are non-blocking, so it failed *silently*: the store looked installed but recorded nothing live.

- Pin an **absolute** `<node> <cli.js>` invocation, resolved from `process.execPath` + `process.argv[1]` at install time.
- Match hooks by the `memory hook <event>` **suffix** → re-install dedupes, and uninstall also cleans up legacy bare-`kit` entries (upgrade path).
- **Warn loudly** in `kit memory install` if an absolute path can't be resolved, instead of writing a silently-broken bare command.

Verified: a real `kit memory install` now writes `/usr/local/bin/node /…/cli.js memory hook user-prompt-submit`, which runs in `/bin/sh` (exit 0). Tests added (absolute-path + legacy-bare migration). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)