### PR TITLE
fix(secrets-sync): redact secret values from sync error messages [HIGH]

### DIFF
--- a/src/secrets-migrate.test.ts
+++ b/src/secrets-migrate.test.ts
@@ -8,7 +8,30 @@ import {
   commentOutInFile,
   writeSecretToBackend,
   planMigration,
+  safeErrorMessage,
 } from "./secrets-migrate.js";
+
+describe("safeErrorMessage", () => {
+  it("redacts a known secret embedded in an execFile-style error (the argv leak)", () => {
+    const secret = ["sk", "live", "A".repeat(40)].join("_");
+    // execFile failures interpolate the full argv into err.message
+    const err = new Error(
+      `Command failed: gh secret set FOO --repo o/r --body ${secret}\nHTTP 403`,
+    );
+    const msg = safeErrorMessage(err, [secret]);
+    assert.ok(!msg.includes(secret), "raw secret must not survive");
+    assert.match(msg, /\[REDACTED\]/);
+  });
+
+  it("keeps only the first diagnostic line (drops trailing lines that may carry data)", () => {
+    const secret = "supersecretvalue123456789";
+    const msg = safeErrorMessage(new Error(`write failed for FOO\n  value was ${secret}`), [
+      secret,
+    ]);
+    assert.ok(!msg.includes(secret), "secret on a later line must not survive");
+    assert.match(msg, /write failed for FOO/);
+  });
+});
 
 describe("isValidKeyName", () => {
   it("accepts env-var-shaped identifiers", () => {

--- a/src/secrets-migrate.ts
+++ b/src/secrets-migrate.ts
@@ -30,7 +30,7 @@ export function escapeRegex(literal: string): string {
  * leaks the secret unless we redact. We keep the first line for diagnostic
  * value but strip anything matching a known secret pattern.
  */
-function safeErrorMessage(err: unknown, knownSecrets: string[] = []): string {
+export function safeErrorMessage(err: unknown, knownSecrets: string[] = []): string {
   let raw = err instanceof Error ? err.message.split("\n")[0] : String(err);
   // Exact-substring redaction for values we hold — deterministic and
   // shape-independent. Pattern redaction alone fails open for lowercase-keyed

--- a/src/secrets-sync.ts
+++ b/src/secrets-sync.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import type { SecretsConfig } from "./config.js";
 import { generateSecrets } from "./secrets.js";
 import { exec } from "./utils/exec.js";
+import { safeErrorMessage } from "./secrets-migrate.js";
 
 export interface SyncResult {
   target: string;
@@ -215,7 +216,8 @@ async function syncToGitHub(
         failed.push(`${name}: ${putResp.status}`);
       }
     } catch (err) {
-      failed.push(`${name}: ${(err as Error).message}`);
+      // Redact: an error here can carry the secret value in its message.
+      failed.push(`${name}: ${safeErrorMessage(err, [value])}`);
     }
   }
 
@@ -259,7 +261,9 @@ async function syncToGitHubViaCli(
       });
       synced.push(name);
     } catch (err) {
-      failed.push(`${name}: ${(err as Error).message}`);
+      // execFile errors embed the full argv (including `--body <value>`) in the
+      // message — redact the secret before it reaches `failed[]`/stdout/CI logs.
+      failed.push(`${name}: ${safeErrorMessage(err, [value])}`);
     }
   }
 


### PR DESCRIPTION
`syncToGitHub` pushed raw `(err as Error).message` into `failed[]`, printed by `kit secrets sync`. execFile errors embed the full argv, so a failed `gh secret set … --body <value>` (bad token, rate-limit, missing perms) leaked every secret in cleartext to stdout/CI logs. The REST path leaked the same way.

**Fix:** export the existing `safeErrorMessage(err, [value])` (exact-substring + pattern redaction) and use it on both sync error paths. `secrets-migrate.ts` already guarded its writes; sync didn't. Test added. (Security audit finding.)