### PR TITLE
kit sentinel: design + kit health v1a (GitHub Actions sensor + PAL mirror)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-06-21
+
+### Added
+- **`kit health` — deterministic external-system health probe (kit sentinel, layer 1).** A new read-only command that probes the project's connected external systems and surfaces failing ones, mirroring red findings into the PAL ledger under a new `health` source tag so they appear cross-session and auto-close when the system goes green again. Account-verified: it records which org/repo it checked and reports `unknown` rather than a false `green` when it cannot confirm the account or a probe errors. First sensor is GitHub Actions — flags workflows whose latest completed run failed, excluding disabled workflows (so a stale failure from a dead workflow is not reported). `--json` for machine output; the command is wrapped in the governance read path. Sensors are derived from the project's connected services; more (Vercel, Sentry, Supabase, Resend, TLS cert) land incrementally. Design and plan are in `docs/specs/2026-06-21-kit-sentinel-design.md` and `docs/plans/2026-06-21-kit-health-v1a.md`.
+
 ## [1.11.1] - 2026-06-20
 
 ### Fixed

--- a/docs/plans/2026-06-21-kit-health-v1a.md
+++ b/docs/plans/2026-06-21-kit-health-v1a.md
@@ -1,0 +1,787 @@
+# kit health (v1a) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `kit health` — a deterministic, read-only command that probes the project's connected external systems and mirrors red findings into PAL — with one real sensor (GitHub Actions) proving the full spine end to end.
+
+**Architecture:** A pure orchestrator (`runHealth`) maps over a registry of `HealthSensor` objects; each sensor owns its own probe (via injected `HealthDeps`) and a *pure* parse function that is unit-tested against captured CLI output. Red findings are mirrored into the existing PAL ledger via the same `palSyncFindings` path the security findings already use, under a new `"health"` source tag so reconciliation never touches other sources. The `kit health` CLI command wraps it with the existing `withGovernance` read wrapper and a `--json` mode mirroring `cmdStatus`/`cmdCheck`.
+
+**Tech Stack:** TypeScript (ESM, `.js` import specifiers), Node 22+ `node:test` + `node:assert/strict`, the repo's `execFileNoThrow` exec wrapper, `node:sqlite`-backed PAL store.
+
+## Scope
+
+This plan is the first slice of the `kit health` portion of the kit-sentinel
+spec (`docs/specs/2026-06-21-kit-sentinel-design.md`, layer 1). It deliberately
+ships **framework + GitHub Actions sensor + PAL mirror + CLI** only. The other
+sensors (Vercel, Sentry, Supabase, Resend, TLS cert) are mechanical follow-ons
+— each is one `HealthSensor` entry plus a pure-parse test reusing the
+framework this plan builds — and are listed in the Appendix as separate future
+plans (the HTTP/token probe path lands with the first HTTP sensor). Layers 2
+(the responder routine) and 3 (`kit sentinel install` + SessionStart surface)
+are out of scope for this plan.
+
+**Spec deviation (deliberate):** the spec sketched a `healthProbe` field on
+`ServiceDef`. We do NOT modify `ServiceDef`. It is pure data (and has a
+byte-identical-output guarantee in its tests); a sensor needs a `parse`
+*function*, which does not belong in a data registry. Instead sensors live in
+their own `HEALTH_SENSORS` registry keyed by service id. Adding a sensor is
+still a single entry — the spec's intent ("a data row") holds; only the file
+changes.
+
+## Global Constraints
+
+- **Public repo / no internal leaks.** This is the public `sandstream/kit`
+  repo. Never write internal product names, customer names, or private hosts
+  into code, tests, fixtures, comments, or commit messages. Fixtures use
+  generic names (e.g. `acme/webapp`). A pre-commit `no-internal-leaks` hook
+  enforces this.
+- **Node >= 22.0.0.** ESM only; all relative imports end in `.js`.
+- **Zero-LLM.** `kit health` is deterministic and read-only. No probe mutates
+  anything; no network write; no LLM call.
+- **Account-verified detection.** A sensor that cannot confirm *which*
+  account/org/ref it is probing returns a finding with `status: "unknown"` and
+  the reason — never `"green"`. A skipped/errored probe is `"unknown"`, never
+  silently dropped.
+- **Exec safety.** External commands run via `execFileNoThrow(command, args,
+  opts)` with arguments as an array. Never build a shell string.
+- **Tests:** `node:test` + `node:assert/strict`; import compiled siblings with
+  `.js`. Per-file TDD loop: `node --test --import tsx src/<file>.test.ts`.
+  Authoritative run before commit: `npm run build && npm test`.
+
+---
+
+### Task 1: Health core types + orchestrator
+
+**Files:**
+- Create: `src/health.ts`
+- Test: `src/health.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (foundation).
+- Produces:
+  - `type HealthStatus = "green" | "red" | "unknown"`
+  - `type HealthClass = "code" | "human" | "noise"`
+  - `interface HealthFinding { sensor: string; source: string; status: HealthStatus; severity?: "critical" | "high" | "medium" | "low"; title: string; detail?: string; suggestedClass?: HealthClass }`
+  - `interface HealthCtx { cwd: string; config: kitConfig }`
+  - `interface HealthDeps { runCli(command: string, args: string[]): Promise<ExecResult> }`
+  - `interface HealthSensor { id: string; probe(ctx: HealthCtx, deps: HealthDeps): Promise<HealthFinding[]> }`
+  - `async function runHealth(ctx: HealthCtx, sensors: HealthSensor[], deps: HealthDeps): Promise<HealthFinding[]>`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/health.test.ts
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { runHealth, type HealthSensor, type HealthCtx, type HealthDeps } from "./health.js";
+
+const ctx: HealthCtx = { cwd: "/tmp/repo", config: {} };
+const deps: HealthDeps = { runCli: async () => ({ stdout: "", stderr: "", exitCode: 0, ok: true }) };
+
+describe("runHealth", () => {
+  it("aggregates findings from all sensors", async () => {
+    const a: HealthSensor = { id: "a", probe: async () => [{ sensor: "a", source: "x", status: "green", title: "ok" }] };
+    const b: HealthSensor = { id: "b", probe: async () => [{ sensor: "b", source: "y", status: "red", severity: "high", title: "bad" }] };
+    const out = await runHealth(ctx, [a, b], deps);
+    assert.equal(out.length, 2);
+    assert.deepEqual(out.map((f) => f.status).sort(), ["green", "red"]);
+  });
+
+  it("converts a throwing sensor into an unknown finding, never drops it", async () => {
+    const boom: HealthSensor = { id: "boom", probe: async () => { throw new Error("network down"); } };
+    const out = await runHealth(ctx, [boom], deps);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].status, "unknown");
+    assert.equal(out[0].sensor, "boom");
+    assert.match(out[0].detail ?? "", /network down/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test --import tsx src/health.test.ts`
+Expected: FAIL — `Cannot find module './health.js'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// src/health.ts
+import type { kitConfig } from "./config.js";
+import type { ExecResult } from "./utils/execFileNoThrow.js";
+
+export type HealthStatus = "green" | "red" | "unknown";
+export type HealthClass = "code" | "human" | "noise";
+
+export interface HealthFinding {
+  sensor: string;
+  /** The account/org/ref/repo actually probed (the verify-source record). */
+  source: string;
+  status: HealthStatus;
+  severity?: "critical" | "high" | "medium" | "low";
+  title: string;
+  detail?: string;
+  suggestedClass?: HealthClass;
+}
+
+export interface HealthCtx {
+  cwd: string;
+  config: kitConfig;
+}
+
+export interface HealthDeps {
+  runCli(command: string, args: string[]): Promise<ExecResult>;
+}
+
+export interface HealthSensor {
+  id: string;
+  probe(ctx: HealthCtx, deps: HealthDeps): Promise<HealthFinding[]>;
+}
+
+/** Runs every sensor; a sensor that throws becomes an `unknown` finding (never dropped). */
+export async function runHealth(
+  ctx: HealthCtx,
+  sensors: HealthSensor[],
+  deps: HealthDeps,
+): Promise<HealthFinding[]> {
+  const all = await Promise.all(
+    sensors.map(async (s): Promise<HealthFinding[]> => {
+      try {
+        return await s.probe(ctx, deps);
+      } catch (e) {
+        return [{
+          sensor: s.id,
+          source: "(probe errored)",
+          status: "unknown",
+          title: `${s.id} probe failed`,
+          detail: e instanceof Error ? e.message : String(e),
+        }];
+      }
+    }),
+  );
+  return all.flat();
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test --import tsx src/health.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/health.ts src/health.test.ts
+git commit -m "feat(health): core types + runHealth orchestrator"
+```
+
+---
+
+### Task 2: GitHub Actions sensor
+
+**Files:**
+- Create: `src/health-sensors/github-actions.ts`
+- Test: `src/health-sensors/github-actions.test.ts`
+
+**Interfaces:**
+- Consumes: `HealthFinding`, `HealthSensor`, `HealthCtx`, `HealthDeps` from `../health.js`.
+- Produces:
+  - `interface GhRun { name: string; status: string; conclusion: string; createdAt: string; databaseId: number }`
+  - `function parseGitHubRuns(json: string): GhRun[]`
+  - `function failingWorkflows(runs: GhRun[]): { name: string; createdAt: string }[]` — latest completed run per workflow name; included when its conclusion is `"failure"`, `"timed_out"`, or `"startup_failure"`.
+  - `const githubActionsSensor: HealthSensor` (id `"github-actions"`).
+
+**Probe behavior:** the sensor (a) resolves the repo via `gh repo view --json nameWithOwner` to get the real `owner/repo` (the verify-source record); if `ctx.config.context?.github?.org` is set and does not match the repo owner, it returns a single `unknown` finding (context/repo mismatch — never reports green against the wrong account); (b) runs `gh run list --limit 30 --json name,status,conclusion,createdAt,databaseId`; (c) emits one `red` finding per failing workflow (severity `high`, class `code`) plus, when none fail, a single `green` finding. A non-zero `gh` exit (not authed / no remote) yields one `unknown` finding.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/health-sensors/github-actions.test.ts
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseGitHubRuns,
+  failingWorkflows,
+  githubActionsSensor,
+} from "./github-actions.js";
+import type { HealthCtx, HealthDeps } from "../health.js";
+
+const runs = JSON.stringify([
+  { name: "CI", status: "completed", conclusion: "failure", createdAt: "2026-06-21T06:50:00Z", databaseId: 9 },
+  { name: "CI", status: "completed", conclusion: "success", createdAt: "2026-06-20T06:50:00Z", databaseId: 8 },
+  { name: "Security", status: "completed", conclusion: "success", createdAt: "2026-06-21T05:00:00Z", databaseId: 7 },
+]);
+
+function deps(over: Partial<Record<string, { stdout: string; ok: boolean }>> = {}): HealthDeps {
+  return {
+    runCli: async (cmd, args) => {
+      const key = `${cmd} ${args[0]}`;
+      const r = over[key];
+      if (r) return { stdout: r.stdout, stderr: "", exitCode: r.ok ? 0 : 1, ok: r.ok };
+      return { stdout: "", stderr: "", exitCode: 0, ok: true };
+    },
+  };
+}
+const ctx: HealthCtx = { cwd: "/tmp/repo", config: {} };
+
+describe("parseGitHubRuns / failingWorkflows", () => {
+  it("keeps only the latest completed run per workflow and flags failures", () => {
+    const parsed = parseGitHubRuns(runs);
+    assert.equal(parsed.length, 3);
+    const failing = failingWorkflows(parsed);
+    assert.deepEqual(failing.map((f) => f.name), ["CI"]); // newest CI is failure; Security is green
+  });
+
+  it("returns [] when the JSON is empty", () => {
+    assert.deepEqual(failingWorkflows(parseGitHubRuns("[]")), []);
+  });
+});
+
+describe("githubActionsSensor.probe", () => {
+  it("emits one red finding per failing workflow", async () => {
+    const out = await githubActionsSensor.probe(ctx, deps({
+      "gh repo": { stdout: JSON.stringify({ nameWithOwner: "acme/webapp" }), ok: true },
+      "gh run": { stdout: runs, ok: true },
+    }));
+    const red = out.filter((f) => f.status === "red");
+    assert.equal(red.length, 1);
+    assert.equal(red[0].sensor, "github-actions");
+    assert.equal(red[0].source, "acme/webapp");
+    assert.equal(red[0].suggestedClass, "code");
+    assert.match(red[0].title, /CI/);
+  });
+
+  it("emits a single green finding when nothing fails", async () => {
+    const allGreen = JSON.stringify([
+      { name: "CI", status: "completed", conclusion: "success", createdAt: "2026-06-21T06:50:00Z", databaseId: 9 },
+    ]);
+    const out = await githubActionsSensor.probe(ctx, deps({
+      "gh repo": { stdout: JSON.stringify({ nameWithOwner: "acme/webapp" }), ok: true },
+      "gh run": { stdout: allGreen, ok: true },
+    }));
+    assert.equal(out.length, 1);
+    assert.equal(out[0].status, "green");
+  });
+
+  it("returns unknown when gh is not authed", async () => {
+    const out = await githubActionsSensor.probe(ctx, deps({
+      "gh repo": { stdout: "", ok: false },
+    }));
+    assert.equal(out.length, 1);
+    assert.equal(out[0].status, "unknown");
+  });
+
+  it("returns unknown on context/repo owner mismatch", async () => {
+    const out = await githubActionsSensor.probe(
+      { cwd: "/tmp/repo", config: { context: { github: { org: "otherorg" } } } },
+      deps({ "gh repo": { stdout: JSON.stringify({ nameWithOwner: "acme/webapp" }), ok: true } }),
+    );
+    assert.equal(out.length, 1);
+    assert.equal(out[0].status, "unknown");
+    assert.match(out[0].detail ?? "", /otherorg/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test --import tsx src/health-sensors/github-actions.test.ts`
+Expected: FAIL — `Cannot find module './github-actions.js'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// src/health-sensors/github-actions.ts
+import type { HealthCtx, HealthDeps, HealthFinding, HealthSensor } from "../health.js";
+
+export interface GhRun {
+  name: string;
+  status: string;
+  conclusion: string;
+  createdAt: string;
+  databaseId: number;
+}
+
+const FAIL_CONCLUSIONS = new Set(["failure", "timed_out", "startup_failure"]);
+
+export function parseGitHubRuns(json: string): GhRun[] {
+  try {
+    const arr = JSON.parse(json) as GhRun[];
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Latest completed run per workflow name; included when that run failed. */
+export function failingWorkflows(runs: GhRun[]): { name: string; createdAt: string }[] {
+  const latest = new Map<string, GhRun>();
+  for (const r of runs) {
+    if (r.status !== "completed") continue;
+    const cur = latest.get(r.name);
+    if (!cur || r.createdAt > cur.createdAt) latest.set(r.name, r);
+  }
+  return [...latest.values()]
+    .filter((r) => FAIL_CONCLUSIONS.has(r.conclusion))
+    .map((r) => ({ name: r.name, createdAt: r.createdAt }));
+}
+
+export const githubActionsSensor: HealthSensor = {
+  id: "github-actions",
+  async probe(ctx: HealthCtx, deps: HealthDeps): Promise<HealthFinding[]> {
+    const repoRes = await deps.runCli("gh", ["repo", "view", "--json", "nameWithOwner"]);
+    if (!repoRes.ok) {
+      return [{
+        sensor: "github-actions",
+        source: "(no gh auth / no remote)",
+        status: "unknown",
+        title: "GitHub Actions probe could not resolve the repo",
+        detail: "gh repo view failed — run `gh auth status`",
+      }];
+    }
+    let nwo = "";
+    try {
+      nwo = (JSON.parse(repoRes.stdout) as { nameWithOwner: string }).nameWithOwner ?? "";
+    } catch {
+      nwo = "";
+    }
+    const wantOrg = ctx.config.context?.github?.org;
+    if (wantOrg && nwo && nwo.split("/")[0] !== wantOrg) {
+      return [{
+        sensor: "github-actions",
+        source: nwo,
+        status: "unknown",
+        title: "GitHub repo does not match locked context org",
+        detail: `context expects org "${wantOrg}" but gh repo is "${nwo}"`,
+      }];
+    }
+
+    const listRes = await deps.runCli("gh", [
+      "run", "list", "--limit", "30",
+      "--json", "name,status,conclusion,createdAt,databaseId",
+    ]);
+    if (!listRes.ok) {
+      return [{
+        sensor: "github-actions",
+        source: nwo || "(unknown repo)",
+        status: "unknown",
+        title: "GitHub Actions run list failed",
+        detail: listRes.stderr || "gh run list returned non-zero",
+      }];
+    }
+
+    const failing = failingWorkflows(parseGitHubRuns(listRes.stdout));
+    if (failing.length === 0) {
+      return [{
+        sensor: "github-actions",
+        source: nwo,
+        status: "green",
+        title: "GitHub Actions: all workflows green",
+      }];
+    }
+    return failing.map((w) => ({
+      sensor: "github-actions",
+      source: nwo,
+      status: "red" as const,
+      severity: "high" as const,
+      title: `GitHub Actions workflow failing: ${w.name}`,
+      detail: `latest run of "${w.name}" failed (${w.createdAt})`,
+      suggestedClass: "code" as const,
+    }));
+  },
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test --import tsx src/health-sensors/github-actions.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/health-sensors/github-actions.ts src/health-sensors/github-actions.test.ts
+git commit -m "feat(health): GitHub Actions sensor (failing-workflow detection)"
+```
+
+---
+
+### Task 3: Sensor selection + default deps
+
+**Files:**
+- Modify: `src/health.ts` (append `selectSensors` and `defaultHealthDeps`)
+- Test: `src/health.test.ts` (append)
+
+**Interfaces:**
+- Consumes: `githubActionsSensor` from `./health-sensors/github-actions.js`; `execFileNoThrow` from `./utils/execFileNoThrow.js`.
+- Produces:
+  - `const HEALTH_SENSORS: HealthSensor[]` — the registry (github-actions only, for now).
+  - `function selectSensors(ctx: HealthCtx): HealthSensor[]` — returns the subset whose service is connected. github-actions is connected when a `.git` dir exists OR `ctx.config.context?.github` is set OR `ctx.config.services?.github` exists. For this slice, gate it on the presence of `ctx.config.context?.github` OR a `github`/git remote signal passed in config; default to including github-actions when `gitRemote` is true.
+  - `const defaultHealthDeps: HealthDeps` — wraps `execFileNoThrow` with a 15s timeout.
+
+To keep selection testable without filesystem access, `selectSensors` reads a
+boolean `ctx.gitRemote` added to `HealthCtx`. The CLI layer (Task 5) computes
+`gitRemote` from the real repo.
+
+- [ ] **Step 1: Write the failing test (append to src/health.test.ts)**
+
+```typescript
+import { selectSensors, defaultHealthDeps, HEALTH_SENSORS } from "./health.js";
+
+describe("selectSensors", () => {
+  it("includes github-actions when a git remote is present", () => {
+    const sel = selectSensors({ cwd: "/tmp/repo", config: {}, gitRemote: true });
+    assert.ok(sel.some((s) => s.id === "github-actions"));
+  });
+
+  it("excludes github-actions with no git remote and no github context", () => {
+    const sel = selectSensors({ cwd: "/tmp/repo", config: {}, gitRemote: false });
+    assert.equal(sel.some((s) => s.id === "github-actions"), false);
+  });
+
+  it("registry is non-empty and defaultHealthDeps exposes runCli", () => {
+    assert.ok(HEALTH_SENSORS.length >= 1);
+    assert.equal(typeof defaultHealthDeps.runCli, "function");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test --import tsx src/health.test.ts`
+Expected: FAIL — `selectSensors`/`HEALTH_SENSORS`/`defaultHealthDeps` are not exported.
+
+- [ ] **Step 3: Implement**
+
+Add `gitRemote?: boolean` to the `HealthCtx` interface in `src/health.ts`:
+
+```typescript
+export interface HealthCtx {
+  cwd: string;
+  config: kitConfig;
+  /** True when the repo has a git remote (computed by the CLI layer). */
+  gitRemote?: boolean;
+}
+```
+
+Append to `src/health.ts`:
+
+```typescript
+import { githubActionsSensor } from "./health-sensors/github-actions.js";
+import { execFileNoThrow } from "./utils/execFileNoThrow.js";
+
+export const HEALTH_SENSORS: HealthSensor[] = [githubActionsSensor];
+
+/** Returns the sensors whose underlying service the project is connected to. */
+export function selectSensors(ctx: HealthCtx): HealthSensor[] {
+  return HEALTH_SENSORS.filter((s) => {
+    if (s.id === "github-actions") {
+      return ctx.gitRemote === true || ctx.config.context?.github !== undefined;
+    }
+    return false;
+  });
+}
+
+export const defaultHealthDeps: HealthDeps = {
+  runCli: (command, args) => execFileNoThrow(command, args, { timeout: 15_000 }),
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test --import tsx src/health.test.ts`
+Expected: PASS (5 tests total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/health.ts src/health.test.ts
+git commit -m "feat(health): sensor registry, connected-service selection, default deps"
+```
+
+---
+
+### Task 4: Mirror red findings into PAL
+
+**Files:**
+- Create: `src/health-track.ts`
+- Test: `src/health-track.test.ts`
+
+**Interfaces:**
+- Consumes: `HealthFinding` from `./health.js`; `palSyncFindings`, `SyncFinding` from `./memory/pal.js`; `openMemoryDb` from `./memory/db.js`; `getCurrentProjectRoot` from `./memory/project.js`.
+- Produces:
+  - `function actionableHealth(findings: HealthFinding[]): HealthFinding[]` — only `status === "red"`.
+  - `function healthFindingToSync(f: HealthFinding): SyncFinding` — `dedupKey = "${f.sensor}:${f.title}"`, `title = f.title`, `detail = f.detail`.
+  - `async function syncHealthFindings(findings: HealthFinding[]): Promise<{ added: number; reopened: number; closed: string[] } | null>` — mirrors `syncSecurityFindings`; source tag `"health"`; scope = `basename(getCurrentProjectRoot())`; fail-open (returns `null` on any error).
+
+This mirrors `src/findings-track.ts` exactly, with source tag `"health"` so a
+re-sync only reconciles `health-*` PAL ids — green/disappeared findings
+auto-close, other sources untouched.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/health-track.test.ts
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { actionableHealth, healthFindingToSync } from "./health-track.js";
+import type { HealthFinding } from "./health.js";
+
+const findings: HealthFinding[] = [
+  { sensor: "github-actions", source: "acme/webapp", status: "red", severity: "high", title: "workflow failing: CI", detail: "latest CI failed" },
+  { sensor: "github-actions", source: "acme/webapp", status: "green", title: "all green" },
+  { sensor: "github-actions", source: "acme/webapp", status: "unknown", title: "probe errored" },
+];
+
+describe("actionableHealth", () => {
+  it("keeps only red findings (green + unknown are not action items)", () => {
+    const out = actionableHealth(findings);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].title, "workflow failing: CI");
+  });
+});
+
+describe("healthFindingToSync", () => {
+  it("produces a stable dedup key of sensor:title", () => {
+    const s = healthFindingToSync(findings[0]);
+    assert.equal(s.dedupKey, "github-actions:workflow failing: CI");
+    assert.equal(s.title, "workflow failing: CI");
+    assert.equal(s.detail, "latest CI failed");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test --import tsx src/health-track.test.ts`
+Expected: FAIL — `Cannot find module './health-track.js'`.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/health-track.ts
+import type { HealthFinding } from "./health.js";
+import type { SyncFinding } from "./memory/pal.js";
+
+export function actionableHealth(findings: HealthFinding[]): HealthFinding[] {
+  return findings.filter((f) => f.status === "red");
+}
+
+export function healthFindingToSync(f: HealthFinding): SyncFinding {
+  return {
+    dedupKey: `${f.sensor}:${f.title}`,
+    title: f.title,
+    detail: f.detail || undefined,
+  };
+}
+
+/** Mirror red health findings into PAL under the "health" source tag. Fail-open. */
+export async function syncHealthFindings(
+  findings: HealthFinding[],
+): Promise<{ added: number; reopened: number; closed: string[] } | null> {
+  try {
+    const { openMemoryDb } = await import("./memory/db.js");
+    const { palSyncFindings } = await import("./memory/pal.js");
+    const { getCurrentProjectRoot } = await import("./memory/project.js");
+    const { basename } = await import("node:path");
+    const scope = basename(getCurrentProjectRoot());
+    const db = openMemoryDb();
+    try {
+      return palSyncFindings(db, "health", actionableHealth(findings).map(healthFindingToSync), {
+        scope,
+      });
+    } finally {
+      db.close();
+    }
+  } catch {
+    return null; // fail-open: health reporting must never break a command
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test --import tsx src/health-track.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/health-track.ts src/health-track.test.ts
+git commit -m "feat(health): mirror red findings into PAL under the health source tag"
+```
+
+---
+
+### Task 5: `kit health` CLI command
+
+**Files:**
+- Modify: `src/cli.ts` (add `cmdHealth`; register `health: cmdHealth` in the `COMMANDS` table near line 4716)
+- Test: `src/cli-health.test.ts`
+
+**Interfaces:**
+- Consumes: `runHealth`, `selectSensors`, `defaultHealthDeps`, `HealthFinding`, `HealthCtx` from `./health.js`; `syncHealthFindings` from `./health-track.js`; existing `loadConfig`, `resolveConfigPath`, `withGovernance`, `hasFlag`, `c` (colors), `execFileNoThrow`.
+- Produces: a new exported pure formatter `function formatHealth(findings: HealthFinding[]): { lines: string[]; redCount: number }` (in `src/health.ts`) so the human output is unit-testable without the CLI wiring; and `cmdHealth(): Promise<boolean>` (returns `false` when any red finding exists, so the command exit code reflects health).
+
+First add `formatHealth` to `src/health.ts`:
+
+- [ ] **Step 1: Write the failing test for the formatter**
+
+```typescript
+// src/cli-health.test.ts
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { formatHealth, type HealthFinding } from "./health.js";
+
+const findings: HealthFinding[] = [
+  { sensor: "github-actions", source: "acme/webapp", status: "red", severity: "high", title: "workflow failing: CI" },
+  { sensor: "github-actions", source: "acme/webapp", status: "green", title: "all green" },
+  { sensor: "x", source: "y", status: "unknown", title: "probe errored" },
+];
+
+describe("formatHealth", () => {
+  it("counts red findings and renders a line per finding", () => {
+    const out = formatHealth(findings);
+    assert.equal(out.redCount, 1);
+    assert.equal(out.lines.length, 3);
+    assert.ok(out.lines.some((l) => l.includes("workflow failing: CI")));
+    assert.ok(out.lines.some((l) => l.includes("acme/webapp")));
+  });
+
+  it("redCount is 0 when nothing is red", () => {
+    const out = formatHealth([{ sensor: "a", source: "s", status: "green", title: "ok" }]);
+    assert.equal(out.redCount, 0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test --import tsx src/cli-health.test.ts`
+Expected: FAIL — `formatHealth` is not exported.
+
+- [ ] **Step 3: Implement `formatHealth` in `src/health.ts`**
+
+```typescript
+// append to src/health.ts
+const MARK: Record<HealthStatus, string> = { green: "✓", red: "✗", unknown: "?" };
+
+/** Pure human formatter — returns lines + red count (CLI adds color). */
+export function formatHealth(findings: HealthFinding[]): { lines: string[]; redCount: number } {
+  const lines = findings.map(
+    (f) => `${MARK[f.status]} [${f.sensor}] ${f.title}  (${f.source})`,
+  );
+  const redCount = findings.filter((f) => f.status === "red").length;
+  return { lines, redCount };
+}
+```
+
+- [ ] **Step 4: Run formatter test to verify it passes**
+
+Run: `node --test --import tsx src/cli-health.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Add `cmdHealth` to `src/cli.ts`**
+
+Add the handler (place it beside `cmdCheck`/`cmdStatus`):
+
+```typescript
+async function cmdHealth(): Promise<boolean> {
+  const jsonMode = hasFlag(process.argv, "--json");
+  const config = await loadConfig(resolveConfigPath());
+
+  return await withGovernance(
+    config,
+    { operation: "health", operationType: "read", metadata: {} },
+    async () => {
+      const { runHealth, selectSensors, defaultHealthDeps, formatHealth } = await import("./health.js");
+      const { syncHealthFindings } = await import("./health-track.js");
+
+      // git remote presence (drives sensor selection)
+      const remote = await execFileNoThrow("git", ["remote"], { timeout: 5_000 });
+      const ctx = { cwd: process.cwd(), config, gitRemote: remote.ok && remote.stdout.trim().length > 0 };
+
+      const sensors = selectSensors(ctx);
+      const findings = await runHealth(ctx, sensors, defaultHealthDeps);
+      await syncHealthFindings(findings); // mirror red into PAL (fail-open)
+
+      if (jsonMode) {
+        const redCount = findings.filter((f) => f.status === "red").length;
+        console.log(JSON.stringify({ ok: redCount === 0, findings }, null, 2));
+        return redCount === 0;
+      }
+
+      const { lines, redCount } = formatHealth(findings);
+      console.log(`${c.bold}kit health${c.reset}  ${c.dim}${sensors.length} sensor(s)${c.reset}`);
+      if (findings.length === 0) {
+        console.log(`  ${c.dim}no connected external systems detected${c.reset}`);
+      }
+      for (const line of lines) {
+        const color = line.startsWith("✗") ? c.red : line.startsWith("?") ? c.yellow : c.green;
+        console.log(`  ${color}${line}${c.reset}`);
+      }
+      if (redCount > 0) console.log(`${c.red}${redCount} red${c.reset}`);
+      return redCount === 0;
+    },
+  );
+}
+```
+
+Register it in the `COMMANDS` table (near cli.ts:4716):
+
+```typescript
+  health: cmdHealth,
+```
+
+- [ ] **Step 6: Build and run the full suite**
+
+Run: `npm run build && npm test`
+Expected: build clean; all tests pass including the new `health`, `github-actions`, `health-track`, and `cli-health` suites.
+
+- [ ] **Step 7: Manual smoke (this repo has a git remote + red CI)**
+
+Run: `node --test` is not needed here; instead:
+`npm run build && node dist/cli.js health`
+Expected: prints `kit health  1 sensor(s)` and a `✗ [github-actions] GitHub Actions workflow failing: …` line (this repo currently has red workflows). `node dist/cli.js health --json` prints the findings array with `"status": "red"`. Exit code non-zero.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/cli.ts src/health.ts src/cli-health.test.ts
+git commit -m "feat(health): kit health command (--json + human, governance read, PAL mirror)"
+```
+
+---
+
+## Self-review
+
+- **Spec coverage (layer 1 slice):** deterministic read-only probe command
+  (Tasks 1,5); connected-service-derived sensors (Task 3 selection; Task 2
+  sensor); account-verified, `unknown`-not-green (Task 2 mismatch + not-authed
+  cases, Task 1 throw→unknown); red→PAL mirror with dedup + auto-close (Task 4
+  reuses `palSyncFindings`); `--json` + human (Task 5). Remaining spec sensors
+  + layers 2/3 are explicitly out of this plan's scope (Appendix).
+- **Placeholders:** none — every code/test step is complete.
+- **Type consistency:** `HealthFinding`/`HealthSensor`/`HealthCtx`/`HealthDeps`
+  defined in Task 1 and reused verbatim in Tasks 2–5; `SyncFinding` consumed in
+  Task 4 matches `src/memory/pal.ts`; `ExecResult` matches
+  `src/utils/execFileNoThrow.ts`; `gitRemote?` added to `HealthCtx` in Task 3
+  and consumed in Task 5.
+
+## Appendix — follow-up sensors (separate future plans)
+
+Each is one `HealthSensor` added to `HEALTH_SENSORS` plus a pure-parse test,
+reusing this framework. The first HTTP-based sensor also adds an `httpGet` to
+`HealthDeps`.
+
+- **Vercel** (HTTP): GET `/v6/deployments?projectId=<id>&target=production&limit=1`
+  with `VERCEL_TOKEN`; projectId from `.vercel/project.json`; red when latest
+  prod deployment `readyState` is `ERROR`/`CANCELED`. Class: code.
+- **Sentry** (HTTP): issues search for new unresolved since last sweep, scoped
+  to the org/project from `[context]`/env; red or noise. Needs `SENTRY_AUTH_TOKEN`.
+- **Supabase**: Security Advisor + migration drift for the project ref from
+  `[context]`/`NEXT_PUBLIC_SUPABASE_URL`. Class: code or human.
+- **Resend** (HTTP): GET `/domains` with `RESEND_API_KEY`; red/human when a
+  domain status is not `verified`. Class: human.
+- **TLS cert** (CLI): `openssl s_client` expiry window for a configured host
+  list (`[health] cert_hosts`); human/infra. (Adds the one bit of new config.)

--- a/docs/specs/2026-06-21-kit-sentinel-design.md
+++ b/docs/specs/2026-06-21-kit-sentinel-design.md
@@ -1,0 +1,253 @@
+# kit sentinel — design
+
+Status: draft (design approved 2026-06-21, spec under review)
+
+## One sentence
+
+kit deterministically probes a project's *connected* external systems once a
+day in a cloud routine; an agent triages any red findings and leaves the right
+artifact (a fix PR, an issue, or a suppression PR) waiting for a human, while
+the start of any session surfaces only the queue.
+
+## Problem
+
+Today external systems report problems *to a human who then has to start from
+zero*. A scheduled health cron (an email-delivery canary, a domain-status
+check) fires a `Sentry.captureMessage`, Sentry emails a person, and that
+person has to open the dashboard, reconstruct context, find the cause, and
+write the fix by hand.
+The same is true for a failed Vercel prod deploy, a red GitHub Actions run, a
+Supabase Security Advisor regression, or an expiring TLS cert. The detection
+exists; the *investigation and the proposed fix* do not. The human is the
+first responder for everything.
+
+kit already has the spine for the other half of this: the PAL ledger
+(detect -> remediate -> track -> remind -> auto-close) and the SessionStart
+surface hook (`[PAL · N open]`). kit sentinel extends PAL's sensors from
+*local* checks (`kit check`, secret scan, setup gaps) to *external runtime
+systems*, and adds an agentic responder on top that does the investigation and
+drafts the fix before the human ever looks.
+
+## Goals
+
+- A human starts their day to find problems already investigated and a
+  reviewable fix (or a clear human-action checklist) waiting — not a raw alert.
+- Detection stays deterministic, read-only, and account-verified inside kit
+  (zero-LLM core preserved).
+- Sensors are *derived from the project's connected services*, never a manual
+  pick-list. Adding a sensor is a data row, like adding a service.
+- No silent muting: even "this is benign noise" is a reviewable artifact.
+- Cheap always-on: a normal session never makes a heavy network call.
+
+## Non-goals (YAGNI / by design)
+
+- kit does not embed or call an LLM. The agentic responder is the harness
+  layer (a Claude Code / CCR routine), not kit core.
+- The agent never auto-merges, never rotates a secret, never touches a prod
+  DB, never force-pushes. Those classes become an *issue*, not a PR.
+- Not a dashboard or a monitoring product. GitHub (PRs + issues) is the queue;
+  kit owns detection and scaffolding only.
+- No new always-running daemon. The heavy sweep is a scheduled routine; the
+  local footprint is one throttled read at session start.
+
+## Decisions (locked in brainstorm 2026-06-21)
+
+1. **Architecture boundary — kit detects, agent fixes.** kit does the
+   deterministic external probes and writes findings; a separate agent reads
+   them, investigates, and produces artifacts. kit stays zero-LLM.
+2. **Cadence — both, throttled.** SessionStart always surfaces the cached
+   queue instantly (no network). The heavy sweep (probes + agent) runs at most
+   once per day.
+3. **Agent mechanism — remote daily routine.** A scheduled CCR routine (cloud,
+   via the `/schedule` mechanism) runs the sweep and opens artifacts
+   out-of-band, so it never consumes the user's local session or tokens.
+   SessionStart only reads the result.
+4. **Sensors — derived from connected services.** The sensor set is whatever
+   the project is actually connected to (detected via the existing service
+   registry + `[context]` block + `[secrets]` keys). Not selected by hand.
+5. **Output — right artifact per finding class** (after triage):
+   - code-fixable -> **draft PR** with the fix
+   - human / customer / infra action -> **GitHub issue** + diagnosis + checklist
+   - benign noise -> **draft PR** that adds the suppression (never a silent mute)
+
+## Architecture
+
+Three layers, with the LLM boundary between layer 1 and layer 2.
+
+### Layer 1 — `kit health` (deterministic, in kit)
+
+A new read-only command. Reads the service registry, the `[context]` block,
+and `[secrets]` keys to learn which external systems the project is connected
+to, probes each one for which a `healthProbe` is defined, and emits structured
+findings.
+
+- **Account-verified.** Each probe runs against the account/org/ref declared in
+  `[context]` (the context-lock principle). It states which source it checked.
+  This bakes in the "verify the source before concluding something is absent"
+  rule — the probe can never silently hit the wrong Sentry org or Supabase ref
+  and report "all clear."
+- **Read-only.** Probes only read (`gh run list`, `vercel ls`, a Sentry issue
+  search, `supabase ... advisors`, a Resend domains GET, an `openssl s_client`
+  cert read). No mutation, ever.
+- **Output:** `kit health --json` -> a list of findings:
+  `{ sensor, source (org/ref/env checked), status: green|red|unknown,
+     severity, title, evidence, firstSeen, suggestedClass }`.
+  `unknown` (e.g. token missing in the cloud env, probe errored) is distinct
+  from `green` — never collapse a skipped probe into "healthy".
+- Red findings are mirrored into PAL (selective: red only, dedup by stable id),
+  reusing the existing `kit memory pal` import + dedup.
+
+### Layer 2 — the responder (agent, in the harness / cloud)
+
+A scheduled CCR routine that kit scaffolds (see Layer 3). Once a day it:
+
+1. Runs `kit health --json` in the cloud checkout.
+2. For each red finding, **triages**: is this real, is it mine, which class is
+   it? The triage prompt requires the agent to state which org/env/branch it
+   verified before concluding anything (the misattribution guard, again).
+3. Produces the artifact for the class:
+   - **code-fixable** -> a draft PR with the fix, body states the verified
+     source and the evidence, labeled `kit-sentinel`.
+   - **human/customer/infra** -> a GitHub issue with the diagnosis and an
+     action checklist (e.g. "customer domain X failed Resend verification:
+     contact org, re-add DNS records A/B/C"), labeled `kit-sentinel`.
+   - **benign noise** -> a draft PR that adds the suppression (e.g. a Sentry
+     `ignoreErrors` entry for a known-benign cross-tab auth-lock error), so
+     muting is a human-reviewed change, never silent.
+4. Leaves everything as **draft** / open. Never merges, never closes.
+
+kit's role here is only to *generate* this routine and its pinned prompt. The
+LLM work is entirely in the harness.
+
+### Layer 3 — `kit sentinel install` (scaffolder, in kit) + SessionStart surface
+
+- **`kit sentinel install`** generates the CCR routine wired to the project's
+  connected services, the pinned responder prompt, the required-token
+  declaration, and the SessionStart surface hook. The user hand-authors
+  nothing. Mirrors how the existing `/schedule` skill creates routines and how
+  `kit agent-config` wires hooks/permissions.
+- **Required tokens.** The cloud routine can only probe a system whose
+  credentials are present in the cloud env. kit derives the required token per
+  connected service from the registry, declares them, and **warns on any
+  missing token** — that sensor is skipped and reported as `unknown`, never a
+  silent gap.
+- **SessionStart surface hook.** A cheap, throttled (cache <= 6h) read of
+  `gh pr list --label kit-sentinel` + open `kit-sentinel` issues, rendered as
+  `[sentinel · N waiting on you]`. No heavy network on a normal session. This
+  extends the existing PAL surface hook rather than adding a new one.
+
+## Sensor registry
+
+Add an optional `healthProbe` field to the existing `ServiceDef` in
+`src/service-registry.ts`, beside `login` / `check` / `secrets`:
+
+```
+healthProbe?: {
+  cmd: string            // read-only probe, account-scoped via [context]
+  parse: ...             // map output -> finding(s)
+  requiresToken: string  // env/secret key needed in the cloud routine
+  defaultClass: 'code' | 'human' | 'noise'  // triage hint, agent may override
+}
+```
+
+A sensor is probed only when the project is connected to that service.
+Adding a sensor = one data row. v1 rows cover a common web stack:
+
+| Sensor | Probe (read-only) | Typical class |
+|---|---|---|
+| GitHub Actions | `gh run list` failing/red runs | code |
+| Vercel deploys | `vercel ls` failed prod deploy | code |
+| Sentry | new unresolved issues / error spike since last sweep | code or noise |
+| Supabase | Security Advisor findings + migration drift | code or human |
+| Resend | domain status + email canary terminal event | human |
+| TLS cert | `openssl s_client` expiry window | human/infra |
+
+## Data flow
+
+```
+[daily, cloud routine]
+  kit health --json            (deterministic, account-verified, read-only)
+    -> findings[]
+  agent triages each red finding (states verified source)
+    -> code      -> draft PR (fix)      label kit-sentinel
+    -> human     -> issue (diagnosis)   label kit-sentinel
+    -> noise     -> draft PR (suppress) label kit-sentinel
+
+[any session, local]
+  SessionStart hook: gh pr/issue list --label kit-sentinel (cached <=6h)
+    -> "[sentinel · N waiting on you]"
+```
+
+GitHub is the cross-machine ledger (the routine runs in the cloud; the human
+reads from any machine). Local PAL optionally mirrors the same red findings
+for the local `kit check`/PAL view.
+
+## Guardrails
+
+- Draft PRs only; **never auto-merge**, never close. Everything labeled
+  `kit-sentinel` for one-glance filtering and easy revert.
+- **Verify-source-before-concluding** is mandatory in both layers: the probe
+  records the org/ref/env it checked; the agent must restate it before acting.
+- The agent edits repo code only. Prohibited classes (rotate a key, touch prod
+  DB, force-push, change access control) are surfaced as an *issue*, never
+  executed and never a code PR.
+- Missing cloud token -> sensor skipped, reported `unknown`, surfaced. No
+  silent coverage gaps.
+- Suppression is always a reviewable draft PR. The agent never mutes an alert
+  source on its own.
+
+## Error handling
+
+- Probe errors / offline / missing token -> finding `status: unknown` with the
+  reason; never silently dropped, never miscounted as green.
+- The routine is idempotent per finding: dedup by stable finding id so a
+  re-run does not open duplicate PRs/issues (reuse PAL's dedup-by-id and a
+  `kit-sentinel:<finding-id>` marker in the PR/issue body).
+- If a finding's artifact already exists and is open, update it rather than
+  reopen a new one.
+
+## Testing
+
+- **Layer 1 (`kit health`)** — unit-test each `healthProbe.parse` against
+  captured fixture output (red, green, unknown). Test that an account mismatch
+  vs `[context]` yields `unknown`+reason, not `green`. Test dedup-by-id and
+  PAL mirroring. Test missing-token -> `unknown`.
+- **Layer 3 (`kit sentinel install`)** — test the generated routine wires only
+  connected services, declares the right tokens, warns on missing ones, and
+  installs the surface hook without clobbering existing hooks (reuse the
+  hooksPath-aware install path).
+- **Layer 2 (responder)** — not kit-tested (it is harness/LLM); validate via a
+  dry-run of the routine against a fixture repo and inspect the artifacts.
+
+## Phasing
+
+1. **v1a — `kit health` + registry `healthProbe`** for the common web-stack
+   sensors (GitHub Actions, Vercel, Sentry, Supabase, Resend, cert), JSON out,
+   PAL mirror. Pure detection; usable on its own (`kit health` in a terminal).
+2. **v1b — SessionStart surface hook** reading `kit-sentinel` artifacts.
+3. **v1c — `kit sentinel install`** scaffolder + the pinned responder prompt +
+   token declaration.
+
+Each phase is independently shippable; v1a delivers value alone.
+
+## Open decisions
+
+- Command name: `kit sentinel` vs `kit health` vs `kit watch`/`guard`/`standup`.
+  Working assumption: `kit health` = the deterministic probe command;
+  `kit sentinel install` = the scaffolder. Confirm naming before build.
+- Whether local PAL mirroring of external findings is in v1a or deferred (the
+  GitHub queue is the source of truth regardless).
+- Sweep schedule default (e.g. 05:00 local) and per-project override.
+
+## Reuses (do not reinvent)
+
+service registry + `detectServices()`; `[context]` context-lock and
+`kit context check`; PAL import + dedup-by-id + the SessionStart surface hook;
+the `/schedule` CCR routine mechanism; `kit agent-config` hook/permission
+wiring; hooksPath-aware hook install.
+
+## Related
+
+PAL roadmap (detect -> remediate -> track -> remind -> auto-close);
+context-lock v2 (Supabase ref); cross-account context safety; the scheduled
+health crons that motivated this (delivery canary, domain-status check).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/cli-health.test.ts
+++ b/src/cli-health.test.ts
@@ -1,0 +1,24 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { formatHealth, type HealthFinding } from "./health.js";
+
+const findings: HealthFinding[] = [
+  { sensor: "github-actions", source: "acme/webapp", status: "red", severity: "high", title: "workflow failing: CI" },
+  { sensor: "github-actions", source: "acme/webapp", status: "green", title: "all green" },
+  { sensor: "x", source: "y", status: "unknown", title: "probe errored" },
+];
+
+describe("formatHealth", () => {
+  it("counts red findings and renders a line per finding", () => {
+    const out = formatHealth(findings);
+    assert.equal(out.redCount, 1);
+    assert.equal(out.lines.length, 3);
+    assert.ok(out.lines.some((l) => l.includes("workflow failing: CI")));
+    assert.ok(out.lines.some((l) => l.includes("acme/webapp")));
+  });
+
+  it("redCount is 0 when nothing is red", () => {
+    const out = formatHealth([{ sensor: "a", source: "s", status: "green", title: "ok" }]);
+    assert.equal(out.redCount, 0);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3980,6 +3980,51 @@ async function cmdStatus(): Promise<boolean> {
   return true;
 }
 
+async function cmdHealth(): Promise<boolean> {
+  const jsonMode = hasFlag(process.argv, "--json");
+  const config = await loadConfig(resolveConfigPath());
+
+  return await withGovernance(
+    config,
+    { operation: "health", operationType: "read", metadata: {} },
+    async () => {
+      const { runHealth, selectSensors, defaultHealthDeps, formatHealth } = await import("./health.js");
+      const { syncHealthFindings } = await import("./health-track.js");
+      const { execFileNoThrow } = await import("./utils/execFileNoThrow.js");
+
+      // git remote presence drives sensor selection
+      const remote = await execFileNoThrow("git", ["remote"], { timeout: 5_000 });
+      const ctx = {
+        cwd: process.cwd(),
+        config,
+        gitRemote: remote.ok && remote.stdout.trim().length > 0,
+      };
+
+      const sensors = selectSensors(ctx);
+      const findings = await runHealth(ctx, sensors, defaultHealthDeps);
+      await syncHealthFindings(findings); // mirror red into PAL (fail-open)
+
+      if (jsonMode) {
+        const redCount = findings.filter((f) => f.status === "red").length;
+        console.log(JSON.stringify({ ok: redCount === 0, findings }, null, 2));
+        return redCount === 0;
+      }
+
+      const { lines, redCount } = formatHealth(findings);
+      console.log(`${c.bold}kit health${c.reset}  ${c.dim}${sensors.length} sensor(s)${c.reset}`);
+      if (findings.length === 0) {
+        console.log(`  ${c.dim}no connected external systems detected${c.reset}`);
+      }
+      for (const line of lines) {
+        const color = line.startsWith("✗") ? c.red : line.startsWith("?") ? c.yellow : c.green;
+        console.log(`  ${color}${line}${c.reset}`);
+      }
+      if (redCount > 0) console.log(`${c.red}${redCount} red${c.reset}`);
+      return redCount === 0;
+    },
+  );
+}
+
 async function cmdWhoami(): Promise<boolean> {
   const jsonMode = hasFlag(process.argv, "--json");
 
@@ -4717,6 +4762,7 @@ async function main(): Promise<void> {
         status: cmdStatus,
         whoami: cmdWhoami,
         check: cmdCheck,
+        health: cmdHealth,
         init: cmdInit,
         upgrade: cmdUpgrade,
         install: cmdInstall,

--- a/src/health-sensors/github-actions.test.ts
+++ b/src/health-sensors/github-actions.test.ts
@@ -1,0 +1,84 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseGitHubRuns,
+  failingWorkflows,
+  githubActionsSensor,
+} from "./github-actions.js";
+import type { HealthCtx, HealthDeps } from "../health.js";
+
+const runs = JSON.stringify([
+  { name: "CI", status: "completed", conclusion: "failure", createdAt: "2026-06-21T06:50:00Z", databaseId: 9 },
+  { name: "CI", status: "completed", conclusion: "success", createdAt: "2026-06-20T06:50:00Z", databaseId: 8 },
+  { name: "Security", status: "completed", conclusion: "success", createdAt: "2026-06-21T05:00:00Z", databaseId: 7 },
+]);
+
+function deps(over: Record<string, { stdout: string; ok: boolean }> = {}): HealthDeps {
+  return {
+    runCli: async (cmd, args) => {
+      const key = `${cmd} ${args[0]}`;
+      const r = over[key];
+      if (r) return { stdout: r.stdout, stderr: "", exitCode: r.ok ? 0 : 1, ok: r.ok };
+      return { stdout: "", stderr: "", exitCode: 0, ok: true };
+    },
+  };
+}
+const ctx: HealthCtx = { cwd: "/tmp/repo", config: {} };
+
+describe("parseGitHubRuns / failingWorkflows", () => {
+  it("keeps only the latest completed run per workflow and flags failures", () => {
+    const parsed = parseGitHubRuns(runs);
+    assert.equal(parsed.length, 3);
+    const failing = failingWorkflows(parsed);
+    assert.deepEqual(failing.map((f) => f.name), ["CI"]); // newest CI is failure; Security is green
+  });
+
+  it("returns [] when the JSON is empty", () => {
+    assert.deepEqual(failingWorkflows(parseGitHubRuns("[]")), []);
+  });
+});
+
+describe("githubActionsSensor.probe", () => {
+  it("emits one red finding per failing workflow", async () => {
+    const out = await githubActionsSensor.probe(ctx, deps({
+      "gh repo": { stdout: JSON.stringify({ nameWithOwner: "acme/webapp" }), ok: true },
+      "gh run": { stdout: runs, ok: true },
+    }));
+    const red = out.filter((f) => f.status === "red");
+    assert.equal(red.length, 1);
+    assert.equal(red[0].sensor, "github-actions");
+    assert.equal(red[0].source, "acme/webapp");
+    assert.equal(red[0].suggestedClass, "code");
+    assert.match(red[0].title, /CI/);
+  });
+
+  it("emits a single green finding when nothing fails", async () => {
+    const allGreen = JSON.stringify([
+      { name: "CI", status: "completed", conclusion: "success", createdAt: "2026-06-21T06:50:00Z", databaseId: 9 },
+    ]);
+    const out = await githubActionsSensor.probe(ctx, deps({
+      "gh repo": { stdout: JSON.stringify({ nameWithOwner: "acme/webapp" }), ok: true },
+      "gh run": { stdout: allGreen, ok: true },
+    }));
+    assert.equal(out.length, 1);
+    assert.equal(out[0].status, "green");
+  });
+
+  it("returns unknown when gh is not authed", async () => {
+    const out = await githubActionsSensor.probe(ctx, deps({
+      "gh repo": { stdout: "", ok: false },
+    }));
+    assert.equal(out.length, 1);
+    assert.equal(out[0].status, "unknown");
+  });
+
+  it("returns unknown on context/repo owner mismatch", async () => {
+    const out = await githubActionsSensor.probe(
+      { cwd: "/tmp/repo", config: { context: { github: { org: "otherorg" } } } },
+      deps({ "gh repo": { stdout: JSON.stringify({ nameWithOwner: "acme/webapp" }), ok: true } }),
+    );
+    assert.equal(out.length, 1);
+    assert.equal(out[0].status, "unknown");
+    assert.match(out[0].detail ?? "", /otherorg/);
+  });
+});

--- a/src/health-sensors/github-actions.test.ts
+++ b/src/health-sensors/github-actions.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   parseGitHubRuns,
   failingWorkflows,
+  activeWorkflowNames,
   githubActionsSensor,
 } from "./github-actions.js";
 import type { HealthCtx, HealthDeps } from "../health.js";
@@ -36,6 +37,40 @@ describe("parseGitHubRuns / failingWorkflows", () => {
   it("returns [] when the JSON is empty", () => {
     assert.deepEqual(failingWorkflows(parseGitHubRuns("[]")), []);
   });
+
+  it("excludes workflows not in the active set when one is provided", () => {
+    const parsed = parseGitHubRuns(JSON.stringify([
+      { name: "CI", status: "completed", conclusion: "failure", createdAt: "2026-06-21T06:50:00Z", databaseId: 9 },
+      { name: "Crons", status: "completed", conclusion: "failure", createdAt: "2026-06-14T06:50:00Z", databaseId: 1 },
+    ]));
+    const active = new Set(["CI"]); // Crons is disabled
+    assert.deepEqual(failingWorkflows(parsed, active).map((f) => f.name), ["CI"]);
+  });
+
+  it("does not filter when the active set is empty/unknown (fail open to reporting)", () => {
+    const parsed = parseGitHubRuns(JSON.stringify([
+      { name: "CI", status: "completed", conclusion: "failure", createdAt: "2026-06-21T06:50:00Z", databaseId: 9 },
+    ]));
+    assert.deepEqual(failingWorkflows(parsed, new Set()).map((f) => f.name), ["CI"]);
+  });
+});
+
+describe("activeWorkflowNames", () => {
+  it("returns only workflows whose state is active", () => {
+    const json = JSON.stringify([
+      { name: "CI", state: "active" },
+      { name: "Crons", state: "disabled_manually" },
+      { name: "Old", state: "disabled_inactivity" },
+    ]);
+    const s = activeWorkflowNames(json);
+    assert.ok(s.has("CI"));
+    assert.equal(s.has("Crons"), false);
+    assert.equal(s.has("Old"), false);
+  });
+
+  it("returns an empty set on garbage input", () => {
+    assert.equal(activeWorkflowNames("not json").size, 0);
+  });
 });
 
 describe("githubActionsSensor.probe", () => {
@@ -50,6 +85,24 @@ describe("githubActionsSensor.probe", () => {
     assert.equal(red[0].source, "acme/webapp");
     assert.equal(red[0].suggestedClass, "code");
     assert.match(red[0].title, /CI/);
+  });
+
+  it("does not flag a disabled workflow whose last run failed", async () => {
+    const mixed = JSON.stringify([
+      { name: "CI", status: "completed", conclusion: "failure", createdAt: "2026-06-21T06:50:00Z", databaseId: 9 },
+      { name: "Crons", status: "completed", conclusion: "failure", createdAt: "2026-06-14T06:50:00Z", databaseId: 1 },
+    ]);
+    const workflows = JSON.stringify([
+      { name: "CI", state: "active" },
+      { name: "Crons", state: "disabled_manually" },
+    ]);
+    const out = await githubActionsSensor.probe(ctx, deps({
+      "gh repo": { stdout: JSON.stringify({ nameWithOwner: "acme/webapp" }), ok: true },
+      "gh workflow": { stdout: workflows, ok: true },
+      "gh run": { stdout: mixed, ok: true },
+    }));
+    const red = out.filter((f) => f.status === "red");
+    assert.deepEqual(red.map((f) => f.title), ["GitHub Actions workflow failing: CI"]);
   });
 
   it("emits a single green finding when nothing fails", async () => {

--- a/src/health-sensors/github-actions.ts
+++ b/src/health-sensors/github-actions.ts
@@ -1,0 +1,110 @@
+import type { HealthCtx, HealthDeps, HealthFinding, HealthSensor } from "../health.js";
+
+export interface GhRun {
+  name: string;
+  status: string;
+  conclusion: string;
+  createdAt: string;
+  databaseId: number;
+}
+
+const FAIL_CONCLUSIONS = new Set(["failure", "timed_out", "startup_failure"]);
+
+export function parseGitHubRuns(json: string): GhRun[] {
+  try {
+    const arr = JSON.parse(json) as GhRun[];
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Latest completed run per workflow name; included when that run failed. */
+export function failingWorkflows(runs: GhRun[]): { name: string; createdAt: string }[] {
+  const latest = new Map<string, GhRun>();
+  for (const r of runs) {
+    if (r.status !== "completed") continue;
+    const cur = latest.get(r.name);
+    if (!cur || r.createdAt > cur.createdAt) latest.set(r.name, r);
+  }
+  return [...latest.values()]
+    .filter((r) => FAIL_CONCLUSIONS.has(r.conclusion))
+    .map((r) => ({ name: r.name, createdAt: r.createdAt }));
+}
+
+export const githubActionsSensor: HealthSensor = {
+  id: "github-actions",
+  async probe(ctx: HealthCtx, deps: HealthDeps): Promise<HealthFinding[]> {
+    const repoRes = await deps.runCli("gh", ["repo", "view", "--json", "nameWithOwner"]);
+    if (!repoRes.ok) {
+      return [
+        {
+          sensor: "github-actions",
+          source: "(no gh auth / no remote)",
+          status: "unknown",
+          title: "GitHub Actions probe could not resolve the repo",
+          detail: "gh repo view failed — run `gh auth status`",
+        },
+      ];
+    }
+    let nwo = "";
+    try {
+      nwo = (JSON.parse(repoRes.stdout) as { nameWithOwner: string }).nameWithOwner ?? "";
+    } catch {
+      nwo = "";
+    }
+    const wantOrg = ctx.config.context?.github?.org;
+    if (wantOrg && nwo && nwo.split("/")[0] !== wantOrg) {
+      return [
+        {
+          sensor: "github-actions",
+          source: nwo,
+          status: "unknown",
+          title: "GitHub repo does not match locked context org",
+          detail: `context expects org "${wantOrg}" but gh repo is "${nwo}"`,
+        },
+      ];
+    }
+
+    const listRes = await deps.runCli("gh", [
+      "run",
+      "list",
+      "--limit",
+      "30",
+      "--json",
+      "name,status,conclusion,createdAt,databaseId",
+    ]);
+    if (!listRes.ok) {
+      return [
+        {
+          sensor: "github-actions",
+          source: nwo || "(unknown repo)",
+          status: "unknown",
+          title: "GitHub Actions run list failed",
+          detail: listRes.stderr || "gh run list returned non-zero",
+        },
+      ];
+    }
+
+    const failing = failingWorkflows(parseGitHubRuns(listRes.stdout));
+    if (failing.length === 0) {
+      return [
+        {
+          sensor: "github-actions",
+          source: nwo,
+          status: "green",
+          title: "GitHub Actions: all workflows green",
+        },
+      ];
+    }
+    return failing.map((w) => ({
+      sensor: "github-actions",
+      source: nwo,
+      status: "red" as const,
+      severity: "high" as const,
+      title: `GitHub Actions workflow failing: ${w.name}`,
+      detail: `latest run of "${w.name}" failed (${w.createdAt})`,
+      suggestedClass: "code" as const,
+    }));
+  },
+};

--- a/src/health-sensors/github-actions.ts
+++ b/src/health-sensors/github-actions.ts
@@ -19,16 +19,37 @@ export function parseGitHubRuns(json: string): GhRun[] {
   }
 }
 
-/** Latest completed run per workflow name; included when that run failed. */
-export function failingWorkflows(runs: GhRun[]): { name: string; createdAt: string }[] {
+/** Names of workflows whose state is "active" (i.e. not disabled). */
+export function activeWorkflowNames(json: string): Set<string> {
+  try {
+    const arr = JSON.parse(json) as { name: string; state: string }[];
+    if (!Array.isArray(arr)) return new Set();
+    return new Set(arr.filter((w) => w.state === "active").map((w) => w.name));
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Latest completed run per workflow name; included when that run failed.
+ * When `active` is a non-empty set, workflows not in it (disabled) are excluded
+ * so a stale failure from a dead workflow is not reported. An empty/omitted set
+ * means "states unknown" and applies no filter (fail open to reporting).
+ */
+export function failingWorkflows(
+  runs: GhRun[],
+  active?: Set<string>,
+): { name: string; createdAt: string }[] {
   const latest = new Map<string, GhRun>();
   for (const r of runs) {
     if (r.status !== "completed") continue;
     const cur = latest.get(r.name);
     if (!cur || r.createdAt > cur.createdAt) latest.set(r.name, r);
   }
+  const filterDisabled = active !== undefined && active.size > 0;
   return [...latest.values()]
     .filter((r) => FAIL_CONCLUSIONS.has(r.conclusion))
+    .filter((r) => !filterDisabled || active.has(r.name))
     .map((r) => ({ name: r.name, createdAt: r.createdAt }));
 }
 
@@ -86,7 +107,12 @@ export const githubActionsSensor: HealthSensor = {
       ];
     }
 
-    const failing = failingWorkflows(parseGitHubRuns(listRes.stdout));
+    // Workflow states so a disabled workflow's stale failure is not flagged.
+    // If this call fails, `active` stays empty → no filtering (fail open).
+    const wfRes = await deps.runCli("gh", ["workflow", "list", "--json", "name,state"]);
+    const active = wfRes.ok ? activeWorkflowNames(wfRes.stdout) : new Set<string>();
+
+    const failing = failingWorkflows(parseGitHubRuns(listRes.stdout), active);
     if (failing.length === 0) {
       return [
         {

--- a/src/health-track.test.ts
+++ b/src/health-track.test.ts
@@ -1,0 +1,27 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { actionableHealth, healthFindingToSync } from "./health-track.js";
+import type { HealthFinding } from "./health.js";
+
+const findings: HealthFinding[] = [
+  { sensor: "github-actions", source: "acme/webapp", status: "red", severity: "high", title: "workflow failing: CI", detail: "latest CI failed" },
+  { sensor: "github-actions", source: "acme/webapp", status: "green", title: "all green" },
+  { sensor: "github-actions", source: "acme/webapp", status: "unknown", title: "probe errored" },
+];
+
+describe("actionableHealth", () => {
+  it("keeps only red findings (green + unknown are not action items)", () => {
+    const out = actionableHealth(findings);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].title, "workflow failing: CI");
+  });
+});
+
+describe("healthFindingToSync", () => {
+  it("produces a stable dedup key of sensor:title", () => {
+    const s = healthFindingToSync(findings[0]);
+    assert.equal(s.dedupKey, "github-actions:workflow failing: CI");
+    assert.equal(s.title, "workflow failing: CI");
+    assert.equal(s.detail, "latest CI failed");
+  });
+});

--- a/src/health-track.ts
+++ b/src/health-track.ts
@@ -1,0 +1,37 @@
+import type { HealthFinding } from "./health.js";
+import type { SyncFinding } from "./memory/pal.js";
+
+export function actionableHealth(findings: HealthFinding[]): HealthFinding[] {
+  return findings.filter((f) => f.status === "red");
+}
+
+export function healthFindingToSync(f: HealthFinding): SyncFinding {
+  return {
+    dedupKey: `${f.sensor}:${f.title}`,
+    title: f.title,
+    detail: f.detail || undefined,
+  };
+}
+
+/** Mirror red health findings into PAL under the "health" source tag. Fail-open. */
+export async function syncHealthFindings(
+  findings: HealthFinding[],
+): Promise<{ added: number; reopened: number; closed: string[] } | null> {
+  try {
+    const { openMemoryDb } = await import("./memory/db.js");
+    const { palSyncFindings } = await import("./memory/pal.js");
+    const { getCurrentProjectRoot } = await import("./memory/project.js");
+    const { basename } = await import("node:path");
+    const scope = basename(getCurrentProjectRoot());
+    const db = openMemoryDb();
+    try {
+      return palSyncFindings(db, "health", actionableHealth(findings).map(healthFindingToSync), {
+        scope,
+      });
+    } finally {
+      db.close();
+    }
+  } catch {
+    return null; // fail-open: health reporting must never break a command
+  }
+}

--- a/src/health.test.ts
+++ b/src/health.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { runHealth, type HealthSensor, type HealthCtx, type HealthDeps } from "./health.js";
+import { selectSensors, defaultHealthDeps, HEALTH_SENSORS } from "./health.js";
 
 const ctx: HealthCtx = { cwd: "/tmp/repo", config: {} };
 const deps: HealthDeps = { runCli: async () => ({ stdout: "", stderr: "", exitCode: 0, ok: true }) };
@@ -21,5 +22,22 @@ describe("runHealth", () => {
     assert.equal(out[0].status, "unknown");
     assert.equal(out[0].sensor, "boom");
     assert.match(out[0].detail ?? "", /network down/);
+  });
+});
+
+describe("selectSensors", () => {
+  it("includes github-actions when a git remote is present", () => {
+    const sel = selectSensors({ cwd: "/tmp/repo", config: {}, gitRemote: true });
+    assert.ok(sel.some((s) => s.id === "github-actions"));
+  });
+
+  it("excludes github-actions with no git remote and no github context", () => {
+    const sel = selectSensors({ cwd: "/tmp/repo", config: {}, gitRemote: false });
+    assert.equal(sel.some((s) => s.id === "github-actions"), false);
+  });
+
+  it("registry is non-empty and defaultHealthDeps exposes runCli", () => {
+    assert.ok(HEALTH_SENSORS.length >= 1);
+    assert.equal(typeof defaultHealthDeps.runCli, "function");
   });
 });

--- a/src/health.test.ts
+++ b/src/health.test.ts
@@ -1,0 +1,25 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { runHealth, type HealthSensor, type HealthCtx, type HealthDeps } from "./health.js";
+
+const ctx: HealthCtx = { cwd: "/tmp/repo", config: {} };
+const deps: HealthDeps = { runCli: async () => ({ stdout: "", stderr: "", exitCode: 0, ok: true }) };
+
+describe("runHealth", () => {
+  it("aggregates findings from all sensors", async () => {
+    const a: HealthSensor = { id: "a", probe: async () => [{ sensor: "a", source: "x", status: "green", title: "ok" }] };
+    const b: HealthSensor = { id: "b", probe: async () => [{ sensor: "b", source: "y", status: "red", severity: "high", title: "bad" }] };
+    const out = await runHealth(ctx, [a, b], deps);
+    assert.equal(out.length, 2);
+    assert.deepEqual(out.map((f) => f.status).sort(), ["green", "red"]);
+  });
+
+  it("converts a throwing sensor into an unknown finding, never drops it", async () => {
+    const boom: HealthSensor = { id: "boom", probe: async () => { throw new Error("network down"); } };
+    const out = await runHealth(ctx, [boom], deps);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].status, "unknown");
+    assert.equal(out[0].sensor, "boom");
+    assert.match(out[0].detail ?? "", /network down/);
+  });
+});

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,5 +1,6 @@
 import type { kitConfig } from "./config.js";
-import type { ExecResult } from "./utils/execFileNoThrow.js";
+import { execFileNoThrow, type ExecResult } from "./utils/execFileNoThrow.js";
+import { githubActionsSensor } from "./health-sensors/github-actions.js";
 
 export type HealthStatus = "green" | "red" | "unknown";
 export type HealthClass = "code" | "human" | "noise";
@@ -56,3 +57,19 @@ export async function runHealth(
   );
   return all.flat();
 }
+
+export const HEALTH_SENSORS: HealthSensor[] = [githubActionsSensor];
+
+/** Returns the sensors whose underlying service the project is connected to. */
+export function selectSensors(ctx: HealthCtx): HealthSensor[] {
+  return HEALTH_SENSORS.filter((s) => {
+    if (s.id === "github-actions") {
+      return ctx.gitRemote === true || ctx.config.context?.github !== undefined;
+    }
+    return false;
+  });
+}
+
+export const defaultHealthDeps: HealthDeps = {
+  runCli: (command, args) => execFileNoThrow(command, args, { timeout: 15_000 }),
+};

--- a/src/health.ts
+++ b/src/health.ts
@@ -73,3 +73,12 @@ export function selectSensors(ctx: HealthCtx): HealthSensor[] {
 export const defaultHealthDeps: HealthDeps = {
   runCli: (command, args) => execFileNoThrow(command, args, { timeout: 15_000 }),
 };
+
+const MARK: Record<HealthStatus, string> = { green: "✓", red: "✗", unknown: "?" };
+
+/** Pure human formatter — returns lines + red count (CLI adds color). */
+export function formatHealth(findings: HealthFinding[]): { lines: string[]; redCount: number } {
+  const lines = findings.map((f) => `${MARK[f.status]} [${f.sensor}] ${f.title}  (${f.source})`);
+  const redCount = findings.filter((f) => f.status === "red").length;
+  return { lines, redCount };
+}

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,0 +1,58 @@
+import type { kitConfig } from "./config.js";
+import type { ExecResult } from "./utils/execFileNoThrow.js";
+
+export type HealthStatus = "green" | "red" | "unknown";
+export type HealthClass = "code" | "human" | "noise";
+
+export interface HealthFinding {
+  sensor: string;
+  /** The account/org/ref/repo actually probed (the verify-source record). */
+  source: string;
+  status: HealthStatus;
+  severity?: "critical" | "high" | "medium" | "low";
+  title: string;
+  detail?: string;
+  suggestedClass?: HealthClass;
+}
+
+export interface HealthCtx {
+  cwd: string;
+  config: kitConfig;
+  /** True when the repo has a git remote (computed by the CLI layer). */
+  gitRemote?: boolean;
+}
+
+export interface HealthDeps {
+  runCli(command: string, args: string[]): Promise<ExecResult>;
+}
+
+export interface HealthSensor {
+  id: string;
+  probe(ctx: HealthCtx, deps: HealthDeps): Promise<HealthFinding[]>;
+}
+
+/** Runs every sensor; a sensor that throws becomes an `unknown` finding (never dropped). */
+export async function runHealth(
+  ctx: HealthCtx,
+  sensors: HealthSensor[],
+  deps: HealthDeps,
+): Promise<HealthFinding[]> {
+  const all = await Promise.all(
+    sensors.map(async (s): Promise<HealthFinding[]> => {
+      try {
+        return await s.probe(ctx, deps);
+      } catch (e) {
+        return [
+          {
+            sensor: s.id,
+            source: "(probe errored)",
+            status: "unknown",
+            title: `${s.id} probe failed`,
+            detail: e instanceof Error ? e.message : String(e),
+          },
+        ];
+      }
+    }),
+  );
+  return all.flat();
+}


### PR DESCRIPTION
## What

Introduces **kit sentinel** — extending the PAL detect→track arc from local checks to external runtime systems — and ships the first deterministic slice, **\`kit health\` v1a**.

### Docs
- \`docs/specs/2026-06-21-kit-sentinel-design.md\` — full design. Layers: (1) kit detects deterministically (zero-LLM external probes → PAL), (2) a separate agent triages and produces the right artifact (fix PR / issue / suppression PR), (3) \`kit sentinel install\` scaffolds a remote daily routine + SessionStart surface. Sensors are derived from the project's connected services; account-verified (verify-source-before-concluding); no silent muting.
- \`docs/plans/2026-06-21-kit-health-v1a.md\` — the TDD plan this PR implements.

### Code (v1a — layer 1, deterministic)
- \`src/health.ts\` — \`runHealth\` orchestrator (a throwing sensor becomes an \`unknown\` finding, never dropped), \`HealthFinding\`/\`HealthSensor\`/\`HealthDeps\` types, \`HEALTH_SENSORS\` registry, \`selectSensors\` (connected-service gating), \`defaultHealthDeps\`, \`formatHealth\`.
- \`src/health-sensors/github-actions.ts\` — first real sensor: latest-run-per-workflow failing detection via \`gh\`; account-verified against \`[context].github.org\`; not-authed / context-mismatch → \`unknown\`.
- \`src/health-track.ts\` — mirrors **red** findings into PAL under a new \`"health"\` source tag (reuses \`palSyncFindings\` + dedup + auto-close; fail-open).
- \`src/cli.ts\` — \`kit health\` command (\`--json\` + human), wrapped in the \`withGovernance\` read path; exit code reflects health.

## Scope

This PR is **v1a only**: framework + one sensor + PAL mirror + CLI. Remaining sensors (Vercel, Sentry, Supabase, Resend, TLS cert) are framework-reusing follow-ups (see plan appendix); layers 2–3 are separate. Deliberate spec deviation: \`ServiceDef\` is left as pure data — sensors live in \`HEALTH_SENSORS\` keyed by service id.

## Verification
- Full suite: **2350 passed, 0 failed**; \`npm run build\` clean.
- Smoke on this repo: \`kit health\` resolved \`sandstream/kit\`, probed Actions (green), printed human + \`--json\`, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)