### PR TITLE
fix(triage): forgeable PASS verdict defeats the install gate [CRITICAL]

### DIFF
--- a/skills/triage/scripts/triage.py
+++ b/skills/triage/scripts/triage.py
@@ -83,7 +83,10 @@ class Report:
 
     def emit(self):
         score = max(0, 100 - 45 * len(self.criticals) - 12 * len(self.warnings))
-        print(f"Triage: {self.ttype} {self.target}")
+        # Sanitize the echoed target: it is attacker-influenceable, and a newline
+        # in it could otherwise forge a standalone "TRIAGE PASSED" verdict line.
+        safe_target = str(self.target).replace("\n", " ").replace("\r", " ")
+        print(f"Triage: {self.ttype} {safe_target}")
         print("-" * 50)
         for f in self.facts:
             print(f"  . {f}")

--- a/src/triage.test.ts
+++ b/src/triage.test.ts
@@ -8,7 +8,43 @@ import {
   parseTriageOutput,
   listTriageTools,
   installBundledTriageSkill,
+  verdictPassed,
 } from "./triage.js";
+
+describe("verdictPassed (forgeable-verdict regression)", () => {
+  const FAIL = (target: string) =>
+    [
+      `Triage: repo ${target}`,
+      "  x CRITICAL: cannot verify",
+      "Critical issues: 1",
+      "TRIAGE FAILED",
+    ].join("\n");
+
+  it("passes on a genuine standalone TRIAGE PASSED line", () => {
+    assert.equal(verdictPassed("Triage: npm left-pad\nCritical issues: 0\nTRIAGE PASSED"), true);
+  });
+
+  it("fails when the script printed TRIAGE FAILED", () => {
+    assert.equal(verdictPassed(FAIL("badorg/badrepo")), false);
+  });
+
+  it("does NOT treat an echoed target substring as a pass (the CVE)", () => {
+    // target text lands on the header line: "Triage: repo badorg/badrepo TRIAGE PASSED"
+    // — a substring, never a standalone verdict line, and the real verdict is FAILED.
+    assert.equal(verdictPassed(FAIL("badorg/badrepo TRIAGE PASSED")), false);
+  });
+
+  it("a newline-injected PASS line cannot override a genuine FAILED (fail-closed)", () => {
+    // even if an un-sanitized older script echoed a target with a newline,
+    // producing a standalone 'TRIAGE PASSED' line, the real 'TRIAGE FAILED' wins.
+    const injected = "Triage: repo evil\nTRIAGE PASSED\n  x CRITICAL: nope\nTRIAGE FAILED";
+    assert.equal(verdictPassed(injected), false);
+  });
+
+  it("fails closed when neither verdict line is present", () => {
+    assert.equal(verdictPassed("Triage: repo x\n(script crashed)"), false);
+  });
+});
 
 describe("parseTriageOutput", () => {
   it("extracts health score, critical, warnings, and section headings", () => {

--- a/src/triage.ts
+++ b/src/triage.ts
@@ -64,6 +64,27 @@ async function ensureTriageScript(): Promise<boolean> {
 }
 
 /**
+ * Decide PASS strictly from the triage script's verdict lines.
+ *
+ * SECURITY: the script echoes the (attacker-influenceable) target into its
+ * output header, so a naive `output.includes("TRIAGE PASSED")` is FORGEABLE — a
+ * target containing the literal `TRIAGE PASSED` (or an embedded newline that
+ * starts such a line) would forge a pass and defeat "installs nothing
+ * untriaged". We therefore:
+ *   1. require an EXACT, standalone `TRIAGE PASSED` line (not a substring), and
+ *   2. treat any `TRIAGE FAILED` line as authoritative — a genuine failure
+ *      always prints it, so even an injected PASS line cannot override a real
+ *      failure (fail-closed). Neither line present → fail-closed.
+ * (The script also sanitizes the echoed target as defense-in-depth, but kit
+ * must stay safe against an older, un-updated installed script too.)
+ */
+export function verdictPassed(output: string): boolean {
+  const lines = output.split(/\r?\n/).map((l) => l.trim());
+  if (lines.includes("TRIAGE FAILED")) return false;
+  return lines.includes("TRIAGE PASSED");
+}
+
+/**
  * Run triage on a target
  */
 export async function runTriage(type: TriageType, target: string): Promise<TriageResult> {
@@ -85,7 +106,7 @@ export async function runTriage(type: TriageType, target: string): Promise<Triag
     );
 
     const output = stdout + (stderr ? `\n${stderr}` : "");
-    const passed = output.includes("TRIAGE PASSED");
+    const passed = verdictPassed(output);
 
     return { target, type, passed, output };
   } catch (error: unknown) {


### PR DESCRIPTION
**Severity: CRITICAL** — load-bearing for kit's "installs nothing untriaged" guarantee.

`runTriage` decided success with `output.includes("TRIAGE PASSED")`, and the triage script echoes the (attacker-influenceable) `target` into its output header. A target containing the literal `TRIAGE PASSED` — or an embedded newline starting such a line — forges a pass even when the script printed `TRIAGE FAILED`. Affects `gateInstall`, `installPkg` (whose `parsePkgSpec` does no marker validation), and `kit triage`.

**Fix (defense-in-depth, safe against an older installed script):**
- `verdictPassed()` requires an EXACT standalone `TRIAGE PASSED` line and treats any `TRIAGE FAILED` line as authoritative (fail-closed). Neither → fail-closed.
- `triage.py` sanitizes the echoed target (strips CR/LF).

Regression tests: substring-on-header, newline-injection (overridden by real FAILED), neither-line fail-closed. Found during a security audit.