### PR TITLE
feat(airgap): offline provenance verification (kit verify-provenance)

### DIFF
--- a/docs/AIR_GAP.md
+++ b/docs/AIR_GAP.md
@@ -144,6 +144,42 @@ periodically refreshing `trusted_root.json` (a TUF mirror snapshot or pinned
 roots) from a connected host — that is the trust anchor for offline
 verification.
 
+## 5. Memory in a classified enclave
+
+kit's memory store inherits the **classification of the machine it runs on**.
+There is intentionally **no per-row classification column**, for two reasons:
+
+1. **Under system-high it is redundant.** A workstation accredited at one level
+   (e.g. SECRET) treats everything on it at that level — every captured row is
+   already SECRET, so a column adds no information.
+2. **kit cannot enforce it.** Multi-level separation is the job of a trusted
+   reference monitor in the OS (SELinux MLS, labeled IPC/filesystems), not a CLI
+   reading and writing its own SQLite file. A classification field that kit
+   manages itself would be advisory metadata dressed up as a control — it would
+   imply a separation guarantee kit cannot keep. kit does not claim to separate
+   classification levels internally.
+
+The operational posture instead:
+
+- **The whole `memory.db` carries the enclave's level.** Run kit at system-high;
+  treat the database, its WAL, and any backups at the accredited level.
+- **File handling is already conservative.** Encrypted backups and restores are
+  written `0o600` (owner-only); store `memory.db` on the same labeled volume as
+  the rest of the enclave's data at that level.
+- **Purge = delete the database.** On a system-high machine there is no lower
+  level to preserve, so spill or decommission response is to destroy `memory.db`
+  (and backups) per your media-handling procedure, not to filter a column.
+- **Capture-time redaction still applies.** `KIT_MEMORY_REDACT` strips secrets
+  before they ever reach the store (see redaction docs); that is orthogonal to
+  classification and worth enabling regardless of level.
+- **Spill (wrong-level content pasted into a higher machine) is a procedural
+  matter**, handled by your incident process — not something an application-level
+  tag can prevent or remediate.
+
+If you genuinely need a single install to span multiple levels, that is an
+OS/MLS platform requirement: accredit the platform for multi-level operation and
+run kit on top of it. It is not, and should not be, a kit feature.
+
 ## What still never leaves the enclave
 
 Secret resolution, the memory store, the audit log, `kit check`/`review`

