### PR TITLE
feat(memory): opt-in redaction-at-capture (KIT_MEMORY_REDACT)

### DIFF
--- a/src/memory/db.test.ts
+++ b/src/memory/db.test.ts
@@ -165,3 +165,35 @@ describe("memory db", () => {
     db.close();
   });
 });
+
+describe("redaction-at-capture (KIT_MEMORY_REDACT)", () => {
+  const SECRET = ["sk", "live", "Z".repeat(40)].join("_");
+  function insertAndRead(redact: boolean): string {
+    const prev = process.env.KIT_MEMORY_REDACT;
+    if (redact) process.env.KIT_MEMORY_REDACT = "1";
+    else delete process.env.KIT_MEMORY_REDACT;
+    try {
+      const db = openMemoryDb(":memory:");
+      upsertSession(db, { sessionId: "s", harness: "claude-code" });
+      insertMessage(db, { uuid: "u", sessionId: "s", type: "user", content: `key ${SECRET}` });
+      const row = db.prepare("SELECT content FROM messages WHERE uuid = ?").get("u") as {
+        content: string;
+      };
+      db.close();
+      return row.content;
+    } finally {
+      if (prev === undefined) delete process.env.KIT_MEMORY_REDACT;
+      else process.env.KIT_MEMORY_REDACT = prev;
+    }
+  }
+
+  it("stores raw content by default (opt-in off)", () => {
+    assert.ok(insertAndRead(false).includes(SECRET));
+  });
+
+  it("masks secrets at capture when KIT_MEMORY_REDACT=1", () => {
+    const c = insertAndRead(true);
+    assert.ok(!c.includes(SECRET), "secret must not be persisted");
+    assert.match(c, /\[REDACTED\]/);
+  });
+});

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -17,8 +17,25 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { existsSync, mkdirSync, chmodSync, statSync } from "node:fs";
 import type { MemoryStats, MessageInput, SearchHit, SessionInput, ToolUseInput } from "./types.js";
+import { redactSecrets } from "../utils/redactSecrets.js";
 
 export const SCHEMA_VERSION = 3;
+
+/**
+ * Opt-in redaction-at-capture (KIT_MEMORY_REDACT=1). The memory store is raw by
+ * default; a regulated/air-gapped deployment can have secret-shaped substrings
+ * masked BEFORE they ever land in memory.db, so a leaked key in a transcript is
+ * never persisted (spillage prevention). Off by default — no behavior change.
+ */
+function captureRedactEnabled(): boolean {
+  return ["1", "true", "yes"].includes((process.env.KIT_MEMORY_REDACT ?? "").trim().toLowerCase());
+}
+
+/** Apply capture-time redaction to a stored text field when enabled. */
+function captureText(text: string | null | undefined): string | null {
+  if (text == null) return null;
+  return captureRedactEnabled() ? redactSecrets(text) : text;
+}
 
 export function getMemoryDir(): string {
   return process.env.KIT_MEMORY_DIR ?? join(homedir(), ".kit");
@@ -235,7 +252,7 @@ export function insertMessage(db: DatabaseSync, m: MessageInput): boolean {
       m.parentUuid ?? null,
       m.type,
       m.role ?? null,
-      m.content ?? null,
+      captureText(m.content),
       m.model ?? null,
       m.inputTokens ?? null,
       m.outputTokens ?? null,
@@ -261,7 +278,7 @@ export function insertToolUse(db: DatabaseSync, t: ToolUseInput): void {
     t.messageUuid ?? null,
     t.sessionId ?? null,
     t.toolName,
-    t.toolInput ?? null,
+    captureText(t.toolInput),
     t.timestamp ?? null,
   );
 }


### PR DESCRIPTION
No-egress roadmap (#80): spillage prevention for the secret-dense memory store.

The store is raw by default (a key in any transcript is persisted to `memory.db` in cleartext). With **`KIT_MEMORY_REDACT=1`**, secret-shaped substrings in a message's `content` and a tool's `tool_input` are masked (same `redactSecrets` patterns) **before** they're written — the secret never lands in the DB.

**Opt-in / off by default** → no behavior change (raw storage stays the documented default; full suite 1445/0). FTS search still works over the redacted text for non-secret terms. Row-level class-tagging is a further follow-up. Independent of the other branches.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_