### PR TITLE
fix(check-gitignore): keep curated shared memory tracked

### DIFF
--- a/src/check-gitignore.test.ts
+++ b/src/check-gitignore.test.ts
@@ -127,6 +127,27 @@ describe("patchGitignore", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("ignores .kit contents via .kit/* and re-includes the curated shared tier", async () => {
+    const dir = tmpRepo();
+    try {
+      await patchGitignore(dir);
+      const text = readFileSync(join(dir, ".gitignore"), "utf-8");
+      // Must use the descendable `.kit/*` form, never the wholesale `.kit/`
+      // (which would make the `!.kit/shared/` negation a no-op).
+      const lines = text.split("\n").map((l) => l.split("#")[0].trim());
+      assert.ok(lines.includes(".kit/*"), "expected .kit/* contents-ignore");
+      assert.ok(!lines.includes(".kit/"), "must not emit wholesale .kit/");
+      assert.ok(lines.includes("!.kit/shared/"), "expected shared re-include");
+      // Order matters: the negation must come AFTER .kit/*.
+      assert.ok(
+        lines.indexOf("!.kit/shared/") > lines.indexOf(".kit/*"),
+        "negation must follow .kit/*",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("findCommittedSensitive", () => {

--- a/src/check-gitignore.ts
+++ b/src/check-gitignore.ts
@@ -34,7 +34,13 @@ const REQUIRED_PATTERNS: RequiredEntry[] = [
   { pattern: ".env.local", reason: "local secrets materialized by kit secrets", aliases: [".env*"] },
   { pattern: ".env.*.local", reason: "per-env local secrets", aliases: [".env*"] },
   { pattern: "node_modules", reason: "dependency tree", aliases: ["node_modules/"] },
-  { pattern: ".kit/", reason: "kit local state (elevation, env, runtime)", aliases: [".kit", ".kit/*"] },
+  // Ignore kit's local-state CONTENTS via `.kit/*` (not the wholesale `.kit/`):
+  // git won't descend into a wholesale-excluded dir, so a later `!.kit/shared/`
+  // negation cannot re-include the curated, committed-by-design shared tier
+  // (.kit/shared/memory.jsonl). `.kit/*` ignores the contents while leaving the
+  // dir descendable, so the negation below works.
+  { pattern: ".kit/*", reason: "kit local state (elevation, env, runtime)", aliases: [".kit", ".kit/", ".kit/*"] },
+  { pattern: "!.kit/shared/", reason: "keep curated shared memory tracked (committed by design)", aliases: ["!.kit/shared", "!.kit/shared/**"] },
   { pattern: ".kit-audit.jsonl", reason: "audit log can contain secret labels + paths" },
   { pattern: "*.pem", reason: "PEM keys / certs" },
   { pattern: "*.key", reason: "private keys" },

--- a/src/status.test.ts
+++ b/src/status.test.ts
@@ -59,7 +59,8 @@ describe("kit status", () => {
       [
         ".env*",
         "node_modules",
-        ".kit/",
+        ".kit/*",
+        "!.kit/shared/",
         ".kit-audit.jsonl",
         "*.pem",
         "*.key",


### PR DESCRIPTION
## Problem

kit's memory has two tiers:
- **private brain** — `~/.kit/memory.db` (global, secret-dense, `0600`, never committed)
- **curated/shared tier** — `.kit/shared/memory.jsonl`, **committed by design** ("travels with the repo", diffable, PR-reviewable, gitleaks-scannable; deny-by-default + fail-closed secret-scan on write)

But `check-gitignore`'s `REQUIRED_PATTERNS` ignored kit's local state with the **wholesale** `.kit/` form. git won't descend into a wholesale-excluded directory, so **no later `!.kit/shared/` negation can re-include the curated tier**. Result: running `kit check` → `patch`/`heal` would silently stop tracking shared memory — you'd *lose* the curated tier, and gitleaks/PR review would no longer see it.

Verified empirically:

| .gitignore | `.kit/elevation.json` | `.kit/shared/memory.jsonl` |
|---|---|---|
| `.kit/` + `!.kit/shared/` | ignored ✅ | **ignored ❌ (lost)** |
| `.kit/*` + `!.kit/shared/` | ignored ✅ | **tracked ✅** |

## Fix

Switch the local-state ignore to the descendable `.kit/*` form plus an explicit `!.kit/shared/` re-include. Existing `.kit` / `.kit/` lines are still recognized as aliases to avoid churn on repos that already have them.

- `src/check-gitignore.ts` — `.kit/` → `.kit/*` + new `!.kit/shared/` entry (with rationale comment).
- `src/check-gitignore.test.ts` — asserts patch emits `.kit/*` (never wholesale `.kit/`), emits `!.kit/shared/`, and that the negation comes **after** `.kit/*`.

All 12 check-gitignore tests pass.

## Known residual (out of scope)

A repo that **already** has a wholesale `.kit/` line above the kit block stays broken — appending can't fix it, the line must be rewritten (patch only appends, never rewrites user lines). Candidate follow-up: have `verify()` flag a pre-existing wholesale `.kit/` and recommend upgrading to `.kit/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_