### PR TITLE
chore: sync package-lock.json with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "1.4.3",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "1.4.3",
+      "version": "1.12.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -31,6 +31,9 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      },
+      "funding": {
+        "url": "https://buymeacoffee.com/sandstream"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {


### PR DESCRIPTION
## Why

The committed `package-lock.json` had drifted from `package.json`: its root `version` was stuck at `1.4.3` (package is `1.12.0`) and it was missing the `funding` field. That mismatch can fail a clean `npm ci` in CI.

## Change

Regenerated with `npm install --package-lock-only` — lockfile metadata only, **no dependency additions/removals/version bumps** (5 insertions, 2 deletions: the version sync + funding field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_