### PR TITLE
feat(registry): add Keycloak + Atlassian (acli) services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **Two services in the registry: Keycloak and Atlassian (acli).** Keycloak is detected from its clients (`keycloak-js`, `keycloak-connect`, `keycloak-admin-client`, `keycloak-angular`, `python-keycloak`, Go `gocloak`) and declares its realm/admin secrets (`KEYCLOAK_URL`, `KEYCLOAK_REALM`, `KEYCLOAK_CLIENT_ID/SECRET`, `KEYCLOAK_ADMIN/_PASSWORD`); it carries no mise tool because it is a self-hosted server (run via Docker), with admin through the server's own `kcadm.sh`. Atlassian is detected from `bitbucket-pipelines.yml` / `.bitbucket`, provisions the Atlassian CLI via mise (`tool: acli` → `aqua:atlassian.com/acli`), and tracks `ATLASSIAN_API_TOKEN` / `ATLASSIAN_SITE_URL`; its auth is left as an informational note rather than a guessed login command. Adding each was a single registry data row (no detector/generator edits), per the unified-registry design.
+
 ### Fixed
 - **Flaky local test runs (intermittent file-level failures + drifting test counts) traced to a dirty `dist/`.** The `build` script (unlike `build:prod`) never cleaned `dist/`, so compiled output from deleted/renamed sources accumulated, and editor/sync conflict copies (` 2.ts`, ` 3.ts`, …) left stale `dist/* [0-9].js` files. The `test` glob (`dist/*.test.js`) then ran those orphans as duplicate/divergent tests, producing nondeterministic counts (e.g. 2355 → 2359 → 2361) and sporadic "not ok" with zero failing subtests. Fix: `build` now `rm -rf dist` before compiling (matching `build:prod`), so every run tests only current sources, and the tsconfig conflict-copy exclude was widened from `* 2.ts` to `* [0-9].ts`/`.tsx` to cover all numbered copies. Verified: 16 consecutive clean runs held a stable 2355 tests / 0 failures.
 

--- a/src/service-registry.test.ts
+++ b/src/service-registry.test.ts
@@ -37,6 +37,35 @@ describe("service-registry", () => {
       const s = await detectServices({ deps: [], fileExists: async (p) => p === "firebase.json" });
       assert.deepEqual(s, ["firebase"]);
     });
