### PR TITLE
chore(config): kit scan → sandstream-common tooling vault

### DIFF
--- a/.kit.toml
+++ b/.kit.toml
@@ -6,6 +6,12 @@ pnpm = "latest"
 pre-commit = ["kit security scan-staged", "npm run build", "npm test"]
 pre-push = ["npm audit --audit-level=high"]
 
+# Scanner tokens (SNYK_TOKEN, …) resolve from the shared sandstream-common
+# Infisical project (#65) so `kit scan` works without an `infisical run` wrapper.
+[scan.tooling]
+project_id = "1c8d0dbc-14b4-487e-85af-add204fc9a6a"
+env = "dev"
+
 [services.github]
 login = "gh auth login"
 check = "gh auth status"


### PR DESCRIPTION
Adds `[scan.tooling]` to kit-public's `.kit.toml` so `kit scan` resolves SNYK_TOKEN from `sandstream-common` (#65) without an `infisical run` wrapper. Repo dogfood config (`.kit.toml` isn't shipped — package `files` = dist/README/skills).

🤖 Generated with [Claude Code](https://claude.com/claude-code)