### PR TITLE
feat(check): verify full-disk encryption + flag memory-store location

### DIFF
--- a/src/check-disk-encryption.test.ts
+++ b/src/check-disk-encryption.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  interpretFileVault,
+  interpretBitLocker,
+  interpretLsblk,
+  memoryDirInsideRepo,
+  checkMemoryDirSafety,
+} from "./check-disk-encryption.js";
+
+describe("interpretFileVault", () => {
+  it("detects on / off / unknown", () => {
+    assert.equal(interpretFileVault("FileVault is On."), true);
+    assert.equal(interpretFileVault("FileVault is Off."), false);
+    assert.equal(interpretFileVault("something else"), null);
+  });
+});
+
+describe("interpretBitLocker", () => {
+  it("detects protection on / off / unknown", () => {
+    assert.equal(interpretBitLocker("Conversion Status: ... Protection On"), true);
+    assert.equal(interpretBitLocker("Protection Off"), false);
+    assert.equal(interpretBitLocker("Percentage Encrypted: Fully Decrypted"), false);
+    assert.equal(interpretBitLocker("weird output"), null);
+  });
+});
+
+describe("interpretLsblk", () => {
+  it("returns true only when a crypt device is present", () => {
+    assert.equal(interpretLsblk("TYPE\ndisk\npart\ncrypt\nlvm"), true);
+    assert.equal(interpretLsblk("TYPE\ndisk\npart\nlvm"), null);
+    // must not match substrings like "encrypted" in some other column
+    assert.equal(interpretLsblk("TYPE\ncryptosomething"), null);
+  });
+});
+
+describe("memoryDirInsideRepo", () => {
+  it("flags a memory dir inside the repo tree", () => {
+    assert.equal(memoryDirInsideRepo("/home/u/proj/.kit", "/home/u/proj"), true);
+    assert.equal(memoryDirInsideRepo("/home/u/proj", "/home/u/proj"), true);
+  });
+  it("passes the default homedir store (outside the repo)", () => {
+    assert.equal(memoryDirInsideRepo("/home/u/.kit", "/home/u/proj"), false);
+    // sibling prefix must not false-positive
+    assert.equal(memoryDirInsideRepo("/home/u/project-2/.kit", "/home/u/proj"), false);
+  });
+});
+
+describe("checkMemoryDirSafety", () => {
+  it("returns a well-formed exposure result and never throws", () => {
+    const r = checkMemoryDirSafety();
+    assert.equal(r.category, "exposure");
+    assert.ok(["pass", "warn", "skip"].includes(r.status));
+    assert.equal(typeof r.detail, "string");
+  });
+});

