### PR TITLE
feat(check): deep secret scan on by default (trufflehog, mise)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 - **`kit check` adds an IaC misconfiguration scan (`trivy config`).** Distinct from the container-CVE scan: it flags insecure *infrastructure config* in Dockerfiles, Compose files, and Terraform (root user, privileged containers, public buckets, missing healthchecks, …). Runs only when IaC is present (Dockerfile/Compose/`.tf`), resolves trivy mise-first, and reports HIGH/CRITICAL as a warning. First of the 1.5.0 scanner-coverage round.
+- **Deep secret scan on by default.** trufflehog is now a default mise-provisioned tool (`aqua:trufflesecurity/trufflehog`), and `kit check` resolves the `trufflehog` bin mise-first — so the deep secret scan runs out of the box instead of only when trufflehog happens to be on PATH. Falls back to the basic regex scan when trufflehog can't be resolved.
 
 ## [1.4.3] - 2026-06-18
 

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -507,13 +507,16 @@ async function checkSecretsInCode(): Promise<SecurityCheckResult> {
     };
   }
   
-  // Try trufflehog first
+  // Deep scan with trufflehog — resolve mise-first so a mise-installed one is
+  // used (kit provisions it as a default), not just a bare-PATH one. Throwing
+  // when it's absent falls through to the basic pattern-matching below.
   try {
-    await exec("trufflehog", ["--version"], { timeout: 5_000 });
-    
+    const trufflehogBin = await resolveToolBin("trufflehog");
+    if (!trufflehogBin) throw new Error("trufflehog not installed");
+
     try {
       const { stdout } = await exec(
-        "trufflehog",
+        trufflehogBin,
         ["filesystem", ".", "--json", "--no-update"],
         { timeout: 60_000 }
       );

--- a/src/toml-generator.test.ts
+++ b/src/toml-generator.test.ts
@@ -28,13 +28,18 @@ describe("generateToml", () => {
     assert.ok(toml.includes('pnpm = "latest"'), `missing pnpm in: ${toml}`);
   });
 
-  it("includes the default security scanners (semgrep + socket) as mise tools", () => {
+  it("includes the default security scanners (semgrep + socket + trufflehog) as mise tools", () => {
     const parsed = parseTOML(generateToml(stack())) as { tools: Record<string, string> };
     assert.equal(parsed.tools.semgrep, "latest", "semgrep should be a default tool");
     assert.equal(
       parsed.tools["npm:@socketsecurity/cli"],
       "latest",
       "socket should be a default tool (npm backend ref, quoted key)",
+    );
+    assert.equal(
+      parsed.tools["aqua:trufflesecurity/trufflehog"],
+      "latest",
+      "trufflehog should be a default tool (deep secret scan on by default)",
     );
   });
 

--- a/src/toml-generator.ts
+++ b/src/toml-generator.ts
@@ -120,6 +120,10 @@ const FRAMEWORK_SETUP: Record<
 export const DEFAULT_SECURITY_SCANNERS: Record<string, string> = {
   semgrep: "latest",
   "npm:@socketsecurity/cli": "latest",
+  // trufflehog (single Go binary via aqua) → deep secret scan on by default;
+  // `kit check` resolves the `trufflehog` bin mise-first and uses it instead of
+  // the basic regex fallback.
+  "aqua:trufflesecurity/trufflehog": "latest",
 };
 
 function lines(...parts: (string | null | undefined)[]): string {


### PR DESCRIPTION
**Theme A, piece 2** — make the *deep* secret scan a default instead of "only if trufflehog happens to be on PATH."

- `checkSecretsInCode` resolves the `trufflehog` bin **mise-first** (`resolveToolBin`), so a mise-installed one is used (same fix class as socket/semgrep/trivy).
- trufflehog added to the default `[tools]` (`aqua:trufflesecurity/trufflehog` — a single Go binary, light), so `kit setup` provisions it.
- Falls back to the basic regex scan when trufflehog can't be resolved (unchanged safety net).

Verified on kjorre: with trufflehog not installed, it still reports the basic-scan pass (graceful fallback). Full suite green (2264).

Next in A: conditional provisioning (trivy/pip-audit by stack detection) + OSV-scanner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)