### PR TITLE
feat(agent-audit): cover OpenCode + Codex agents

### DIFF
--- a/src/agent-audit.test.ts
+++ b/src/agent-audit.test.ts
@@ -99,3 +99,26 @@ describe("auditMcpStdio", () => {
     assert.deepEqual(auditMcpStdio("not json"), []);
   });
 });
+
+describe("OpenCode `mcp` container coverage", () => {
+  it("flags a cleartext http:// remote server nested under `mcp`", () => {
+    const cfg = JSON.stringify({
+      mcp: {
+        local: { type: "remote", url: "http://mcp.internal:8080" },
+        good: { type: "remote", url: "https://mcp.ok" },
+      },
+    });
+    const hits = auditMcpServers(cfg);
+    assert.equal(hits.length, 1);
+    assert.match(hits[0], /^local → http:\/\//);
+  });
+
+  it("flags an inline-code stdio server nested under `mcp`", () => {
+    const cfg = JSON.stringify({
+      mcp: { evil: { command: "node", args: ["-e", "doBadThings()"] } },
+    });
+    const hits = auditMcpStdio(cfg);
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0].server, "evil");
+  });
+});

--- a/src/agent-audit.ts
+++ b/src/agent-audit.ts
@@ -39,6 +39,7 @@ export function auditMcpServers(json: string): string[] {
   const containers = [
     (obj as { mcpServers?: Record<string, unknown> })?.mcpServers,
     (obj as { servers?: Record<string, unknown> })?.servers,
+    (obj as { mcp?: Record<string, unknown> })?.mcp, // OpenCode nests servers under `mcp`
   ].filter((c): c is Record<string, unknown> => !!c && typeof c === "object");
   for (const servers of containers) {
     for (const [name, def] of Object.entries(servers)) {
@@ -110,6 +111,7 @@ export function auditMcpStdio(json: string): StdioMcpFinding[] {
   const containers = [
     (obj as { mcpServers?: Record<string, unknown> })?.mcpServers,
     (obj as { servers?: Record<string, unknown> })?.servers,
+    (obj as { mcp?: Record<string, unknown> })?.mcp, // OpenCode nests servers under `mcp`
   ].filter((c): c is Record<string, unknown> => !!c && typeof c === "object");
   const out: StdioMcpFinding[] = [];
   for (const servers of containers) {
@@ -154,6 +156,13 @@ const CONFIG_FILES = [
   ".vscode/mcp.json",
   ".claude/settings.json",
   ".claude/settings.local.json",
+  // OpenCode (project config carries an `mcp` block) + Codex CLI. secrets-in-config
+  // is format-agnostic (findSecrets reads raw text); the JSON-shaped MCP checks
+  // simply no-op on the TOML files.
+  "opencode.json",
+  "opencode.jsonc",
+  ".codex/config.toml",
+  ".codex/config.json",
 ];
 
 const HOOK_DIRS = [".git/hooks", ".githooks", ".husky"];

--- a/src/scan-transcripts.test.ts
+++ b/src/scan-transcripts.test.ts
@@ -66,4 +66,17 @@ describe("scanTranscripts", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("scans the Codex CLI .codex dir", async () => {
+    const dir = makeRepo();
+    try {
+      mkdirSync(join(dir, ".codex"), { recursive: true });
+      writeFileSync(join(dir, ".codex", "session.jsonl"), '{"text":"AKIA0123456789ABCDEF"}\n');
+      const hits = await scanTranscripts(dir);
+      assert.equal(hits.length, 1);
+      assert.ok(hits[0].file.includes(".codex"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/scan-transcripts.ts
+++ b/src/scan-transcripts.ts
@@ -14,6 +14,7 @@ import { findSecrets, type SecretFinding } from "./utils/redactSecrets.js";
  * Scans:
  *   - `<repo>/.claude/`           — project-local Claude Code state
  *   - `<repo>/.opencode/`         — OpenCode local state
+ *   - `<repo>/.codex/`            — Codex CLI local state
  *   - `~/.claude/projects/<repo>/` — global Claude Code project cache
  *   - `~/.claude/projects/-<repo-path>/` — same, with normalized slashes
  *
@@ -72,17 +73,18 @@ export async function scanTranscripts(cwd: string = process.cwd()): Promise<Tran
   const candidates: string[] = [];
 
   // Project-local agent dirs
-  for (const local of [".claude", ".opencode", ".cursor", ".aider"]) {
+  for (const local of [".claude", ".opencode", ".cursor", ".aider", ".codex"]) {
     const full = resolve(cwd, local);
     if (await dirExists(full)) candidates.push(full);
   }
 
-  // Global Claude Code project cache (best-effort slug match)
+  // Global agent project caches (best-effort slug match)
   const home = homedir();
   const slug = repoSlug(cwd);
   for (const global of [
     join(home, ".claude", "projects", slug),
     join(home, ".opencode", "projects", slug),
+    join(home, ".codex", "projects", slug),
   ]) {
     if (await dirExists(global)) candidates.push(global);
   }


### PR DESCRIPTION
Broadens kit's agent coverage beyond Claude/Cursor/VSCode (the opencode/codex/t3code question):

- **agent-audit**: scans `opencode.json`/`opencode.jsonc` + `.codex/config.*` for plaintext secrets (format-agnostic via findSecrets), and recognizes OpenCode's `mcp` server container in the cleartext-http and inline-code stdio checks.
- **scan-transcripts**: walks `.codex/` (+ `~/.codex/projects/<slug>`) for replayed-secret leaks, alongside the existing `.claude`/`.opencode`/`.cursor`/`.aider`.

Covers agents driven through the **t3code** GUI harness too, since it runs the underlying Codex/Claude/Cursor/OpenCode whose dirs these are. Follow-up: OpenCode's array-form `command` isn't stdio-audited yet (missed detection, not a false positive).

⚠️ **Stacked on #75** (base = `feat/agent-audit-stdio-mcp`).

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_