### PR TITLE
feat(airgap): declarative [air_gap] config in .kit.toml

### DIFF
--- a/docs/AIR_GAP.md
+++ b/docs/AIR_GAP.md
@@ -12,6 +12,23 @@ queries at your **internal mirrors** instead, and run the heavy scanners against
 > install rather than waving it through. Point the endpoints at reachable
 > internal mirrors so triage can actually evaluate targets.
 
+## Declarative config (recommended)
+
+Everything below can be set with `KIT_*` env vars **or** checked into
+`.kit.toml` so the enclave posture is reproducible and versioned. Env vars
+override the file when both are set.
+
+```toml
+[air_gap]
+enabled = true                                   # turns on offline scan mode
+npm_registry = "https://npm.corp.internal"
+pypi_index = "https://pypi.corp.internal"
+github_api = "https://ghe.corp.internal/api/v3"
+docker_registry = "https://registry.corp.internal"
+threat_data_dir = "/opt/kit/threat-data"
+threat_data_pubkey = "/etc/kit/threat-data.pub"
+```
+
 ## 1. Point the triage gate at internal mirrors
 
 The triage script reads its registry hosts from the environment, defaulting to

--- a/src/airgap/config.test.ts
+++ b/src/airgap/config.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolveAirGap, airGapTriageEnv } from "./config.js";
+
+describe("resolveAirGap", () => {
+  it("reads settings from .kit.toml [air_gap] when no env is set", () => {
+    const s = resolveAirGap(
+      {
+        enabled: true,
+        npm_registry: "https://npm.corp",
+        threat_data_dir: "/opt/td",
+        threat_data_pubkey: "/etc/k.pub",
+      },
+      {},
+    );
+    assert.equal(s.enabled, true);
+    assert.equal(s.npmRegistry, "https://npm.corp");
+    assert.equal(s.threatDataDir, "/opt/td");
+    assert.equal(s.threatDataPubkey, "/etc/k.pub");
+  });
+
+  it("env overrides the checked-in config value", () => {
+    const s = resolveAirGap(
+      { npm_registry: "https://npm.corp" },
+      { KIT_NPM_REGISTRY: "https://npm.override" },
+    );
+    assert.equal(s.npmRegistry, "https://npm.override");
+  });
+
+  it("KIT_AIRGAP truthy enables even if config is silent", () => {
+    assert.equal(resolveAirGap(undefined, { KIT_AIRGAP: "1" }).enabled, true);
+    assert.equal(resolveAirGap(undefined, { KIT_AIRGAP: "true" }).enabled, true);
+    assert.equal(resolveAirGap(undefined, {}).enabled, false);
+  });
+
+  it("config enabled=true holds even without the env var", () => {
+    assert.equal(resolveAirGap({ enabled: true }, {}).enabled, true);
+  });
+
+  it("is all-undefined / disabled with empty inputs", () => {
+    const s = resolveAirGap(undefined, {});
+    assert.equal(s.enabled, false);
+    assert.equal(s.npmRegistry, undefined);
+    assert.equal(s.threatDataDir, undefined);
+  });
+});
+
+describe("airGapTriageEnv", () => {
+  it("emits only the mirror vars that resolved to a value", () => {
+    const env = airGapTriageEnv({
+      enabled: true,
+      npmRegistry: "https://npm.corp",
+      githubApi: "https://ghe.corp/api/v3",
+    });
+    assert.deepEqual(env, {
+      KIT_NPM_REGISTRY: "https://npm.corp",
+      KIT_GITHUB_API: "https://ghe.corp/api/v3",
+    });
+  });
+
+  it("is empty when no mirrors are configured", () => {
+    assert.deepEqual(airGapTriageEnv({ enabled: true }), {});
+  });
+});

