### PR TITLE
fix(check): Socket scan fails closed — not-logged-in Socket can't pass → 1.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.25.1] - 2026-06-24
+
+### Fixed
+
+- **`kit check` Socket scan no longer fails open — a not-logged-in Socket can't masquerade as "passed".** `checkSocket` previously treated any non-JSON `socket check` output as "passed" (`catch { /* passed */ }` + a bare exit-0 → `pass`), so an installed-but-unauthenticated Socket — which appears to run while checking nothing — could report a green "no supply chain issues detected" and give false assurance. Now a `pass` requires POSITIVE proof the scan ran (valid result JSON); not-logged-in / unparseable output / non-zero exit all surface loudly as **"socket NOT scanning — supply chain UNVERIFIED"** with a `socket login` hint, never as pass. Decision logic extracted to a pure, fixture-tested `classifySocketResult`. (Same fail-closed principle as #74 for `kit scan`; `checkSemgrep` was already fail-closed.)
+
 ## [1.25.0] - 2026-06-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/check-security.test.ts
+++ b/src/check-security.test.ts
@@ -5,7 +5,51 @@ import {
   parseTrivyMisconfigCount,
   parseOsvVulnCount,
   parseTrivyVulnCount,
+  classifySocketResult,
 } from "./check-security.js";
