### PR TITLE
fix(check-disk-encryption): fail-open (skip) on Linux when FDE unconfirmable

### DIFF
--- a/src/check-disk-encryption.ts
+++ b/src/check-disk-encryption.ts
@@ -115,13 +115,13 @@ export async function checkDiskEncryption(): Promise<SecurityCheckResult> {
       if (interpretLsblk(stdout) === true) {
         return { category: "exposure", name: "disk encryption", status: "pass", detail: "LUKS-encrypted volume detected" };
       }
-      // No crypt device found — can't confirm. Warn at low severity (honest "verify").
+      // No crypt device found. Per this module's fail-open contract, absence is
+      // NOT proof FDE is off (encrypted host VM, LVM-on-LUKS not surfaced, etc.),
+      // and unlike macOS/Windows, Linux has no authoritative "off" signal. Skip
+      // rather than cry wolf with a warn that would flip kit check's exit code.
       return {
-        category: "exposure",
-        name: "disk encryption",
-        status: "warn",
-        severity: "low",
-        detail: "could not confirm full-disk encryption (no LUKS device found) — verify your disk is encrypted",
+        ...SKIP,
+        detail: "could not confirm full-disk encryption on Linux (no LUKS device found) — verify your disk is encrypted",
         suggestion: "Confirm with: lsblk (look for type 'crypt'), or your distro's disk-encryption settings",
       };
     }


### PR DESCRIPTION
## What

On Linux, the disk-encryption check returned a low-severity `warn` whenever no `crypt` device was found via `lsblk`. A warn counts as an issue, so this flipped `kit check`'s exit code to `1` on **any non-CI Linux host without a detected LUKS device** — including ordinary dev laptops and this repo's own remote dev container.

It was only masked in GitHub Actions because the check short-circuits to `skip` when `process.env.CI` is set. Running the suite locally (no `CI`) surfaced 6 failures, all tracing back to `kit check` exiting 1 when the tests assert exit 0.

## Why skip, not warn

This module documents a **FAIL-OPEN** contract ("when we cannot determine the status … SKIP rather than cry wolf") and the code itself notes that *absence of a crypt device is NOT proof FDE is off* (encrypted host VMs, LVM layouts, etc.). Unlike macOS (`fdesetup`) and Windows (`manage-bde`), Linux has no authoritative "encryption is OFF" signal. The macOS/Windows indeterminate branches already return `skip`; this aligns Linux with them.

Authoritative "OFF" detection on macOS/Windows still warns at high severity — unchanged.

## Verification

- `npm test`: **1361/1361 pass** (was 1355/1361 with 6 failures in `kit check` / `kit setup` / default-command suites).
- `check-disk-encryption.test.ts` still green (it asserts status ∈ {pass, warn, skip}).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_