### PR TITLE
feat(health): Sentry + Resend sensors (service-detected)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **`kit health` adds Sentry + Resend sensors (runtime errors + email-delivery).** Sentry probes the issues API (`GET /api/0/projects/:org/:project/issues/?query=is:unresolved firstSeen:-24h`) with `SENTRY_AUTH_TOKEN` (`SENTRY_URL` overrides the region) and goes red on new unresolved issues in the last 24h. Resend probes `GET /domains` with `RESEND_API_KEY` and goes red (class `human` — a DNS/customer action, not a code fix) when any sending domain is not `verified`. Both report `unknown` (never a false `green`) on missing creds or a non-OK response. These two are **selected by connected-service detection** (the registry sees `@sentry/*` / `resend` in deps), per the sentinel design's "derive from connected services". Live API smoke pending real tokens; parsers fixture-tested.
 - **`kit health` adds a Vercel sensor (failed production deploys).** Probes the Vercel REST API (`GET /v6/deployments?target=production`) with `VERCEL_TOKEN`, using the `projectId`/`teamId` from `.vercel/project.json`; flags the most recent *terminal* production deployment as red when its state is `ERROR` (`CANCELED` is not red), and reports `unknown` (never a false `green`) when the project isn't linked, the token is missing, or the API errors. Reuses the `httpGet` probe path the GitLab/Bitbucket sensors introduced. Live API smoke is pending a real token; the parsers are fixture-tested.
 
 ## [1.13.0] - 2026-06-22

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4074,6 +4074,19 @@ async function cmdHealth(): Promise<boolean> {
       } catch {
         vercel = undefined;
       }
