### PR TITLE
fix(check): resolve socket/semgrep mise-first (so kit check finds them)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Fixed
+- **`kit check` finds mise-installed scanners (socket, semgrep).** The security step looked for them with a bare `socket`/`semgrep` PATH lookup, so a scanner installed via mise — whose shims aren't on kit's own PATH — was reported "not installed" even when present. A new `resolveToolBin` resolves mise-first (`mise which`) then PATH; check-security uses it for both. Groundwork for managing semgrep/socket as default mise-provisioned scanners.
 - **`kit memory install` writes hooks that actually run.** Hooks were written as a bare `kit memory hook …`, but Claude Code runs hooks in a non-login `/bin/sh` whose PATH usually does **not** include the npm global bin (`~/.npm-global/bin`, nvm/volta/pnpm shims, …). So the hook failed with `kit: command not found` and **silently broke memory capture** — the store looked installed but recorded nothing live. Install now pins an absolute `<node> <cli.js>` invocation resolved from the running process, matches existing hooks by suffix (so re-install dedupes and uninstall cleans up legacy bare entries), and **warns loudly** if it cannot resolve an absolute path instead of failing silently.
 
 ### Added

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -3,6 +3,7 @@ import { promisify } from "node:util";
 import { readFile, access } from "node:fs/promises";
 import { resolve } from "node:path";
 import { execFileNoThrow } from "./utils/execFileNoThrow.js";
+import { resolveToolBin } from "./utils/resolveTool.js";
 import { ruleForCheck, type RuleRef } from "./rules/catalog.js";
 import {
   ensureBumblebee,
@@ -608,19 +609,21 @@ async function checkSocket(): Promise<SecurityCheckResult> {
     return { category: "supply-chain", name: "socket scan", status: "skip", detail: "no package.json found" };
   }
 
-  const versionCheck = await execFileNoThrow("socket", ["--version"], { timeout: 5_000 });
-  if (!versionCheck.ok) {
+  // Resolve mise-first: kit installs scanners via mise, whose shims aren't on
+  // kit's PATH. A bare "socket" lookup would miss a mise-installed one.
+  const socketBin = await resolveToolBin("socket");
+  if (!socketBin) {
     return {
       category: "supply-chain",
       name: "socket scan",
       status: "warn",
       detail: "socket not installed -supply chain malware undetected",
       severity: "medium",
-      suggestion: "npm install -g @socketsecurity/cli",
+      suggestion: "mise use npm:@socketsecurity/cli  (or: npm install -g @socketsecurity/cli)",
     };
   }
 
-  const result = await execFileNoThrow("socket", ["check", "--json"], { timeout: 60_000 });
+  const result = await execFileNoThrow(socketBin, ["check", "--json"], { timeout: 60_000 });
   const raw = result.stdout || result.stderr;
 
   try {
@@ -793,18 +796,19 @@ async function checkLicenses(): Promise<SecurityCheckResult> {
  * Run static analysis using Semgrep to catch security anti-patterns in source code.
  */
 async function checkSemgrep(): Promise<SecurityCheckResult> {
-  const versionCheck = await execFileNoThrow("semgrep", ["--version"], { timeout: 5_000 });
-  if (!versionCheck.ok) {
+  // Resolve mise-first (see socket): a mise-installed semgrep isn't on kit's PATH.
+  const semgrepBin = await resolveToolBin("semgrep");
+  if (!semgrepBin) {
     return {
       category: "supply-chain",
       name: "semgrep SAST",
       status: "skip",
-      detail: "semgrep not installed (brew install semgrep)",
+      detail: "semgrep not installed (mise use pipx:semgrep, or brew install semgrep)",
     };
   }
 
   const result = await execFileNoThrow(
-    "semgrep",
+    semgrepBin,
     ["scan", "--config", "auto", "--json", "--quiet", "--no-rewrite-rule-ids"],
     { timeout: 120_000 },
   );

--- a/src/utils/resolveTool.test.ts
+++ b/src/utils/resolveTool.test.ts
@@ -1,0 +1,16 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolveToolBin } from "./resolveTool.js";
+
+describe("resolveToolBin", () => {
+  it("resolves an existing tool (node) to an absolute path", async () => {
+    const p = await resolveToolBin("node");
+    assert.ok(p, "node should resolve via mise or PATH");
+    assert.ok(p!.startsWith("/"), `expected an absolute path, got: ${p}`);
+  });
+
+  it("returns null for a tool that does not exist anywhere", async () => {
+    const p = await resolveToolBin("kit-definitely-not-a-real-tool-zzz");
+    assert.equal(p, null);
+  });
+});

--- a/src/utils/resolveTool.ts
+++ b/src/utils/resolveTool.ts
@@ -1,0 +1,29 @@
+import { execFileNoThrow } from "./execFileNoThrow.js";
+
+/**
+ * Resolve a tool's executable to an absolute path — mise-first, then PATH.
+ *
+ * kit installs tools via mise, but mise shims are only on a shell's PATH when
+ * mise is *activated* there. kit's own process (and the hooks it writes) run
+ * without that activation, so a bare `execFileNoThrow("semgrep")` can't find a
+ * mise-installed scanner even though it's installed. `mise which <tool>` returns
+ * the real binary path regardless of shim activation; we fall back to the
+ * system PATH (`which`) for tools installed outside mise. Returns null if the
+ * tool can't be found either way.
+ *
+ * Args are always passed as an array (no shell string) per the exec security
+ * invariant, so a tool name can't inject.
+ */
+export async function resolveToolBin(tool: string): Promise<string | null> {
+  const viaMise = await execFileNoThrow("mise", ["which", tool], { timeout: 8_000 });
+  if (viaMise.ok) {
+    const p = viaMise.stdout.trim().split("\n")[0]?.trim();
+    if (p) return p;
+  }
+  const viaPath = await execFileNoThrow("which", [tool], { timeout: 5_000 });
+  if (viaPath.ok) {
+    const p = viaPath.stdout.trim().split("\n")[0]?.trim();
+    if (p) return p;
+  }
+  return null;
+}


### PR DESCRIPTION
**Prototype on a real repo proved the gap** (step 1 of "scanners on by default via mise"): a scanner installed via mise — `mise use npm:@socketsecurity/cli` — is resolvable (`mise which socket` → real path) but **not on kit's bare PATH**, so `check-security`'s `execFileNoThrow("socket"|"semgrep")` reported *"not installed"* even though it was present. Same PATH class as the memory-hook silent-failure.

`resolveToolBin(tool)` resolves **mise-first** (`mise which`) then PATH; check-security uses it for both scanners and execs the resolved absolute path.

**Verified end-to-end:** with socket mise-installed, `kit check` now actually runs it — the result moved from "socket not installed" to socket's own `socket login` auth prompt (socket's deep checks need an account; the basic CLI resolves + runs).

This is the groundwork for managing semgrep/socket as **default** mise-provisioned scanners (next increment), and the recommended-setup capstone after that. Tests added; full suite green (2259).

🤖 Generated with [Claude Code](https://claude.com/claude-code)