### PR TITLE
fix(elevation): separate scope for irreversible jwt cutover [MEDIUM]

### DIFF
--- a/src/elevation-scopes.test.ts
+++ b/src/elevation-scopes.test.ts
@@ -5,13 +5,23 @@ import { scopeFor, isOneShot, listScopes } from "./elevation-scopes.js";
 describe("scopeFor", () => {
   it("matches composite operation:mode keys", () => {
     const m = scopeFor("rotate", "jwt-secret-roll");
-    assert.equal(m.scope, "rotate");
+    assert.equal(m.scope, "rotate-jwt-cutover");
     assert.equal(m.oneShot, true);
   });
 
   it("scoped-key-mint is NOT one-shot (reversible)", () => {
     const m = scopeFor("rotate", "scoped-key-mint");
     assert.equal(m.oneShot, false);
+  });
+
+  it("irreversible jwt cutover uses a DISTINCT scope from the reversible mint", () => {
+    // Regression: sharing scope "rotate" let an elevation minted for the benign
+    // scoped-key-mint authorize the irreversible jwt-secret-roll within its TTL.
+    const cutover = scopeFor("rotate", "jwt-secret-roll");
+    const mint = scopeFor("rotate", "scoped-key-mint");
+    assert.notEqual(cutover.scope, mint.scope);
+    assert.equal(mint.scope, "rotate");
+    assert.equal(cutover.scope, "rotate-jwt-cutover");
   });
 
   it("falls back to bare operation when no mode given", () => {

--- a/src/elevation-scopes.ts
+++ b/src/elevation-scopes.ts
@@ -33,7 +33,11 @@ export interface ElevationScopeMapping {
 const SCOPE_MAP: Record<string, ElevationScopeMapping> = {
   // Rotation modes
   "rotate:jwt-secret-roll": {
-    scope: "rotate",
+    // Distinct scope (not "rotate"): the irreversible HARD CUTOVER must NOT be
+    // authorizable by an elevation minted for the reversible scoped-key-mint.
+    // Sharing "rotate" let a benign `--scope rotate` marker fire the cutover
+    // within its TTL.
+    scope: "rotate-jwt-cutover",
     oneShot: true,
     description: "Supabase JWT-secret reset — invalidates anon + service_role + all sessions",
   },

--- a/src/secrets-rotate-cli.ts
+++ b/src/secrets-rotate-cli.ts
@@ -134,6 +134,7 @@ import { isNonInteractive } from "./environment.js";
 import { writeSecretToBackend } from "./secrets-migrate.js";
 import { planRotation } from "./secrets-rotate.js";
 import { requireElevation, consumeElevation } from "./elevation.js";
+import { scopeFor } from "./elevation-scopes.js";
 import {
   propagate,
   parseTargets,
@@ -311,10 +312,15 @@ async function cmdSecretsRotateSupabaseMgmt(keyName: string, args: string[]): Pr
   // S12 elevation required for rotation. jwt-secret-roll is a hard cutover
   // — one elevation = one rotation. Other modes (scoped-key-mint with
   // rollback) keep the standard 15-min TTL.
+  // Derive the scope from the mode so the irreversible cutover requires its own
+  // distinct elevation ("rotate-jwt-cutover") and can't be satisfied by a marker
+  // minted for the reversible scoped-key-mint (scope "rotate"). Single source of
+  // truth = elevation-scopes.ts; never hard-code the scope string here.
+  const rotateScope = scopeFor("rotate", mode).scope;
   const elev =
     mode === "jwt-secret-roll"
-      ? await consumeElevation("rotate")
-      : await requireElevation("rotate");
+      ? await consumeElevation(rotateScope)
+      : await requireElevation(rotateScope);
   if (!elev.ok) {
     console.error(`${c.red}✗ ${elev.reason}${c.reset}`);
     return false;


### PR DESCRIPTION
`rotate:jwt-secret-roll` (irreversible HARD CUTOVER) and `rotate:scoped-key-mint` (reversible) both mapped to scope `"rotate"`, and the elevation marker carries only the scope. So `kit auth elevate --scope rotate` for the benign mint minted a marker the destructive cutover would consume within its TTL — a routine elevation silently escalates (an agent could exploit the window).

**Fix:** distinct scope `"rotate-jwt-cutover"` in the scope map, and the call site derives it via `scopeFor("rotate", mode).scope` instead of a hard-coded string. The not-elevated hint already echoes the scope, so the user is told the right one. Regression test added. (Security audit finding.)