### PR TITLE
fix(security): revocation fail-closed + secret temp-file perms + elevation tamper-audit (1.33.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.33.1] - 2026-06-25
+
+### Security
+
+- **Revocation now fails CLOSED.** `fetchRevocationStatus` returned `{revoked: false}` when the revocation endpoint was unreachable or errored — so anyone who could disrupt the endpoint could disable the kill-switch. It now returns `{revoked: true}` on any endpoint error. (The "no endpoint configured / disabled" case stays not-revoked — the feature is simply off.) Caught while it's still latent, before anything gates on it. New `revocation.test.ts` locks the behavior.
+- **Secret temp files locked to the owner.** `mkdtemp` is 0o777-masked, so the plaintext-secret temp files written by `kit secrets purge-history` (the scrub-pattern file) and the OneCLI key-materialization path were briefly world-readable on multi-user systems. Both now go through `secureDir`/`secureFile` (0o700/0o600; icacls on Windows).
+- **Elevation-marker tampering is no longer silent.** `readElevation` caught every error and returned null, so a corrupted/forged marker looked identical to "expired". A missing file is still silently "not elevated", but a present-but-unparseable or bad-signature marker now warns (still fail-closed).
+
 ## [1.33.0] - 2026-06-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2226,7 +2226,9 @@ async function readSecretValueFromVault(
   const { mkdtempSync, writeFileSync, readFileSync, rmSync } = await import("node:fs");
   const { tmpdir } = await import("node:os");
   const { join } = await import("node:path");
+  const { secureDir, secureFile } = await import("./utils/secure-perms.js");
   const dir = mkdtempSync(join(tmpdir(), "kit-onecli-"));
+  secureDir(dir); // mkdtemp is 0o777-masked; the .env below holds a materialized secret
   const tmpEnv = join(dir, ".env");
   try {
     // We need generateSecrets to write to a path of our choosing; the current
@@ -2239,6 +2241,7 @@ async function readSecretValueFromVault(
     };
     void writeFileSync; // keep import for future expansion
     await generateSecrets(isolated, tmpEnv);
+    secureFile(tmpEnv); // materialized plaintext secret → owner-only
     const content = readFileSync(tmpEnv, "utf-8");
     const match = content.match(new RegExp(`^${keyName}=(.*)$`, "m"));
     return match ? match[1] : null;

--- a/src/elevation.ts
+++ b/src/elevation.ts
@@ -154,6 +154,13 @@ export async function readElevation(cwd: string = process.cwd()): Promise<Elevat
   const path = resolve(cwd, ELEVATION_FILE);
   try {
     await access(path);
+  } catch {
+    return null; // no marker file → not elevated (the normal, expected case)
+  }
+  // The file EXISTS — from here a failure is an anomaly (corruption / tampering),
+  // not "not elevated". Stay fail-closed (return null) but never SILENTLY: a
+  // tampered marker must not look identical to an expired one.
+  try {
     const text = await readFile(path, "utf-8");
     const parsed = JSON.parse(text) as Partial<ElevationState> & { sig?: string };
     if (!parsed.expiresAt || !parsed.scope) return null;
@@ -165,9 +172,15 @@ export async function readElevation(cwd: string = process.cwd()): Promise<Elevat
     };
     // Reject unsigned / tampered / forged markers — only an HMAC signed with the
     // machine-local key is honored. This is what makes the gate unforgeable.
-    if (!(await verifyElevationSig(state, parsed.sig ?? ""))) return null;
+    if (!(await verifyElevationSig(state, parsed.sig ?? ""))) {
+      console.warn(
+        "[kit] elevation marker present but signature invalid — ignoring (tampered/forged?)",
+      );
+      return null;
+    }
     return state;
   } catch {
+    console.warn("[kit] elevation marker present but unreadable/corrupt — ignoring");
     return null;
   }
 }

