### PR TITLE
feat(check): GuardDog local malware scanner (opt-in) + scan/air_gap config sections → 1.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.28.0] - 2026-06-24
+
+### Added
+
+- **GuardDog — local behavioral-malware heuristics for `kit check` (#105, opt-in).** The local-first replacement for the dropped cloud Socket scanner (#103): GuardDog (DataDog, OSS) flags malicious npm/PyPI packages via Semgrep-rules-on-source + metadata heuristics, runs locally, and doesn't upload your manifest. **Opt-in** (`KIT_GUARDDOG=1`) — it needs Semgrep and `verify` fetches/scans each dep, too heavy for the default check; otherwise it surfaces as a `skip` with the enable hint. Resolved mise-first (`pipx:guarddog`). Pure, fixture-tested `classifyGuardDog` is **fail-closed**: a `pass` requires a COMPLETE scan — zero indicators _with rule-errors_ (e.g. missing Semgrep) is a `warn` ("INCOMPLETE/UNVERIFIED"), never a false pass; real indicators always fail. (Triaged before adding: `kit triage pip guarddog` → 100/100.)
+
+### Fixed
+
+- **`scan` and `air_gap` no longer warn as "unknown section" in `.kit.toml`.** Both are valid config sections (added to the zod schema in #65 / #85) but were missing from the `KNOWN_SECTIONS` allowlist, so `[scan.tooling]` (#102) and `[air_gap]` (#85) triggered a spurious "unknown section" warning on every command.
+
 ## [1.27.0] - 2026-06-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "1.27.0",
+      "version": "1.28.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -5,6 +5,7 @@ import { resolve } from "node:path";
 import { homedir } from "node:os";
 import { execFileNoThrow } from "./utils/execFileNoThrow.js";
 import { resolveToolBin } from "./utils/resolveTool.js";
+import { classifyGuardDog } from "./guarddog.js";
 import { ruleForCheck, type RuleRef } from "./rules/catalog.js";
 import {
   ensureBumblebee,
@@ -667,6 +668,64 @@ async function checkSocket(): Promise<SecurityCheckResult> {
     detail:
       "Socket is cloud-only (uploads manifest; no offline/air-gap) — excluded from kit's local-first check. Local cover: bumblebee + osv-scanner + kit supply-chain",
   };
+}
+
+/**
+ * GuardDog (DataDog, OSS) — LOCAL behavioral-malware heuristics, the local-first
+ * replacement for Socket (#105). OPT-IN (KIT_GUARDDOG=1): GuardDog needs semgrep
+ * and `verify` fetches/scans each dependency, so it's too heavy for the default
+ * check. Classification (incl. fail-closed on incomplete scans) is in guarddog.ts.
+ */
+async function checkGuardDog(): Promise<SecurityCheckResult> {
+  const base = { category: "supply-chain", name: "guarddog (malware)" } as const;
+  const enabled = ["1", "true", "yes", "on"].includes(
+    (process.env.KIT_GUARDDOG ?? "").trim().toLowerCase(),
+  );
+  if (!enabled) {
+    return {
+      ...base,
+      status: "skip",
+      detail: "opt-in — set KIT_GUARDDOG=1 to run local malware heuristics (needs semgrep)",
+    };
+  }
+
+  // Pick the ecosystem from the lockfile/manifest present.
+  const candidates: { ecosystem: string; file: string }[] = [
+    { ecosystem: "npm", file: "package-lock.json" },
+    { ecosystem: "npm", file: "package.json" },
+    { ecosystem: "pypi", file: "requirements.txt" },
+  ];
+  let target: { ecosystem: string; file: string } | undefined;
+  for (const c of candidates) {
+    try {
+      await access(resolve(process.cwd(), c.file));
+      target = c;
+      break;
+    } catch {
+      // not present — try the next
+    }
+  }
+  if (!target) {
+    return { ...base, status: "skip", detail: "no package-lock.json / requirements.txt to scan" };
+  }
+
+  const bin = await resolveToolBin("guarddog");
+  if (!bin) {
+    return {
+      ...base,
+      status: "warn",
+      detail: "guarddog not installed — malware heuristics unavailable",
+      severity: "medium",
+      suggestion: "mise use pipx:guarddog",
+    };
+  }
+
+  const result = await execFileNoThrow(
+    bin,
+    [target.ecosystem, "verify", target.file, "--output-format=json"],
+    { timeout: 300_000 },
+  );
+  return classifyGuardDog(result.stdout || result.stderr);
 }
 
 /**
@@ -1352,6 +1411,7 @@ export async function checkSecurity(): Promise<SecurityCheckResult[]> {
     trivyConfigResult,
     osvResult,
     mavenResult,
+    guarddogResult,
     ...lockfileResults
   ] = await Promise.all([
     checkNpmAudit(),
@@ -1367,6 +1427,7 @@ export async function checkSecurity(): Promise<SecurityCheckResult[]> {
     checkTrivyConfig(),
     checkOsvScanner(),
     checkMavenAudit(),
+    checkGuardDog(),
     ...(await checkLockfilesCommitted()),
   ]);
 
@@ -1384,6 +1445,7 @@ export async function checkSecurity(): Promise<SecurityCheckResult[]> {
     trivyConfigResult,
     osvResult,
     mavenResult,
+    guarddogResult,
   );
   results.push(...lockfileResults);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -518,6 +518,8 @@ const KNOWN_SECTIONS = new Set([
   "context",
   "memory",
   "update",
+  "scan", // [scan.tooling] — vault-backed scanner tokens (#65)
+  "air_gap", // [air_gap] — no-egress / offline config (#85)
 ]);
 
 const kitConfigSchema = z

--- a/src/guarddog.test.ts
+++ b/src/guarddog.test.ts
@@ -1,0 +1,54 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { classifyGuardDog } from "./guarddog.js";
+
+const pkg = (over: Record<string, unknown> = {}) =>
+  JSON.stringify({ package: "x", issues: 0, errors: {}, results: {}, ...over });
+
+describe("classifyGuardDog", () => {
+  it("passes ONLY on a complete scan with zero indicators", () => {
+    const r = classifyGuardDog(pkg({ issues: 0, errors: {} }));
+    assert.equal(r.status, "pass");
+  });
+
+  it("fails on malware indicators (issues > 0)", () => {
+    const r = classifyGuardDog(pkg({ issues: 3 }));
+    assert.equal(r.status, "fail");
+    assert.equal(r.severity, "critical");
+    assert.match(r.detail, /3 malware indicator/);
+  });
+
+  it("FAIL CLOSED: zero issues but a rule errored (e.g. semgrep missing) → warn, not pass", () => {
+    // the real GuardDog shape when semgrep isn't found
+    const r = classifyGuardDog(
+      pkg({ issues: 0, errors: { "rules-all": "unable to find semgrep binary" } }),
+    );
+    assert.equal(r.status, "warn");
+    assert.match(r.detail, /INCOMPLETE|UNVERIFIED/);
+  });
+
+  it("real indicators still fail even if some rules errored", () => {
+    const r = classifyGuardDog(pkg({ issues: 2, errors: { "rules-all": "boom" } }));
+    assert.equal(r.status, "fail");
+  });
+
+  it("handles an array (verify mode) — sums issues across packages", () => {
+    const arr = JSON.stringify([
+      { package: "a", issues: 0, errors: {} },
+      { package: "b", issues: 1, errors: {} },
+    ]);
+    const r = classifyGuardDog(arr);
+    assert.equal(r.status, "fail");
+    assert.match(r.detail, /1 malware indicator.* 2 package/);
+  });
+
+  it("warns (not pass) on unparseable output", () => {
+    const r = classifyGuardDog("not json at all");
+    assert.equal(r.status, "warn");
+    assert.match(r.detail, /UNVERIFIED/);
+  });
+
+  it("warns on empty results array", () => {
+    assert.equal(classifyGuardDog("[]").status, "warn");
+  });
+});

--- a/src/guarddog.ts
+++ b/src/guarddog.ts
@@ -1,0 +1,90 @@
+/**
+ * GuardDog (DataDog, OSS) — local behavioral-malware heuristics for npm/PyPI
+ * packages (Semgrep rules on source + metadata heuristics). kit's local-first
+ * answer to Socket's behavioral niche (#105): unlike Socket it runs locally and
+ * doesn't upload your manifest.
+ *
+ * This module is the PURE classifier (fixture-tested). The check wiring lives in
+ * check-security.ts and is OPT-IN (KIT_GUARDDOG=1) — GuardDog needs Semgrep, and
+ * `verify` fetches/scans each dep, so it's too heavy for the default local check.
+ */
+import type { SecurityCheckResult } from "./check-security.js";
+
+/** One package's GuardDog result (`guarddog npm verify|scan --output-format=json`). */
+export interface GuardDogResult {
+  package?: string;
+  /** count of detected malware indicators for this package */
+  issues?: number;
+  /** rule-name → error message; non-empty means some rules could NOT run */
+  errors?: Record<string, string>;
+  results?: Record<string, unknown>;
+}
+
+/**
+ * Classify GuardDog JSON output (a single object or an array of them) — PURE.
+ *
+ * FAIL CLOSED (the recurring lesson): a `pass` requires a COMPLETE scan. GuardDog
+ * reports per-rule `errors` (e.g. "unable to find semgrep binary") — when its
+ * source rules couldn't run, `issues: 0` is meaningless, so an errored-but-zero
+ * scan is a `warn` ("incomplete — UNVERIFIED"), never a pass. Real indicators
+ * (issues > 0) always fail regardless.
+ */
+export function classifyGuardDog(stdout: string): SecurityCheckResult {
+  const base = { category: "supply-chain", name: "guarddog (malware)" } as const;
+
+  let entries: GuardDogResult[];
+  try {
+    const j = JSON.parse(stdout);
+    entries = Array.isArray(j) ? j : [j];
+  } catch {
+    return {
+      ...base,
+      status: "warn",
+      detail: "guarddog produced no parseable result — malware scan UNVERIFIED",
+      severity: "medium",
+    };
+  }
+
+  if (entries.length === 0) {
+    return {
+      ...base,
+      status: "warn",
+      detail: "guarddog returned no results — UNVERIFIED",
+      severity: "medium",
+    };
+  }
+
+  let totalIssues = 0;
+  let errored = 0;
+  for (const e of entries) {
+    totalIssues += Number(e.issues ?? 0);
+    if (e.errors && Object.keys(e.errors).length > 0) errored++;
+  }
+
+  if (totalIssues > 0) {
+    return {
+      ...base,
+      status: "fail",
+      detail: `${totalIssues} malware indicator(s) across ${entries.length} package(s) -run: guarddog npm verify`,
+      severity: "critical",
+    };
+  }
+
+  // Zero issues but some rules errored → the scan didn't actually complete.
+  if (errored > 0) {
+    return {
+      ...base,
+      status: "warn",
+      detail: `guarddog rules failed to run on ${errored}/${entries.length} package(s) (e.g. missing semgrep) — malware scan INCOMPLETE/UNVERIFIED`,
+      severity: "medium",
+      suggestion: "mise use pipx:semgrep  (GuardDog's source rules need semgrep)",
+    };
+  }
+
+  // Complete scan, zero indicators — the only path that earns a pass.
+  return {
+    ...base,
+    status: "pass",
+    detail: `no malware indicators (${entries.length} package(s) scanned)`,
+  };
+}


### PR DESCRIPTION
Closes #105.

## GuardDog — the local-first Socket replacement
After dropping the cloud Socket scanner (#103), this adds **GuardDog** (DataDog, OSS) as kit's local behavioral-malware scanner: Semgrep-rules-on-source + metadata heuristics for npm/PyPI, **runs locally, no manifest upload**.

- **Opt-in** (`KIT_GUARDDOG=1`) — GuardDog needs Semgrep and `verify` fetches/scans each dep, too heavy for the default check; otherwise a `skip` with the enable hint. Resolved mise-first (`pipx:guarddog`).
- **Fail-closed** `classifyGuardDog` (pure, fixture-tested): a `pass` requires a COMPLETE scan. Zero indicators *with rule-errors* (e.g. the real "unable to find semgrep binary" case) is a `warn` ("INCOMPLETE/UNVERIFIED") — never a false pass. Real indicators (`issues > 0`) always fail. (Same lesson as socket #103 / scan #74.)
- Triaged before adding: `kit triage pip guarddog` → 100/100, 0 critical.

## Fix: config sections
`scan` (#65 `[scan.tooling]`) and `air_gap` (#85) are valid (in the zod schema) but were missing from `KNOWN_SECTIONS` → spurious "unknown section" warning on every command. Added both.

## Verify
- scoped tsc clean; 15 new/affected tests green (`guarddog` 7 + `config`); confirmed `guarddog npm verify … --output-format=json` is a valid command (not a dead one). Board: guarddog shows as opt-in `skip`; no more `[scan]` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)