### PR TITLE
chore(hardening): remove dead one-shot scope code + harden tar extraction

### DIFF
--- a/src/bumblebee.ts
+++ b/src/bumblebee.ts
@@ -298,7 +298,15 @@ async function downloadAndInstall(
     const tarPath = join(staging, target.assetName);
     await writeFile(tarPath, buf);
     // bumblebee tarballs extract flat: ./bumblebee, ./threat_intel/, LICENSE, README.md
-    await exec("tar", ["-xzf", tarPath, "-C", staging], { timeout: 60_000 });
+    // --no-same-owner/--no-same-permissions: don't let archived ownership/mode
+    // bits carry over (defense-in-depth; the tarball is checksum-pinned).
+    await exec(
+      "tar",
+      ["--no-same-owner", "--no-same-permissions", "-xzf", tarPath, "-C", staging],
+      {
+        timeout: 60_000,
+      },
+    );
 
     const stagedBin = join(staging, "bumblebee");
     const stagedCatalog = join(staging, "threat_intel");

--- a/src/elevation.test.ts
+++ b/src/elevation.test.ts
@@ -10,7 +10,6 @@ import {
   clearElevation,
   requireElevation,
   consumeElevation,
-  isOneShotScope,
   _resetConsumedElevationForTests,
   generateTotp,
   verifyTotp,
@@ -262,13 +261,6 @@ describe("requireElevation audit emission", () => {
 });
 
 describe("consumeElevation (one-shot)", () => {
-  it("identifies the destructive scopes", () => {
-    assert.equal(isOneShotScope("jwt-secret-roll"), true);
-    assert.equal(isOneShotScope("purge-history"), true);
-    assert.equal(isOneShotScope("onecli-register"), true);
-    assert.equal(isOneShotScope("rotate"), false);
-  });
-
   it("only allows one consume per process for the same scope", async () => {
     const dir = tmpRepo();
     _resetConsumedElevationForTests();

--- a/src/elevation.ts
+++ b/src/elevation.ts
@@ -23,21 +23,10 @@ import { appendAuditEventDirect } from "./audit.js";
 const ELEVATION_FILE = ".kit/elevation.json";
 const DEFAULT_TTL_MINUTES = 15;
 
-/**
- * Scopes that, when granted, MUST be consumed (atomically deleted) on use.
- * One elevation = one destructive operation. Rotation modes that need a
- * follow-up rollback path (scoped-key-mint) are intentionally absent — they
- * retain the standard 15-min TTL because the rollback re-uses the marker.
- */
-const ONE_SHOT_SCOPES: ReadonlySet<string> = new Set([
-  "jwt-secret-roll",
-  "purge-history",
-  "onecli-register",
-]);
-
-export function isOneShotScope(scope: string): boolean {
-  return ONE_SHOT_SCOPES.has(scope);
-}
+// (Removed dead `ONE_SHOT_SCOPES` / `isOneShotScope`: never called in
+// production, and its scope strings had drifted from the real ones. The
+// authoritative one-shot decision lives in elevation-scopes.ts →
+// `scopeFor(...).oneShot`.)
 
 /**
  * Loud one-time stderr warning for the CI escape hatch. Emitted once per

--- a/src/triage-sandbox.ts
+++ b/src/triage-sandbox.ts
@@ -90,7 +90,11 @@ export async function triageNpmSandbox(
   }
 
   // 2. Extract into the same tmpdir for inspection.
-  await exec("tar", ["xzf", tarballPath, "-C", work], { timeout: 30_000 });
+  // --no-same-owner/--no-same-permissions: archived ownership/mode bits must not
+  // carry over to the inspecting host (defense-in-depth).
+  await exec("tar", ["--no-same-owner", "--no-same-permissions", "xzf", tarballPath, "-C", work], {
+    timeout: 30_000,
+  });
   const pkgRoot = join(work, "package");
 
   // 3. Path traversal check — npm packs everything under "package/", anything


### PR DESCRIPTION
Two small #81 hardening items:

- **Remove dead `ONE_SHOT_SCOPES`/`isOneShotScope`** (elevation.ts): never called in production, and its scope strings had drifted from the real ones (a misleading second source of truth). The authoritative one-shot decision is `scopeFor(...).oneShot` in elevation-scopes.ts.
- **Harden tar extraction** (bumblebee + triage-sandbox): add `--no-same-owner --no-same-permissions` so archived ownership/mode bits don't carry onto the host. Defense-in-depth — the bumblebee tarball is checksum-pinned; deeper symlink-escape containment for a future poisoned pin stays a tracked follow-up.

Full suite green. Independent of the other branches.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_