+
+describe("classifySocketResult (fail-closed)", () => {
+  it("never passes when Socket is not logged in (the false-green guard)", () => {
+    for (const raw of [
+      "Please run `socket login` first",
+      "Error: unauthenticated",
+      "401 Unauthorized",
+      "Set SOCKET_API_TOKEN to continue",
+    ]) {
+      const r = classifySocketResult(raw, false);
+      assert.strictEqual(r.status, "warn", `expected warn for: ${raw}`);
+      assert.match(r.detail, /UNVERIFIED|not logged in/);
+      assert.strictEqual(r.suggestion, "socket login");
+    }
+  });
+
+  it("passes ONLY on a valid scan result with zero issues", () => {
+    const r = classifySocketResult(JSON.stringify({ issues: [] }), true);
+    assert.strictEqual(r.status, "pass");
+  });
+
+  it("fails on critical/high issues, warns on lower issues", () => {
+    assert.strictEqual(
+      classifySocketResult(JSON.stringify({ issues: [{ severity: "critical" }] }), false).status,
+      "fail",
+    );
+    assert.strictEqual(
+      classifySocketResult(JSON.stringify({ issues: [{ severity: "low" }] }), true).status,
+      "warn",
+    );
+  });
+
+  it("does NOT pass on unparseable output, even with exit 0 (no proof of scan)", () => {
+    const r = classifySocketResult("some human-readable banner, not JSON", true);
+    assert.strictEqual(r.status, "warn");
+    assert.match(r.detail, /UNVERIFIED/);
+  });
+
+  it("warns (not pass) on non-zero exit with no parseable output", () => {
+    const r = classifySocketResult("", false);
+    assert.strictEqual(r.status, "warn");
+  });
+});
 
 describe("parseTrivyMisconfigCount", () => {
   it("counts only HIGH/CRITICAL misconfigurations", () => {

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -609,6 +609,75 @@ async function checkSecretsInCode(): Promise<SecurityCheckResult> {
 }
 
 /**
+ * Classify `socket check --json` output into a result (pure — fixture-tested).
+ *
+ * FAIL CLOSED: a `pass` requires POSITIVE proof the scan ran (valid result JSON).
+ * The dangerous case is a Socket that's installed but NOT authenticated — it can
+ * appear to "run" yet check nothing, and a fail-open `pass` would give false
+ * assurance the supply chain is covered. So not-logged-in / unparseable output /
+ * non-zero exit all surface LOUDLY as "not scanning — UNVERIFIED", never as pass.
+ * (Same principle as #74 for `kit scan`.)
+ */
+export function classifySocketResult(raw: string, ok: boolean): SecurityCheckResult {
+  const base = { category: "supply-chain", name: "socket scan" } as const;
+  if (
+    /(socket login|log[\s-]?in|unauthenticat|not authenticated|api[\s_-]*token|forbidden|\b401\b|\b403\b)/i.test(
+      raw,
+    )
+  ) {
+    return {
+      ...base,
+      status: "warn",
+      detail: "socket NOT scanning — not logged in; supply chain UNVERIFIED",
+      severity: "medium",
+      suggestion: "socket login",
+    };
+  }
+
+  let parsed: { issues?: { severity?: string }[]; alerts?: { severity?: string }[] } | null = null;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    parsed = null;
+  }
+
+  if (parsed) {
+    const issues = parsed.issues ?? parsed.alerts ?? [];
+    const critical = issues.filter((i) => i.severity === "critical" || i.severity === "high");
+    if (critical.length > 0) {
+      return {
+        ...base,
+        status: "fail",
+        detail: `${critical.length} critical/high supply chain issue(s) -run: socket check`,
+        severity: "critical",
+      };
+    }
+    if (issues.length > 0) {
+      return {
+        ...base,
+        status: "warn",
+        detail: `${issues.length} supply chain warning(s) -run: socket check`,
+        severity: "medium",
+      };
+    }
+    // Valid scan result with zero issues — the ONLY path that earns a pass.
+    return { ...base, status: "pass", detail: "no supply chain issues detected" };
+  }
+
+  // No parseable result (and no recognized auth error): cannot confirm a scan
+  // happened — never pass on that assumption.
+  return {
+    ...base,
+    status: "warn",
+    detail: ok
+      ? "socket check returned no parseable result — supply chain UNVERIFIED"
+      : "socket check failed -verify installation or run: socket login",
+    severity: "medium",
+    suggestion: "socket login",
+  };
+}
+
+/**
  * Check for supply chain attacks using Socket CLI.
  * Detects behavioral anomalies (obfuscated files, unexpected network calls, install scripts)
  * that npm audit misses -catches intentional malware like node-ipc and compromised packages.
@@ -640,52 +709,7 @@ async function checkSocket(): Promise<SecurityCheckResult> {
   }
 
   const result = await execFileNoThrow(socketBin, ["check", "--json"], { timeout: 60_000 });
-  const raw = result.stdout || result.stderr;
-
-  try {
-    const parsed = JSON.parse(raw);
-    const issues: Array<{ severity?: string }> = parsed.issues ?? parsed.alerts ?? [];
-    const critical = issues.filter((i) => i.severity === "critical" || i.severity === "high");
-
-    if (critical.length > 0) {
-      return {
-        category: "supply-chain",
-        name: "socket scan",
-        status: "fail",
-        detail: `${critical.length} critical/high supply chain issue(s) -run: socket check`,
-        severity: "critical",
-      };
-    }
-    if (issues.length > 0) {
-      return {
-        category: "supply-chain",
-        name: "socket scan",
-        status: "warn",
-        detail: `${issues.length} supply chain warning(s) -run: socket check`,
-        severity: "medium",
-      };
-    }
-  } catch {
-    // Non-JSON output: socket check passed (exit 0, human-readable)
-  }
-
-  if (!result.ok) {
-    return {
-      category: "supply-chain",
-      name: "socket scan",
-      status: "warn",
-      detail: "socket check failed -verify installation or run: socket login",
-      severity: "medium",
-      suggestion: "socket login",
-    };
-  }
-
-  return {
-    category: "supply-chain",
-    name: "socket scan",
-    status: "pass",
-    detail: "no supply chain issues detected",
-  };
+  return classifySocketResult(result.stdout || result.stderr, result.ok);
 }
 
 /**


### PR DESCRIPTION
## The bug (false green)
`checkSocket` treated any non-JSON `socket check` output as "passed" — `catch { /* passed */ }` then a bare exit-0 → `status: pass, "no supply chain issues detected"`. So an **installed-but-unauthenticated Socket** — which appears to run but checks nothing — could report a green supply-chain result and give false assurance you're covered.

## Fix (fail closed)
A `pass` now requires **positive proof the scan ran** (valid result JSON). Everything else surfaces loudly, never as pass:
- not logged in → `warn`: **"socket NOT scanning — not logged in; supply chain UNVERIFIED"** (+ `socket login` hint)
- unparseable output, even with exit 0 → `warn`: "no parseable result — supply chain UNVERIFIED"
- non-zero exit → `warn`: "socket check failed"

Decision logic extracted to a pure `classifySocketResult(raw, ok)`, fixture-tested (6 cases incl. the false-green guard).

Same fail-closed principle as #74 (`kit scan`); `checkSemgrep` was already fail-closed (pass requires a successful parse).

## Verify
- scoped tsc clean; `check-security` tests 16/16 incl. new `classifySocketResult` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)