--- a/docs/AIR_GAP.md
+++ b/docs/AIR_GAP.md
@@ -116,13 +116,33 @@ Build the bundle on a connected host (sync DBs → write manifest with SHA-256 �
 - `KIT_BUMBLEBEE_CATALOG` — point at an internally-mirrored exposure catalog.
 - `KIT_BUMBLEBEE=0` — disable the download/scan entirely where policy forbids it.
 
-## 4. Known limitation: provenance verification
+## 4. Offline provenance verification
 
-cosign/SLSA provenance verification depends on Sigstore's Fulcio CA + Rekor
-transparency log, which are public services. Full online verification is not
-possible in a no-egress enclave today; use offline-bundle verification where
-your toolchain supports it, or treat provenance as an out-of-band, connected-host
-check. (Tracked as an air-gap follow-up.)
+cosign/SLSA verification normally reaches Sigstore's Fulcio CA + Rekor log
+(public). `kit verify-provenance` runs cosign **fully offline** instead: it uses
+the bundle's inclusion proof (`--offline`) and a **shipped-in** Sigstore
+`trusted_root.json` (`--trusted-root`) that you distribute and refresh into the
+enclave — no Fulcio/Rekor egress. kit does not reimplement the crypto; it
+orchestrates cosign and is **fail-closed** (missing cosign, missing trust root,
+missing identity constraints, or any non-zero cosign exit ⇒ NOT verified).
+
+```bash
+kit verify-provenance dist/app.tar.gz \
+  --bundle dist/app.sigstore \
+  --trusted-root /etc/kit/trusted_root.json \
+  --identity "https://github.com/org/repo/.github/workflows/release.yml@refs/tags/v1" \
+  --issuer  "https://token.actions.githubusercontent.com"
+```
+
+Defaults for `--trusted-root` / `--identity` / `--issuer` can live in
+`.kit.toml [air_gap]` (`provenance_trusted_root` / `provenance_cert_identity` /
+`provenance_cert_issuer`) or the matching `KIT_PROVENANCE_*` env vars, so the
+command is just `kit verify-provenance <artifact> --bundle <file>`.
+
+**Operational note:** the enclave owner is responsible for distributing and
+periodically refreshing `trusted_root.json` (a TUF mirror snapshot or pinned
+roots) from a connected host — that is the trust anchor for offline
+verification.
 
 ## What still never leaves the enclave
 

--- a/src/airgap/config.ts
+++ b/src/airgap/config.ts
@@ -16,6 +16,10 @@ export interface AirGapSettings {
   threatDataDir?: string;
   /** Trusted Ed25519 public key — a file path or an inline PEM. */
   threatDataPubkey?: string;
+  /** Offline provenance: shipped-in Sigstore trusted_root.json + identity constraints. */
+  provenanceTrustedRoot?: string;
+  provenanceCertIdentity?: string;
+  provenanceCertIssuer?: string;
 }
 
 function envTrue(v: string | undefined): boolean {
@@ -44,6 +48,9 @@ export function resolveAirGap(
     dockerRegistry: pick(env.KIT_DOCKER_REGISTRY, ag.docker_registry),
     threatDataDir: pick(env.KIT_THREAT_DATA_DIR, ag.threat_data_dir),
     threatDataPubkey: pick(env.KIT_THREAT_DATA_PUBKEY, ag.threat_data_pubkey),
+    provenanceTrustedRoot: pick(env.KIT_PROVENANCE_TRUSTED_ROOT, ag.provenance_trusted_root),
+    provenanceCertIdentity: pick(env.KIT_PROVENANCE_CERT_IDENTITY, ag.provenance_cert_identity),
+    provenanceCertIssuer: pick(env.KIT_PROVENANCE_CERT_ISSUER, ag.provenance_cert_issuer),
   };
 }
 

--- a/src/airgap/provenance.test.ts
+++ b/src/airgap/provenance.test.ts
@@ -1,0 +1,78 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildCosignArgs,
+  missingField,
+  verifyProvenance,
+  type ProvenanceVerifyOptions,
+  type ProvenanceDeps,
+} from "./provenance.js";
+
+const full: ProvenanceVerifyOptions = {
+  artifact: "dist/app.tar.gz",
+  bundle: "dist/app.sigstore",
+  trustedRoot: "/etc/kit/trusted_root.json",
+  certIdentity: "https://github.com/org/repo/.github/workflows/release.yml@refs/tags/v1",
+  certIssuer: "https://token.actions.githubusercontent.com",
+};
+
+describe("missingField", () => {
+  it("returns null when all required fields are present", () => {
+    assert.equal(missingField(full), null);
+  });
+  it("flags the first missing/empty field", () => {
+    assert.equal(missingField({ ...full, bundle: "" }), "bundle");
+    assert.equal(missingField({ artifact: "a" }), "bundle");
+  });
+});
+
+describe("buildCosignArgs", () => {
+  it("builds an offline verify-blob argv with trust root + identity constraints", () => {
+    assert.deepEqual(buildCosignArgs(full), [
+      "verify-blob",
+      "--offline",
+      "--trusted-root",
+      "/etc/kit/trusted_root.json",
+      "--bundle",
+      "dist/app.sigstore",
+      "--certificate-identity",
+      full.certIdentity,
+      "--certificate-oidc-issuer",
+      full.certIssuer,
+      "dist/app.tar.gz",
+    ]);
+  });
+});
+
+describe("verifyProvenance (fail-closed)", () => {
+  const okRun = async () => ({ ok: true, stdout: "Verified OK", stderr: "" });
+
+  it("verifies when cosign exits 0", async () => {
+    const deps: ProvenanceDeps = { resolveBin: async () => "/usr/bin/cosign", run: okRun };
+    assert.deepEqual(await verifyProvenance(full, deps), { ok: true });
+  });
+
+  it("refuses (fail-closed) when a required field is missing", async () => {
+    const deps: ProvenanceDeps = { resolveBin: async () => "/usr/bin/cosign", run: okRun };
+    const r = await verifyProvenance({ ...full, certIdentity: "" }, deps);
+    assert.equal(r.ok, false);
+    assert.match(r.ok === false ? r.reason : "", /certIdentity/);
+  });
+
+  it("refuses when cosign is not installed", async () => {
+    const deps: ProvenanceDeps = { resolveBin: async () => null, run: okRun };
+    const r = await verifyProvenance(full, deps);
+    assert.equal(r.ok, false);
+    assert.match(r.ok === false ? r.reason : "", /cosign not found/);
+  });
+
+  it("refuses when cosign rejects the bundle (non-zero)", async () => {
+    const deps: ProvenanceDeps = {
+      resolveBin: async () => "/usr/bin/cosign",
+      run: async () => ({ ok: false, stdout: "", stderr: "error: no matching signatures" }),
+    };
+    const r = await verifyProvenance(full, deps);
+    assert.equal(r.ok, false);
+    assert.match(r.ok === false ? r.reason : "", /cosign rejected the bundle/);
+  });
+});

