### PR TITLE
fix(check): drop Socket from kit check — cloud-only, not air-gappable → 1.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.26.1] - 2026-06-24
+
+### Changed
+
+- **Dropped the Socket scan from `kit check` (#103) — it's cloud-only and can't be local-first or air-gapped.** `checkSocket` ran `socket check`, a command **removed in Socket CLI v1.x** (so it never actually scanned), and Socket's v1.x model (`socket scan create`) uploads your dependency manifest to socket.dev — server-side analysis that breaks kit's zero-network promise and has no offline/self-host path (verified: neither Socket nor Snyk offer an air-gappable analysis engine; their "self-hosted" = your _source_, not their scanner). Socket now surfaces as an informative `skip` ("cloud-only … excluded from kit's local-first check. Local cover: bumblebee + osv-scanner + kit supply-chain") rather than a broken/false-green warn. Removed the now-unused `classifySocketResult`. Run Socket via its own CLI / in CI if you have egress; a local behavioral-malware scanner (GuardDog) is tracked as the local-first replacement.
+
 ## [1.26.0] - 2026-06-24
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "1.26.0",
+      "version": "1.26.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/check-security.test.ts
+++ b/src/check-security.test.ts
@@ -5,7 +5,6 @@ import {
   parseTrivyMisconfigCount,
   parseOsvVulnCount,
   parseTrivyVulnCount,
-  classifySocketResult,
   classifyTrufflehogFindings,
 } from "./check-security.js";
 
@@ -31,49 +30,6 @@ describe("classifyTrufflehogFindings (verified vs unverified)", () => {
   it("counts an unparseable DetectorName line conservatively as unverified", () => {
     const out = classifyTrufflehogFindings('{"DetectorName":"X" broken json');
     assert.deepStrictEqual(out, { verified: 0, unverified: 1 });
-  });
-});
-
-describe("classifySocketResult (fail-closed)", () => {
-  it("never passes when Socket is not logged in (the false-green guard)", () => {
-    for (const raw of [
-      "Please run `socket login` first",
-      "Error: unauthenticated",
-      "401 Unauthorized",
-      "Set SOCKET_API_TOKEN to continue",
-    ]) {
-      const r = classifySocketResult(raw, false);
-      assert.strictEqual(r.status, "warn", `expected warn for: ${raw}`);
-      assert.match(r.detail, /UNVERIFIED|not logged in/);
-      assert.strictEqual(r.suggestion, "socket login");
-    }
-  });
-
-  it("passes ONLY on a valid scan result with zero issues", () => {
-    const r = classifySocketResult(JSON.stringify({ issues: [] }), true);
-    assert.strictEqual(r.status, "pass");
-  });
-
-  it("fails on critical/high issues, warns on lower issues", () => {
-    assert.strictEqual(
-      classifySocketResult(JSON.stringify({ issues: [{ severity: "critical" }] }), false).status,
-      "fail",
-    );
-    assert.strictEqual(
-      classifySocketResult(JSON.stringify({ issues: [{ severity: "low" }] }), true).status,
-      "warn",
-    );
-  });
-
-  it("does NOT pass on unparseable output, even with exit 0 (no proof of scan)", () => {
-    const r = classifySocketResult("some human-readable banner, not JSON", true);
-    assert.strictEqual(r.status, "warn");
-    assert.match(r.detail, /UNVERIFIED/);
-  });
-
-  it("warns (not pass) on non-zero exit with no parseable output", () => {
-    const r = classifySocketResult("", false);
-    assert.strictEqual(r.status, "warn");
   });
 });
 

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -646,107 +646,27 @@ async function checkSecretsInCode(): Promise<SecurityCheckResult> {
 }
 
 /**
- * Classify `socket check --json` output into a result (pure — fixture-tested).
+ * Socket is intentionally NOT part of kit's local-first security check (#103).
  *
- * FAIL CLOSED: a `pass` requires POSITIVE proof the scan ran (valid result JSON).
- * The dangerous case is a Socket that's installed but NOT authenticated — it can
- * appear to "run" yet check nothing, and a fail-open `pass` would give false
- * assurance the supply chain is covered. So not-logged-in / unparseable output /
- * non-zero exit all surface LOUDLY as "not scanning — UNVERIFIED", never as pass.
- * (Same principle as #74 for `kit scan`.)
- */
-export function classifySocketResult(raw: string, ok: boolean): SecurityCheckResult {
-  const base = { category: "supply-chain", name: "socket scan" } as const;
-  if (
-    /(socket login|log[\s-]?in|unauthenticat|not authenticated|api[\s_-]*token|forbidden|\b401\b|\b403\b)/i.test(
-      raw,
-    )
-  ) {
-    return {
-      ...base,
-      status: "warn",
-      detail: "socket NOT scanning — not logged in; supply chain UNVERIFIED",
-      severity: "medium",
-      suggestion: "socket login",
-    };
-  }
-
-  let parsed: { issues?: { severity?: string }[]; alerts?: { severity?: string }[] } | null = null;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    parsed = null;
-  }
-
-  if (parsed) {
-    const issues = parsed.issues ?? parsed.alerts ?? [];
-    const critical = issues.filter((i) => i.severity === "critical" || i.severity === "high");
-    if (critical.length > 0) {
-      return {
-        ...base,
-        status: "fail",
-        detail: `${critical.length} critical/high supply chain issue(s) -run: socket check`,
-        severity: "critical",
-      };
-    }
-    if (issues.length > 0) {
-      return {
-        ...base,
-        status: "warn",
-        detail: `${issues.length} supply chain warning(s) -run: socket check`,
-        severity: "medium",
-      };
-    }
-    // Valid scan result with zero issues — the ONLY path that earns a pass.
-    return { ...base, status: "pass", detail: "no supply chain issues detected" };
-  }
-
-  // No parseable result (and no recognized auth error): cannot confirm a scan
-  // happened — never pass on that assumption.
-  return {
-    ...base,
-    status: "warn",
-    detail: ok
-      ? "socket check returned no parseable result — supply chain UNVERIFIED"
-      : "socket check failed -verify installation or run: socket login",
-    severity: "medium",
-    suggestion: "socket login",
-  };
-}
-
-/**
- * Check for supply chain attacks using Socket CLI.
- * Detects behavioral anomalies (obfuscated files, unexpected network calls, install scripts)
- * that npm audit misses -catches intentional malware like node-ipc and compromised packages.
+ * Socket is a CLOUD service: its supply-chain analysis runs server-side (the v1.x
+ * CLI's `socket scan create` UPLOADS your dependency manifest to socket.dev), so it
+ * (a) breaks kit's local-first / zero-network promise, and (b) cannot run air-gapped
+ * at all — there is no offline/self-host of the analysis engine (Snyk is the same).
+ * The legacy `socket check` command kit used was also removed in Socket CLI v1.x.
+ *
+ * Local supply-chain coverage is provided by bumblebee, osv-scanner, and
+ * `kit supply-chain` (#49); a local behavioral/malware-heuristic scanner (GuardDog)
+ * is the candidate to fill Socket's niche the local-first way. Run Socket via its
+ * own CLI / in CI if you have egress and want its server-side analysis.
  */
 async function checkSocket(): Promise<SecurityCheckResult> {
-  try {
-    await access(resolve(process.cwd(), "package.json"));
-  } catch {
-    return {
-      category: "supply-chain",
-      name: "socket scan",
-      status: "skip",
-      detail: "no package.json found",
-    };
-  }
-
-  // Resolve mise-first: kit installs scanners via mise, whose shims aren't on
-  // kit's PATH. A bare "socket" lookup would miss a mise-installed one.
-  const socketBin = await resolveToolBin("socket");
-  if (!socketBin) {
-    return {
-      category: "supply-chain",
-      name: "socket scan",
-      status: "warn",
-      detail: "socket not installed -supply chain malware undetected",
-      severity: "medium",
-      suggestion: "mise use npm:@socketsecurity/cli  (or: npm install -g @socketsecurity/cli)",
-    };
-  }
-
-  const result = await execFileNoThrow(socketBin, ["check", "--json"], { timeout: 60_000 });
-  return classifySocketResult(result.stdout || result.stderr, result.ok);
+  return {
+    category: "supply-chain",
+    name: "socket scan",
+    status: "skip",
+    detail:
+      "Socket is cloud-only (uploads manifest; no offline/air-gap) — excluded from kit's local-first check. Local cover: bumblebee + osv-scanner + kit supply-chain",
+  };
 }
 
 /**


### PR DESCRIPTION
Closes #103.

`checkSocket` ran `socket check` — a command **removed in Socket CLI v1.x** (so it never actually scanned) — and Socket's v1.x model (`socket scan create`) **uploads your dependency manifest to socket.dev** (server-side). That breaks kit's local-first / zero-network promise and **cannot run air-gapped** (confirmed: neither Socket nor Snyk offer a self-hostable/offline analysis engine — their "self-hosted" means your *source repo*, not their scanner).

Decision (option 2 of #103): **drop Socket from the local check.** It now surfaces as an informative `skip` — `"Socket is cloud-only … excluded from kit's local-first check. Local cover: bumblebee + osv-scanner + kit supply-chain"` — instead of a broken / false-green warn. Removed the now-unused `classifySocketResult`.

Local supply-chain coverage is unchanged + complete: bumblebee, osv-scanner, `kit supply-chain` (#49). Run Socket via its own CLI / in CI if you have egress.

Board effect on kit: socket `warn` → `skip`; no real coverage lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)