### PR TITLE
fix(governance): fail-closed audit for destructive ops (F2)

### DIFF
--- a/src/audit.test.ts
+++ b/src/audit.test.ts
@@ -408,3 +408,49 @@ describe("verifyAuditChain (tamper-evidence)", () => {
     assert.match(r.reason!, /missing hash/);
   });
 });
+
+describe("logAuditEvent return value (fail-closed signal)", () => {
+  function cfg(logFile: string): any {
+    return {
+      enabled: true,
+      environment: "dev",
+      access: {},
+      agent: { id: "a", name: "A" },
+      audit: { enabled: true, log_file: logFile, include_secrets: false },
+      approval: {},
+      secrets: {},
+      revocation: {},
+    };
+  }
+
+  it("returns true when the local append succeeds", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-audit-ok-"));
+    try {
+      const ok = await logAuditEvent(cfg(join(dir, ".kit-audit.jsonl")), {
+        operation: "x",
+        environment: "dev",
+        success: true,
+      });
+      assert.equal(ok, true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns false when the local append fails (unwritable path)", async () => {
+    const bad = join(tmpdir(), `kit-audit-nope-${process.pid}`, "deep", ".kit-audit.jsonl");
+    const ok = await logAuditEvent(cfg(bad), {
+      operation: "x",
+      environment: "dev",
+      success: true,
+    });
+    assert.equal(ok, false);
+  });
+
+  it("returns true when audit is disabled (nothing to gate)", async () => {
+    const c = cfg("/whatever");
+    c.audit.enabled = false;
+    const ok = await logAuditEvent(c, { operation: "x", environment: "dev", success: true });
+    assert.equal(ok, true);
+  });
+});

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -264,9 +264,10 @@ export async function logAuditEvent(
   config: Required<GovernanceConfig>,
   event: Omit<AuditEvent, "timestamp" | "agent_id" | "agent_name">,
   companyId?: string,
-): Promise<void> {
+): Promise<boolean> {
+  // Audit disabled by config → nothing to write, nothing to gate on.
   if (!config.audit.enabled) {
-    return;
+    return true;
   }
 
   const auditEvent: AuditEvent = {
@@ -281,12 +282,16 @@ export async function logAuditEvent(
     auditEvent.metadata = sanitizeMetadata(auditEvent.metadata);
   }
 
-  // Write to local JSONL file (hash-chained for tamper-evidence)
+  // Write to local JSONL file (hash-chained for tamper-evidence). The boolean
+  // return lets fail-closed callers (e.g. destructive ops in withGovernance)
+  // refuse to proceed when the local audit append fails.
   const logFile = config.audit.log_file || ".kit-audit.jsonl";
   const logPath = resolve(process.cwd(), logFile);
 
+  let wroteLocal = false;
   try {
     await appendChained(logPath, auditEvent);
+    wroteLocal = true;
   } catch (error) {
     console.error(`Failed to write audit log: ${error}`);
   }
@@ -299,6 +304,9 @@ export async function logAuditEvent(
     warnFirstRemotePush(companyId);
     await sendToRemoteAPI(auditEvent, companyId);
   }
+
+  // Auditability is the local append; remote is best-effort and does not gate.
+  return wroteLocal;
 }
 
 /**

--- a/src/governance-middleware.ts
+++ b/src/governance-middleware.ts
@@ -130,6 +130,22 @@ export async function withGovernance<T>(
     }
   }
 
+  // Fail-closed auditability for DESTRUCTIVE ops: persist an authorization entry
+  // BEFORE executing and refuse if it can't be written. The post-execution
+  // success log alone is fail-open (the op would run unlogged if the audit
+  // append failed) — this closes that gap for the operations that matter most.
+  if (context.destructive) {
+    const logged = await logAuditEvent(governanceConfig, {
+      operation: context.operation,
+      environment: governanceConfig.environment,
+      success: true,
+      metadata: { ...context.metadata, phase: "authorized" },
+    });
+    if (!logged) {
+      throw new Error("audit-log unavailable; refusing destructive operation (fail-closed)");
+    }
+  }
+
   // Execute the operation
   let error: string | undefined;
   let result: T;


### PR DESCRIPTION
Closes the F2 finding (#81): `withGovernance`'s allow-path was fail-OPEN on audit logging — a destructive op ran (success logged only AFTER execution), so a failed audit append left the op executed-but-unlogged. Only deny paths failed closed, despite the "fails closed" framing.

- `logAuditEvent` now returns a boolean (true on local-append success, true when audit disabled, false on write failure). Backward-compatible — existing callers ignore it.
- `withGovernance` persists an "authorized" audit entry **before** executing a `context.destructive` op and **refuses (throws fail-closed)** if it can't be written. Non-destructive ops keep best-effort logging.

Tests cover logAuditEvent's return (success / unwritable / disabled). Full suite 1451/0.

⚠️ **Stacked on #86** (base = `feat/audit-tamper-evident`).

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_