### PR TITLE
fix(scan): surface unparseable scanner output as error, not "ran clean"

### DIFF
--- a/src/adapters/ingest.test.ts
+++ b/src/adapters/ingest.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parseSarif, parseOsv, ingest } from "./ingest.js";
+import { parseSarif, parseOsv, ingest, ingestStrict } from "./ingest.js";
 
 const sarif = JSON.stringify({
   runs: [
@@ -102,5 +102,33 @@ describe("ingest dispatch", () => {
     assert.equal(ingest("osv", osv).length, 1);
     // @ts-expect-error unknown format
     assert.deepEqual(ingest("nope", sarif), []);
+  });
+});
+
+describe("ingestStrict", () => {
+  it("parses valid input into findings (ok:true)", () => {
+    const a = ingestStrict("sarif", sarif);
+    assert.equal(a.ok, true);
+    assert.ok(a.ok && a.findings.length === 2);
+    const b = ingestStrict("osv", osv);
+    assert.ok(b.ok && b.findings.length === 1);
+  });
+
+  it("accepts a valid but EMPTY report as ok:true with no findings", () => {
+    const a = ingestStrict("sarif", JSON.stringify({ runs: [] }));
+    assert.ok(a.ok && a.findings.length === 0);
+    const b = ingestStrict("osv", JSON.stringify({ results: [] }));
+    assert.ok(b.ok && b.findings.length === 0);
+  });
+
+  it("rejects malformed JSON (ok:false) — the masked-failure case", () => {
+    assert.equal(ingestStrict("sarif", "panic: boom").ok, false);
+    assert.equal(ingestStrict("osv", "not json").ok, false);
+  });
+
+  it("rejects valid JSON of the wrong shape (ok:false)", () => {
+    // parses fine, but it's an error blob, not a SARIF/OSV report
+    assert.equal(ingestStrict("sarif", JSON.stringify({ error: "no db" })).ok, false);
+    assert.equal(ingestStrict("osv", JSON.stringify({ runs: [] })).ok, false);
   });
 });

--- a/src/adapters/ingest.ts
+++ b/src/adapters/ingest.ts
@@ -182,7 +182,42 @@ export function parseOsv(json: string): SecurityCheckResult[] {
 
 export type IngestFormat = "sarif" | "osv";
 
-/** Dispatch to the right parser. Unknown format → []. */
+/** Dispatch to the right parser. Unknown format → []. Lenient: malformed input → []. */
 export function ingest(format: IngestFormat, json: string): SecurityCheckResult[] {
   return format === "sarif" ? parseSarif(json) : format === "osv" ? parseOsv(json) : [];
+}
+
+export type IngestOutcome =
+  | { ok: true; findings: SecurityCheckResult[] }
+  | { ok: false; reason: string };
+
+/**
+ * Strict ingest: distinguishes a *valid but empty* report (scanner ran, found
+ * nothing) from *malformed/unexpected* output (scanner errored, printed junk, or
+ * emitted a different format). The lenient `ingest()` collapses both to `[]`,
+ * which lets a broken scanner masquerade as "ran clean" — dangerous in a
+ * consolidated security verdict. Callers that gate on scanner health (e.g.
+ * `kit scan`) must use this and treat `ok:false` as an error, not a pass.
+ */
+export function ingestStrict(format: IngestFormat, json: string): IngestOutcome {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return { ok: false, reason: "output is not valid JSON" };
+  }
+  const isObj = !!parsed && typeof parsed === "object";
+  if (format === "sarif") {
+    if (!isObj || !Array.isArray((parsed as SarifLog).runs)) {
+      return { ok: false, reason: "not a SARIF log (no `runs` array)" };
+    }
+    return { ok: true, findings: parseSarif(json) };
+  }
+  if (format === "osv") {
+    if (!isObj || !Array.isArray((parsed as OsvLog).results)) {
+      return { ok: false, reason: "not an OSV report (no `results` array)" };
+    }
+    return { ok: true, findings: parseOsv(json) };
+  }
+  return { ok: false, reason: `unknown format: ${format as string}` };
 }

--- a/src/scanners.test.ts
+++ b/src/scanners.test.ts
@@ -81,6 +81,33 @@ describe("runScanners (injected deps)", () => {
     assert.equal(byId.trivy, "ran");
     assert.equal(merged.length, 1); // trivy's one CVE
   });
+
+  it("marks a scanner whose output we cannot parse as error, NOT ran-clean", async () => {
+    const only: ScannerDef[] = [{ id: "trivy", bin: "trivy", args: [], format: "sarif" }];
+    const deps: ScanDeps = {
+      resolve: async (bin) => `/usr/bin/${bin}`,
+      // scanner printed a junk error blob to stdout (e.g. a stack trace / wrong format)
+      run: async () => ({ ok: false, stdout: "panic: could not open db\n" }),
+      hasEnv: () => true,
+      detect: () => true,
+    };
+    const { merged, runs } = await runScanners(deps, only);
+    assert.equal(runs[0].status, "error", "unparseable output must surface as error");
+    assert.equal(merged.length, 0);
+  });
+
+  it("treats a valid but empty SARIF as ran/0 (not error)", async () => {
+    const only: ScannerDef[] = [{ id: "trivy", bin: "trivy", args: [], format: "sarif" }];
+    const deps: ScanDeps = {
+      resolve: async (bin) => `/usr/bin/${bin}`,
+      run: async () => ({ ok: true, stdout: JSON.stringify({ runs: [] }) }),
+      hasEnv: () => true,
+      detect: () => true,
+    };
+    const { runs } = await runScanners(deps, only);
+    assert.equal(runs[0].status, "ran");
+    assert.equal(runs[0].findings, 0);
+  });
 });
 
 describe("suppressBaselined", () => {

--- a/src/scanners.ts
+++ b/src/scanners.ts
@@ -11,7 +11,7 @@
  * injectable deps so the orchestration is testable without real scanners.
  */
 import type { SecurityCheckResult } from "./check-security.js";
-import { ingest, type IngestFormat } from "./adapters/ingest.js";
+import { ingestStrict, type IngestFormat } from "./adapters/ingest.js";
 
 export interface ScannerDef {
   id: string;
@@ -124,15 +124,22 @@ export async function runScanners(
       continue;
     }
     const res = await deps.run(bin, s.args);
-    // Most scanners exit non-zero WHEN findings exist — parse stdout regardless;
-    // only a truly empty + failed run is an error.
-    if (!res.stdout && !res.ok) {
+    // Most scanners exit non-zero WHEN findings exist, so a non-zero exit alone
+    // is not an error — parse the output regardless. But a non-empty output we
+    // CANNOT parse (junk, an error blob, the wrong format) must NOT be silently
+    // treated as "ran clean": that lets a broken scanner hide behind a green
+    // verdict. Empty output is "ran/0" only if the process also succeeded.
+    if (!res.stdout) {
+      runs.push({ id: s.id, status: res.ok ? "ran" : "error", findings: 0 });
+      continue;
+    }
+    const outcome = ingestStrict(s.format, res.stdout);
+    if (!outcome.ok) {
       runs.push({ id: s.id, status: "error", findings: 0 });
       continue;
     }
-    const findings = res.stdout ? ingest(s.format, res.stdout) : [];
-    perScanner.push({ id: s.id, findings });
-    runs.push({ id: s.id, status: "ran", findings: findings.length });
+    perScanner.push({ id: s.id, findings: outcome.findings });
+    runs.push({ id: s.id, status: "ran", findings: outcome.findings.length });
   }
   return { merged: mergeFindings(perScanner), runs };
 }


### PR DESCRIPTION
`runScanners` piped scanner stdout through the lenient `ingest()`, which returns `[]` on any malformed input — so a scanner that printed a stack trace or the wrong format was recorded as `ran` with 0 findings, hiding behind a green consolidated verdict (classic fail-open).

**Fix:** new `ingestStrict()` distinguishes a *valid-but-empty* report from *malformed/wrong-shape* output (discriminated `{ ok }`). `runScanners` marks unparseable output (and empty output from a failed process) as `error`; a valid empty SARIF/OSV stays `ran/0`. Lenient `ingest()` unchanged for `kit ingest`. Tests added. (Security review finding.)