### PR TITLE
fix(win): resolveToolBin uses 'where' on native Windows (#43 incremental) → 1.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.28.1] - 2026-06-24
+
+### Fixed
+
+- **Tool resolution works on native Windows (#43, incremental).** `resolveToolBin` shelled out to `which`, which doesn't exist on native Windows (PowerShell/cmd). It now uses `where` on `win32` and `which` elsewhere — same first-line path parsing. POSIX behavior is byte-identical (verified); checks off one of #43's hard blockers. (Remaining #43 blockers — POSIX git hooks, `tar` extraction, secret-file ACLs, the build script's `rm`/`chmod`, and a `windows-latest` CI job to verify it all — need a Windows runner and stay open.)
+
 ## [1.28.0] - 2026-06-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "1.28.0",
+      "version": "1.28.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/utils/resolveTool.ts
+++ b/src/utils/resolveTool.ts
@@ -20,7 +20,9 @@ export async function resolveToolBin(tool: string): Promise<string | null> {
     const p = viaMise.stdout.trim().split("\n")[0]?.trim();
     if (p) return p;
   }
-  const viaPath = await execFileNoThrow("which", [tool], { timeout: 5_000 });
+  // POSIX `which`, Windows `where` (no POSIX shell on native Windows) — #43.
+  const finder = process.platform === "win32" ? "where" : "which";
+  const viaPath = await execFileNoThrow(finder, [tool], { timeout: 5_000 });
   if (viaPath.ok) {
     const p = viaPath.stdout.trim().split("\n")[0]?.trim();
     if (p) return p;


### PR DESCRIPTION
Incremental progress on #43 (native Windows). `resolveToolBin` shelled out to `which`, which doesn't exist on native Windows (PowerShell/cmd) — so tool resolution failed there. Now uses `where` on `win32`, `which` elsewhere; same first-line path parsing.

POSIX behavior byte-identical (verified: `resolveToolBin("node")` still resolves via `which`; tests 2/2). Checks off one of #43's hard blockers.

Remaining #43 blockers need a Windows runner to implement + verify, so they stay open: POSIX git hooks, `tar` extraction, secret-file ACLs, the build script's `rm`/`chmod`, and a `windows-latest` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)