--- a/src/check-disk-encryption.ts
+++ b/src/check-disk-encryption.ts
@@ -1,0 +1,162 @@
+/**
+ * Disk-encryption check — verify the host's full-disk encryption is enabled.
+ *
+ * Why: kit's secret-dense local state (`~/.kit/memory.db`, materialized
+ * `.env.local`) is plaintext at rest, protected only by 0600 perms. The correct
+ * at-rest control for a whole secret-dense store is OS full-disk encryption
+ * (FileVault / LUKS / BitLocker). This verifies it is ON and warns loudly if not —
+ * a stolen laptop with FDE off exposes every cached secret.
+ *
+ * Also flags the `KIT_MEMORY_DIR` foot-gun: if the memory store is redirected
+ * INTO a git working tree, the secret-dense DB could be committed and pushed.
+ *
+ * Deterministic, zero-LLM, FAIL-OPEN: when we cannot determine the status
+ * (unknown OS, command missing, CI/container), we SKIP rather than cry wolf.
+ */
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { resolve } from "node:path";
+import type { SecurityCheckResult } from "./check-security.js";
+import { getMemoryDir } from "./memory/db.js";
+import { getCurrentProjectRoot } from "./memory/project.js";
+
+const exec = promisify(execFile);
+
+// ─── Pure interpreters (unit-tested) ────────────────────────────────────────
+
+/** macOS `fdesetup status`: true = on, false = off, null = indeterminate. */
+export function interpretFileVault(out: string): boolean | null {
+  const s = out.toLowerCase();
+  if (s.includes("filevault is on")) return true;
+  if (s.includes("filevault is off")) return false;
+  return null;
+}
+
+/** Windows `manage-bde -status`: true = protected, false = off, null = unknown. */
+export function interpretBitLocker(out: string): boolean | null {
+  const s = out.toLowerCase();
+  if (s.includes("protection on")) return true;
+  if (s.includes("protection off") || s.includes("fully decrypted")) return false;
+  return null;
+}
+
+/** Linux `lsblk -o TYPE`: a `crypt` device ⇒ encrypted volume present (true),
+ *  otherwise indeterminate (null) — absence is NOT proof of "off". */
+export function interpretLsblk(out: string): boolean | null {
+  return /(^|\s)crypt(\s|$)/m.test(out) ? true : null;
+}
+
+/** Is the memory dir inside the repo working tree (committable foot-gun)? */
+export function memoryDirInsideRepo(memDir: string, repoRoot: string): boolean {
+  const m = resolve(memDir);
+  const r = resolve(repoRoot);
+  return m === r || m.startsWith(r + "/");
+}
+
+// ─── Checks ─────────────────────────────────────────────────────────────────
+
+const SKIP: Omit<SecurityCheckResult, "detail"> & { detail: string } = {
+  category: "exposure",
+  name: "disk encryption",
+  status: "skip",
+  detail: "could not determine full-disk-encryption status",
+};
+
+/**
+ * Verify full-disk encryption. Fail-open: any uncertainty → skip.
+ */
+export async function checkDiskEncryption(): Promise<SecurityCheckResult> {
+  // Don't cry wolf in CI / containers — those aren't the at-rest threat model.
+  if (process.env.CI) {
+    return { ...SKIP, detail: "skipped in CI (not the at-rest threat model)" };
+  }
+
+  try {
+    if (process.platform === "darwin") {
+      const { stdout } = await exec("fdesetup", ["status"], { timeout: 5_000 });
+      const on = interpretFileVault(stdout);
+      if (on === true) {
+        return { category: "exposure", name: "disk encryption", status: "pass", detail: "FileVault is enabled" };
+      }
+      if (on === false) {
+        return {
+          category: "exposure",
+          name: "disk encryption",
+          status: "warn",
+          severity: "high",
+          detail: "FileVault is OFF — kit's local secret-dense store (~/.kit/memory.db) is unencrypted at rest",
+          suggestion: "Enable FileVault: System Settings → Privacy & Security → FileVault",
+        };
+      }
+      return SKIP;
+    }
+
+    if (process.platform === "win32") {
+      const { stdout } = await exec("manage-bde", ["-status", "C:"], { timeout: 8_000 });
+      const on = interpretBitLocker(stdout);
+      if (on === true) {
+        return { category: "exposure", name: "disk encryption", status: "pass", detail: "BitLocker protection is on" };
+      }
+      if (on === false) {
+        return {
+          category: "exposure",
+          name: "disk encryption",
+          status: "warn",
+          severity: "high",
+          detail: "BitLocker is OFF — kit's local secret-dense store is unencrypted at rest",
+          suggestion: "Enable BitLocker: Settings → Privacy & security → Device encryption",
+        };
+      }
+      return SKIP;
+    }
+
+    if (process.platform === "linux") {
+      const { stdout } = await exec("lsblk", ["-o", "TYPE"], { timeout: 5_000 });
+      if (interpretLsblk(stdout) === true) {
+        return { category: "exposure", name: "disk encryption", status: "pass", detail: "LUKS-encrypted volume detected" };
+      }
+      // No crypt device found — can't confirm. Warn at low severity (honest "verify").
+      return {
+        category: "exposure",
+        name: "disk encryption",
+        status: "warn",
+        severity: "low",
+        detail: "could not confirm full-disk encryption (no LUKS device found) — verify your disk is encrypted",
+        suggestion: "Confirm with: lsblk (look for type 'crypt'), or your distro's disk-encryption settings",
+      };
+    }
+
+    return SKIP;
+  } catch {
+    return SKIP; // command missing / not permitted → fail-open
+  }
+}
+
+/**
+ * Flag the KIT_MEMORY_DIR foot-gun: secret-dense store redirected into a repo.
+ * Sync, fail-open.
+ */
+export function checkMemoryDirSafety(): SecurityCheckResult {
+  try {
+    const memDir = getMemoryDir();
+    const repoRoot = getCurrentProjectRoot();
+    if (memoryDirInsideRepo(memDir, repoRoot)) {
+      return {
+        category: "exposure",
+        name: "memory store location",
+        status: "warn",
+        severity: "high",
+        detail: `kit memory store (${memDir}) is inside the repo working tree — the secret-dense DB could be committed`,
+        suggestion: "Unset KIT_MEMORY_DIR (defaults to ~/.kit, outside any repo) or point it outside the working tree",
+      };
+    }
+    return {
+      category: "exposure",
+      name: "memory store location",
+      status: "pass",
+      detail: "memory store lives outside the repo working tree",
+    };
+  } catch {
+    return { category: "exposure", name: "memory store location", status: "skip", detail: "could not resolve memory store / repo root" };
+  }
+}

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -1165,6 +1165,12 @@ export async function checkSecurity(): Promise<SecurityCheckResult[]> {
   const exposureResults = await checkServiceExposure();
   results.push(...exposureResults);
 
+  // At-rest exposure of kit's own secret-dense local state: verify full-disk
+  // encryption is on, and that the memory store isn't redirected into a repo.
+  const { checkDiskEncryption, checkMemoryDirSafety } = await import("./check-disk-encryption.js");
+  results.push(await checkDiskEncryption());
+  results.push(checkMemoryDirSafety());
+
   // Attach a rule citation (CWE/OWASP) to each finding whose check is mapped in
   // the local rules catalog. Deterministic lookup, no network. Unmapped checks
   // pass through unchanged.


### PR DESCRIPTION
## Why

kit's local state — `~/.kit/memory.db` (secret-dense; it indexes raw transcripts) and materialized `.env.local` — is **plaintext at rest**, protected only by `0600` perms. For a *security tool going public*, "a stolen laptop exposes every cached secret" is the worst headline.

Full app-level encryption of the live FTS5 DB is a large, risky change (node:sqlite has no SQLCipher; encrypting `content` breaks full-text search) — deliberately **not** rushed here. The correct at-rest control for a whole secret-dense store is **OS full-disk encryption**, so this PR verifies it.

## What

New `src/check-disk-encryption.ts`, wired into `kit check` security results:

- **`checkDiskEncryption()`** — verifies FDE is on per-OS: FileVault (`fdesetup status`), BitLocker (`manage-bde -status`), LUKS (`lsblk` → `crypt`). Warns (high severity) when off; **fail-open** (skips on unknown OS / missing command / CI — not the at-rest threat model).
- **`checkMemoryDirSafety()`** — flags the `KIT_MEMORY_DIR` foot-gun: if the secret-dense store is redirected **into** a git working tree it could be committed.

Pure interpreter/helper functions are unit-tested (6/6); `check-security` suite still green (9/9).

## Follow-up (tracked, not in scope)

Application-level at-rest encryption of `memory.db` (design doc first — reuse the AES-256-GCM primitive already in `memory/backup.ts`, solve the FTS5-over-ciphertext problem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_