+      // Connected services (registry detection) drive the dep-detected sensors (sentry/resend).
+      let services: string[] = [];
+      try {
+        const pkg = JSON.parse(readFileSync(resolve(cwd, "package.json"), "utf8")) as {
+          dependencies?: Record<string, string>;
+          devDependencies?: Record<string, string>;
+        };
+        const deps = [...Object.keys(pkg.dependencies ?? {}), ...Object.keys(pkg.devDependencies ?? {})];
+        const { detectServices } = await import("./service-registry.js");
+        services = await detectServices({ deps, fileExists: async (p) => existsSync(resolve(cwd, p)) });
+      } catch {
+        services = [];
+      }
       const ctx = {
         cwd,
         config,
@@ -4081,6 +4094,7 @@ async function cmdHealth(): Promise<boolean> {
         gitlabCi: existsSync(resolve(cwd, ".gitlab-ci.yml")),
         bitbucketPipelines: existsSync(resolve(cwd, "bitbucket-pipelines.yml")),
         vercel,
+        services,
       };
 
       const sensors = selectSensors(ctx);

--- a/src/health-sensors/resend.test.ts
+++ b/src/health-sensors/resend.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { parseResendDomains, unverifiedDomains, resendSensor } from "./resend.js";
+import type { HealthCtx, HealthDeps, HttpResponse } from "../health.js";
+
+const domains = JSON.stringify({
+  data: [
+    { id: "1", name: "mail.acme.com", status: "verified" },
+    { id: "2", name: "gamedaydj.example", status: "failed" },
+  ],
+});
+
+function deps(over: { http?: HttpResponse } = {}): HealthDeps {
+  return {
+    runCli: async () => ({ stdout: "", stderr: "", exitCode: 0, ok: true }),
+    httpGet: async () => over.http ?? { ok: true, status: 200, body: domains },
+  };
+}
+const ctx: HealthCtx = { cwd: "/tmp/repo", config: {} };
+
+describe("parseResendDomains / unverifiedDomains", () => {
+  it("flags any domain not 'verified'", () => {
+    const bad = unverifiedDomains(parseResendDomains(domains));
+    assert.equal(bad.length, 1);
+    assert.equal(bad[0].name, "gamedaydj.example");
+  });
+  it("returns [] when all verified", () => {
+    const all = JSON.stringify({ data: [{ name: "a", status: "verified" }] });
+    assert.deepEqual(unverifiedDomains(parseResendDomains(all)), []);
+  });
+});
+
+describe("resendSensor.probe", () => {
+  afterEach(() => {
+    delete process.env.RESEND_API_KEY;
+  });
+
+  it("emits red (human class) when a domain is unverified", async () => {
+    process.env.RESEND_API_KEY = "re_x";
+    const out = await resendSensor.probe(ctx, deps());
+    assert.equal(out[0].status, "red");
+    assert.equal(out[0].suggestedClass, "human");
+    assert.match(out[0].title, /not verified/);
+  });
+
+  it("emits green when all domains verified", async () => {
+    process.env.RESEND_API_KEY = "re_x";
+    const all = JSON.stringify({ data: [{ name: "a", status: "verified" }] });
+    const out = await resendSensor.probe(ctx, deps({ http: { ok: true, status: 200, body: all } }));
+    assert.equal(out[0].status, "green");
+  });
+
+  it("is unknown (not green) when RESEND_API_KEY is missing", async () => {
+    const out = await resendSensor.probe(ctx, deps());
+    assert.equal(out[0].status, "unknown");
+  });
+
+  it("is unknown on a non-OK API response", async () => {
+    process.env.RESEND_API_KEY = "re_x";
+    const out = await resendSensor.probe(ctx, deps({ http: { ok: false, status: 401, body: "" } }));
+    assert.equal(out[0].status, "unknown");
+    assert.match(out[0].title, /401/);
+  });
+});

--- a/src/health-sensors/resend.ts
+++ b/src/health-sensors/resend.ts
@@ -1,0 +1,61 @@
+import type { HealthFinding, HealthSensor } from "../health.js";
+
+export interface ResendDomain {
+  id?: string;
+  name?: string;
+  status?: string;
+}
+
+export function parseResendDomains(body: string): ResendDomain[] {
+  try {
+    const obj = JSON.parse(body) as { data?: ResendDomain[] };
+    return Array.isArray(obj.data) ? obj.data : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Domains whose status is anything other than "verified". */
+export function unverifiedDomains(domains: ResendDomain[]): ResendDomain[] {
+  return domains.filter((d) => (d.status ?? "") !== "verified");
+}
+
+export const resendSensor: HealthSensor = {
+  id: "resend",
+  async probe(_ctx, deps): Promise<HealthFinding[]> {
+    const key = process.env.RESEND_API_KEY;
+    if (!key) {
+      return [{
+        sensor: "resend",
+        source: "resend",
+        status: "unknown",
+        title: "Resend probe skipped: RESEND_API_KEY not set",
+        detail: "set RESEND_API_KEY to enable the Resend sensor",
+      }];
+    }
+    const res = await deps.httpGet("https://api.resend.com/domains", { Authorization: `Bearer ${key}` });
+    if (!res.ok) {
+      return [{
+        sensor: "resend",
+        source: "resend",
+        status: "unknown",
+        title: `Resend API returned HTTP ${res.status}`,
+        detail: "check RESEND_API_KEY",
+      }];
+    }
+    const bad = unverifiedDomains(parseResendDomains(res.body));
+    if (bad.length === 0) {
+      return [{ sensor: "resend", source: "resend", status: "green", title: "Resend: all sending domains verified" }];
+    }
+    const names = bad.map((d) => `${d.name ?? "?"}=${d.status ?? "?"}`).join(", ");
+    return [{
+      sensor: "resend",
+      source: "resend",
+      status: "red",
+      severity: "high",
+      title: `Resend: ${bad.length} domain(s) not verified`,
+      detail: `${names} — re-check DNS (SPF/DKIM/DMARC); customer/DNS action, not a code fix`,
+      suggestedClass: "human",
+    }];
+  },
+};

--- a/src/health-sensors/sentry.test.ts
+++ b/src/health-sensors/sentry.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { parseSentryIssues, sentrySensor } from "./sentry.js";
+import type { HealthCtx, HealthDeps, HttpResponse } from "../health.js";
+
+const issues = JSON.stringify([
+  { id: "1", title: "TypeError: x is not a function", level: "error", status: "unresolved" },
+]);
+
+function deps(over: { http?: HttpResponse } = {}): HealthDeps {
+  return {
+    runCli: async () => ({ stdout: "", stderr: "", exitCode: 0, ok: true }),
+    httpGet: async () => over.http ?? { ok: true, status: 200, body: issues },
+  };
+}
+const ctx: HealthCtx = { cwd: "/tmp/repo", config: {} };
+
+describe("parseSentryIssues", () => {
+  it("parses an issue array; [] on garbage", () => {
+    assert.equal(parseSentryIssues(issues).length, 1);
+    assert.deepEqual(parseSentryIssues("nope"), []);
+  });
+});
+
+describe("sentrySensor.probe", () => {
+  afterEach(() => {
+    delete process.env.SENTRY_AUTH_TOKEN;
+    delete process.env.SENTRY_ORG;
+    delete process.env.SENTRY_PROJECT;
+    delete process.env.SENTRY_URL;
+  });
+
+  function setEnv() {
+    process.env.SENTRY_AUTH_TOKEN = "t";
+    process.env.SENTRY_ORG = "acme";
+    process.env.SENTRY_PROJECT = "web";
+  }
+
+  it("emits red when there are new unresolved issues", async () => {
+    setEnv();
+    const out = await sentrySensor.probe(ctx, deps());
+    assert.equal(out[0].status, "red");
+    assert.equal(out[0].source, "acme/web");
+    assert.match(out[0].title, /1 new unresolved/);
+  });
+
+  it("emits green when none", async () => {
+    setEnv();
+    const out = await sentrySensor.probe(ctx, deps({ http: { ok: true, status: 200, body: "[]" } }));
+    assert.equal(out[0].status, "green");
+  });
+
+  it("is unknown (not green) when token/org/project not all set", async () => {
+    const out = await sentrySensor.probe(ctx, deps());
+    assert.equal(out[0].status, "unknown");
+  });
+
+  it("is unknown on a non-OK API response", async () => {
+    setEnv();
+    const out = await sentrySensor.probe(ctx, deps({ http: { ok: false, status: 401, body: "" } }));
+    assert.equal(out[0].status, "unknown");
+    assert.match(out[0].title, /401/);
+  });
+});

--- a/src/health-sensors/sentry.ts
+++ b/src/health-sensors/sentry.ts
@@ -1,0 +1,64 @@
+import type { HealthFinding, HealthSensor } from "../health.js";
+
+export interface SentryIssue {
+  id?: string;
+  title?: string;
+  level?: string;
+  status?: string;
+}
+
+export function parseSentryIssues(body: string): SentryIssue[] {
+  try {
+    const arr = JSON.parse(body) as SentryIssue[];
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+export const sentrySensor: HealthSensor = {
+  id: "sentry",
+  async probe(_ctx, deps): Promise<HealthFinding[]> {
+    const token = process.env.SENTRY_AUTH_TOKEN;
+    const org = process.env.SENTRY_ORG;
+    const project = process.env.SENTRY_PROJECT;
+    const base = (process.env.SENTRY_URL || "https://sentry.io").replace(/\/+$/, "");
+    const source = org && project ? `${org}/${project}` : "(sentry org/project unset)";
+    if (!token || !org || !project) {
+      return [{
+        sensor: "sentry",
+        source,
+        status: "unknown",
+        title: "Sentry probe skipped: SENTRY_AUTH_TOKEN / SENTRY_ORG / SENTRY_PROJECT not all set",
+        detail: "set the three to enable the Sentry sensor",
+      }];
+    }
+    // New unresolved issues in the last 24h = a fresh-errors signal (not the whole backlog).
+    const q = encodeURIComponent("is:unresolved firstSeen:-24h");
+    const url = `${base}/api/0/projects/${encodeURIComponent(org)}/${encodeURIComponent(project)}/issues/?query=${q}&statsPeriod=24h`;
+    const res = await deps.httpGet(url, { Authorization: `Bearer ${token}` });
+    if (!res.ok) {
+      return [{
+        sensor: "sentry",
+        source,
+        status: "unknown",
+        title: `Sentry API returned HTTP ${res.status}`,
+        detail: "check SENTRY_AUTH_TOKEN scope / org+project / SENTRY_URL region",
+      }];
+    }
+    const issues = parseSentryIssues(res.body);
+    if (issues.length === 0) {
+      return [{ sensor: "sentry", source, status: "green", title: "Sentry: no new unresolved issues in 24h" }];
+    }
+    const sample = issues[0]?.title ? ` (e.g. "${issues[0].title}")` : "";
+    return [{
+      sensor: "sentry",
+      source,
+      status: "red",
+      severity: "high",
+      title: `Sentry: ${issues.length} new unresolved issue(s) in 24h${sample}`,
+      detail: "triage at the Sentry dashboard; may be a real regression or benign noise to filter",
+      suggestedClass: "code",
+    }];
+  },
+};

--- a/src/health.ts
+++ b/src/health.ts
@@ -4,6 +4,8 @@ import { githubActionsSensor } from "./health-sensors/github-actions.js";
 import { gitlabSensor } from "./health-sensors/gitlab-ci.js";
 import { bitbucketSensor } from "./health-sensors/bitbucket-pipelines.js";
 import { vercelSensor } from "./health-sensors/vercel.js";
+import { sentrySensor } from "./health-sensors/sentry.js";
+import { resendSensor } from "./health-sensors/resend.js";
 
 export type HealthStatus = "green" | "red" | "unknown";
 export type HealthClass = "code" | "human" | "noise";
@@ -30,6 +32,8 @@ export interface HealthCtx {
   bitbucketPipelines?: boolean;
   /** Vercel link from .vercel/project.json (orgId = teamId, projectId), if present. */
   vercel?: { orgId?: string; projectId?: string };
+  /** Service ids the project is connected to (from the registry), for dep-detected sensors. */
+  services?: string[];
 }
 
 export interface HttpResponse {
@@ -75,7 +79,14 @@ export async function runHealth(
   return all.flat();
 }
 
-export const HEALTH_SENSORS: HealthSensor[] = [githubActionsSensor, gitlabSensor, bitbucketSensor, vercelSensor];
+export const HEALTH_SENSORS: HealthSensor[] = [
+  githubActionsSensor,
+  gitlabSensor,
+  bitbucketSensor,
+  vercelSensor,
+  sentrySensor,
+  resendSensor,
+];
 
 /** Returns the sensors whose underlying CI platform the project actually uses. */
 export function selectSensors(ctx: HealthCtx): HealthSensor[] {
@@ -89,6 +100,10 @@ export function selectSensors(ctx: HealthCtx): HealthSensor[] {
         return ctx.bitbucketPipelines === true;
       case "vercel":
         return Boolean(ctx.vercel?.projectId);
+      case "sentry":
+        return ctx.services?.includes("sentry") === true;
+      case "resend":
+        return ctx.services?.includes("resend") === true;
       default:
         return false;
     }


### PR DESCRIPTION
Sensors 5 & 6 on the sentinel ladder — the two highest-value detection gaps (runtime errors + email delivery), reusing the `httpGet` probe path.

## Sentry
`GET {SENTRY_URL|sentry.io}/api/0/projects/:org/:project/issues/?query=is:unresolved firstSeen:-24h` with `SENTRY_AUTH_TOKEN`. Red on **new** unresolved issues in the last 24h (fresh errors, not the whole backlog); detail notes it may be a real regression or benign noise to filter (the KJORRE-6/7 story). `SENTRY_URL` overrides for regional/self-hosted.

## Resend
`GET https://api.resend.com/domains` with `RESEND_API_KEY`. Red — class **`human`** (a DNS/customer action, not a code fix) — when any sending domain is not `verified`. Mirrors your existing domain-status cron.

## Selection = connected services
Unlike the CI sensors (gated on repo files), these are **dep-detected**: `cmdHealth` now computes `ctx.services` via the registry's `detectServices` (sees `@sentry/*` / `resend` in `package.json`), and the sensors are selected only when their service is present — per the sentinel design's "sensors derive from connected services". Both report `unknown` (never a false `green`) on missing creds / non-OK.

## Verify
build clean, **1359 tests, 0 fail** (+11). Parsers fixture-tested; live API smoke pending real tokens.

`kit health` now covers GitHub/GitLab/Bitbucket CI, Vercel deploys, Sentry errors, Resend delivery. Remaining sensors: Supabase advisor (API shape to verify) + TLS cert (needs `[health] cert_hosts`). Then **layer 2 — the responder routine**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)