### PR TITLE
fix(redact): catch URL-embedded credentials and sk-svcacct/admin keys

### DIFF
--- a/src/utils/redactSecrets.test.ts
+++ b/src/utils/redactSecrets.test.ts
@@ -2,6 +2,31 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { redactSecrets, safeStatusLine } from "./redactSecrets.js";
 
+describe("redactSecrets — connection-string + sk-svcacct (regression)", () => {
+  it("redacts the password in a DB URL but keeps scheme/user/host as context", () => {
+    const out = redactSecrets("DATABASE_URL=postgres://app:S3cr3tPassw0rd@db.internal:5432/prod");
+    assert.ok(!out.includes("S3cr3tPassw0rd"), "password must be gone");
+    assert.match(out, /postgres:\/\/app:\[REDACTED\]@db\.internal/);
+  });
+
+  it("redacts a userless redis URL password", () => {
+    const out = redactSecrets("redis://:topsecretvalue@cache.internal:6379");
+    assert.ok(!out.includes("topsecretvalue"));
+    assert.match(out, /\[REDACTED\]@cache\.internal/);
+  });
+
+  it("does not touch a plain URL with a port but no credentials", () => {
+    const url = "https://api.example.com:8443/v1/health";
+    assert.equal(redactSecrets(url), url);
+  });
+
+  it("redacts modern OpenAI sk-svcacct- / sk-admin- keys", () => {
+    const out = redactSecrets("OPENAI_API_KEY=sk-svcacct-" + "A".repeat(24));
+    assert.ok(!out.includes("AAAA"), "service-account key must be redacted");
+    assert.ok(out.includes("[REDACTED]"));
+  });
+});
+
 describe("redactSecrets", () => {
   it("redacts stripe test secret keys", () => {
     const out = redactSecrets("test_mode_api_key = 'sk_test_51T2AMtJLRlXeUG4dKBwX2nsve3BLEzy'");

--- a/src/utils/redactSecrets.ts
+++ b/src/utils/redactSecrets.ts
@@ -14,6 +14,12 @@ interface RedactPattern {
   re: RegExp;
   /** Optional label for the redaction (e.g. "stripe-key") for debugging. */
   label: string;
+  /**
+   * Replacement applied by `redactSecrets`. Defaults to `"[REDACTED]"` (whole
+   * match). Set this to keep diagnostic context while masking only the secret
+   * sub-part, e.g. `"$1[REDACTED]@"` to redact a URL password but keep the host.
+   */
+  replacement?: string;
 }
 
 export const SECRET_PATTERNS: RedactPattern[] = [
@@ -40,8 +46,9 @@ export const SECRET_PATTERNS: RedactPattern[] = [
   // Generic JWT (3 dot-separated base64url segments)
   { re: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g, label: "jwt" },
   // Supabase service-role JWT pattern (anon/service keys are JWTs; caught above)
-  // OpenAI / Anthropic API keys
-  { re: /\bsk-(proj-|ant-)[A-Za-z0-9_-]{30,}/g, label: "ai-api-key" },
+  // OpenAI / Anthropic API keys. `svcacct-`/`admin-` have an internal hyphen
+  // that breaks the bare `sk-[alnum]{40,}` run below, so list the prefixes.
+  { re: /\bsk-(proj|ant|svcacct|admin)-[A-Za-z0-9_-]{20,}/g, label: "ai-api-key" },
   { re: /\bsk-[A-Za-z0-9]{40,}/g, label: "openai-key" },
   // Resend
   { re: /\bre_[A-Za-z0-9_]{20,}/g, label: "resend-key" },
@@ -77,6 +84,15 @@ export const SECRET_PATTERNS: RedactPattern[] = [
     re: /"(sensitive_value|value)"\s*:\s*"([A-Za-z0-9_\-+/]{20,})"/g,
     label: "tfstate-value",
   },
+  // Credentials embedded in a connection-string URL, e.g.
+  // `postgres://user:supersecret@host/db`, `redis://:pw@host`, `mongodb+srv://…`.
+  // The `kv-secret` class stops at the `:`/`@`, so these slipped through. Redact
+  // ONLY the password and keep the scheme/user/host as diagnostic context.
+  {
+    re: /\b([a-z][a-z0-9+.-]*:\/\/[^\s:@/]*:)[^\s@/]{3,}@/gi,
+    label: "url-credentials",
+    replacement: "$1[REDACTED]@",
+  },
   // Generic high-entropy hex tokens (32+ hex chars) — last resort
   // Skipped intentionally: too many false-positives against commit hashes.
 ];
@@ -84,8 +100,8 @@ export const SECRET_PATTERNS: RedactPattern[] = [
 export function redactSecrets(input: string): string {
   if (!input) return input;
   let out = input;
-  for (const { re } of SECRET_PATTERNS) {
-    out = out.replace(re, "[REDACTED]");
+  for (const { re, replacement } of SECRET_PATTERNS) {
+    out = out.replace(re, replacement ?? "[REDACTED]");
   }
   return out;
 }


### PR DESCRIPTION
Two redaction false-negatives (security audit):

- Connection-string passwords (`postgres://user:pw@host`, `redis://:pw@host`) passed through — `kv-secret` stops at `:`/`@`. Added a `url-credentials` pattern that redacts **only** the password and keeps scheme/user/host (via a new optional per-pattern `replacement`).
- Modern OpenAI `sk-svcacct-…` / `sk-admin-…` keys missed (internal hyphen breaks the bare `sk-[alnum]{40,}` run). Broadened the prefix list.

Tests: DB-URL redaction (host kept), userless redis URL, plain ported URL untouched (no false positive), service-account key. ReDoS-safe.

_(Replaces #77, reopened from a clean single-commit branch.)_

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_