### PR TITLE
feat(memory): auto-index all harnesses on session end (debounced sweep)

### DIFF
--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -46,7 +46,7 @@ export function getMemoryDbPath(): string {
   return process.env.KIT_MEMORY_DB ?? join(getMemoryDir(), "memory.db");
 }
 
-function ensureMemoryDir(): void {
+export function ensureMemoryDir(): void {
   const dir = getMemoryDir();
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
 }

--- a/src/memory/hook.test.ts
+++ b/src/memory/hook.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { openMemoryDb, upsertSession, insertMessage } from "./db.js";
-import { userPromptSubmitReminder, sessionStartRecovery } from "./hook.js";
+import { userPromptSubmitReminder, sessionStartRecovery, dueForHarnessSweep } from "./hook.js";
 import { getCurrentProjectRoot } from "./project.js";
 
 describe("memory hook — UserPromptSubmit reminder", () => {
@@ -85,5 +85,33 @@ describe("memory hook — SessionStart recovery", () => {
     assert.match(text, /kit memory search/);
     // newest-first ordering: the latest message precedes the older one
     assert.ok(text.indexOf("latest decision") < text.indexOf("older note"));
+  });
+});
+
+describe("memory hook — harness sweep debounce", () => {
+  let tmp: string;
+  const prevDir = process.env.KIT_MEMORY_DIR;
+
+  before(() => {
+    tmp = mkdtempSync(join(tmpdir(), "kit-sweep-"));
+    process.env.KIT_MEMORY_DIR = tmp;
+  });
+
+  after(() => {
+    if (prevDir === undefined) delete process.env.KIT_MEMORY_DIR;
+    else process.env.KIT_MEMORY_DIR = prevDir;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("is due when no sweep marker exists yet", () => {
+    assert.equal(dueForHarnessSweep(), true);
+  });
+
+  it("is not due right after a sweep, but due once the 6h interval elapses", () => {
+    const marker = join(tmp, ".harness-sweep");
+    writeFileSync(marker, new Date().toISOString());
+    const mtime = statSync(marker).mtimeMs;
+    assert.equal(dueForHarnessSweep(mtime + 60_000), false, "1 min later → not due");
+    assert.equal(dueForHarnessSweep(mtime + 7 * 60 * 60 * 1000), true, "7h later → due");
   });
 });

--- a/src/memory/hook.ts
+++ b/src/memory/hook.ts
@@ -8,9 +8,10 @@
  * Both are FAIL-OPEN: any error yields an empty/no-op result so a hook can never
  * block a prompt or break a session. Deterministic, zero model calls.
  */
-import { basename } from "node:path";
-import { openMemoryDb, getStats, recentMessages } from "./db.js";
-import { indexClaudeTranscripts } from "./parser.js";
+import { basename, join } from "node:path";
+import { existsSync, statSync, writeFileSync } from "node:fs";
+import { openMemoryDb, getStats, recentMessages, getMemoryDir, ensureMemoryDir } from "./db.js";
+import { indexClaudeTranscripts, indexAllHarnesses } from "./parser.js";
 import { palList } from "./pal.js";
 import { getCurrentProjectRoot } from "./project.js";
 import { readCachedUpdateSync, getKitVersionSync } from "../update-check.js";
@@ -100,13 +101,55 @@ export function sessionStartRecovery(opts: { limit?: number } = {}): string {
   }
 }
 
+/**
+ * The just-ended session is Claude Code, so we always index that (cheap +
+ * incremental). The OTHER harnesses (codex/cursor/gemini/cline/amazon-q/opencode…)
+ * have no kit hook, so they'd only get indexed on a manual `kit memory index`.
+ * To pick them up automatically WITHOUT walking six extra dirs on every single
+ * session end, we sweep all harnesses at most once per interval, debounced by a
+ * marker file's mtime. Keeps SessionEnd cheap on the common path.
+ */
+const HARNESS_SWEEP_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6h
+
+function harnessSweepMarker(): string {
+  return join(getMemoryDir(), ".harness-sweep");
+}
+
+/** True if the periodic all-harness sweep is due (marker missing or older than the interval). */
+export function dueForHarnessSweep(now: number = Date.now()): boolean {
+  try {
+    const marker = harnessSweepMarker();
+    if (!existsSync(marker)) return true;
+    return now - statSync(marker).mtimeMs >= HARNESS_SWEEP_INTERVAL_MS;
+  } catch {
+    return false; // can't tell → don't add the sweep's latency
+  }
+}
+
+function markHarnessSwept(): void {
+  try {
+    ensureMemoryDir();
+    writeFileSync(harnessSweepMarker(), new Date().toISOString(), { mode: 0o600 });
+  } catch {
+    /* best-effort: a missed marker just means we sweep again next time */
+  }
+}
+
 /** Index the just-ended session. Returns count of newly indexed messages (fail-open). */
 export function runSessionEndIndex(): { messages: number } {
   try {
     const db = openMemoryDb();
-    const res = indexClaudeTranscripts(db);
+    let messages: number;
+    if (dueForHarnessSweep()) {
+      // includes claude-code, so no separate Claude pass needed
+      const all = indexAllHarnesses(db);
+      messages = Object.values(all).reduce((sum, r) => sum + r.messages, 0);
+      markHarnessSwept();
+    } else {
+      messages = indexClaudeTranscripts(db).messages;
+    }
     db.close();
-    return { messages: res.messages };
+    return { messages };
   } catch {
     return { messages: 0 }; // fail-open
   }


### PR DESCRIPTION
Closes item 3 from the OpenCode/memory follow-ups: get **all** harnesses indexed automatically, without paying for it on every session.

## Problem
The SessionEnd hook (`runSessionEndIndex`) only ran `indexClaudeTranscripts`. The other harnesses (codex/cursor/gemini/cline/amazon-q, and OpenCode once #115 lands) have no kit hook, so they were only indexed when a user manually ran `kit memory index`.

## Fix — debounced sweep, not hot-path
`runSessionEndIndex` now runs the full `indexAllHarnesses`, but **debounced to at most once per 6h**, gated by a `.harness-sweep` marker file's mtime under the memory dir:
- **Common path** stays cheap — just the incremental Claude index of the just-ended session.
- **When due** — sweep all harness dirs once, then touch the marker.
- Deliberately **not** added to the SessionStart hot path (that one only does fast recovery).
- **Fail-open** throughout: if the marker can't be read we *skip* the sweep rather than add latency; a missed marker just means we sweep next time.

`ensureMemoryDir` is exported for the marker writer (written `0o600`).

This was the design choice flagged earlier — periodic background-style sweep rather than walking six extra dirs on every session end.

Test: debounce logic (due when no marker; not due for 6h after a sweep; due again once the interval elapses). Full suite **1537/0**. Independent of #115 (composes with it — once #115 merges, the sweep picks up OpenCode too).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_