--- a/src/revocation.test.ts
+++ b/src/revocation.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { forceRevocationCheck } from "./revocation.js";
+
+// Revocation is a kill-switch: an endpoint that is configured but unreachable /
+// errors must FAIL CLOSED (assume revoked), or anyone who can disrupt the
+// endpoint could disable it. These lock that behavior.
+describe("revocation fail-closed", () => {
+  type Cfg = Parameters<typeof forceRevocationCheck>[0];
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  const enabled = {
+    agent: { id: "a1" },
+    revocation: { enabled: true, revocation_endpoint: "https://rev.example/{agent_id}" },
+  } as unknown as Cfg;
+
+  it("network error → fail closed (revoked: true)", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    assert.equal((await forceRevocationCheck(enabled)).revoked, true);
+  });
+
+  it("non-ok response → fail closed (revoked: true)", async () => {
+    globalThis.fetch = (async () => ({ ok: false, statusText: "503" })) as unknown as typeof fetch;
+    assert.equal((await forceRevocationCheck(enabled)).revoked, true);
+  });
+
+  it("a clean revoked=false response is honored", async () => {
+    globalThis.fetch = (async () => ({
+      ok: true,
+      json: async () => ({ revoked: false }),
+    })) as unknown as typeof fetch;
+    assert.equal((await forceRevocationCheck(enabled)).revoked, false);
+  });
+
+  it("disabled / no endpoint → not revoked (feature off, not an error)", async () => {
+    const off = { agent: { id: "a1" }, revocation: { enabled: false } } as unknown as Cfg;
+    assert.equal((await forceRevocationCheck(off)).revoked, false);
+  });
+});

--- a/src/revocation.ts
+++ b/src/revocation.ts
@@ -60,17 +60,21 @@ async function fetchRevocationStatus(
     });
 
     if (!response.ok) {
-      // If endpoint is unreachable, assume not revoked
-      console.warn(`Revocation check failed: ${response.statusText}`);
-      return { revoked: false };
+      // Fail CLOSED: a revocation endpoint that is configured but errors must NOT
+      // be read as "not revoked" — that lets a possibly-revoked agent keep running
+      // and lets anyone who can disrupt the endpoint disable the kill-switch.
+      console.warn(
+        `Revocation check failed (${response.statusText}) — failing closed (assume revoked)`,
+      );
+      return { revoked: true };
     }
 
     const data = (await response.json()) as RevocationStatus;
     return data;
   } catch (error) {
-    // If endpoint is unreachable, assume not revoked
-    console.warn(`Revocation check failed: ${error}`);
-    return { revoked: false };
+    // Network/parse failure — fail CLOSED (see above).
+    console.warn(`Revocation check failed (${error}) — failing closed (assume revoked)`);
+    return { revoked: true };
   }
 }
 

--- a/src/secrets-purge-history.ts
+++ b/src/secrets-purge-history.ts
@@ -22,6 +22,7 @@ import { writeFile, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { exec } from "./utils/exec.js";
+import { secureDir, secureFile } from "./utils/secure-perms.js";
 
 export type Tool = "git-filter-repo" | "bfg";
 
@@ -127,6 +128,7 @@ export async function purgeHistory(
 
   const tools = await detectTools();
   const dir = await mkdtemp(join(tmpdir(), "kit-purge-"));
+  secureDir(dir); // mkdtemp is 0o777-masked; the replacement file holds secret patterns → owner-only
   try {
     const replacementFile = join(dir, "replacements.txt");
     // git filter-repo replace-text format: `literal==>REPLACEMENT` or
@@ -136,6 +138,7 @@ export async function purgeHistory(
       patterns.map((p) => `${p}==>***REMOVED***`).join("\n") + "\n",
       "utf-8",
     );
+    secureFile(replacementFile); // contains the secret values being scrubbed
 
     if (tools.filterRepoAvailable) {
       try {


### PR DESCRIPTION
## Tier-1 hardening (from the flaw audit) — 1.33.1

- **Revocation fails CLOSED.** `fetchRevocationStatus` returned `{revoked:false}` on endpoint error → disrupting the endpoint disabled the kill-switch. Now `{revoked:true}` on any error ("no endpoint/disabled" stays off). Latent (not yet enforced) — fixed before it gates. New `revocation.test.ts` (4 cases).
- **Secret temp files owner-only.** `mkdtemp` is 0o777-masked; the `secrets purge-history` scrub-pattern file + the OneCLI materialized `.env` held plaintext secrets briefly world-readable → now `secureDir`/`secureFile` (0o700/0o600; icacls on Windows).
- **Elevation tamper no longer silent.** `readElevation` swallowed all errors → a tampered marker looked like "expired". Missing file is still silent not-elevated; a present-but-bad marker now warns (still fail-closed).

Build + affected suites green (elevation, cli, revocation).

Generated with Claude Code