### PR TITLE
feat(setup): kit setup --recommended (the batteries-included capstone)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **`kit setup --recommended` — opinionated, batteries-included profile.** After the core pipeline it wires the cross-harness **memory hooks**, a **pre-commit secret-scan** gate, and a **pre-push context-check** gate (only when `[context]` is declared) — using the hardened installers (absolute-path memory hooks; hooksPath-aware, no-clobber, absolute-`kit` git hooks). It announces up front that it touches `~/.claude` and the repo's git hooks. So one command takes a repo from clone to a fully-wired, agent-runnable, self-checking environment. Plain `kit setup` now *also* grants the read-only kit permission allowlist in `[5/6]` (previously only `kit agent-config` did), so the agent can run kit after setup.
+
 ### Fixed
 - **`kit check` finds mise-installed scanners (socket, semgrep).** The security step looked for them with a bare `socket`/`semgrep` PATH lookup, so a scanner installed via mise — whose shims aren't on kit's own PATH — was reported "not installed" even when present. A new `resolveToolBin` resolves mise-first (`mise which`) then PATH; check-security uses it for both. Groundwork for managing semgrep/socket as default mise-provisioned scanners.
 - **`kit memory install` writes hooks that actually run.** Hooks were written as a bare `kit memory hook …`, but Claude Code runs hooks in a non-login `/bin/sh` whose PATH usually does **not** include the npm global bin (`~/.npm-global/bin`, nvm/volta/pnpm shims, …). So the hook failed with `kit: command not found` and **silently broke memory capture** — the store looked installed but recorded nothing live. Install now pins an absolute `<node> <cli.js>` invocation resolved from the running process, matches existing hooks by suffix (so re-install dedupes and uninstall cleans up legacy bare entries), and **warns loudly** if it cannot resolve an absolute path instead of failing silently.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -88,6 +88,7 @@ import { formatGovernanceStatus, mergeGovernanceConfigAsync } from "./governance
 import { withGovernance } from "./governance-middleware.js";
 import { SKIPPED_COMMITS_LOG } from "./hooks.js";
 import { writeAgentConfig, detectAgentTargets, installKitPermissions } from "./agent-config.js";