--- a/src/airgap/provenance.ts
+++ b/src/airgap/provenance.ts
@@ -1,0 +1,103 @@
+/**
+ * Offline SLSA/Sigstore provenance verification for an air-gapped enclave.
+ *
+ * kit does NOT reimplement Sigstore verification — it orchestrates **cosign**,
+ * the correct verifier, in fully OFFLINE mode:
+ *
+ *   cosign verify-blob --offline \
+ *     --trusted-root <shipped-in trusted_root.json> \
+ *     --bundle <artifact.bundle> \
+ *     --certificate-identity <id> --certificate-oidc-issuer <iss> \
+ *     <artifact>
+ *
+ * `--offline` skips the Rekor network lookup (uses the bundle's inclusion
+ * proof); `--trusted-root` supplies the Fulcio/Rekor/CT trust roots that the
+ * operator distributes into the enclave (no Fulcio/Rekor egress). Everything is
+ * FAIL-CLOSED: a missing cosign, missing trust root, missing identity
+ * constraints, or a non-zero exit all mean NOT VERIFIED — kit never reports
+ * "verified" unless cosign returned success.
+ */
+
+export interface ProvenanceVerifyOptions {
+  /** Path to the artifact whose provenance is being checked. */
+  artifact: string;
+  /** Path to the Sigstore bundle (.sigstore/.bundle) for the artifact. */
+  bundle: string;
+  /** Path to a shipped-in Sigstore trusted_root.json (the offline trust anchor). */
+  trustedRoot: string;
+  /** Required identity constraint — the SAN cosign must match (e.g. a repo URI). */
+  certIdentity: string;
+  /** Required OIDC issuer constraint (e.g. https://token.actions.githubusercontent.com). */
+  certIssuer: string;
+}
+
+/** Fields that must all be present, or verification is refused (fail-closed). */
+const REQUIRED: (keyof ProvenanceVerifyOptions)[] = [
+  "artifact",
+  "bundle",
+  "trustedRoot",
+  "certIdentity",
+  "certIssuer",
+];
+
+/** Returns the first missing/empty required field, or null when all present. */
+export function missingField(opts: Partial<ProvenanceVerifyOptions>): string | null {
+  for (const k of REQUIRED) {
+    const v = opts[k];
+    if (typeof v !== "string" || v.trim() === "") return k;
+  }
+  return null;
+}
+
+/** Build the cosign argv for offline blob verification. Pure (assumes validated opts). */
+export function buildCosignArgs(opts: ProvenanceVerifyOptions): string[] {
+  return [
+    "verify-blob",
+    "--offline",
+    "--trusted-root",
+    opts.trustedRoot,
+    "--bundle",
+    opts.bundle,
+    "--certificate-identity",
+    opts.certIdentity,
+    "--certificate-oidc-issuer",
+    opts.certIssuer,
+    opts.artifact,
+  ];
+}
+
+export interface ProvenanceDeps {
+  /** Resolve the cosign binary, or null if not installed. */
+  resolveBin: (bin: string) => Promise<string | null>;
+  /** Run a command without throwing; ok=true iff exit 0. */
+  run: (bin: string, args: string[]) => Promise<{ ok: boolean; stdout: string; stderr: string }>;
+}
+
+export type ProvenanceResult = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Verify provenance offline via cosign. Fail-closed: any missing input,
+ * missing cosign, or non-zero cosign exit → `{ ok: false }`. Only a clean
+ * cosign success returns `{ ok: true }`.
+ */
+export async function verifyProvenance(
+  opts: Partial<ProvenanceVerifyOptions>,
+  deps: ProvenanceDeps,
+): Promise<ProvenanceResult> {
+  const missing = missingField(opts);
+  if (missing) {
+    return { ok: false, reason: `missing ${missing} — cannot verify provenance (fail-closed)` };
+  }
+  const cosign = await deps.resolveBin("cosign");
+  if (!cosign) {
+    return { ok: false, reason: "cosign not found — cannot verify provenance (fail-closed)" };
+  }
+  const args = buildCosignArgs(opts as ProvenanceVerifyOptions);
+  const res = await deps.run(cosign, args);
+  if (!res.ok) {
+    const detail =
+      (res.stderr || res.stdout || "").trim().split("\n").pop() ?? "verification failed";
+    return { ok: false, reason: `cosign rejected the bundle: ${detail}` };
+  }
+  return { ok: true };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4486,6 +4486,57 @@ async function cmdSentinelStatus(): Promise<boolean> {
   return true;
 }
 
+async function cmdVerifyProvenance(): Promise<boolean> {
+  const args = process.argv.slice(3);
+  // First positional that isn't a value-flag's argument = the artifact.
+  const VALUE_FLAGS = new Set(["--bundle", "--trusted-root", "--identity", "--issuer"]);
+  let artifact: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    if (VALUE_FLAGS.has(args[i])) {
+      i++;
+      continue;
+    }
+    if (!args[i].startsWith("-")) {
+      artifact = args[i];
+      break;
+    }
+  }
+  if (!artifact) {
+    console.error(
+      "usage: kit verify-provenance <artifact> --bundle <file> [--trusted-root <f>] [--identity <id>] [--issuer <iss>]",
+    );
+    return false;
+  }
+  const { resolveAirGap } = await import("./airgap/config.js");
+  const { verifyProvenance } = await import("./airgap/provenance.js");
+  const { resolveToolBin } = await import("./utils/resolveTool.js");
+  const { execFileNoThrow } = await import("./utils/execFileNoThrow.js");
+  const config = await loadConfig(resolveConfigPath());
+  const ag = resolveAirGap(config.air_gap, process.env);
+  const res = await verifyProvenance(
+    {
+      artifact,
+      bundle: flagValue(args, "--bundle"),
+      trustedRoot: flagValue(args, "--trusted-root") ?? ag.provenanceTrustedRoot,
+      certIdentity: flagValue(args, "--identity") ?? ag.provenanceCertIdentity,
+      certIssuer: flagValue(args, "--issuer") ?? ag.provenanceCertIssuer,
+    },
+    {
+      resolveBin: (b) => resolveToolBin(b),
+      run: async (b, a) => {
+        const r = await execFileNoThrow(b, a, { timeout: 60_000 });
+        return { ok: r.ok, stdout: r.stdout, stderr: r.stderr };
+      },
+    },
+  );
+  if (res.ok) {
+    console.log(`${c.green}✓ provenance verified${c.reset}  ${c.dim}${artifact}${c.reset}`);
+    return true;
+  }
+  console.error(`${c.red}✗ ${res.reason}${c.reset}`);
+  return false;
+}
+
 async function cmdScan(): Promise<boolean> {
   const jsonMode = hasFlag(process.argv, "--json");
   const { runScanners, suppressBaselined, dedupKey } = await import("./scanners.js");
@@ -5464,6 +5515,7 @@ async function main(): Promise<void> {
         "agent-audit": cmdAgentAudit,
         sentinel: cmdSentinel,
         scan: cmdScan,
+        "verify-provenance": cmdVerifyProvenance,
         "gha-audit": cmdGhaAudit,
         sbom: cmdSbom,
         init: cmdInit,

--- a/src/config.ts
+++ b/src/config.ts
@@ -313,6 +313,10 @@ export interface kitConfig {
     docker_registry?: string;
     threat_data_dir?: string;
     threat_data_pubkey?: string;
+    /** Offline provenance (`kit verify-provenance`): shipped-in Sigstore trust + identity constraints. */
+    provenance_trusted_root?: string;
+    provenance_cert_identity?: string;
+    provenance_cert_issuer?: string;
   };
   web?: {
     search?: WebSearchConfig;
@@ -589,6 +593,9 @@ const kitConfigSchema = z
         docker_registry: z.string().optional(),
         threat_data_dir: z.string().optional(),
         threat_data_pubkey: z.string().optional(),
+        provenance_trusted_root: z.string().optional(),
+        provenance_cert_identity: z.string().optional(),
+        provenance_cert_issuer: z.string().optional(),
       })
       .passthrough()
       .optional(),


### PR DESCRIPTION
Closes the headline remaining air-gap gap (#80): verify cosign/SLSA provenance in a **no-egress** enclave.

kit does **not** reimplement Sigstore — it orchestrates cosign fully offline:
```
cosign verify-blob --offline --trusted-root <shipped-in trusted_root.json> \
  --bundle <b> --certificate-identity <id> --certificate-oidc-issuer <iss> <artifact>
```
`--offline` uses the bundle's inclusion proof (no Rekor); `--trusted-root` is the operator-distributed anchor (no Fulcio/Rekor egress — the trust-root distribution model you OK'd).

- `verifyProvenance` is **fail-closed**: missing input, missing cosign, or any non-zero cosign exit ⇒ NOT verified. kit never prints "verified" unless cosign succeeded. Pure `buildCosignArgs`/`missingField` unit-tested.
- `kit verify-provenance <artifact> --bundle <f> [--trusted-root/--identity/--issuer]`; defaults from `.kit.toml [air_gap].provenance_*` or `KIT_PROVENANCE_*`.
- `docs/AIR_GAP.md` §4 rewritten from "known limitation" to the offline flow + the operator's trust-root-refresh responsibility.

Full suite 1467/0. ⚠️ **Stacked on #85** (→ #84 → #83 → #73).

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_