### PR TITLE
feat(setup,scan): network-posture choice + Socket cloud scanner (1.33.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.33.0] - 2026-06-25
+
+### Added
+
+- **Network-posture choice in `kit setup` / `kit init`.** Setup now asks **Connected** vs **Air-gapped enclave** and writes `[air_gap] enabled` to `.kit.toml` (idempotent — reports + skips if already set; non-interactive defaults to connected without writing). Air-gapped prompts for internal mirrors (npm/pypi/github/docker) + signed threat-data dir. Connected points at _where_ the cloud-scanner tokens live — kit **never captures, echoes, or stores** them; it only references the source (vault `[scan.tooling]` or env) and reads them at scan time.
+- **Socket wired as a real cloud scanner.** `kit scan` runs `socket ci` when `SOCKET_SECURITY_API_TOKEN` is present (cloud-only → dropped in air-gap). Because Socket has no stable findings-JSON, kit gates on the exit code via a new `exitGate` scanner mode — exit 0 = clean, non-zero = one high-severity policy-violation finding (never false-green). Pure helpers (`airGapTomlBlock`, the exitGate path) fixture-tested.
+
 ### Security
 
 - **CI: every GitHub Action pinned to a node24 commit SHA.** Cleared the Node 20 deprecation warning by SHA-pinning the first-party actions to current node24 releases (`checkout` v7, `setup-node` v6, `setup-python` v6, `github-script` v9, `upload-artifact` v7, `attest-build-provenance` v4, `codeql-action`) and froze the remaining mutable tags (`anchore/sbom-action`, `aquasecurity/tfsec-action`, `gitleaks-action`) to commit SHAs. This is `kit gha-audit`'s own advice (no unpinned/`@vN` action refs), applied to kit's own pipeline.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/airgap/config.test.ts
