### PR TITLE
fix(cli): config-free verify-provenance / sentinel / supply-chain (1.33.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.33.2] - 2026-06-25
+
+### Fixed
+
+- **`kit verify-provenance`, `kit sentinel`, and `kit supply-chain` are now config-free** — like `kit scan` (1.32.0). All three aborted with "Create a .kit.toml" when no config was present, even though they're project-agnostic (verify a bundle, propose health fixes from codebase analysis, read the lockfile). A missing `.kit.toml` now falls back to an empty config and none of them writes one. Covered by the `vendor-repo safety` integration tests.
+
 ## [1.33.1] - 2026-06-25
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "1.33.1",
+  "version": "1.33.2",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -665,4 +665,17 @@ describe("vendor-repo safety: config-free scan + honored --no-setup", () => {
       `expected 'Setup skipped'; got: ${result.stdout}`,
     );
   });
+
+  // Project-agnostic commands must not require (or create) a .kit.toml either.
+  for (const args of [["supply-chain"], ["sentinel", "status"], ["verify-provenance"]]) {
+    it(`kit ${args.join(" ")} runs without a .kit.toml`, async () => {
+      const result = await runCli(args, dir);
+      assert.ok(
+        !result.stdout.includes("Create a .kit.toml") &&
+          !result.stderr.includes("Create a .kit.toml"),
+        `${args[0]} must not demand config; got: ${result.stdout}\n${result.stderr}`,
+      );
+      await assert.rejects(access(join(dir, ".kit.toml")), `${args[0]} must not write a .kit.toml`);
+    });
+  }
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4395,7 +4395,11 @@ async function cmdIngest(): Promise<boolean> {
 
 async function cmdSupplyChain(): Promise<boolean> {
   const jsonMode = hasFlag(process.argv, "--json");
-  const config = await loadConfig(resolveConfigPath());
+  // Config-free: supply-chain triage is project-agnostic (it reads the lockfile,
+  // not .kit.toml), so a missing config is not an error — mirror `kit scan`.
+  const config = existsSync(resolveConfigPath())
+    ? await loadConfig(resolveConfigPath())
+    : ({} as kitConfig);
   const scopes = config.supply_chain?.internal_scopes ?? [];
   const { runSupplyChain } = await import("./supply-chain.js");
   const results = runSupplyChain(process.cwd(), scopes);
@@ -4461,7 +4465,11 @@ async function cmdSentinel(): Promise<boolean> {
     return false;
   }
   const jsonMode = hasFlag(process.argv, "--json");
-  const config = await loadConfig(resolveConfigPath());
+  // Config-free: sentinel proposes fixes from codebase analysis; the optional
+  // [sentinel] block only adds integrations. Missing .kit.toml is not an error.
+  const config = existsSync(resolveConfigPath())
+    ? await loadConfig(resolveConfigPath())
+    : ({} as kitConfig);
   const { runSentinel, healthToRedFindings, proposalSummary, SENTINEL_CACHE } =
     await import("./sentinel.js");
   const { runHealth, selectSensors, defaultHealthDeps } = await import("./health.js");
@@ -4607,7 +4615,12 @@ async function cmdVerifyProvenance(): Promise<boolean> {
   const { verifyProvenance } = await import("./airgap/provenance.js");
   const { resolveToolBin } = await import("./utils/resolveTool.js");
   const { execFileNoThrow } = await import("./utils/execFileNoThrow.js");
-  const config = await loadConfig(resolveConfigPath());
+  // Config-free: verifying a provenance bundle needs the artifact + bundle, not
+  // .kit.toml. Missing config is not an error — only [air_gap] trust settings are
+  // read (optional). Mirrors `kit scan`.
+  const config = existsSync(resolveConfigPath())
+    ? await loadConfig(resolveConfigPath())
+    : ({} as kitConfig);
   const ag = resolveAirGap(config.air_gap, process.env);
   const res = await verifyProvenance(
     {


### PR DESCRIPTION
## Consistency: config-free commands (1.33.2)

`kit verify-provenance`, `kit sentinel`, and `kit supply-chain` aborted with "Create a .kit.toml" when no config existed — the **same bug** `kit scan` had (fixed 1.32.0). All three are project-agnostic (verify a bundle / propose fixes from codebase analysis / read the lockfile). Each now falls back to an empty config (verified each only reads optional fields) and none writes a config file.

`vendor-repo safety` integration tests extended to cover all three. Build + suite green.

Generated with Claude Code