### PR TITLE
fix(cli): surface 11 hidden commands in kit help + drift guard (1.31.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.31.1] - 2026-06-25
+
+### Fixed
+
+- **`kit help` was hiding 11 of 47 commands.** `COMMAND_HELP` was hand-maintained separately from the dispatch table, so 11 dispatched commands had no help entry and were absent from both `kit help` and the did-you-mean suggestions: `health`, `scan`, `sentinel`, `supply-chain`, `agent-audit`, `gha-audit`, `sbom`, `ingest`, `verify-provenance`, plus bare `auth` and `security`. Added all 11. The dispatch table (`COMMANDS`) is now the single source of truth — exported, with `main()` guarded to the real CLI entry — and a new `command-surface.test.ts` fails the build if help ever drifts from dispatch again.
+
+### Docs
+
+- **README no longer claims `kit check` runs Socket.** Socket is cloud-only (dropped #103); the README now describes it as an honest `skip` (local cover: GuardDog + osv-scanner + `kit supply-chain`), documents GuardDog, and surfaces `kit scan`/`supply-chain`/`sbom`/`gha-audit`/`sentinel`/`verify-provenance` in the command shortlist + Supply-chain section. `docs/COMMANDS.md` gains a "Supply chain + scanners" section + `health`/`heal` rows; the stale "Generated 2026-06-08" header is refreshed to 1.31.0.
+
 ## [1.31.0] - 2026-06-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ kit context check  # lock each CLI to the declared account + project (no wrong-o
 ## Problem
 
 Every time you (or an agent) starts on a new project:
+
 - Missing CLI tools (supabase, vercel, eas, gcloud...)
 - Not logged in to services
 - Missing API keys and secrets
@@ -92,10 +93,13 @@ with them. It runs them, folds in their results, and adds the layer they do not 
   goes **broad across the whole setup lifecycle**: tools, auth, secrets and vaults,
   git hooks, supply-chain triage, env routing, memory, governance. One command from
   `git clone` to a working, secret-safe environment.
-- **kit orchestrates, it does not replace.** `kit check` runs Semgrep, Trivy and
-  Socket when present; the `snyk` and `wiz` plugins ingest their findings; everything
-  lands in one consolidated report next to kit's own checks, each with a remediation
-  step.
+- **kit orchestrates, it does not replace.** `kit check` runs the local scanners it
+  finds (Semgrep, Trivy, osv-scanner, GuardDog); `kit scan` drives the wider registry
+  (snyk/trivy/grype/semgrep/osv) and merges it into one verdict; the `snyk` and `wiz`
+  plugins ingest their findings; everything lands in one consolidated report next to
+  kit's own checks, each with a remediation step. Cloud-only tools like Socket can't
+  run air-gapped, so kit surfaces them as an honest `skip` (local cover: GuardDog +
+  osv-scanner + `kit supply-chain`) — never a false green.
 - **The one gate your agent runs.** Before an AI agent acts it runs `kit review` once
   and gets a single deterministic verdict across every source. No agent, no socket,
   no telemetry, zero LLM calls. Your code never leaves the machine.
@@ -116,7 +120,7 @@ kit is a security tool, so it holds itself to the bar it sets. The receipts:
   incident-response plan with severity SLAs.
 - **Secrets never live in the repo.** kit keeps credentials in a vault, materializes
   `.env.local` locally (gitignored), and scans code, staged diffs, git history and its own
-  memory store for leaked keys. A stolen *repo* should contain no live secrets.
+  memory store for leaked keys. A stolen _repo_ should contain no live secrets.
 - **Supply chain is gated, not trusted.** `kit triage` runs before any install — fail-closed,
   "installs nothing untriaged" (aligns with OpenSSF S2C2F).
 - **Local-first, zero LLM, no telemetry.** Your code never leaves the machine.
@@ -179,6 +183,11 @@ Complete reference: [`docs/COMMANDS.md`](./docs/COMMANDS.md). The shortlist:
 - `kit setup`: Full pipeline: install → hooks → login → secrets → check
 - `kit check`: Status of tools, services, secrets, hooks, security, tests
 - `kit fix`: Auto-remediate gaps (tools, gitignore, hooks, .env.template)
+- `kit review` / `kit heal`: One-gate repo audit (check + design); bounded self-heal loop
+- `kit scan`: Run external scanners (snyk/trivy/grype/semgrep/osv) → one merged, air-gap-aware verdict
+- `kit supply-chain` / `kit sbom` / `kit gha-audit` / `kit agent-audit`: Install-time triage, SBOM, Actions hardening, agent/MCP/hook audit
+- `kit sentinel {run,install,status}`: Autonomous redline watcher (propose/apply guarded fixes)
+- `kit verify-provenance` / `kit ingest`: Verify SLSA provenance offline; ingest external SARIF/OSV
 - `kit login --plan`: Show the resolved auth strategy (vault/capture/interactive) per service without logging in
 - `kit secrets {set,migrate,rotate,propagate,onecli,validate}`: Secret lifecycle
 - `kit memory {index,search,stats,suggest,merge,save,threads,share,backup}`: Local-first, cross-harness second brain (per-harness `stats`, project recall, saved copilots) + `kit memory pal` pending-action ledger
@@ -224,7 +233,7 @@ Setup complete, you're ready to go! ✓
 ```
 
 Step 5 teaches the agent in the repo (Claude Code, Codex, Cursor, Cline) to
-*use* kit, it writes a small managed "run kit check / triage before install /
+_use_ kit, it writes a small managed "run kit check / triage before install /
 vault your secrets" block into the agent's rules file (`CLAUDE.md`, `AGENTS.md`,
 `.cursorrules`, `.clinerules`). Run it standalone any time with `kit agent-config`.
 The block is regenerated in place on re-run; edit outside its markers freely.
@@ -287,6 +296,7 @@ TRIAGE PASSED
 Trust model documented in [`docs/THREAT_MODEL.md`](./docs/THREAT_MODEL.md);
 data flow per command in [`docs/DATA_FLOW.md`](./docs/DATA_FLOW.md);
 release-verification in [`docs/VERIFY.md`](./docs/VERIFY.md).
+
 - `kit doctor`: Deep diagnostics: Node.js version, mise, .env.local, tools in PATH, git hooks
 - `kit env`: Inspect environment variables from .env.local (`--show-values`, `--missing`, `--json`)
 - `kit mcp`: Run the MCP server over stdio for AI assistants (auto-detected: no sub-command + non-TTY). Interactively, `kit mcp list|auth|set-token|clear` manages declared servers
@@ -313,16 +323,16 @@ provisions its CLI like any other tool — it adds the CLI to `[tools]`, so `kit
 installs it via mise, resolves it mise-first at read time, and prints the login step.
 This covers the dedicated vault CLIs:
 
-| Backend | CLI installed by `kit setup`? | Authenticate with |
-|---|---|---|
-| 1Password | yes (`op` via mise) | `op signin` |
-| Infisical | yes (`infisical` via mise) | `infisical login` + `infisical init` |
-| Doppler | yes (`doppler` via mise) | `doppler login` + `doppler setup` |
-| Bitwarden | yes (`bw` via mise) | `bw login` + `bw unlock` |
-| HashiCorp Vault | yes (`vault` via mise) | `vault login` |
-| AWS Secrets Manager | **no** — uses your existing `aws` CLI | `aws configure` / IAM role |
-| GCP Secret Manager | **no** — uses your existing `gcloud` CLI | `gcloud auth login` |
-| Azure Key Vault | **no** — uses your existing `az` CLI | `az login` |
+| Backend             | CLI installed by `kit setup`?            | Authenticate with                    |
+| ------------------- | ---------------------------------------- | ------------------------------------ |
+| 1Password           | yes (`op` via mise)                      | `op signin`                          |
+| Infisical           | yes (`infisical` via mise)               | `infisical login` + `infisical init` |
+| Doppler             | yes (`doppler` via mise)                 | `doppler login` + `doppler setup`    |
+| Bitwarden           | yes (`bw` via mise)                      | `bw login` + `bw unlock`             |
+| HashiCorp Vault     | yes (`vault` via mise)                   | `vault login`                        |
+| AWS Secrets Manager | **no** — uses your existing `aws` CLI    | `aws configure` / IAM role           |
+| GCP Secret Manager  | **no** — uses your existing `gcloud` CLI | `gcloud auth login`                  |
+| Azure Key Vault     | **no** — uses your existing `az` CLI     | `az login`                           |
 
 The three cloud secret managers are a deliberate exception: their CLIs are normally
 already present (cloud installer, CI image, IAM environment), authenticate through
@@ -395,13 +405,14 @@ Context pointers are non-secret and live in config; the credentials they authent
 - **Bumblebee**: Built-in supply-chain scanner. Verifies every dependency against pinned SHA-256 checksums in `bumblebee.lock.json`. Re-verifies the cache before reuse so a tampered local file is caught (kind `integrity`). Runs in CI on every PR
 - `kit triage npm|pip|docker|repo|skill <target>`: Pre-install security evaluation via triage skill
 - `kit triage npm <pkg> --sandbox`: Offline behavioral inspection: `npm pack` → extract → scan for install scripts, eval/base64/network patterns, unexpected scripts, oversized files. No code executes
+- `kit scan`: Run the installed external scanners (Snyk, Trivy, Grype, Semgrep, osv-scanner) and merge them into one local, air-gap-aware verdict. **GuardDog** (opt-in via `KIT_GUARDDOG=1` or `[scan] guarddog`) adds local malware detection. Cloud-only **Socket** can't run air-gapped, so it surfaces as an honest `skip` (local cover: GuardDog + osv-scanner + `kit supply-chain`), never a false green
 - Supply-chain findings auto-append to `.kit-audit.jsonl` (one JSON line per finding) for SIEM ingest
 - Releases ship with SLSA provenance (`npm publish --provenance`), CycloneDX + SPDX SBOMs on every GitHub release, cosign-signed Docker images, and weekly OpenSSF Scorecard
 
 ## Memory
 
 `kit memory` gives an agent a local-first, deterministic second brain, it stores
-your raw conversation history and searches it *before answering*, so it pulls
+your raw conversation history and searches it _before answering_, so it pulls
 receipts instead of guessing. SQLite + FTS5, two hooks, no vectors, no model calls.
 It indexes transcripts from **seven** coding agents (Claude Code, Codex, Gemini,
 Continue, Cursor, Amazon Q, and Cline), each parsed against the agent's own
@@ -510,35 +521,36 @@ kit add vercel/hosting     # Link repository to Vercel
 
 The full adapter set (each provisions/reuses the relevant keys; run `kit add <id>`):
 
-| Service | Purpose |
-|---|---|
-| `stripe/payments` | Stripe payment processing (products + price IDs) |
-| `supabase/db` | Supabase database + authentication |
-| `vercel/hosting` | Vercel hosting + deployment |
-| `flyio/hosting` | Fly.io container deployment |
-| `railway/hosting` | Railway (Heroku-style) deployment |
-| `neon/db` | Neon serverless Postgres |
-| `planetscale/db` | PlanetScale serverless MySQL |
-| `upstash/redis` | Upstash serverless Redis |
-| `cloudflare/r2` | Cloudflare R2 object storage (S3-compatible) |
-| `clerk/auth` | Clerk authentication + user management |
-| `resend/email` | Resend transactional email |
-| `loops/email` | Loops marketing + transactional email |
-| `sentry/monitoring` | Sentry error tracking + performance monitoring |
-| `posthog/analytics` | PostHog product analytics + session recording |
-| `tinybird/analytics` | Tinybird real-time analytics on ClickHouse |
+| Service               | Purpose                                               |
+| --------------------- | ----------------------------------------------------- |
+| `stripe/payments`     | Stripe payment processing (products + price IDs)      |
+| `supabase/db`         | Supabase database + authentication                    |
+| `vercel/hosting`      | Vercel hosting + deployment                           |
+| `flyio/hosting`       | Fly.io container deployment                           |
+| `railway/hosting`     | Railway (Heroku-style) deployment                     |
+| `neon/db`             | Neon serverless Postgres                              |
+| `planetscale/db`      | PlanetScale serverless MySQL                          |
+| `upstash/redis`       | Upstash serverless Redis                              |
+| `cloudflare/r2`       | Cloudflare R2 object storage (S3-compatible)          |
+| `clerk/auth`          | Clerk authentication + user management                |
+| `resend/email`        | Resend transactional email                            |
+| `loops/email`         | Loops marketing + transactional email                 |
+| `sentry/monitoring`   | Sentry error tracking + performance monitoring        |
+| `posthog/analytics`   | PostHog product analytics + session recording         |
+| `tinybird/analytics`  | Tinybird real-time analytics on ClickHouse            |
 | `liveblocks/realtime` | Liveblocks collaborative realtime (presence, cursors) |
-| `trigger/background` | Trigger.dev background jobs |
-| `inngest/background` | Inngest event-driven background jobs |
-| `flagsmith/flags` | Flagsmith feature flags + remote config |
-| `expo/eas` | Expo Application Services (mobile builds) |
-| `searxng/instance` | Self-hosted SearXNG search engine |
+| `trigger/background`  | Trigger.dev background jobs                           |
+| `inngest/background`  | Inngest event-driven background jobs                  |
+| `flagsmith/flags`     | Flagsmith feature flags + remote config               |
+| `expo/eas`            | Expo Application Services (mobile builds)             |
+| `searxng/instance`    | Self-hosted SearXNG search engine                     |
 
 Add your own with `kit create-plugin <name>` (see [docs/PLUGIN_DEVELOPMENT.md](./docs/PLUGIN_DEVELOPMENT.md)).
 
 ### Example Workflows
 
 **New project setup:**
+
 ```bash
 # Clone project
 git clone https://github.com/user/my-app
@@ -557,6 +569,7 @@ kit check
 ```
 
 **Agent-driven provisioning:**
+
 ```bash
 # Agent provisions services automatically
 kit add stripe/payments
@@ -578,6 +591,7 @@ See [docs/CUSTOM_ADAPTERS.md](./docs/CUSTOM_ADAPTERS.md) for a complete guide on
 **Troubleshooting:**
 
 Common issues and solutions:
+
 - **"Required tool not installed"**: Install the service's CLI tool (see examples above)
 - **"Not authenticated"**: Run the service's login command (e.g., `stripe login`)
 - **"Provisioning failed"**: Check CLI is in your PATH: `which stripe`
@@ -586,6 +600,7 @@ Common issues and solutions:
 ## Agent Integration
 
 Agents run `kit check` at start. If anything fails:
+
 1. Auto-fix what's possible (`kit fix`)
 2. Escalate to human what requires browser auth (`kit escalate`)
 3. Continue working on what's available
@@ -635,11 +650,13 @@ revocation_endpoint = "https://audit.example.com/agents/{agent_id}/status"
 ### Environment Detection
 
 kit automatically detects the current environment using:
+
 1. **NODE_ENV** environment variable (highest priority)
 2. **Git branch** name (fallback: main/master→prod, staging→staging, others→dev)
 3. **Default** to dev if neither is available
 
 Set NODE_ENV in your `.env.local`:
+
 ```bash
 # Options: development, staging, production
 NODE_ENV=development
@@ -720,33 +737,47 @@ For Cline, add the same config to your `cline_mcp_settings.json`.
 
 ### Available MCP Tools
 
-| Tool | Description |
-|------|-------------|
-| `kit_check` | Run all checks, return structured status JSON |
-| `kit_install` | Install missing tools via mise |
-| `kit_login` | Attempt service logins (non-interactive) |
-| `kit_secrets` | Generate `.env.local` from configured sources |
-| `kit_fix` | Auto-fix issues (install tools, generate lock files) |
-| `kit_add` | Provision a service integration (stripe, supabase, etc.) |
-| `kit_env` | Inspect `.env.local`, list keys with set/missing status and redacted values |
+| Tool          | Description                                                                 |
+| ------------- | --------------------------------------------------------------------------- |
+| `kit_check`   | Run all checks, return structured status JSON                               |
+| `kit_install` | Install missing tools via mise                                              |
+| `kit_login`   | Attempt service logins (non-interactive)                                    |
+| `kit_secrets` | Generate `.env.local` from configured sources                               |
+| `kit_fix`     | Auto-fix issues (install tools, generate lock files)                        |
+| `kit_add`     | Provision a service integration (stripe, supabase, etc.)                    |
+| `kit_env`     | Inspect `.env.local`, list keys with set/missing status and redacted values |
 
 ### Example: kit_check response
 
 ```json
 {
   "ok": true,
-  "tools": [
-    { "name": "node", "required": "latest", "installed": "22.22.2", "ok": true }
-  ],
+  "tools": [{ "name": "node", "required": "latest", "installed": "22.22.2", "ok": true }],
   "secrets": [
     { "name": "APP_NAME", "source": "config", "available": true, "detail": "Derived from config" }
   ],
   "security": [
-    { "category": "secrets", "name": ".env gitignored", "status": "pass", "detail": "all .env patterns in .gitignore" },
-    { "category": "supply-chain", "name": "pinned versions", "status": "pass", "detail": "all dependencies pinned" }
+    {
+      "category": "secrets",
+      "name": ".env gitignored",
+      "status": "pass",
+      "detail": "all .env patterns in .gitignore"
+    },
+    {
+      "category": "supply-chain",
+      "name": "pinned versions",
+      "status": "pass",
+      "detail": "all dependencies pinned"
+    }
   ],
   "locks": [
-    { "category": "cli-lock", "exists": true, "inSync": true, "missing": [], "detail": "all tools locked" }
+    {
+      "category": "cli-lock",
+      "exists": true,
+      "inSync": true,
+      "missing": [],
+      "detail": "all tools locked"
+    }
   ]
 }
 ```

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,184 +1,199 @@
 # kit commands
 
-> Complete reference for every `kit <subcommand>`. Generated 2026-06-08.
+> Complete reference for every `kit <subcommand>`. Last updated 2026-06-24 (kit 1.31.0).
 > Pair this with `docs/THREAT_MODEL.md` (what data flows where) and
 > `docs/DATA_FLOW.md` (exact reads/writes per op).
 
 ## Global flags
 
-| Flag | Effect |
-|---|---|
+| Flag                         | Effect                                                                                     |
+| ---------------------------- | ------------------------------------------------------------------------------------------ |
 | `--read-only` / `--readonly` | Activate session-wide refusal of every mutating op. Also honored as `KIT_READ_ONLY=1` env. |
-| `--non-interactive` | Skip all confirmation prompts. Required in CI / agent contexts. |
-| `--version` / `-v` | Print kit version + exit. |
-| `--help` / `-h` | Print top-level help + exit. |
+| `--non-interactive`          | Skip all confirmation prompts. Required in CI / agent contexts.                            |
+| `--version` / `-v`           | Print kit version + exit.                                                                  |
+| `--help` / `-h`              | Print top-level help + exit.                                                               |
 
 ## Core lifecycle
 
-| Command | Purpose |
-|---|---|
-| `kit init` | Auto-detect project stack → generate `.kit.toml` + lockfiles. |
-| `kit setup` | 5-step orchestrator: install → hooks → login → secrets → check. |
-| `kit check` | Verify tools / services / secrets / skills / hooks / security / tests. |
-| `kit status [--json]` | Adoption checklist — which subsystems are set up (config, vault, tools, gitignore hygiene, dependency policy, agent-config, memory, hooks) + the next step for each gap. |
-| `kit install` | Install missing tools declared in `[tools]` via mise. |
-| `kit login [--service <name>] [--retry-count <N>]` | Guided login to configured services. Optionally narrow to one service / retry failures with backoff. |
-| `kit login --plan [--json]` | Read-only: show the resolved auth strategy per service (vault / interactive / capture) + a passkey warning for browser logins that can't be scripted on a fresh machine. |
-| `kit skills` | Check status of agent skills declared in `[skills]` against the registry (clawhub default). |
-| `kit fix` | Auto-remediate common gaps (tools, lockfiles, gitignore, hooks, .env.template). |
-| `kit upgrade` | Refresh lockfiles from `.kit.toml`. |
-| `kit doctor` | Diagnostic sweep — surfaces config drift + CLI version skew. |
-| `kit clone <url>` | Clone + setup in one step (skip setup with `--no-setup`). |
+| Command                                            | Purpose                                                                                                                                                                  |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `kit init`                                         | Auto-detect project stack → generate `.kit.toml` + lockfiles.                                                                                                            |
+| `kit setup`                                        | 5-step orchestrator: install → hooks → login → secrets → check.                                                                                                          |
+| `kit check`                                        | Verify tools / services / secrets / skills / hooks / security / tests.                                                                                                   |
+| `kit health [--json]`                              | Deep environment health diagnostics — granular pass/fail across tools, services, and config (more detail than `check`).                                                  |
+| `kit status [--json]`                              | Adoption checklist — which subsystems are set up (config, vault, tools, gitignore hygiene, dependency policy, agent-config, memory, hooks) + the next step for each gap. |
+| `kit install`                                      | Install missing tools declared in `[tools]` via mise.                                                                                                                    |
+| `kit login [--service <name>] [--retry-count <N>]` | Guided login to configured services. Optionally narrow to one service / retry failures with backoff.                                                                     |
+| `kit login --plan [--json]`                        | Read-only: show the resolved auth strategy per service (vault / interactive / capture) + a passkey warning for browser logins that can't be scripted on a fresh machine. |
+| `kit skills`                                       | Check status of agent skills declared in `[skills]` against the registry (clawhub default).                                                                              |
+| `kit fix`                                          | Auto-remediate common gaps (tools, lockfiles, gitignore, hooks, .env.template).                                                                                          |
+| `kit heal [--dry-run] [--agent]`                   | Bounded self-heal loop: auto-fix safe findings, re-scan until green; gates destructive ops, fail-closed on tamper.                                                       |
+| `kit upgrade`                                      | Refresh lockfiles from `.kit.toml`.                                                                                                                                      |
+| `kit doctor`                                       | Diagnostic sweep — surfaces config drift + CLI version skew.                                                                                                             |
+| `kit clone <url>`                                  | Clone + setup in one step (skip setup with `--no-setup`).                                                                                                                |
 
 ## Code quality + reviews
 
-| Command | Purpose |
-|---|---|
-| `kit design` | A11y + design-token checks, baseline-aware. |
-| `kit review` | Meta-runner — `check + design + tests` gate for PR. |
-| `kit baseline [freeze]` | Snapshot current acceptable warnings to `.kit-baseline.json`. |
+| Command                 | Purpose                                                                |
+| ----------------------- | ---------------------------------------------------------------------- |
+| `kit design`            | A11y + design-token checks, baseline-aware.                            |
+| `kit review`            | Meta-runner — `check + design + tests` gate for PR.                    |
+| `kit baseline [freeze]` | Snapshot current acceptable warnings to `.kit-baseline.json`.          |
 | `kit analyze [--write]` | Mine git history + framework markers → draft `CLAUDE.md` / `RULES.md`. |
 
 ## Secrets
 
-| Command | Purpose |
-|---|---|
-| `kit secrets sync [--target=<github\|dotenv-ci\|stdout>]` | Sync vault → CI / `.env.local`. |
-| `kit secrets migrate [--keep-commented \| --purge]` | Plaintext `.env*` → vault. Default leaves `KEY=` (value blanked). |
-| `kit secrets vault-migrate --from <a> --to <b>` | Cross-vault key transfer (1Password → Infisical, etc.). |
+| Command                                                              | Purpose                                                                                                             |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `kit secrets sync [--target=<github\|dotenv-ci\|stdout>]`            | Sync vault → CI / `.env.local`.                                                                                     |
+| `kit secrets migrate [--keep-commented \| --purge]`                  | Plaintext `.env*` → vault. Default leaves `KEY=` (value blanked).                                                   |
+| `kit secrets vault-migrate --from <a> --to <b>`                      | Cross-vault key transfer (1Password → Infisical, etc.).                                                             |
 | `kit secrets set <KEY> [--stdin \| --value <v>] [--store <backend>]` | Capture a value to the vault. `--stdin` (safer — not in argv/ps) or `--value`. Execution behind `auth = "capture"`. |
-| `kit secrets rotate [--mode <jwt-secret-roll \| scoped-key-mint>]` | Rotate via supabase-mgmt-api. JWT roll is one-shot elevation. |
-| `kit secrets onecli register` | Register fake-key in OneCLI gateway. |
-| `kit secrets purge-history --force-history` | git-history rewrite to scrub leaked credentials. |
-| `kit secrets propagate` | Sync vault → deploy platform (Vercel / Fly / etc.). |
-| `kit secrets revoke-old` | Revoke superseded credential after rotation. |
-| `kit secrets pull --from <vercel\|github\|fly\|cloudflare>` | Read env-vars from deploy platform into vault. |
-| `kit secrets set-value <KEY> <VALUE>` | Write a single key/value to the configured vault. |
-| `kit secrets validate [--fix\|--auto]` | Verify every declared key resolves in vault. `--auto` pulls from `.env.template`. |
+| `kit secrets rotate [--mode <jwt-secret-roll \| scoped-key-mint>]`   | Rotate via supabase-mgmt-api. JWT roll is one-shot elevation.                                                       |
+| `kit secrets onecli register`                                        | Register fake-key in OneCLI gateway.                                                                                |
+| `kit secrets purge-history --force-history`                          | git-history rewrite to scrub leaked credentials.                                                                    |
+| `kit secrets propagate`                                              | Sync vault → deploy platform (Vercel / Fly / etc.).                                                                 |
+| `kit secrets revoke-old`                                             | Revoke superseded credential after rotation.                                                                        |
+| `kit secrets pull --from <vercel\|github\|fly\|cloudflare>`          | Read env-vars from deploy platform into vault.                                                                      |
+| `kit secrets set-value <KEY> <VALUE>`                                | Write a single key/value to the configured vault.                                                                   |
+| `kit secrets validate [--fix\|--auto]`                               | Verify every declared key resolves in vault. `--auto` pulls from `.env.template`.                                   |
 
 ## Auth + elevation
 
-| Command | Purpose |
-|---|---|
+| Command                                                 | Purpose                                                         |
+| ------------------------------------------------------- | --------------------------------------------------------------- |
 | `kit auth elevate [--scope <name>] [--ttl-minutes <N>]` | TTY prompt + TOTP → mints elevation marker for destructive ops. |
-| `kit auth status` | Show current elevation state. |
-| `kit auth revoke` | Clear elevation marker. |
-| `kit auth setup-totp` | Enroll TOTP secret in `~/.kit/totp-secret`. |
+| `kit auth status`                                       | Show current elevation state.                                   |
+| `kit auth revoke`                                       | Clear elevation marker.                                         |
+| `kit auth setup-totp`                                   | Enroll TOTP secret in `~/.kit/totp-secret`.                     |
 
 ## Environment
 
-| Command | Purpose |
-|---|---|
-| `kit env list` | List configured environments (`[env.<name>]`). |
-| `kit env switch <env>` | Activate env in `.kit/active-env.json`. |
-| `kit env current` | Print active env. |
+| Command                          | Purpose                                                                                       |
+| -------------------------------- | --------------------------------------------------------------------------------------------- |
+| `kit env list`                   | List configured environments (`[env.<name>]`).                                                |
+| `kit env switch <env>`           | Activate env in `.kit/active-env.json`.                                                       |
+| `kit env current`                | Print active env.                                                                             |
 | `kit env diff --compare <other>` | Drift report between two `.env*` files (values shown as sha256:8 prefixes — never plaintext). |
 
 ## MCP orchestrator
 
-| Command | Purpose |
-|---|---|
-| `kit mcp` / `kit mcp list` | Show declared MCPs + auth status. |
-| `kit mcp status` | Alias for `list`. |
-| `kit mcp auth <name>` | Show OAuth-flow guidance for vendor. |
-| `kit mcp set-token <name> [--from-env VAR \| --paste]` | Headless / paste-token install. |
-| `kit mcp clear <name>` | Remove stored token. |
+| Command                                                | Purpose                              |
+| ------------------------------------------------------ | ------------------------------------ |
+| `kit mcp` / `kit mcp list`                             | Show declared MCPs + auth status.    |
+| `kit mcp status`                                       | Alias for `list`.                    |
+| `kit mcp auth <name>`                                  | Show OAuth-flow guidance for vendor. |
+| `kit mcp set-token <name> [--from-env VAR \| --paste]` | Headless / paste-token install.      |
+| `kit mcp clear <name>`                                 | Remove stored token.                 |
 
 ## Hooks
 
-| Command | Purpose |
-|---|---|
-| `kit hooks install` | Install pre-commit / post-commit hooks declared in `[hooks]`. Pulls in bypass-detector sentinel pair. |
-| `kit hooks add <name>` | Add a built-in hook (secret-scan, post-pull-audit). |
-| `kit hooks sync` | Reconcile installed hooks with config. |
+| Command                | Purpose                                                                                               |
+| ---------------------- | ----------------------------------------------------------------------------------------------------- |
+| `kit hooks install`    | Install pre-commit / post-commit hooks declared in `[hooks]`. Pulls in bypass-detector sentinel pair. |
+| `kit hooks add <name>` | Add a built-in hook (secret-scan, post-pull-audit).                                                   |
+| `kit hooks sync`       | Reconcile installed hooks with config.                                                                |
 
 ## Security
 
-| Command | Purpose |
-|---|---|
-| `kit security check-gitignore [--fix]` | Verify secret-file patterns are gitignored. |
-| `kit security scan-staged` | Block commit if staged files contain credential patterns. |
+| Command                                   | Purpose                                                               |
+| ----------------------------------------- | --------------------------------------------------------------------- |
+| `kit security check-gitignore [--fix]`    | Verify secret-file patterns are gitignored.                           |
+| `kit security scan-staged`                | Block commit if staged files contain credential patterns.             |
 | `kit security verify-pull [--base <ref>]` | Post-`git pull` audit: new deps, gitignore drops, introduced secrets. |
-| `kit security scan-build [<dir>]` | Walk `.next` / `dist` for credential leaks in build artifacts. |
-| `kit security clear-cache` | Wipe bumblebee cache. |
-| `kit security costs` | Run cost-monitor leak-detection (P3.1). |
-| `kit security policy` | Validate `.kit-allowlist.json` against current deps. |
+| `kit security scan-build [<dir>]`         | Walk `.next` / `dist` for credential leaks in build artifacts.        |
+| `kit security clear-cache`                | Wipe bumblebee cache.                                                 |
+| `kit security costs`                      | Run cost-monitor leak-detection (P3.1).                               |
+| `kit security policy`                     | Validate `.kit-allowlist.json` against current deps.                  |
+
+## Supply chain + scanners
+
+| Command                                        | Purpose                                                                                                                                                                                                                                                                                                                       |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kit scan [--sarif]`                           | Run installed external scanners (Snyk, Trivy, Grype, Semgrep, osv-scanner) and merge into one local, air-gap-aware verdict. **GuardDog** opt-in via `KIT_GUARDDOG=1` / `[scan] guarddog`. Cloud-only **Socket** surfaces as an honest `skip` (local cover: GuardDog + osv-scanner + `kit supply-chain`), never a false green. |
+| `kit supply-chain`                             | Install-time supply-chain triage: install-scripts, lockfile-drift, dep-confusion, slopsquat.                                                                                                                                                                                                                                  |
+| `kit agent-audit`                              | Audit agent / MCP / hook configs for plaintext secrets + malware-shaped hooks.                                                                                                                                                                                                                                                |
+| `kit gha-audit`                                | GitHub Actions hardening lint — unpinned action refs + pwn-request patterns in `.github/workflows`.                                                                                                                                                                                                                           |
+| `kit sbom [--format cyclonedx\|spdx]`          | Generate an SBOM from the lockfile.                                                                                                                                                                                                                                                                                           |
+| `kit ingest <sarif\|osv> <file>`               | Ingest an external SARIF / OSV report into kit's consolidated verdict (one parser per format).                                                                                                                                                                                                                                |
+| `kit verify-provenance <bundle>`               | Verify a release's SLSA provenance bundle offline (Ed25519 + SHA-256 / cosign `--offline`).                                                                                                                                                                                                                                   |
+| `kit sentinel <run\|install\|status> [--json]` | Autonomous redline watcher — propose/apply guarded remediations; `install` scaffolds the GitHub Actions workflow.                                                                                                                                                                                                             |
 
 ## Triage (pre-install)
 
-| Command | Purpose |
-|---|---|
-| `kit triage npm <pkg>` | Evaluate npm package: registry + GitHub health. |
+| Command                          | Purpose                                                              |
+| -------------------------------- | -------------------------------------------------------------------- |
+| `kit triage npm <pkg>`           | Evaluate npm package: registry + GitHub health.                      |
 | `kit triage npm <pkg> --sandbox` | + offline tarball inspection (install-script + path-traversal scan). |
-| `kit triage pip <pkg>` | PyPI evaluation. |
-| `kit triage docker <image>` | Docker image: CVE + sandbox. |
-| `kit triage repo <github-url>` | GitHub repo evaluation. |
-| `kit triage skill <path\|name>` | Claude Code / agent skill evaluation. |
-| `kit triage all <target>` | Auto-detect + run all checks. |
-| `kit triage tools` | List installed security tools. |
-| `kit triage check-deps` | Pre-commit gate: fail if staged deps lack triage entries. |
+| `kit triage pip <pkg>`           | PyPI evaluation.                                                     |
+| `kit triage docker <image>`      | Docker image: CVE + sandbox.                                         |
+| `kit triage repo <github-url>`   | GitHub repo evaluation.                                              |
+| `kit triage skill <path\|name>`  | Claude Code / agent skill evaluation.                                |
+| `kit triage all <target>`        | Auto-detect + run all checks.                                        |
+| `kit triage tools`               | List installed security tools.                                       |
+| `kit triage check-deps`          | Pre-commit gate: fail if staged deps lack triage entries.            |
 
 ## Packages + plugins
 
-| Command | Purpose |
-|---|---|
-| `kit pkg install <pkg>` | Triage → install with pinned version. |
-| `kit plugin search <query>` | Search plugin marketplace. |
-| `kit plugin install <id>` | Install a plugin. |
-| `kit plugin info <id>` | Plugin metadata. |
-| `kit plugin scaffold <name>` | Generate a new plugin skeleton. |
+| Command                      | Purpose                               |
+| ---------------------------- | ------------------------------------- |
+| `kit pkg install <pkg>`      | Triage → install with pinned version. |
+| `kit plugin search <query>`  | Search plugin marketplace.            |
+| `kit plugin install <id>`    | Install a plugin.                     |
+| `kit plugin info <id>`       | Plugin metadata.                      |
+| `kit plugin scaffold <name>` | Generate a new plugin skeleton.       |
 
 ## Governance
 
-| Command | Purpose |
-|---|---|
-| `kit governance status` | Budget + revocation + agent info. |
-| `kit audit` | Print recent `.kit-audit.jsonl` entries. |
-| `kit whoami [--json]` | Show current agent / user identity, active environment, and budget usage. |
-| `kit team create <name>` | Create a new team. |
-| `kit team invite <email> [--role=<role>]` | Invite a user to the team (roles: owner, admin, developer, guest). |
-| `kit team members list` | List team members. |
-| `kit team member remove <email>` | Remove a team member. |
-| `kit team audit log [--limit=<N>]` | View team audit logs. |
+| Command                                   | Purpose                                                                   |
+| ----------------------------------------- | ------------------------------------------------------------------------- |
+| `kit governance status`                   | Budget + revocation + agent info.                                         |
+| `kit audit`                               | Print recent `.kit-audit.jsonl` entries.                                  |
+| `kit whoami [--json]`                     | Show current agent / user identity, active environment, and budget usage. |
+| `kit team create <name>`                  | Create a new team.                                                        |
+| `kit team invite <email> [--role=<role>]` | Invite a user to the team (roles: owner, admin, developer, guest).        |
+| `kit team members list`                   | List team members.                                                        |
+| `kit team member remove <email>`          | Remove a team member.                                                     |
+| `kit team audit log [--limit=<N>]`        | View team audit logs.                                                     |
 
 ## Misc
 
-| Command | Purpose |
-|---|---|
-| `kit open <service>` | Open service dashboard in browser (stripe, vercel, etc.). |
-| `kit run <cmd>` | Arbitrary command runner (audit-logged). |
-| `kit escalate` | Collect failures + format for manual handoff. |
-| `kit ci` | One-shot CI gate (check + design + tests). |
-| `kit context [--format json]` | Print kit context for agent introspection. |
-| `kit create-plugin <name>` | Scaffold a new adapter. |
-| `kit add <service>` | Add service to `.kit.toml`. |
-| `kit version` | Print kit version + exit. |
-| `kit completions <bash\|zsh\|fish>` | Output shell completion script for the given shell. |
+| Command                             | Purpose                                                   |
+| ----------------------------------- | --------------------------------------------------------- |
+| `kit open <service>`                | Open service dashboard in browser (stripe, vercel, etc.). |
+| `kit run <cmd>`                     | Arbitrary command runner (audit-logged).                  |
+| `kit escalate`                      | Collect failures + format for manual handoff.             |
+| `kit ci`                            | One-shot CI gate (check + design + tests).                |
+| `kit context [--format json]`       | Print kit context for agent introspection.                |
+| `kit create-plugin <name>`          | Scaffold a new adapter.                                   |
+| `kit add <service>`                 | Add service to `.kit.toml`.                               |
+| `kit version`                       | Print kit version + exit.                                 |
+| `kit completions <bash\|zsh\|fish>` | Output shell completion script for the given shell.       |
 
 ## Memory
 
 Local-first second brain — SQLite + FTS5, deterministic, zero model calls. Full guide: `docs/MEMORY.md`.
 
-| Command | Purpose |
-|---|---|
-| `kit memory index` | Index `~/.claude` transcripts into `~/.kit/memory.db` (idempotent). |
-| `kit memory search <query>` | Full-text recall; defaults to the current project, `--global` across all. |
-| `kit memory stats` | Sessions / messages / tool-uses / DB size. |
-| `kit memory suggest [--limit N] [--json]` | Emit a BYO-LLM review prompt (recent activity + open items) to stdout — pipe to your own model. kit never calls a model. |
-| `kit memory install` / `uninstall` | Wire (or remove) the `UserPromptSubmit` + `SessionEnd` hooks in `~/.claude/settings.json`. |
-| `kit memory scan` | Scan the store for stored secrets (masked; exits 1 if any found). |
-| `kit memory backup <file>` / `restore <file>` | Encrypted AES-256-GCM backup/restore (`KIT_MEMORY_PASSPHRASE`). |
-| `kit memory pal [list\|add\|done\|snooze\|verify\|import]` | Pending-action ledger; auto-closes on verify. Project-scoped (`--global` for all). |
-| `kit memory save <name>` / `threads` / `resume <name\|n>` / `forget <name>` | Named copilots — bookmark + resume sessions. |
-| `kit memory share …` / `areas` / `area <name>` | Shared, area-organized team memory (committed, secret-scanned, reviewed like code). |
+| Command                                                                     | Purpose                                                                                                                  |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `kit memory index`                                                          | Index `~/.claude` transcripts into `~/.kit/memory.db` (idempotent).                                                      |
+| `kit memory search <query>`                                                 | Full-text recall; defaults to the current project, `--global` across all.                                                |
+| `kit memory stats`                                                          | Sessions / messages / tool-uses / DB size.                                                                               |
+| `kit memory suggest [--limit N] [--json]`                                   | Emit a BYO-LLM review prompt (recent activity + open items) to stdout — pipe to your own model. kit never calls a model. |
+| `kit memory install` / `uninstall`                                          | Wire (or remove) the `UserPromptSubmit` + `SessionEnd` hooks in `~/.claude/settings.json`.                               |
+| `kit memory scan`                                                           | Scan the store for stored secrets (masked; exits 1 if any found).                                                        |
+| `kit memory backup <file>` / `restore <file>`                               | Encrypted AES-256-GCM backup/restore (`KIT_MEMORY_PASSPHRASE`).                                                          |
+| `kit memory pal [list\|add\|done\|snooze\|verify\|import]`                  | Pending-action ledger; auto-closes on verify. Project-scoped (`--global` for all).                                       |
+| `kit memory save <name>` / `threads` / `resume <name\|n>` / `forget <name>` | Named copilots — bookmark + resume sessions.                                                                             |
+| `kit memory share …` / `areas` / `area <name>`                              | Shared, area-organized team memory (committed, secret-scanned, reviewed like code).                                      |
 
 ## Exit codes
 
-| Code | Meaning |
-|---|---|
-| 0 | success / all checks passing |
-| 1 | one or more checks failed |
-| 2 | usage error |
+| Code | Meaning                      |
+| ---- | ---------------------------- |
+| 0    | success / all checks passing |
+| 1    | one or more checks failed    |
+| 2    | usage error                  |
 
 ## Notes on read-only mode
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, realpathSync } from "node:fs";
 import { writeFile, access, mkdir } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { resolve, dirname, join } from "node:path";
@@ -4817,9 +4817,22 @@ function cmdVersion(): boolean {
   return true;
 }
 
-const COMMAND_HELP: Record<string, string> = {
+export const COMMAND_HELP: Record<string, string> = {
   status: "Adoption checklist — what's set up across kit + the next step for each gap",
   check: "Check status of all tools, services, secrets, and lock files",
+  health: "Deep environment health diagnostics — granular pass/fail across tools, services, config",
+  scan: "Run external scanners (snyk/trivy/grype/semgrep/osv) and merge them into one local verdict",
+  sentinel: "Autonomous redline watcher — propose/apply guarded remediations (run|install|status)",
+  "supply-chain":
+    "Install-time supply-chain triage: install-scripts, lockfile-drift, dep-confusion, slopsquat",
+  "agent-audit": "Audit agent / MCP / hook configs for plaintext secrets + malware-shaped hooks",
+  "gha-audit":
+    "GitHub Actions hardening lint — unpinned actions + pwn-request patterns in .github/workflows",
+  sbom: "Generate a CycloneDX / SPDX SBOM from the lockfile (SARIF emit via kit scan --sarif)",
+  ingest:
+    "Ingest external SARIF / OSV reports into kit's consolidated verdict (kit ingest <sarif|osv> <file>)",
+  "verify-provenance":
+    "Verify a release's SLSA provenance bundle offline (Ed25519 + SHA256 / cosign)",
   review: "Full repo audit — runs check + design in one gate (for agents / PR checks)",
   design: "Check design quality (a11y, design tokens) against the baseline",
   baseline:
@@ -4866,6 +4879,8 @@ const COMMAND_HELP: Record<string, string> = {
   analyze: "Analyze repo + emit draft CLAUDE.md / RULES.md",
   "agent-config":
     "Inject a managed 'use kit' block into CLAUDE.md / AGENTS.md / .cursorrules / .clinerules",
+  security:
+    "Security policy + scanners (policy | scan-staged | scan-build | verify-pull | prescan | …)",
   "security policy": "Dependency allowlist enforcement (init|add|check)",
   "security clear-cache": "Clear cached scanner binary (after intentional rebuild)",
   "security scan-staged": "Pre-commit: scan staged files for credential patterns",
@@ -4879,6 +4894,9 @@ const COMMAND_HELP: Record<string, string> = {
   "security prescan-diff":
     "Diff two prescan reports — surface new regressions + fixed findings since baseline",
   "audit secrets": "Forensics: who/what touched each key + when (reads audit log)",
+  "audit verify": "Verify the audit log's tamper-evident hash chain (exit 1 on break)",
+  "audit export": "Emit the audit log for a SIEM (--format cef|syslog|json)",
+  auth: "TOTP-gated elevation for destructive secret ops (elevate|status|revoke|setup-totp)",
   "auth elevate": "Mint elevation marker for destructive secret ops (TOTP/yes-prompt)",
   "auth status": "Show active elevation",
   "auth revoke": "Drop the elevation marker",
@@ -5505,56 +5523,9 @@ async function main(): Promise<void> {
       process.stdout.write(script);
       ok = true;
     } else {
-      const COMMANDS: Record<string, () => boolean | Promise<boolean>> = {
-        status: cmdStatus,
-        whoami: cmdWhoami,
-        check: cmdCheck,
-        health: cmdHealth,
-        ingest: cmdIngest,
-        "supply-chain": cmdSupplyChain,
-        "agent-audit": cmdAgentAudit,
-        sentinel: cmdSentinel,
-        scan: cmdScan,
-        "verify-provenance": cmdVerifyProvenance,
-        "gha-audit": cmdGhaAudit,
-        sbom: cmdSbom,
-        init: cmdInit,
-        upgrade: cmdUpgrade,
-        install: cmdInstall,
-        login: cmdLogin,
-        secrets: cmdSecrets,
-        setup: cmdSetup,
-        skills: cmdSkills,
-        fix: cmdFix,
-        heal: cmdHeal,
-        escalate: cmdEscalate,
-        governance: cmdGovernance,
-        "agent-config": cmdAgentConfig,
-        hooks: cmdHooks,
-        add: cmdAdd,
-        audit: cmdAudit,
-        auth: cmdAuth,
-        mcp: cmdMcp,
-        env: cmdEnv,
-        doctor: cmdDoctor,
-        analyze: cmdAnalyze,
-        security: cmdSecurity,
-        "create-plugin": cmdCreatePlugin,
-        plugin: cmdPlugin,
-        ci: cmdCi,
-        clone: cmdClone,
-        run: cmdRun,
-        open: cmdOpen,
-        context: cmdContext,
-        triage: cmdTriage,
-        baseline: cmdBaseline,
-        design: cmdDesign,
-        review: cmdReview,
-        pkg: cmdPkg,
-        team: cmdTeam,
-        memory: cmdMemory,
-      };
       // no command → `check` (the prior `case undefined` behaviour).
+      // COMMANDS is the module-scope dispatch table (single source of truth for the
+      // command surface; help coverage is verified against it in command-surface.test.ts).
       const handler = COMMANDS[command ?? "check"];
       if (handler) {
         ok = await handler();
@@ -5600,6 +5571,72 @@ async function main(): Promise<void> {
   }
 }
 
-// Entrypoint — fire-and-forget by design; main() handles its own errors and sets
-// process.exitCode. `void` marks the intentional non-await for no-floating-promises.
-void main();
+// Single source of truth for kit's top-level command surface. Every key here MUST
+// have a COMMAND_HELP entry — command-surface.test.ts fails the build otherwise, so
+// `kit help` and the did-you-mean suggestions can never silently drift from dispatch.
+// Declared at module scope (after every cmd* handler) so the coverage test can import
+// it without running the CLI; referenced by main() above, which only runs as the entry.
+export const COMMANDS: Record<string, () => boolean | Promise<boolean>> = {
+  status: cmdStatus,
+  whoami: cmdWhoami,
+  check: cmdCheck,
+  health: cmdHealth,
+  ingest: cmdIngest,
+  "supply-chain": cmdSupplyChain,
+  "agent-audit": cmdAgentAudit,
+  sentinel: cmdSentinel,
+  scan: cmdScan,
+  "verify-provenance": cmdVerifyProvenance,
+  "gha-audit": cmdGhaAudit,
+  sbom: cmdSbom,
+  init: cmdInit,
+  upgrade: cmdUpgrade,
+  install: cmdInstall,
+  login: cmdLogin,
+  secrets: cmdSecrets,
+  setup: cmdSetup,
+  skills: cmdSkills,
+  fix: cmdFix,
+  heal: cmdHeal,
+  escalate: cmdEscalate,
+  governance: cmdGovernance,
+  "agent-config": cmdAgentConfig,
+  hooks: cmdHooks,
+  add: cmdAdd,
+  audit: cmdAudit,
+  auth: cmdAuth,
+  mcp: cmdMcp,
+  env: cmdEnv,
+  doctor: cmdDoctor,
+  analyze: cmdAnalyze,
+  security: cmdSecurity,
+  "create-plugin": cmdCreatePlugin,
+  plugin: cmdPlugin,
+  ci: cmdCi,
+  clone: cmdClone,
+  run: cmdRun,
+  open: cmdOpen,
+  context: cmdContext,
+  triage: cmdTriage,
+  baseline: cmdBaseline,
+  design: cmdDesign,
+  review: cmdReview,
+  pkg: cmdPkg,
+  team: cmdTeam,
+  memory: cmdMemory,
+};
+
+// Run only when invoked as the real CLI entry — NOT when imported by a test
+// (command-surface.test.ts imports COMMANDS/COMMAND_HELP). main() handles its own
+// errors and sets process.exitCode; `void` marks the intentional non-await.
+function isCliEntry(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+if (isCliEntry()) void main();

--- a/src/command-surface.test.ts
+++ b/src/command-surface.test.ts
@@ -1,0 +1,33 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { COMMANDS, COMMAND_HELP } from "./cli.js";
+
+// Guards against the `kit help` ↔ dispatch drift that hid 11 commands
+// (health, scan, sentinel, supply-chain, agent-audit, gha-audit, sbom, ingest,
+// verify-provenance, auth, security) from `kit help` and from did-you-mean.
+// COMMANDS is the single source of truth; help must cover it exactly.
+describe("command surface", () => {
+  it("every dispatched command has a COMMAND_HELP entry", () => {
+    const missing = Object.keys(COMMANDS).filter(
+      (cmd) => !COMMAND_HELP[cmd] || COMMAND_HELP[cmd].length === 0,
+    );
+    assert.deepEqual(
+      missing,
+      [],
+      `commands dispatched but missing from kit help: ${missing.join(", ")}`,
+    );
+  });
+
+  it("no COMMAND_HELP entry points at a command that is not dispatched", () => {
+    // help/version/completions are handled before the dispatch table (special-cased in main()).
+    const known = new Set([...Object.keys(COMMANDS), "help", "version", "completions"]);
+    const stale = Object.keys(COMMAND_HELP)
+      .map((key) => key.split(" ")[0])
+      .filter((top) => !known.has(top));
+    assert.deepEqual(
+      [...new Set(stale)],
+      [],
+      `stale help entries for unknown commands: ${stale.join(", ")}`,
+    );
+  });
+});


### PR DESCRIPTION
## What

`kit help` and the did-you-mean suggestions were listing only 36 of 47 dispatched commands. `COMMAND_HELP` was hand-maintained separately from the dispatch table, so 11 commands were invisible: `health`, `scan`, `sentinel`, `supply-chain`, `agent-audit`, `gha-audit`, `sbom`, `ingest`, `verify-provenance`, plus bare `auth` and `security`.

## Fix (root cause, not just +11 entries)

- Added all 11 missing entries.
- `COMMANDS` (dispatch) is now the **single source of truth**: exported, `main()` guarded to the real CLI entry so it can be imported.
- New `command-surface.test.ts` fails the build if help ever drifts from dispatch in either direction.

## Docs honesty

- README no longer claims `kit check` runs **Socket** (cloud-only, dropped in #103) — now an honest `skip` with local cover (GuardDog + osv-scanner + `kit supply-chain`). GuardDog documented; `scan`/`supply-chain`/`sbom`/`gha-audit`/`sentinel`/`verify-provenance` added to the README shortlist + Supply-chain section.
- `docs/COMMANDS.md`: new "Supply chain + scanners" section + `health`/`heal` rows; stale "Generated 2026-06-08" header refreshed.

## Verify

- `npx tsc` clean; `command-surface.test.ts` green; `cli.test.ts`/`completions.test.ts` still pass (binary runs, help shows all 47).
- Bumped to **1.31.1** (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)