### PR TITLE
fix(scan,init): config-free kit scan + honor init --no-setup (1.32.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.32.0] - 2026-06-25
+
+### Fixed
+
+- **`kit scan` is now config-free.** Scanning is project-agnostic, yet `kit scan` aborted with "Create a .kit.toml" when no config was present — forcing a `kit init` (which writes a `.kit.toml` and runs setup) just to scan a repo. Now a missing config falls back to an empty one: scan runs in any directory and never writes a config file. Air-gap posture + scanner tokens still come from `.kit.toml` when present, otherwise from env.
+- **`kit init --no-setup` is honored.** `--no-setup` was only parsed by `kit clone`; `kit init --no-setup` silently ignored it and ran the full install/login/secrets pipeline anyway. It now stops after generating `.kit.toml` + lock files.
+
+Both surfaced by running kit against third-party / vendor repos, where the old behavior wrote a config and ran partial setup into a repo you only wanted to scan. Covered by new integration tests (`vendor-repo safety`).
+
 ## [1.31.2] - 2026-06-25
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "1.31.2",
+  "version": "1.32.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -631,3 +631,38 @@ describe("kit secrets validate", () => {
     assert.ok(result.stdout.includes("_KIT_VAL_ABSENT"), "names the missing key");
   });
 });
+
+// Regressions from running kit on third-party / vendor repos: `kit scan` must not
+// require (or create) a .kit.toml, and `kit init --no-setup` must actually stop
+// after config instead of running the full setup pipeline.
+describe("vendor-repo safety: config-free scan + honored --no-setup", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "kit-cfgfree-"));
+    await writeFile(join(dir, "package.json"), '{"name":"t","dependencies":{}}', "utf-8");
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("kit scan runs without a .kit.toml and never creates one", async () => {
+    const result = await runCli(["scan"], dir);
+    // The regression: a missing config used to ENOENT into "Create a .kit.toml".
+    // (Assertion is timeout-safe: that error fires at config-load, before scanners.)
+    assert.ok(
+      !result.stdout.includes("Create a .kit.toml") &&
+        !result.stderr.includes("Create a .kit.toml"),
+      `scan must not demand config; got: ${result.stdout}\n${result.stderr}`,
+    );
+    await assert.rejects(access(join(dir, ".kit.toml")), "scan must not write a .kit.toml");
+  });
+
+  it("kit init --no-setup generates config then stops (no install/login/secrets)", async () => {
+    const result = await runCli(["init", "--no-setup", "--non-interactive"], dir);
+    await access(join(dir, ".kit.toml")); // init's job: the config IS created
+    assert.ok(
+      /Setup skipped/.test(result.stdout),
+      `expected 'Setup skipped'; got: ${result.stdout}`,
+    );
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1772,6 +1772,16 @@ async function cmdInit(): Promise<boolean> {
     console.log();
   }
 
+  // --no-setup: stop after .kit.toml + lock files; skip install / login / secrets.
+  // (Mirrors `kit clone --no-setup`; previously `kit init` silently ignored this flag
+  // and ran full setup anyway.)
+  if (hasFlag(process.argv, "--no-setup")) {
+    console.log(
+      `${c.yellow}Setup skipped (--no-setup): .kit.toml + lock files generated; install / login / secrets not run.${c.reset}`,
+    );
+    return true;
+  }
+
   // Now run the setup process
   const setupOk = await cmdSetup();
 
@@ -4545,7 +4555,11 @@ async function cmdScan(): Promise<boolean> {
   const { loadBaseline, baselineGet, baselineSet, saveBaseline } = await import("./baseline.js");
   const { SCANNERS, airGapScanners } = await import("./scanners.js");
   const cwd = process.cwd();
-  const config = await loadConfig(resolveConfigPath());
+  // Config-free by design: scanning is project-agnostic, so a missing .kit.toml is
+  // NOT an error — fall back to an empty config (air-gap + tooling tokens then come
+  // from env). This is what lets `kit scan` run in any repo without `kit init` first.
+  const configPath = resolveConfigPath();
+  const config = existsSync(configPath) ? await loadConfig(configPath) : ({} as kitConfig);
 
   // Air-gap posture from `.kit.toml [air_gap]` + env (env overrides). When
   // enabled, drop cloud-only scanners and run the rest against local DBs with no
@@ -4856,7 +4870,7 @@ export const COMMAND_HELP: Record<string, string> = {
   "memory save": "Bookmark the current session as a named copilot",
   "memory threads": "List saved copilots (current project; --global for all)",
   "memory resume": "Print the resume command for a saved copilot (by name or number)",
-  init: "Detect stack, generate .kit.toml, and run full setup",
+  init: "Detect stack, generate .kit.toml, and run full setup (--no-setup: config + lock files only)",
   upgrade: "Update lock files from .kit.toml",
   install: "Install missing tools via mise",
   login: "Guided login to all configured services",


### PR DESCRIPTION
## Why
Surfaced by running kit against third-party / **vendor** repos: getting a read-only `kit scan` to run forced a `kit init` (which **wrote a `.kit.toml` + ran partial setup** into a repo you only wanted to scan).

## Fixes
- **`kit scan` is config-free.** Missing config → empty fallback; scan runs in any directory and **never writes a config file** (air-gap + tokens still read `.kit.toml` when present, else env).
- **`kit init --no-setup` is honored.** Flag was only parsed by `kit clone`; init now stops after `.kit.toml` + lock files. Surfaced in `kit init` help.

## Tests
New `vendor-repo safety` integration block. Full suite green, `tsc` clean. Bumped **1.32.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)