+import { applyRecommendedHardening } from "./recommended.js";
 import { checkHooks, isGitRepository } from "./check-hooks.js";
 import {
   readkitMeta,
@@ -889,10 +890,18 @@ async function cmdEscalate(): Promise<boolean> {
 }
 
 async function cmdSetup(): Promise<boolean> {
-  console.log(`${c.bold}${c.cyan}kit setup${c.reset}`);
+  const recommended = hasFlag(process.argv, "--recommended");
+  console.log(`${c.bold}${c.cyan}kit setup${recommended ? " --recommended" : ""}${c.reset}`);
   console.log(`${c.dim}${"─".repeat(50)}${c.reset}\n`);
 
   const config = await loadConfig(resolveConfigPath());
+
+  if (recommended) {
+    console.log(
+      `${c.dim}Recommended profile also wires cross-harness memory hooks (in ~/.claude) ` +
+        `and git hooks (secret-scan${config.context ? " + context-check" : ""}) after the core steps.${c.reset}\n`,
+    );
+  }
 
   // Step 1: Install
   console.log(`${c.bold}[1/6] Install${c.reset}`);
@@ -935,11 +944,33 @@ async function cmdSetup(): Promise<boolean> {
       console.log(`  ${mark}${c.reset} ${r.agent} ${c.dim}→ ${r.file} (${r.action})${c.reset}`);
     }
   }
+  // Let the agent actually run kit: grant the read-only kit commands (same as
+  // `kit agent-config`). Without this the agent hits the permission wall.
+  const perms = await installKitPermissions();
+  if (perms.action === "created" || perms.action === "updated") {
+    console.log(`  ${c.green}✓${c.reset} allowed ${perms.added.length} read-only kit command(s) ${c.dim}→ ${perms.file}${c.reset}`);
+  }
   console.log();
 
   // Step 6: Verify
   console.log(`${c.bold}[6/6] Verify${c.reset}`);
   const verifyOk = await cmdCheck();
+
+  // Recommended hardening: memory hooks + git hooks (opt-in via --recommended).
+  if (recommended) {
+    console.log(`\n${c.bold}[+] Recommended hardening${c.reset}`);
+    const h = await applyRecommendedHardening(config);
+    for (const e of h.memory.added) console.log(`  ${c.green}✓${c.reset} memory hook ${c.dim}${e}${c.reset}`);
+    if (h.memory.added.length === 0) console.log(`  ${c.dim}= memory hooks already wired${c.reset}`);
+    if (!h.memory.resolved) {
+      console.log(`  ${c.yellow}!${c.reset} ${c.dim}memory hooks use a bare \`kit\` (kit not resolvable to an absolute path)${c.reset}`);
+    }
+    for (const r of h.hooks) {
+      const icon = r.action === "failed" ? `${c.red}✗` : r.action === "skipped" ? `${c.yellow}!` : `${c.green}✓`;
+      console.log(`  ${icon}${c.reset} git ${r.hookName} ${c.dim}(${r.action})${c.reset}`);
+    }
+    console.log();
+  }
 
   const allOk = installOk && loginOk && secretsOk && verifyOk;
 
@@ -3722,7 +3753,8 @@ const COMMAND_HELP: Record<string, string> = {
   "auth revoke":    "Drop the elevation marker",
   "auth setup-totp": "Enroll TOTP secret (writes ~/.kit/totp-secret 0600)",
   "hooks add": "Install a built-in hook (e.g. secret-scan)",
-  setup:          "Full pipeline: install → login → secrets → project setup",
+  setup:          "Full pipeline: install → login → secrets → agent config → verify",
+  "setup --recommended": "Opinionated profile: setup + memory hooks + git secret-scan/context-check gates",
   fix:            "Auto-fix what is possible",
   escalate:       "List what needs human action",
   governance:     "View governance status and agent access controls",

--- a/src/recommended.test.ts
+++ b/src/recommended.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { applyRecommendedHardening } from "./recommended.js";
+
+describe("applyRecommendedHardening", () => {
+  let tmp: string;
+  const prev = process.env.KIT_CLAUDE_SETTINGS;
+
+  before(() => {
+    tmp = mkdtempSync(join(tmpdir(), "kit-recommended-"));
+  });
+  beforeEach(() => {
+    process.env.KIT_CLAUDE_SETTINGS = join(tmp, `claude-${Math.random().toString(36).slice(2)}.json`);
+  });
+  after(() => {
+    if (prev === undefined) delete process.env.KIT_CLAUDE_SETTINGS;
+    else process.env.KIT_CLAUDE_SETTINGS = prev;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function gitDir(): string {
+    return mkdtempSync(join(tmp, "git-")) + "/.git";
+  }
+
+  it("wires memory hooks + a pre-commit secret-scan, and a pre-push when context is declared", async () => {
+    const g = gitDir();
+    const r = await applyRecommendedHardening({ context: { git: { email: "x@y.z" } } }, g);
+
+    // 3 memory hooks (UserPromptSubmit/SessionEnd/SessionStart).
+    assert.equal(r.memory.added.length, 3);
+
+    // pre-commit secret-scan gate.
+    const pc = readFileSync(join(g, "hooks", "pre-commit"), "utf-8");
+    assert.ok(pc.includes("security scan-staged"), "pre-commit runs security scan-staged");
+
+    // pre-push context-check gate (context was declared).
+    assert.ok(existsSync(join(g, "hooks", "pre-push")), "pre-push installed when context declared");
+    const pp = readFileSync(join(g, "hooks", "pre-push"), "utf-8");
+    assert.ok(pp.includes("context check"), "pre-push runs context check");
+  });
+
+  it("omits the pre-push context-check gate when no context is declared", async () => {
+    const g = gitDir();
+    const r = await applyRecommendedHardening({}, g);
+    assert.ok(r.hooks.some((h) => h.hookName === "pre-commit"), "still installs pre-commit");
+    assert.equal(existsSync(join(g, "hooks", "pre-push")), false, "no pre-push without context");
+  });
+});

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -1,0 +1,48 @@
+import { resolve } from "node:path";
+import type { kitConfig, HooksConfig } from "./config.js";
+import { installMemoryHooks } from "./memory/install.js";
+import { installHooks, type HookInstallResult } from "./hooks.js";
+
+export interface RecommendedResult {
+  memory: { added: string[]; alreadyPresent: string[]; resolved: boolean };
+  hooks: HookInstallResult[];
+}
+
+/**
+ * Absolute self-invocation of kit for embedding in a generated git hook —
+ * same reasoning as the memory-hook installer: git hooks may run in a shell
+ * whose PATH lacks the npm global bin, so a bare `kit` can fail. Resolved from
+ * the running process (`node <cli.js>`); falls back to bare `kit`.
+ */
+function kitInvocation(): string {
+  const entry = process.argv[1];
+  return entry ? `${process.execPath} ${resolve(entry)}` : "kit";
+}
+
+/**
+ * The opinionated "recommended" hardening layered on top of `kit setup`:
+ *   - cross-harness memory capture (the Claude Code hooks)
+ *   - a pre-commit secret-scan gate
+ *   - a pre-push context-check gate (only when `[context]` is declared)
+ *
+ * Each piece is idempotent and uses the already-hardened installers
+ * (absolute-path memory hooks; hooksPath-aware, no-clobber git hooks). It
+ * touches GLOBAL `~/.claude` (memory hooks) and the repo's git hooks, so the
+ * caller must surface that to the user first.
+ */
+export async function applyRecommendedHardening(
+  config: kitConfig,
+  gitDir = ".git",
+): Promise<RecommendedResult> {
+  const memory = installMemoryHooks();
+
+  const kit = kitInvocation();
+  const hookConfig: HooksConfig = { "pre-commit": [`${kit} security scan-staged`] };
+  // The context-check gate only makes sense once a context is declared.
+  if (config.context) {
+    hookConfig["pre-push"] = [`${kit} context check`];
+  }
+  const hooks = await installHooks(hookConfig, gitDir);
+
+  return { memory, hooks };
+}


### PR DESCRIPTION
The capstone of the "recommended setup" arc: one flag takes a repo from clone to a fully-wired, agent-runnable, self-checking environment — instead of assembling vault + scanners + memory + permissions + context + hooks piece by piece.

After the core `kit setup` pipeline, `--recommended` adds:
- **cross-harness memory hooks** (absolute-path — the hardened installer)
- a **pre-commit secret-scan** gate
- a **pre-push context-check** gate (only when `[context]` is declared)

via the hardened installers: hooksPath-aware + no-clobber git hooks, and an **absolute `kit` invocation** embedded in the generated hooks so they don't hit the bare-PATH silent-failure we fixed for memory. It **announces up front** that it touches `~/.claude` and git hooks (consented, not silent).

Also fixes an inconsistency: plain `kit setup [5/6]` now grants the **read-only kit permission allowlist** (like `kit agent-config`) — previously setup wrote the CLAUDE.md block but never made kit actually runnable by the agent.

New testable `recommended.ts` (`applyRecommendedHardening`); tests cover memory + pre-commit always, pre-push gated on context. Full suite green (2262).

This bundles everything shipped this arc (mise-provisioned scanners, agent-config block + permissions, context lock, memory). With this, the 1.4.3 line is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)