### PR TITLE
feat(check): IaC misconfiguration scan via trivy config (1.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **`kit check` adds an IaC misconfiguration scan (`trivy config`).** Distinct from the container-CVE scan: it flags insecure *infrastructure config* in Dockerfiles, Compose files, and Terraform (root user, privileged containers, public buckets, missing healthchecks, …). Runs only when IaC is present (Dockerfile/Compose/`.tf`), resolves trivy mise-first, and reports HIGH/CRITICAL as a warning. First of the 1.5.0 scanner-coverage round.
+
 ## [1.4.3] - 2026-06-18
 
 ### Added

--- a/src/check-security.test.ts
+++ b/src/check-security.test.ts
@@ -1,6 +1,23 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
-import { checkSecurity } from "./check-security.js";
+import { checkSecurity, parseTrivyMisconfigCount } from "./check-security.js";
+
+describe("parseTrivyMisconfigCount", () => {
+  it("counts only HIGH/CRITICAL misconfigurations", () => {
+    const json = JSON.stringify({
+      Results: [
+        { Misconfigurations: [{ Severity: "HIGH" }, { Severity: "LOW" }, { Severity: "CRITICAL" }] },
+        { Misconfigurations: [{ Severity: "MEDIUM" }] },
+      ],
+    });
+    assert.strictEqual(parseTrivyMisconfigCount(json), 2);
+  });
+
+  it("returns 0 for a clean scan and -1 for unparseable output", () => {
+    assert.strictEqual(parseTrivyMisconfigCount(JSON.stringify({ Results: [] })), 0);
+    assert.strictEqual(parseTrivyMisconfigCount("not json"), -1);
+  });
+});
 
 describe("checkSecurity", () => {
   // Bumblebee disabled so tests stay fast/offline (real scan downloads binary, walks machine).

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { readFile, access } from "node:fs/promises";
+import { readFile, access, readdir } from "node:fs/promises";
 import { resolve } from "node:path";
 import { execFileNoThrow } from "./utils/execFileNoThrow.js";
 import { resolveToolBin } from "./utils/resolveTool.js";
@@ -721,6 +721,91 @@ async function checkTrivy(): Promise<SecurityCheckResult> {
   }
 }
 
+/** Count HIGH/CRITICAL misconfigurations in a `trivy config --format json`
+ *  payload. PURE so it can be unit-tested without running trivy. */
+export function parseTrivyMisconfigCount(stdout: string): number {
+  try {
+    const parsed = JSON.parse(stdout) as {
+      Results?: { Misconfigurations?: { Severity?: string }[] }[];
+    };
+    return (parsed.Results ?? [])
+      .flatMap((r) => r.Misconfigurations ?? [])
+      .filter((m) => m.Severity === "HIGH" || m.Severity === "CRITICAL").length;
+  } catch {
+    return -1; // unparseable
+  }
+}
+
+/**
+ * IaC misconfiguration scan (Dockerfile / Compose / Terraform) via
+ * `trivy config`. Distinct from the container-CVE scan above: that finds
+ * vulnerable packages, this finds insecure infrastructure config (root user,
+ * privileged containers, public buckets, missing healthchecks, …). Runs only
+ * when there is IaC to scan; resolves trivy mise-first like the CVE scan.
+ */
+async function checkTrivyConfig(): Promise<SecurityCheckResult> {
+  const name = "trivy config (IaC)";
+  const cwd = process.cwd();
+  const fileMarkers = [
+    "Dockerfile",
+    "docker-compose.yml",
+    "docker-compose.yaml",
+    "compose.yml",
+    "compose.yaml",
+  ];
+  let hasIaC = false;
+  for (const m of fileMarkers) {
+    if (await access(resolve(cwd, m)).then(() => true).catch(() => false)) {
+      hasIaC = true;
+      break;
+    }
+  }
+  if (!hasIaC) {
+    // Any top-level Terraform?
+    try {
+      const entries = await readdir(cwd);
+      hasIaC = entries.some((e) => e.endsWith(".tf"));
+    } catch {
+      /* unreadable cwd — treat as no IaC */
+    }
+  }
+  if (!hasIaC) {
+    return { category: "supply-chain", name, status: "skip", detail: "no Dockerfile/Compose/Terraform found" };
+  }
+
+  const trivyBin = await resolveToolBin("trivy");
+  if (!trivyBin) {
+    return {
+      category: "supply-chain",
+      name,
+      status: "warn",
+      detail: "trivy not installed -IaC misconfigurations undetected",
+      severity: "medium",
+      suggestion: "mise use aqua:aquasecurity/trivy  (or: brew install trivy)",
+    };
+  }
+
+  const result = await execFileNoThrow(
+    trivyBin,
+    ["config", ".", "--format", "json", "--severity", "HIGH,CRITICAL", "--quiet"],
+    { timeout: 120_000 },
+  );
+  const count = parseTrivyMisconfigCount(result.stdout);
+  if (count < 0) {
+    return { category: "supply-chain", name, status: "warn", detail: "trivy config scan failed", severity: "medium" };
+  }
+  if (count === 0) {
+    return { category: "supply-chain", name, status: "pass", detail: "no high/critical IaC misconfigurations" };
+  }
+  return {
+    category: "supply-chain",
+    name,
+    status: "warn",
+    detail: `${count} high/critical IaC misconfiguration(s) -run: trivy config .`,
+    severity: "high",
+  };
+}
+
 /**
  * Check dependency licenses for GPL/AGPL that create legal obligations.
  */
@@ -980,6 +1065,7 @@ export async function checkSecurity(): Promise<SecurityCheckResult[]> {
     licenseResult,
     semgrepResult,
     bumblebeeResult,
+    trivyConfigResult,
     ...lockfileResults
   ] = await Promise.all([
     checkNpmAudit(),
@@ -992,6 +1078,7 @@ export async function checkSecurity(): Promise<SecurityCheckResult[]> {
     checkLicenses(),
     checkSemgrep(),
     checkBumblebee(),
+    checkTrivyConfig(),
     ...await checkLockfilesCommitted(),
   ]);
 
@@ -1006,6 +1093,7 @@ export async function checkSecurity(): Promise<SecurityCheckResult[]> {
     licenseResult,
     semgrepResult,
     bumblebeeResult,
+    trivyConfigResult,
   );
   results.push(...lockfileResults);
 


### PR DESCRIPTION
**1.5.0 scanner-coverage round, piece 1** — closes the biggest gap from the coverage review: IaC misconfiguration.

`checkTrivyConfig` runs `trivy config` to flag insecure *infrastructure config* (root user, privileged containers, public buckets, missing healthchecks, …) in Dockerfiles, Compose files, and Terraform — distinct from the existing container-CVE scan (`trivy fs`). Runs only when IaC is present (Dockerfile/Compose/`.tf`), resolves trivy mise-first (`resolveToolBin`), reports HIGH/CRITICAL as a warning. Cheap because trivy is already wired.

Pure `parseTrivyMisconfigCount` extracted + unit-tested. Verified on kjorre: skips cleanly (no IaC). Full suite green.

⚠️ **Do not merge until v1.4.3 is tagged** — this is 1.5.0 work and would otherwise ride the 1.4.3 release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)