+++ b/src/airgap/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { resolveAirGap, airGapTriageEnv } from "./config.js";
+import { resolveAirGap, airGapTriageEnv, airGapTomlBlock } from "./config.js";
 
 describe("resolveAirGap", () => {
   it("reads settings from .kit.toml [air_gap] when no env is set", () => {
@@ -60,5 +60,31 @@ describe("airGapTriageEnv", () => {
 
   it("is empty when no mirrors are configured", () => {
     assert.deepEqual(airGapTriageEnv({ enabled: true }), {});
+  });
+});
+
+describe("airGapTomlBlock", () => {
+  it("connected posture is just enabled = false (no mirror keys)", () => {
+    assert.equal(airGapTomlBlock(false), "[air_gap]\nenabled = false");
+  });
+
+  it("enclave posture emits only the non-empty mirrors", () => {
+    const block = airGapTomlBlock(true, {
+      npmRegistry: "https://npm.corp",
+      pypiIndex: "  ", // blank → skipped
+      threatDataDir: "/opt/td",
+    });
+    assert.equal(
+      block,
+      '[air_gap]\nenabled = true\nnpm_registry = "https://npm.corp"\nthreat_data_dir = "/opt/td"',
+    );
+  });
+
+  it("round-trips: the block resolveAirGap-parses back to the same posture", () => {
+    // (shape check — the keys airGapTomlBlock writes are the keys resolveAirGap reads)
+    const block = airGapTomlBlock(true, { githubApi: "https://ghe.corp/api/v3" });
+    assert.match(block, /^\[air_gap\]$/m);
+    assert.match(block, /enabled = true/);
+    assert.match(block, /github_api = "https:\/\/ghe\.corp\/api\/v3"/);
   });
 });

--- a/src/airgap/config.ts
+++ b/src/airgap/config.ts
@@ -67,3 +67,35 @@ export function airGapTriageEnv(s: AirGapSettings): Record<string, string> {
   if (s.dockerRegistry) e.KIT_DOCKER_REGISTRY = s.dockerRegistry;
   return e;
 }
+
+export interface PostureMirrors {
+  npmRegistry?: string;
+  pypiIndex?: string;
+  githubApi?: string;
+  dockerRegistry?: string;
+  threatDataDir?: string;
+}
+
+/**
+ * Render the `[air_gap]` block for `.kit.toml` from a setup posture choice.
+ * `enabled = false` = connected (cloud scanners allowed); `enabled = true` =
+ * enclave (cloud-only scanners dropped) with optional internal mirrors — only
+ * non-empty mirror values are emitted. Pure — fixture-tested.
+ */
+export function airGapTomlBlock(enabled: boolean, mirrors: PostureMirrors = {}): string {
+  const lines = ["[air_gap]", `enabled = ${enabled}`];
+  if (enabled) {
+    const map: [keyof PostureMirrors, string][] = [
+      ["npmRegistry", "npm_registry"],
+      ["pypiIndex", "pypi_index"],
+      ["githubApi", "github_api"],
+      ["dockerRegistry", "docker_registry"],
+      ["threatDataDir", "threat_data_dir"],
+    ];
+    for (const [field, key] of map) {
+      const v = mirrors[field]?.trim();
+      if (v) lines.push(`${key} = "${v}"`);
+    }
+  }
+  return lines.join("\n");
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1148,6 +1148,11 @@ async function cmdSetup(): Promise<boolean> {
 
   const config = await loadConfig(resolveConfigPath());
 
+  // Network posture (connected vs air-gapped enclave): writes [air_gap], and for
+  // connected points at where the cloud-scanner tokens live (kit never captures
+  // them). Idempotent — reports + skips if a posture is already declared.
+  await offerPosture(resolveConfigPath(), config, isNonInteractive());
+
   // Recommended profile: an explicit flag always wins; otherwise ASK
   // interactively (the flag is just the scriptable answer to this question).
   // CI/agents without a flag get the core setup — we never silently wire global
@@ -1693,6 +1698,84 @@ async function offerContextLock(configPath: string, nonInteractive: boolean): Pr
   await writeFile(configPath, existing.trimEnd() + "\n\n" + block + "\n", "utf-8");
   console.log(
     `  ${c.green}✓${c.reset} Locked ${c.bold}[context]${c.reset} ${c.dim}→ verify with ${c.reset}${c.bold}kit context check${c.reset}\n`,
+  );
+}
+
+// Network-posture setup step: connected (cloud scanners allowed) vs air-gapped
+// enclave (cloud-only scanners dropped, internal mirrors). Writes [air_gap].
+// Security: kit NEVER captures/echoes/stores scanner tokens here — connected mode
+// only points at where they live (vault [scan.tooling] or env); kit reads them at
+// scan time. Idempotent: if a posture is already declared, report it and return.
+async function offerPosture(
+  configPath: string,
+  config: kitConfig,
+  nonInteractive: boolean,
+): Promise<void> {
+  if (config.air_gap?.enabled !== undefined) {
+    const mode = config.air_gap.enabled ? "air-gapped enclave" : "connected";
+    console.log(
+      `${c.dim}Network posture: ${c.reset}${c.bold}${mode}${c.reset} ${c.dim}(from .kit.toml [air_gap]).${c.reset}\n`,
+    );
+    return;
+  }
+  if (nonInteractive) {
+    console.log(
+      `${c.dim}Network posture: connected (default). Set ${c.reset}${c.bold}[air_gap] enabled = true${c.reset}${c.dim} for an air-gapped enclave.${c.reset}\n`,
+    );
+    return;
+  }
+
+  const { airGapTomlBlock } = await import("./airgap/config.js");
+  const choice = await promptSelect("Network posture for this project?", [
+    {
+      value: "connected",
+      label: "Connected",
+      hint: "cloud scanners (Snyk, Socket) available",
+      recommended: true,
+    },
+    {
+      value: "airgap",
+      label: "Air-gapped enclave",
+      hint: "no egress — cloud-only scanners dropped, offline DBs + internal mirrors",
+    },
+  ]);
+
+  let block: string;
+  if (choice === "airgap") {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    try {
+      const ask = async (q: string) => (await rl.question(`  ${q} `)).trim();
+      console.log(`${c.dim}Internal mirrors (Enter to skip each):${c.reset}`);
+      block = airGapTomlBlock(true, {
+        npmRegistry: await ask("npm registry URL:"),
+        pypiIndex: await ask("PyPI index URL:"),
+        githubApi: await ask("GitHub API base URL:"),
+        dockerRegistry: await ask("Docker registry URL:"),
+        threatDataDir: await ask("Signed threat-data dir (path):"),
+      });
+    } finally {
+      rl.close();
+    }
+    console.log(
+      `\n  ${c.yellow}⚠${c.reset} ${c.dim}Air-gapped: ${c.reset}${c.bold}kit scan${c.reset}${c.dim} drops cloud-only scanners (Snyk, Socket, semgrep) and runs trivy/grype/osv against local DBs. See docs/AIR_GAP.md.${c.reset}`,
+    );
+  } else {
+    block = airGapTomlBlock(false);
+    console.log(
+      `\n  ${c.dim}Connected: cloud scanners are available. Provide their tokens via your vault ${c.reset}${c.bold}[scan.tooling]${c.reset}${c.dim} or env — kit reads them at scan time and ${c.reset}${c.bold}never stores them${c.reset}${c.dim}:${c.reset}`,
+    );
+    console.log(
+      `    ${c.green}SNYK_TOKEN${c.reset}                 ${c.dim}→ kit scan runs Snyk${c.reset}`,
+    );
+    console.log(
+      `    ${c.green}SOCKET_SECURITY_API_TOKEN${c.reset}  ${c.dim}→ kit scan runs Socket (socket ci)${c.reset}`,
+    );
+  }
+
+  const existing = readFileSync(configPath, "utf-8");
+  await writeFile(configPath, `${existing.trimEnd()}\n\n${block}\n`, "utf-8");
+  console.log(
+    `\n  ${c.green}✓${c.reset} Wrote ${c.bold}[air_gap]${c.reset} ${c.dim}(${choice === "airgap" ? "enabled" : "disabled"}) to .kit.toml${c.reset}\n`,
   );
 }
 

--- a/src/scanners.test.ts
+++ b/src/scanners.test.ts
@@ -111,6 +111,39 @@ describe("runScanners (injected deps)", () => {
     assert.equal(runs[0].status, "ran");
     assert.equal(runs[0].findings, 0);
   });
+
+  it("exitGate scanner: clean exit → ran/0, no finding (stdout ignored)", async () => {
+    const only: ScannerDef[] = [
+      { id: "socket", bin: "socket", args: ["ci"], format: "sarif", exitGate: true },
+    ];
+    const deps: ScanDeps = {
+      resolve: async (bin) => `/usr/bin/${bin}`,
+      run: async () => ({ ok: true, stdout: "ok\n" }),
+      hasEnv: () => true,
+      detect: () => true,
+    };
+    const { merged, runs } = await runScanners(deps, only);
+    assert.equal(runs[0].status, "ran");
+    assert.equal(runs[0].findings, 0);
+    assert.equal(merged.length, 0);
+  });
+
+  it("exitGate scanner: non-zero exit → one high-severity policy violation (never false-green)", async () => {
+    const only: ScannerDef[] = [
+      { id: "socket", bin: "socket", args: ["ci"], format: "sarif", exitGate: true },
+    ];
+    const deps: ScanDeps = {
+      resolve: async (bin) => `/usr/bin/${bin}`,
+      run: async () => ({ ok: false, stdout: "" }),
+      hasEnv: () => true,
+      detect: () => true,
+    };
+    const { merged, runs } = await runScanners(deps, only);
+    assert.equal(runs[0].status, "ran");
+    assert.equal(runs[0].findings, 1);
+    assert.equal(merged.length, 1);
+    assert.equal(merged[0].severity, "high");
+  });
 });
 
 describe("isAirGap", () => {
@@ -133,9 +166,11 @@ describe("airGapScanners", () => {
 
   it("drops cloud-only scanners and folds offline args/env for the rest", () => {
     const plan = airGapScanners(SCANNERS, true);
-    // cloud-only (snyk, semgrep) are excluded
-    assert.deepEqual(plan.dropped.sort(), ["semgrep", "snyk"]);
-    assert.ok(!plan.scanners.some((s) => s.id === "snyk" || s.id === "semgrep"));
+    // cloud-only (snyk, semgrep, socket) are excluded
+    assert.deepEqual(plan.dropped.sort(), ["semgrep", "snyk", "socket"]);
+    assert.ok(
+      !plan.scanners.some((s) => s.id === "snyk" || s.id === "semgrep" || s.id === "socket"),
+    );
     // trivy gets its offline flags appended
     const trivy = plan.scanners.find((s) => s.id === "trivy")!;
     assert.ok(trivy.args.includes("--offline-scan") && trivy.args.includes("--skip-db-update"));
@@ -172,9 +207,11 @@ describe("airGapScanners", () => {
 
   it("drops cloud-only scanners and folds offline args/env for the rest", () => {
     const plan = airGapScanners(SCANNERS, true);
-    // cloud-only (snyk, semgrep) are excluded
-    assert.deepEqual(plan.dropped.sort(), ["semgrep", "snyk"]);
-    assert.ok(!plan.scanners.some((s) => s.id === "snyk" || s.id === "semgrep"));
+    // cloud-only (snyk, semgrep, socket) are excluded
+    assert.deepEqual(plan.dropped.sort(), ["semgrep", "snyk", "socket"]);
+    assert.ok(
+      !plan.scanners.some((s) => s.id === "snyk" || s.id === "semgrep" || s.id === "socket"),
+    );
     // trivy gets its offline flags appended
     const trivy = plan.scanners.find((s) => s.id === "trivy")!;
     assert.ok(trivy.args.includes("--offline-scan") && trivy.args.includes("--skip-db-update"));

--- a/src/scanners.ts
+++ b/src/scanners.ts
@@ -28,6 +28,13 @@ export interface ScannerDef {
   cloudOnly?: boolean;
   /** Extra args/env applied in air-gap mode so the scanner runs against a local DB. */
   offline?: { args?: string[]; env?: Record<string, string> };
+  /**
+   * Exit-code gate: the tool has no stable findings-JSON to parse, so its own exit
+   * status IS the verdict — exit 0 = clean, non-zero = one high-severity policy
+   * violation. (Socket: `socket ci` uploads manifests + fails on policy; `format`
+   * is unused because the exitGate branch short-circuits before ingest.)
+   */
+  exitGate?: boolean;
 }
 
 export const SCANNERS: ScannerDef[] = [
@@ -71,6 +78,19 @@ export const SCANNERS: ScannerDef[] = [
     args: ["--format", "json", "-r", "."],
     format: "osv",
     offline: { args: ["--offline"] },
+  },
+  {
+    // Socket uploads manifests to socket.dev (cloud) → not air-gappable. The CLI
+    // has no stable findings-JSON, so kit gates on `socket ci`'s exit code rather
+    // than parsing output. Opt-in: needs SOCKET_SECURITY_API_TOKEN (wired by
+    // `kit setup` in connected/non-air-gap posture).
+    id: "socket",
+    bin: "socket",
+    args: ["ci"],
+    format: "sarif", // unused — exitGate short-circuits before ingest
+    needsToken: "SOCKET_SECURITY_API_TOKEN",
+    cloudOnly: true,
+    exitGate: true,
   },
 ];
 
@@ -195,6 +215,29 @@ export async function runScanners(
       continue;
     }
     const res = await deps.run(bin, s.args);
+    // Exit-code-gated scanners (e.g. Socket): no parseable findings — the tool's
+    // own exit status IS the verdict. Never false-green on a crash: any non-zero
+    // exit becomes one high-severity policy-violation finding.
+    if (s.exitGate) {
+      if (res.ok) {
+        runs.push({ id: s.id, status: "ran", findings: 0 });
+      } else {
+        perScanner.push({
+          id: s.id,
+          findings: [
+            {
+              category: "supply-chain",
+              name: `${s.id}: policy violation`,
+              status: "fail",
+              detail: `${s.id} ci exited non-zero — dependency security/license policy issues found (see the ${s.id} dashboard)`,
+              severity: "high",
+            },
+          ],
+        });
+        runs.push({ id: s.id, status: "ran", findings: 1 });
+      }
+      continue;
+    }
     // Most scanners exit non-zero WHEN findings exist, so a non-zero exit alone
     // is not an error — parse the output regardless. But a non-empty output we
     // CANNOT parse (junk, an error blob, the wrong format) must NOT be silently


### PR DESCRIPTION
## Network posture + Socket scanner (1.33.0)

**Posture in `kit setup`/`init`:** asks Connected vs Air-gapped enclave → writes `[air_gap] enabled` (idempotent; non-interactive → connected, no write). Air-gapped prompts internal mirrors + signed threat-data dir. Connected points at **where** cloud-scanner tokens live (vault `[scan.tooling]` / env) — kit **never captures/echoes/stores** them (the safest path; no new token-capture prompt, since kit has no no-echo input).

**Socket wired as a real cloud scanner:** `kit scan` runs `socket ci` when `SOCKET_SECURITY_API_TOKEN` is set (cloud-only → dropped in air-gap). Socket has no stable findings-JSON, so a new `exitGate` mode gates on exit code — 0 = clean, non-zero = one high-severity policy violation, never false-green.

Pure helpers fixture-tested; vendor-safety + command-surface suites green.

Generated with Claude Code