### PR TITLE
fix(ci): valid Windows workflow YAML (colon broke parse) + probe results

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 22
       - name: Install
         run: npm ci
-      - name: Build (cross-platform: rimraf + node chmod, no POSIX rm/chmod)
+      - name: Build (cross-platform — no POSIX rm/chmod)
         run: npm run build
       - name: Unit tests
         run: npm test


### PR DESCRIPTION
The Windows probe (#43) workflow had a colon-space in a step name (`Build (cross-platform: rimraf …)`) → GitHub rejected the whole file ("workflow file issue") and never registered `workflow_dispatch`. Removed the colon; YAML now valid (verified locally with a yaml parser).

**First real Windows probe result** (windows-latest): **Install ✓, Build ✓** — the cross-platform build (#1.28.2) is confirmed working on native Windows. **Unit tests ✗** (fails fast at startup; the specific failures aren't capturable from gh's truncated logs — needs Windows-side diagnosis). That's the next #43 layer (runtime blockers: POSIX hooks / tar / ACLs / path handling surfaced via the test suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)