--- a/src/airgap/config.ts
+++ b/src/airgap/config.ts
@@ -1,0 +1,62 @@
+/**
+ * Resolve the effective air-gap posture from `.kit.toml [air_gap]` + env.
+ *
+ * The checked-in `.kit.toml` makes the enclave config reproducible; env vars
+ * (KIT_AIRGAP, KIT_NPM_REGISTRY, …) override it for one-off/CI runs. Pure +
+ * deterministic so it is fully testable.
+ */
+import type { kitConfig } from "../config.js";
+
+export interface AirGapSettings {
+  enabled: boolean;
+  npmRegistry?: string;
+  pypiIndex?: string;
+  githubApi?: string;
+  dockerRegistry?: string;
+  threatDataDir?: string;
+  /** Trusted Ed25519 public key — a file path or an inline PEM. */
+  threatDataPubkey?: string;
+}
+
+function envTrue(v: string | undefined): boolean {
+  return ["1", "true", "yes"].includes((v ?? "").trim().toLowerCase());
+}
+
+/** env value wins when set (non-empty); otherwise the checked-in config value. */
+function pick(envVal: string | undefined, cfgVal: string | undefined): string | undefined {
+  const e = envVal?.trim();
+  return e ? e : (cfgVal ?? undefined);
+}
+
+export function resolveAirGap(
+  cfg: kitConfig["air_gap"],
+  env: NodeJS.ProcessEnv = process.env,
+): AirGapSettings {
+  const ag = cfg ?? {};
+  return {
+    // env KIT_AIRGAP (truthy) OR config enabled; an explicit KIT_AIRGAP=0 does
+    // NOT force-disable a config-enabled posture (env only adds), keeping the
+    // checked-in enclave config authoritative unless the operator opts in.
+    enabled: envTrue(env.KIT_AIRGAP) || ag.enabled === true,
+    npmRegistry: pick(env.KIT_NPM_REGISTRY, ag.npm_registry),
+    pypiIndex: pick(env.KIT_PYPI_INDEX, ag.pypi_index),
+    githubApi: pick(env.KIT_GITHUB_API, ag.github_api),
+    dockerRegistry: pick(env.KIT_DOCKER_REGISTRY, ag.docker_registry),
+    threatDataDir: pick(env.KIT_THREAT_DATA_DIR, ag.threat_data_dir),
+    threatDataPubkey: pick(env.KIT_THREAT_DATA_PUBKEY, ag.threat_data_pubkey),
+  };
+}
+
+/**
+ * The `KIT_*` mirror env vars to inject into the triage subprocess so a
+ * config-declared mirror is honored (triage.py reads these from its env).
+ * Only includes keys that resolved to a value.
+ */
+export function airGapTriageEnv(s: AirGapSettings): Record<string, string> {
+  const e: Record<string, string> = {};
+  if (s.npmRegistry) e.KIT_NPM_REGISTRY = s.npmRegistry;
+  if (s.pypiIndex) e.KIT_PYPI_INDEX = s.pypiIndex;
+  if (s.githubApi) e.KIT_GITHUB_API = s.githubApi;
+  if (s.dockerRegistry) e.KIT_DOCKER_REGISTRY = s.dockerRegistry;
+  return e;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4492,26 +4492,31 @@ async function cmdScan(): Promise<boolean> {
   const { resolveToolBin } = await import("./utils/resolveTool.js");
   const { execFileNoThrow } = await import("./utils/execFileNoThrow.js");
   const { loadBaseline, baselineGet, baselineSet, saveBaseline } = await import("./baseline.js");
-  const { SCANNERS, airGapScanners, isAirGap } = await import("./scanners.js");
+  const { SCANNERS, airGapScanners } = await import("./scanners.js");
   const cwd = process.cwd();
-  // Air-gap mode (KIT_AIRGAP=1): drop cloud-only scanners and run the rest
-  // against local DBs with no network. See docs/AIR_GAP.md.
-  const airgap = airGapScanners(SCANNERS, isAirGap());
-  if (isAirGap()) {
+  const config = await loadConfig(resolveConfigPath());
+
+  // Air-gap posture from `.kit.toml [air_gap]` + env (env overrides). When
+  // enabled, drop cloud-only scanners and run the rest against local DBs with no
+  // network. See docs/AIR_GAP.md.
+  const { resolveAirGap } = await import("./airgap/config.js");
+  const ag = resolveAirGap(config.air_gap, process.env);
+  const airgap = airGapScanners(SCANNERS, ag.enabled);
+  if (ag.enabled) {
     console.log(
       `${c.dim}air-gap mode: offline scanners only${airgap.dropped.length ? ` (skipping cloud-only: ${airgap.dropped.join(", ")})` : ""}${c.reset}`,
     );
     // Verified offline threat-data bundle (optional): point scanners at a
     // signed, integrity-checked local DB set. Fail-closed — never scan against
-    // unverified threat data. See docs/AIR_GAP.md.
-    const tdDir = process.env.KIT_THREAT_DATA_DIR;
-    if (tdDir) {
+    // unverified threat data.
+    if (ag.threatDataDir) {
+      const tdDir = ag.threatDataDir;
       const { verifyThreatData } = await import("./airgap/threat-data.js");
-      const pubRef = process.env.KIT_THREAT_DATA_PUBKEY ?? "";
-      const pubPem = existsSync(pubRef) ? readFileSync(pubRef, "utf8") : pubRef;
+      const pubRef = ag.threatDataPubkey ?? "";
+      const pubPem = pubRef && existsSync(pubRef) ? readFileSync(pubRef, "utf8") : pubRef;
       if (!pubPem) {
         console.error(
-          `${c.red}✗ KIT_THREAT_DATA_DIR set but KIT_THREAT_DATA_PUBKEY missing — cannot verify the bundle (fail-closed)${c.reset}`,
+          `${c.red}✗ air-gap threat-data dir set but no public key (threat_data_pubkey / KIT_THREAT_DATA_PUBKEY) — cannot verify (fail-closed)${c.reset}`,
         );
         return false;
       }
@@ -4533,7 +4538,6 @@ async function cmdScan(): Promise<boolean> {
       );
     }
   }
-  const config = await loadConfig(resolveConfigPath());
 
   // Resolve scanner tokens (SNYK_TOKEN, …) from a configured tooling Infisical
   // project so `kit scan` works without an `infisical run` wrapper (#65). The

--- a/src/config.ts
+++ b/src/config.ts
@@ -300,6 +300,20 @@ export interface kitConfig {
   supply_chain?: { internal_scopes?: string[] };
   /** `kit scan` settings — a tooling Infisical project to resolve scanner tokens (SNYK_TOKEN, …) from. */
   scan?: { tooling?: { project_id?: string; env?: string } };
+  /**
+   * No-egress / air-gapped posture (declarative; see docs/AIR_GAP.md). Equivalent
+   * to the `KIT_*` env vars, but checked in so the enclave config is reproducible.
+   * Env vars, when set, override these. `enabled` turns on offline scan mode.
+   */
+  air_gap?: {
+    enabled?: boolean;
+    npm_registry?: string;
+    pypi_index?: string;
+    github_api?: string;
+    docker_registry?: string;
+    threat_data_dir?: string;
+    threat_data_pubkey?: string;
+  };
   web?: {
     search?: WebSearchConfig;
   };
@@ -563,6 +577,18 @@ const kitConfigSchema = z
           .object({ project_id: z.string().optional(), env: z.string().optional() })
           .passthrough()
           .optional(),
+      })
+      .passthrough()
+      .optional(),
+    air_gap: z
+      .object({
+        enabled: z.boolean().optional(),
+        npm_registry: z.string().optional(),
+        pypi_index: z.string().optional(),
+        github_api: z.string().optional(),
+        docker_registry: z.string().optional(),
+        threat_data_dir: z.string().optional(),
+        threat_data_pubkey: z.string().optional(),
       })
       .passthrough()
       .optional(),

--- a/src/triage.ts
+++ b/src/triage.ts
@@ -64,6 +64,23 @@ async function ensureTriageScript(): Promise<boolean> {
 }
 
 /**
+ * Mirror env vars (KIT_NPM_REGISTRY, …) derived from `.kit.toml [air_gap]`, so a
+ * config-declared internal mirror is honored by the triage subprocess even when
+ * the operator didn't export the env var. Best-effort: never breaks triage if
+ * the config can't be read. Env vars already in `process.env` still win.
+ */
+async function airGapMirrorEnv(): Promise<Record<string, string>> {
+  try {
+    const { loadConfig } = await import("./config.js");
+    const { resolveAirGap, airGapTriageEnv } = await import("./airgap/config.js");
+    const cfg = await loadConfig(resolve(process.cwd(), ".kit.toml"));
+    return airGapTriageEnv(resolveAirGap(cfg.air_gap, process.env));
+  } catch {
+    return {};
+  }
+}
+
+/**
  * Run triage on a target
  */
 export async function runTriage(type: TriageType, target: string): Promise<TriageResult> {
@@ -78,11 +95,11 @@ export async function runTriage(type: TriageType, target: string): Promise<Triag
   }
 
   try {
-    const { stdout, stderr } = await exec(
-      "python3",
-      [TRIAGE_SCRIPT, type, target],
-      { timeout: 300_000 }, // 5 min for Docker pulls
-    );
+    const { stdout, stderr } = await exec("python3", [TRIAGE_SCRIPT, type, target], {
+      timeout: 300_000, // 5 min for Docker pulls
+      // config-declared mirrors, with real env taking precedence
+      env: { ...(await airGapMirrorEnv()), ...process.env },
+    });
 
     const output = stdout + (stderr ? `\n${stderr}` : "");
     const passed = output.includes("TRIAGE PASSED");


### PR DESCRIPTION
Fourth step of the no-egress roadmap (#80). The air-gap posture was env-only; this makes it **declarative + checked in** so an enclave config is reproducible and versioned.

- New `[air_gap]` section in the config schema (interface + zod): `enabled`, `npm_registry`/`pypi_index`/`github_api`/`docker_registry`, `threat_data_dir`/`threat_data_pubkey`.
- `resolveAirGap(config, env)` (pure, tested) merges config + env with **env taking precedence**; `airGapTriageEnv()` emits the mirror vars to inject.
- `kit scan` resolves the posture from config+env (so `enabled = true` in `.kit.toml` turns on offline mode without an env var) and reads threat-data dir/pubkey from the resolved settings.
- `runTriage` injects config-declared mirror env into the triage subprocess (best-effort; real env still wins) so a `.kit.toml` mirror is honored without exporting `KIT_*`.
- `docs/AIR_GAP.md` documents the declarative block.

```toml
[air_gap]
enabled = true
npm_registry = "https://npm.corp.internal"
threat_data_dir = "/opt/kit/threat-data"
threat_data_pubkey = "/etc/kit/threat-data.pub"
```

⚠️ **Stacked on #84** (→ #83 → #73). Merge order: #73 → #83 → #84 → this.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_