+
+    it("matches atlassian by bitbucket-pipelines.yml", async () => {
+      const s = await detectServices({ deps: [], fileExists: async (p) => p === "bitbucket-pipelines.yml" });
+      assert.deepEqual(s, ["atlassian"]);
+    });
+  });
+
+  describe("new services — keycloak + atlassian", () => {
+    it("detects keycloak by a node client dep", async () => {
+      const s = await detectServices({ deps: ["keycloak-js"], fileExists: noFiles });
+      assert.deepEqual(s, ["keycloak"]);
+    });
+
+    it("detects keycloak by the python client", async () => {
+      const s = await detectServices({ pyText: "python-keycloak==3.9.1", fileExists: noFiles });
+      assert.deepEqual(s, ["keycloak"]);
+    });
+
+    it("keycloak declares admin/realm secrets and no mise tool (it is a server)", () => {
+      const kc = SERVICE_BY_ID["keycloak"];
+      assert.ok(kc.secrets?.includes("KEYCLOAK_CLIENT_SECRET"));
+      assert.ok(kc.secrets?.includes("KEYCLOAK_REALM"));
+      assert.equal(kc.tool, undefined);
+    });
+
+    it("atlassian provisions the acli CLI as its mise tool", () => {
+      assert.equal(SERVICE_BY_ID["atlassian"].tool, "acli");
+      assert.ok(SERVICE_BY_ID["atlassian"].secrets?.includes("ATLASSIAN_API_TOKEN"));
+    });
   });
 
   describe("detectServices — cross-language (the Node-only gap fix)", () => {

--- a/src/service-registry.ts
+++ b/src/service-registry.ts
@@ -255,6 +255,43 @@ export const SERVICE_REGISTRY: ServiceDef[] = [
     check: "# auth0 - check AUTH0_CLIENT_ID is set",
     secrets: ["AUTH0_SECRET", "AUTH0_BASE_URL", "AUTH0_ISSUER_BASE_URL", "AUTH0_CLIENT_ID", "AUTH0_CLIENT_SECRET"],
   },
+  {
+    id: "keycloak",
+    deps: [
+      "keycloak-js",
+      "keycloak-connect",
+      "keycloak-admin-client",
+      "@keycloak/keycloak-admin-client",
+      "keycloak-angular",
+    ],
+    pyDeps: ["python-keycloak"],
+    goMods: ["github.com/Nerzal/gocloak"],
+    // Keycloak is a self-hosted server (run via Docker/standalone), not a mise
+    // CLI — so no `tool`; admin is the server's own kcadm.sh.
+    login: "# keycloak - no CLI login; admin via the server's kcadm.sh or set KEYCLOAK_* env",
+    check: "# keycloak - verify KEYCLOAK_URL + realm are reachable",
+    secrets: [
+      "KEYCLOAK_URL",
+      "KEYCLOAK_REALM",
+      "KEYCLOAK_CLIENT_ID",
+      "KEYCLOAK_CLIENT_SECRET",
+      "KEYCLOAK_ADMIN",
+      "KEYCLOAK_ADMIN_PASSWORD",
+    ],
+  },
+  {
+    id: "atlassian",
+    // Bitbucket Pipelines is the one reliable in-repo Atlassian marker; Jira/
+    // Confluence usage isn't detectable from a checkout, so detection is
+    // conservative (acli still covers all three once installed).
+    files: ["bitbucket-pipelines.yml", ".bitbucket"],
+    // acli auth is interactive + subcommand-specific; left as a note so kit
+    // doesn't run a guessed login. The CLI itself is provisioned via mise.
+    login: "# atlassian - run the acli auth flow (acli --help); needs ATLASSIAN_API_TOKEN",
+    check: "# atlassian - check ATLASSIAN_API_TOKEN is set",
+    secrets: ["ATLASSIAN_API_TOKEN", "ATLASSIAN_SITE_URL"],
+    tool: "acli",
+  },
 ];
 
 /** Lookup by service id, for the generator. */


### PR DESCRIPTION
Adds two services to kit's unified service-registry (one data row each — no detector/generator edits, per the registry design). Requested: have acli + Keycloak managed by kit.

## Keycloak (self-hosted identity server)
- **Detect:** `keycloak-js`, `keycloak-connect`, `keycloak-admin-client`, `@keycloak/keycloak-admin-client`, `keycloak-angular` (node), `python-keycloak` (py), `github.com/Nerzal/gocloak` (go).
- **Secrets:** `KEYCLOAK_URL`, `KEYCLOAK_REALM`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET`, `KEYCLOAK_ADMIN`, `KEYCLOAK_ADMIN_PASSWORD`.
- **No mise tool** — Keycloak is a server (Docker/standalone); admin is the server's own `kcadm.sh`. login/check are informational notes.

## Atlassian (acli)
- **Detect:** `bitbucket-pipelines.yml` / `.bitbucket` (the one reliable in-repo Atlassian marker; Jira/Confluence aren't detectable from a checkout, so detection is conservative — acli still covers all three once installed).
- **Tool:** `acli` → mise `aqua:atlassian.com/acli` (verified present in the mise registry; this is why it's a real `tool`, not a brew note).
- **Secrets:** `ATLASSIAN_API_TOKEN`, `ATLASSIAN_SITE_URL`.
- **login left as a note:** acli's auth is interactive + subcommand-specific, so kit won't run a guessed login command.

## Verify
`npm run build && npm test` → build clean, **1309 tests, 0 fail** (5 new registry tests: detection by dep/file + the tool/secrets assertions).

Note: at `kit setup`, provisioning `acli` still passes through the watertight triage gate; if the `aqua:atlassian.com/acli` ref doesn't map to a triageable GitHub repo it will be blocked fail-closed (gate working as designed), which can be revisited separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)