### PR TITLE
fix(check): JVM CVE scan covers Gradle + nested projects (#110) → 1.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.31.0] - 2026-06-24
+
+### Fixed
+
+- **JVM dependency CVE scan now covers Gradle + nested projects (#110, follow-up to #67).** `checkMavenAudit` only detected `pom.xml` at depth ≤1, so **Gradle** projects (`build.gradle`/`build.gradle.kts`) and Maven/Gradle projects in monorepo subdirs (`services/backend/pom.xml`) passed the gate green — the exact false-green #67 set out to close, for the other half of the JVM ecosystem. Now: detects Maven **and** Gradle via a depth-≤3 BFS (skipping vendor/build dirs); a Gradle project **without** a `gradle.lockfile` `warn`s (trivy sees only direct deps) instead of `skip`ping green, mirroring the `~/.m2` handling. Pure `jvmProjectKind` + `findJvmProject` fixture-tested.
+
 ## [1.30.0] - 2026-06-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "1.30.0",
+      "version": "1.31.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/check-security.test.ts
+++ b/src/check-security.test.ts
@@ -6,7 +6,59 @@ import {
   parseOsvVulnCount,
   parseTrivyVulnCount,
   classifyTrufflehogFindings,
+  jvmProjectKind,
+  findJvmProject,
 } from "./check-security.js";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("jvmProjectKind (#110)", () => {
+  it("detects Maven and Gradle (incl. .kts), null otherwise", () => {
+    assert.strictEqual(jvmProjectKind(["pom.xml"]), "maven");
+    assert.strictEqual(jvmProjectKind(["build.gradle"]), "gradle");
+    assert.strictEqual(jvmProjectKind(["build.gradle.kts"]), "gradle");
+    assert.strictEqual(jvmProjectKind(["package.json", "README.md"]), null);
+    // pom.xml wins when both present
+    assert.strictEqual(jvmProjectKind(["pom.xml", "build.gradle"]), "maven");
+  });
+});
+
+describe("findJvmProject (#110 — Gradle + nested depth)", () => {
+  it("finds a Gradle project nested at depth 2", async () => {
+    const root = mkdtempSync(join(tmpdir(), "kit-jvm-"));
+    const deep = join(root, "services", "backend");
+    mkdirSync(deep, { recursive: true });
+    writeFileSync(join(deep, "build.gradle.kts"), "plugins {}\n");
+    const found = await findJvmProject(root);
+    assert.ok(found);
+    assert.strictEqual(found!.kind, "gradle");
+    assert.strictEqual(found!.dir, deep);
+  });
+
+  it("finds a Maven pom.xml at depth 2 (the monorepo layout #67 missed)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "kit-jvm-"));
+    const deep = join(root, "apps", "api");
+    mkdirSync(deep, { recursive: true });
+    writeFileSync(join(deep, "pom.xml"), "<project/>\n");
+    const found = await findJvmProject(root);
+    assert.strictEqual(found?.kind, "maven");
+  });
+
+  it("returns null when there is no JVM project", async () => {
+    const root = mkdtempSync(join(tmpdir(), "kit-jvm-"));
+    writeFileSync(join(root, "package.json"), "{}\n");
+    assert.strictEqual(await findJvmProject(root), null);
+  });
+
+  it("skips vendor dirs (node_modules) when searching", async () => {
+    const root = mkdtempSync(join(tmpdir(), "kit-jvm-"));
+    const buried = join(root, "node_modules", "x");
+    mkdirSync(buried, { recursive: true });
+    writeFileSync(join(buried, "pom.xml"), "<project/>\n");
+    assert.strictEqual(await findJvmProject(root), null);
+  });
+});
 
 describe("classifyTrufflehogFindings (verified vs unverified)", () => {
   const line = (det: string, verified: boolean) =>

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -922,32 +922,55 @@ async function checkTrivyConfig(): Promise<SecurityCheckResult> {
   };
 }
 
-/** Locate a Maven project: a `pom.xml` at cwd, or in an immediate child dir
- *  (the common monorepo layout, e.g. `backend/pom.xml`). Returns the directory
- *  to scan, or null when there's no Maven project. Skips build/vendor dirs. */
-async function findMavenDir(cwd: string): Promise<string | null> {
-  if (
-    await access(resolve(cwd, "pom.xml"))
-      .then(() => true)
-      .catch(() => false)
-  ) {
-    return cwd;
-  }
-  try {
-    const ignore = new Set(["node_modules", ".git", "target", "dist", "build", ".kit"]);
-    const entries = await readdir(cwd, { withFileTypes: true });
-    for (const e of entries) {
-      if (!e.isDirectory() || ignore.has(e.name)) continue;
-      if (
-        await access(resolve(cwd, e.name, "pom.xml"))
-          .then(() => true)
-          .catch(() => false)
-      ) {
-        return resolve(cwd, e.name);
+export type JvmKind = "maven" | "gradle";
+
+/** Classify a directory's filenames as a JVM project root (pure, testable). #110 */
+export function jvmProjectKind(files: string[]): JvmKind | null {
+  if (files.includes("pom.xml")) return "maven";
+  if (files.includes("build.gradle") || files.includes("build.gradle.kts")) return "gradle";
+  return null;
+}
+
+const JVM_IGNORE = new Set([
+  "node_modules",
+  ".git",
+  "target",
+  "dist",
+  "build",
+  ".kit",
+  ".gradle",
+  ".next",
+]);
+
+/** Locate the nearest JVM project — Maven (`pom.xml`) or Gradle (`build.gradle[.kts]`)
+ *  — within `maxDepth` directories of cwd (BFS, shallowest wins), skipping
+ *  build/vendor dirs. Returns `{dir, kind}` or null. Depth ≤3 covers monorepo
+ *  layouts like `services/backend/pom.xml` that the old depth-1 scan missed (#110). */
+export async function findJvmProject(
+  cwd: string,
+  maxDepth = 3,
+): Promise<{ dir: string; kind: JvmKind } | null> {
+  let frontier: { dir: string; depth: number }[] = [{ dir: cwd, depth: 0 }];
+  while (frontier.length > 0) {
+    const next: { dir: string; depth: number }[] = [];
+    for (const { dir, depth } of frontier) {
+      let entries;
+      try {
+        entries = await readdir(dir, { withFileTypes: true });
+      } catch {
+        continue; // unreadable dir — skip
+      }
+      const kind = jvmProjectKind(entries.filter((e) => e.isFile()).map((e) => e.name));
+      if (kind) return { dir, kind };
+      if (depth < maxDepth) {
+        for (const e of entries) {
+          if (e.isDirectory() && !JVM_IGNORE.has(e.name)) {
+            next.push({ dir: resolve(dir, e.name), depth: depth + 1 });
+          }
+        }
       }
     }
-  } catch {
-    /* unreadable cwd — treat as no Maven project */
+    frontier = next;
   }
   return null;
 }
@@ -979,11 +1002,17 @@ export function parseTrivyVulnCount(stdout: string): number {
  * deps and silently under-reports, so we warn rather than pass.
  */
 async function checkMavenAudit(): Promise<SecurityCheckResult> {
-  const name = "trivy fs (maven)";
-  const mavenDir = await findMavenDir(process.cwd());
-  if (!mavenDir) {
-    return { category: "dependency", name, status: "skip", detail: "no pom.xml found" };
+  const found = await findJvmProject(process.cwd());
+  const name = `trivy fs (${found?.kind ?? "jvm"})`;
+  if (!found) {
+    return {
+      category: "dependency",
+      name: "trivy fs (jvm)",
+      status: "skip",
+      detail: "no Maven/Gradle project found",
+    };
   }
+  const { dir: mavenDir, kind } = found;
 
   const trivyBin = await resolveToolBin("trivy");
   if (!trivyBin) {
@@ -997,22 +1026,40 @@ async function checkMavenAudit(): Promise<SecurityCheckResult> {
     };
   }
 
-  // Transitive resolution comes from ~/.m2; an empty cache means trivy reports
-  // only direct deps. Warn (don't pass) so a green check never hides that gap.
-  const m2 = resolve(homedir(), ".m2", "repository");
-  const hasM2 = await access(m2)
-    .then(() => true)
-    .catch(() => false);
-  if (!hasM2) {
-    return {
-      category: "dependency",
-      name,
-      status: "warn",
-      detail: "no ~/.m2 cache -maven transitive CVEs undetected",
-      severity: "medium",
-      suggestion:
-        "populate the Maven cache: mvn dependency:go-offline (cache ~/.m2 in CI), then re-run",
-    };
+  // Transitive resolution source: Maven reads ~/.m2; Gradle reads gradle.lockfile.
+  // Without it trivy sees only direct deps, so warn (don't pass) — a green check
+  // must never hide the transitive gap (#110).
+  if (kind === "maven") {
+    const m2 = resolve(homedir(), ".m2", "repository");
+    const hasM2 = await access(m2)
+      .then(() => true)
+      .catch(() => false);
+    if (!hasM2) {
+      return {
+        category: "dependency",
+        name,
+        status: "warn",
+        detail: "no ~/.m2 cache -maven transitive CVEs undetected",
+        severity: "medium",
+        suggestion:
+          "populate the Maven cache: mvn dependency:go-offline (cache ~/.m2 in CI), then re-run",
+      };
+    }
+  } else {
+    const hasLock = await access(resolve(mavenDir, "gradle.lockfile"))
+      .then(() => true)
+      .catch(() => false);
+    if (!hasLock) {
+      return {
+        category: "dependency",
+        name,
+        status: "warn",
+        detail: "no gradle.lockfile -gradle transitive CVEs undetected (only direct deps scanned)",
+        severity: "medium",
+        suggestion:
+          "generate a lockfile: gradle dependencies --write-locks (commit gradle.lockfile), then re-run",
+      };
+    }
   }
 
   const result = await execFileNoThrow(
@@ -1036,7 +1083,7 @@ async function checkMavenAudit(): Promise<SecurityCheckResult> {
       category: "dependency",
       name,
       status: "warn",
-      detail: "trivy maven scan failed",
+      detail: "trivy JVM scan failed",
       severity: "medium",
     };
   }
@@ -1046,7 +1093,7 @@ async function checkMavenAudit(): Promise<SecurityCheckResult> {
       category: "dependency",
       name,
       status: "warn",
-      detail: "trivy maven scan failed",
+      detail: "trivy JVM scan failed",
       severity: "medium",
     };
   }
@@ -1055,14 +1102,14 @@ async function checkMavenAudit(): Promise<SecurityCheckResult> {
       category: "dependency",
       name,
       status: "pass",
-      detail: "no high/critical Maven dependency CVEs",
+      detail: "no high/critical JVM dependency CVEs",
     };
   }
   return {
     category: "dependency",
     name,
     status: "fail",
-    detail: `${count} high/critical Maven dependency CVE(s) -run: trivy fs --offline-scan ${mavenDir}`,
+    detail: `${count} high/critical JVM dependency CVE(s) -run: trivy fs --offline-scan ${mavenDir}`,
     severity: "high",
   };
 }


### PR DESCRIPTION
Closes #110 (follow-up to #67).

#67's `checkMavenAudit` detected only `pom.xml` at depth ≤1 → **Gradle** projects (`build.gradle`/`.kts`) and Maven/Gradle projects in monorepo subdirs (`services/backend/pom.xml`) passed the gate green: the same false-green #67 closed, for the rest of the JVM ecosystem.

- **Detection**: `jvmProjectKind` (pure) classifies Maven vs Gradle; `findJvmProject` does a **depth-≤3 BFS** (skipping `node_modules`/`target`/`build`/`.git`/`.gradle`).
- **Gradle transitive gap**: a Gradle project **without** `gradle.lockfile` → `warn` ("only direct deps scanned"), not `skip` green — mirrors the `~/.m2` handling for Maven.
- Result messages are now JVM-generic (not Maven-only).

Fixture-tested: Gradle@depth-2, Maven pom@depth-2, no-JVM→null, node_modules skipped. 19/19 check-security tests green on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)