### PR TITLE
security: paranoid-audit hardening campaign (1.35.0)

### DIFF
--- a/.github/workflows/triage-deps.yml
+++ b/.github/workflows/triage-deps.yml
@@ -3,10 +3,10 @@ name: Triage New Dependencies
 on:
   pull_request:
     paths:
-      - 'package-lock.json'
-      - 'pnpm-lock.yaml'
-      - 'requirements.txt'
-      - 'package.json'
+      - "package-lock.json"
+      - "pnpm-lock.yaml"
+      - "requirements.txt"
+      - "package.json"
 
 permissions:
   contents: read
@@ -21,11 +21,11 @@ jobs:
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: '3.12'
+          python-version: "3.12"
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: "22"
 
       - name: Install trivy
         run: |
@@ -61,6 +61,17 @@ jobs:
           echo "deps=$DEPS_FLAT" >> "$GITHUB_OUTPUT"
           echo "Found new deps: $DEPS_FLAT"
 
+      - name: Verify triage script is present
+        if: steps.detect.outputs.deps != ''
+        run: |
+          # .claude/ is gitignored/absent in the checkout — the committed script
+          # lives under skills/. Fail loudly if it's missing rather than silently
+          # passing every dependency untriaged.
+          if [ ! -f skills/triage/scripts/triage.py ]; then
+            echo "::error::skills/triage/scripts/triage.py not found — cannot triage dependencies; failing closed."
+            exit 1
+          fi
+
       - name: Run triage on new dependencies
         if: steps.detect.outputs.deps != ''
         env:
@@ -80,14 +91,28 @@ jobs:
             fi
 
             echo "Triaging: $dep"
-            RESULT=$(python3 .claude/skills/triage/scripts/triage.py npm "$dep" 2>&1 || true)
+            # Capture output AND exit code separately — no `|| true` (that swallowed
+            # the failure so every dep passed untriaged). A non-zero exit, or output
+            # carrying neither marker, is a hard FAILED (fail-closed).
+            set +e
+            RESULT=$(python3 skills/triage/scripts/triage.py npm "$dep" 2>&1)
+            RC=$?
+            set -e
 
-            if echo "$RESULT" | grep -q "TRIAGE WARNING"; then
+            if [ "$RC" -ne 0 ]; then
+              echo "::error::$dep triage errored (exit $RC)"
+              REPORT="$REPORT\n[FAIL] $dep: triage error (exit $RC)"
+              FAILED=true
+            elif echo "$RESULT" | grep -q "TRIAGE WARNING"; then
               echo "::warning::$dep failed triage"
               REPORT="$REPORT\n[WARN] $dep: WARNING"
               FAILED=true
             elif echo "$RESULT" | grep -q "TRIAGE PASSED"; then
               REPORT="$REPORT\n[PASS] $dep: passed"
+            else
+              echo "::error::$dep triage produced no verdict (neither PASSED nor WARNING)"
+              REPORT="$REPORT\n[FAIL] $dep: no verdict"
+              FAILED=true
             fi
           done
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.35.0] - 2026-06-26
+
+### Security
+
+Paranoid line-by-line audit hardening pass — a batch of fail-closed and least-privilege fixes found by an exhaustive review. None were known-exploited; all close latent gaps before anything gates on them.
+
+- **CI dependency-triage gate now fails CLOSED.** `.github/workflows/triage-deps.yml` ran the triage script from a stale path with `|| true`, so a moved/missing script or a non-zero exit silently passed the gate. It now verifies the script is present (hard-fails if not), drops `|| true`, captures the real exit code, and treats a non-zero exit **or** a missing `PASSED`/`WARNING` verdict as a hard `FAILED`.
+- **Publish supply-chain gate can be forced fail-closed.** `KIT_BUMBLEBEE_REQUIRED=1` promotes a "scanner unavailable" `warn` to a `fail`, so the release pipeline cannot green-light a publish when the supply-chain scanners never actually ran.
+- **Supply-chain findings no longer corrupt the audit hash-chain.** `logSupplyChainFindings` appended to `.kit-audit.jsonl`, breaking the tamper-evident chain; findings now go to a separate `.kit-findings.jsonl`. Extracted a pure `buildSupplyChainFindingLines()` (fixture-tested).
+- **MCP `kit_secrets` never returns plaintext.** The tool stripped to a sanitized projection — secret `value`s are no longer included in the MCP response. All mutating MCP tools are gated behind read-only mode and refuse to write when it's on.
+- **MCP `kit_run` is bounded.** Added an execution timeout and a bounded output buffer so a hung or chatty child can't wedge or balloon the server.
+- **Triage sandbox hardened against malicious packages.** Fetch runs with `--ignore-scripts`; non-registry specs are rejected; archive entries are listed and any `..`, leading-`/`, or symlink entry is rejected **before** extraction; tarball extraction uses the dash form (`tar -xzf`) to fix a silent macOS bsdtar failure.
+- **Plugin loader validates before import.** Plugin names are regex-validated and a path-containment assertion (resolved path must not escape the plugins dir) runs before `import()`.
+- **Revocation fails closed on malformed responses.** `fetchRevocationStatus` now requires `typeof revoked === "boolean"` and treats anything else as revoked; an enabled-but-misconfigured revocation (blank endpoint or agent id) also fails closed.
+- **Secret/state files locked to the owner.** `.env.local`, `.env.ci`, provisioned tokens, and the memory DB (`memory.db` + `-wal`/`-shm`) are written via `secureFile`/`secureDir` (0o600/0o700; icacls on Windows).
+- **CI annotation output is escaped.** GitHub annotations, the GitLab JUnit report, and the step-summary now escape their data (`escData`/`xmlEscape`), so a crafted finding string can't inject annotation/markup. `cmdTriageCheckDeps` treats a NaN/invalid cache timestamp as expired (fail-closed).
+- **Read-only mode is enforced on more write paths** — `kit install` (mise), `kit context use`, `kit env` switch, and `kit fix` now refuse and audit instead of writing when read-only mode is active.
+
+### Fixed
+
+- **`kit upgrade --self` gives actionable guidance on EACCES.** A failed global `npm install -g sandstream-kit@latest` (the common permission error on system Node) now prints the remediation — `npm config set prefix ~/.npm-global` (or a Node version manager) — instead of a bare "command failed".
+
 ## [1.34.0] - 2026-06-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "1.31.0",
+  "version": "1.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "1.31.0",
+      "version": "1.35.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/scripts/run-supply-chain-check.mjs
+++ b/scripts/run-supply-chain-check.mjs
@@ -9,10 +9,18 @@ const bumblebee = all.filter((r) => r.name && r.name.startsWith("bumblebee"));
 
 console.log(JSON.stringify(bumblebee, null, 2));
 
-const failed = bumblebee.filter((r) => r.status === "fail");
-if (failed.length > 0) {
-  console.error(`\nFAIL: ${failed.length} bumblebee check(s) failed:`);
-  for (const f of failed) console.error(`  - ${f.name}: ${f.detail}`);
+// Publish gate: by default only a hard "fail" blocks. But scanner-unavailable /
+// download-failed / scan-incomplete return "warn" — an UNSCANNED release would
+// then ship green. KIT_BUMBLEBEE_REQUIRED=1 makes "warn" block too (fail-closed),
+// so a release can never ship without a completed, clean scan.
+const required = ["1", "true", "on", "yes"].includes(
+  (process.env.KIT_BUMBLEBEE_REQUIRED ?? "").trim().toLowerCase(),
+);
+const blocking = bumblebee.filter((r) => r.status === "fail" || (required && r.status === "warn"));
+if (blocking.length > 0) {
+  console.error(`\nFAIL: ${blocking.length} bumblebee check(s) blocked the publish gate:`);
+  for (const f of blocking) console.error(`  - ${f.name} [${f.status}]: ${f.detail}`);
+  if (required) console.error("(KIT_BUMBLEBEE_REQUIRED=1 — warnings are fatal)");
   process.exit(1);
 }
 console.log(`\nPASS: bumblebee scan ok (${bumblebee.length} result(s))`);

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -1351,6 +1351,13 @@ async function checkBumblebee(): Promise<SecurityCheckResult> {
   const name = "bumblebee (supply-chain)";
   const category = "supply-chain" as const;
 
+  // Publish gate: when set, an UNSCANNED release must not ship. Scanner-
+  // unavailable / scan-failed / scan-incomplete are "warn" (advisory) in normal
+  // runs but become a hard "fail" here so the gate can fail-closed (#supply).
+  const required = envFlagEnabled(process.env.KIT_BUMBLEBEE_REQUIRED);
+  // "could not scan" status under the required gate: fail-closed instead of warn.
+  const unscanned = required ? ("fail" as const) : ("warn" as const);
+
   if (envFlagDisabled(process.env.KIT_BUMBLEBEE)) {
     return { category, name, status: "skip", detail: "disabled via KIT_BUMBLEBEE" };
   }
@@ -1375,9 +1382,9 @@ async function checkBumblebee(): Promise<SecurityCheckResult> {
     return {
       category,
       name,
-      status: "warn",
-      detail: `scanner unavailable: ${reason}`,
-      severity: "low",
+      status: unscanned,
+      detail: `scanner unavailable: ${reason}${required ? " (KIT_BUMBLEBEE_REQUIRED — cannot ship unscanned)" : ""}`,
+      severity: required ? "high" : "low",
       suggestion:
         "Provide a binary with KIT_BUMBLEBEE_BIN, or allow downloads (unset KIT_NO_DOWNLOAD). Manual install: go install github.com/perplexityai/bumblebee/cmd/bumblebee@latest",
     };
@@ -1394,9 +1401,9 @@ async function checkBumblebee(): Promise<SecurityCheckResult> {
     return {
       category,
       name,
-      status: "warn",
-      detail: `scan failed: ${error ?? "no output"}`,
-      severity: "medium",
+      status: unscanned,
+      detail: `scan failed: ${error ?? "no output"}${required ? " (KIT_BUMBLEBEE_REQUIRED — cannot ship unscanned)" : ""}`,
+      severity: required ? "high" : "medium",
     };
   }
 
@@ -1421,9 +1428,9 @@ async function checkBumblebee(): Promise<SecurityCheckResult> {
     return {
       category,
       name,
-      status: "warn",
-      detail: `scan incomplete (status=${outcome.status}${outcome.timedOut ? ", timed out" : ""})`,
-      severity: "low",
+      status: unscanned,
+      detail: `scan incomplete (status=${outcome.status}${outcome.timedOut ? ", timed out" : ""})${required ? " (KIT_BUMBLEBEE_REQUIRED — cannot ship unscanned)" : ""}`,
+      severity: required ? "high" : "low",
     };
   }
 
@@ -1537,21 +1544,19 @@ export async function checkSecurity(): Promise<SecurityCheckResult[]> {
   });
 }
 
-/**
- * F9 — append bumblebee supply-chain findings to the local audit JSONL.
- * Bypasses the governance config so the trail is captured even when
- * `kit check` is run without `.kit.toml`. One JSON line per finding.
- */
-async function logSupplyChainFindings(
+/** Separate findings sink — deliberately NOT the chained audit log. */
+export const SUPPLY_CHAIN_FINDINGS_FILE = ".kit-findings.jsonl";
+
+/** Build the JSONL lines for a batch of supply-chain findings. PURE/testable. */
+export function buildSupplyChainFindingLines(
   findings: BumblebeeFinding[],
   profile: string,
-): Promise<void> {
-  const { appendFile } = await import("node:fs/promises");
-  const path = resolve(process.cwd(), ".kit-audit.jsonl");
-  const lines = findings
+  now: Date = new Date(),
+): string {
+  return findings
     .map((f) =>
       JSON.stringify({
-        timestamp: new Date().toISOString(),
+        timestamp: now.toISOString(),
         event_type: "supply_chain_finding",
         source: "bumblebee",
         profile,
@@ -1566,6 +1571,23 @@ async function logSupplyChainFindings(
       }),
     )
     .join("\n");
+}
+
+/**
+ * F9 — append bumblebee supply-chain findings to a SEPARATE local JSONL sink
+ * (`.kit-findings.jsonl`), NOT the chained `.kit-audit.jsonl`. These are raw,
+ * unchained lines; appending them to the tamper-evident audit log would break
+ * its hash chain and make `kit audit verify` falsely report BROKEN. Bypasses
+ * governance config so the trail is captured even without `.kit.toml`.
+ */
+async function logSupplyChainFindings(
+  findings: BumblebeeFinding[],
+  profile: string,
+  cwd: string = process.cwd(),
+): Promise<void> {
+  const { appendFile } = await import("node:fs/promises");
+  const path = resolve(cwd, SUPPLY_CHAIN_FINDINGS_FILE);
+  const lines = buildSupplyChainFindingLines(findings, profile);
   if (lines) {
     await appendFile(path, lines + "\n", "utf-8");
   }

--- a/src/ci-escaping.test.ts
+++ b/src/ci-escaping.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { escapeWorkflowCmd, xmlEscape } from "./cli.js";
+
+// Guards the CI-output injection fixes: attacker-controlled check
+// category/name/detail must not be able to forge or hide GitHub workflow
+// annotations or JUnit testcases.
+describe("escapeWorkflowCmd (GitHub Actions workflow commands)", () => {
+  it("escapes CR and LF so detail can't inject extra annotation lines", () => {
+    const out = escapeWorkflowCmd("evil\n::error::forged\rtail");
+    assert.equal(out, "evil%0A::error::forged%0Dtail");
+    assert(!out.includes("\n"));
+    assert(!out.includes("\r"));
+  });
+
+  it("escapes % first so encoded sequences aren't double-decoded", () => {
+    // A literal "%" must become "%25", so an embedded "%0A" can't be re-decoded
+    // into a newline downstream.
+    assert.equal(escapeWorkflowCmd("a%0Ab"), "a%250Ab");
+  });
+
+  it("leaves benign text untouched", () => {
+    assert.equal(escapeWorkflowCmd("tools/git: installed 2.40"), "tools/git: installed 2.40");
+  });
+});
+
+describe("xmlEscape (JUnit XML)", () => {
+  it("escapes quotes so detail can't break out of an attribute", () => {
+    const out = xmlEscape(`x"/><testcase name="forged"/>`);
+    assert(!out.includes('"'));
+    assert(!out.includes("<"));
+    assert(!out.includes(">"));
+    assert.equal(out, "x&quot;/&gt;&lt;testcase name=&quot;forged&quot;/&gt;");
+  });
+
+  it("escapes & first to avoid double-encoding", () => {
+    assert.equal(xmlEscape("a & <b>"), "a &amp; &lt;b&gt;");
+  });
+
+  it("leaves benign text untouched", () => {
+    assert.equal(xmlEscape("not installed"), "not installed");
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1450,6 +1450,33 @@ async function cmdGovernance(): Promise<boolean> {
 }
 
 /**
+ * Detect the npm global-install permission failure (EACCES / EPERM writing into
+ * a root-owned prefix). This is the #1 cause of `npm i -g` failures and the raw
+ * "Command failed" message gives no hint, so we sniff the combined message +
+ * stderr for the well-known signatures.
+ */
+export function isNpmPermissionError(text: string): boolean {
+  return /\bEACCES\b|\bEPERM\b|permission denied|operation not permitted|EACCES: permission/i.test(
+    text,
+  );
+}
+
+/**
+ * The documented remediation for an `npm -g` EACCES: switch to a user-owned
+ * prefix instead of `sudo` (sudo-installed globals leave root-owned files that
+ * break every later install). Returns ready-to-print lines.
+ */
+export function npmPermissionRemediation(): string[] {
+  return [
+    `${c.yellow}This is an npm permission error (EACCES) — npm cannot write to its global prefix.${c.reset}`,
+    `${c.dim}Do NOT use sudo. Point npm at a user-owned prefix, then re-run the upgrade:${c.reset}`,
+    `  ${c.bold}npm config set prefix ~/.npm-global${c.reset}`,
+    `  ${c.bold}export PATH=~/.npm-global/bin:$PATH${c.reset}  ${c.dim}# add to your ~/.zshrc or ~/.bashrc${c.reset}`,
+    `  ${c.bold}kit upgrade --self${c.reset}`,
+  ];
+}
+
+/**
  * Governed self-upgrade: kit triages its OWN npm package before installing a new
  * version of itself. WATERTIGHT — an untriaged kit is never installed; offline /
  * triage-unavailable → blocked (fail-closed). The raw `npm i -g sandstream-kit`
@@ -1478,8 +1505,26 @@ async function selfUpgrade(): Promise<boolean> {
     );
     return true;
   } catch (err: unknown) {
+    const { redactSecrets } = await import("./utils/redactSecrets.js");
     const msg = err instanceof Error ? err.message : String(err);
-    console.error(`${c.red}✗ npm install failed: ${msg.split("\n")[0]}${c.reset}`);
+    // promisified execFile attaches the child's stderr to the error object
+    const stderr =
+      typeof (err as { stderr?: unknown })?.stderr === "string"
+        ? (err as { stderr: string }).stderr
+        : "";
+    const combined = `${msg}\n${stderr}`;
+    console.error(`${c.red}✗ npm install failed: ${redactSecrets(msg.split("\n")[0])}${c.reset}`);
+    if (stderr.trim()) {
+      console.error(`${c.dim}${redactSecrets(stderr.trim())}${c.reset}`);
+    }
+    if (isNpmPermissionError(combined)) {
+      console.error();
+      for (const line of npmPermissionRemediation()) console.error(line);
+    } else {
+      console.error(
+        `${c.dim}If this persists, install manually: ${c.reset}${c.bold}npm install -g sandstream-kit@latest${c.reset}`,
+      );
+    }
     return false;
   }
 }
@@ -2999,14 +3044,33 @@ function detectCiFormat(): CiFormat {
   return "text";
 }
 
+// Escape data interpolated into GitHub Actions workflow commands (`::error::` etc).
+// CR/LF would otherwise let attacker-controlled detail strings forge or hide
+// additional annotation lines. Order matters: `%` must be escaped first.
+export function escapeWorkflowCmd(s: string): string {
+  return String(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+}
+
 function emitGithubAnnotations(checks: JsonCheck[]): void {
   for (const ch of checks) {
+    const msg = escapeWorkflowCmd(`${ch.category}/${ch.name}: ${ch.detail}`);
     if (ch.status === "fail") {
-      console.log(`::error::${ch.category}/${ch.name}: ${ch.detail}`);
+      console.log(`::error::${msg}`);
     } else if (ch.status === "warn") {
-      console.log(`::warning::${ch.category}/${ch.name}: ${ch.detail}`);
+      console.log(`::warning::${msg}`);
     }
   }
+}
+
+// Escape data interpolated into the JUnit XML. Without this, attacker-controlled
+// name/category/detail strings could close attributes/elements and forge or delete
+// testcases. `&` must be replaced first; `"` is only needed inside attributes.
+export function xmlEscape(s: string): string {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
 }
 
 function emitGitlabJunit(checks: JsonCheck[], allOk: boolean): void {
@@ -3018,11 +3082,11 @@ function emitGitlabJunit(checks: JsonCheck[], allOk: boolean): void {
     `  <testsuite name="kit" tests="${checks.length}" failures="${failures.length}">`,
   ];
   for (const ch of checks) {
-    lines.push(`    <testcase name="${ch.name}" classname="${ch.category}">`);
+    lines.push(`    <testcase name="${xmlEscape(ch.name)}" classname="${xmlEscape(ch.category)}">`);
     if (ch.status === "fail") {
-      lines.push(`      <failure message="${ch.detail}"/>`);
+      lines.push(`      <failure message="${xmlEscape(ch.detail)}"/>`);
     } else if (ch.status === "warn") {
-      lines.push(`      <system-out>${ch.detail}</system-out>`);
+      lines.push(`      <system-out>${xmlEscape(ch.detail)}</system-out>`);
     }
     lines.push(`    </testcase>`);
   }
@@ -3133,14 +3197,20 @@ async function cmdCi(): Promise<boolean> {
 
       if (format === "github") {
         if (process.env.GITHUB_STEP_SUMMARY) {
-          // Emit markdown summary to GitHub Actions step summary
+          // Emit markdown summary to GitHub Actions step summary. Strip CR/LF so a
+          // crafted detail can't inject new markdown/table rows, and escape `|` so
+          // it can't forge extra table cells.
+          const mdCell = (s: string) =>
+            String(s)
+              .replace(/[\r\n]+/g, " ")
+              .replace(/\|/g, "\\|");
           const lines = [
             "## kit CI Report",
             `| Status | Check | Detail |`,
             `|--------|-------|--------|`,
             ...checks.map(
               (c) =>
-                `| ${c.status === "pass" ? "✅" : c.status === "warn" ? "⚠️" : "❌"} | \`${c.category}/${c.name}\` | ${c.detail} |`,
+                `| ${c.status === "pass" ? "✅" : c.status === "warn" ? "⚠️" : "❌"} | \`${mdCell(`${c.category}/${c.name}`)}\` | ${mdCell(c.detail)} |`,
             ),
             ``,
             `**${summary.passed} passed, ${summary.failed} failed, ${summary.warnings} warnings**`,
@@ -5490,7 +5560,11 @@ async function cmdTriageCheckDeps(): Promise<boolean> {
   for (const dep of newDeps) {
     const key = `${dep.ecosystem}:${dep.name}`;
     const ts = latest[key];
-    if (!ts || Date.parse(ts) < cutoff) {
+    // Parse first and reject non-finite: an unparseable timestamp yields NaN, and
+    // `NaN < cutoff` is false — treating a forged/garbage ts as "fresh triage"
+    // (fail-open). A missing or unparseable ts both count as "no valid triage".
+    const parsed = ts ? Date.parse(ts) : NaN;
+    if (!Number.isFinite(parsed) || parsed < cutoff) {
       missing.push(
         `  - ${dep.ecosystem}:${dep.name}  (run: kit triage ${dep.ecosystem} ${dep.name})`,
       );

--- a/src/context-lock.test.ts
+++ b/src/context-lock.test.ts
@@ -10,6 +10,7 @@ import {
   parseSshConfigIdentity,
   parseKeygenFingerprint,
   planContext,
+  applyContext,
   parseGcloudProject,
   suggestContextToml,
   hasLockableContext,
@@ -312,5 +313,21 @@ describe("clerkEnvFromKey", () => {
     assert.equal(clerkEnvFromKey("sk_live_nope"), null);
     assert.equal(clerkEnvFromKey(null), null);
     assert.equal(clerkEnvFromKey(""), null);
+  });
+});
+
+describe("applyContext read-only mode", () => {
+  it("applies nothing (no steps) when KIT_READ_ONLY=1", async () => {
+    // A context that plans a git step — proves the refusal short-circuits
+    // before any step runs (empty result), not just that there's nothing to do.
+    const ctx = { git: { email: "dev@example.com" } };
+    assert.ok(planContext(ctx).length > 0); // sanity: there is work to refuse
+    process.env.KIT_READ_ONLY = "1";
+    try {
+      const results = await applyContext(ctx, process.cwd());
+      assert.deepEqual(results, []);
+    } finally {
+      delete process.env.KIT_READ_ONLY;
+    }
   });
 });

--- a/src/context-lock.ts
+++ b/src/context-lock.ts
@@ -485,6 +485,14 @@ export async function applyContext(
   ctx: ContextConfig,
   cwd: string = process.cwd(),
 ): Promise<ApplyResult[]> {
+  // Read-only mode: activating a context mutates gcloud config / repo git
+  // identity. Refuse + audit; apply nothing (no-op, no steps run).
+  const { isReadOnlyMode, refuseWrite } = await import("./read-only-mode.js");
+  if (isReadOnlyMode()) {
+    await refuseWrite("context-use", { step_count: planContext(ctx).length });
+    return [];
+  }
+
   const results: ApplyResult[] = [];
   for (const step of planContext(ctx)) {
     let ok = false;

--- a/src/env-switch.test.ts
+++ b/src/env-switch.test.ts
@@ -36,6 +36,20 @@ describe("writeActiveEnv / readActiveEnv", () => {
     }
   });
 
+  it("refuses to write the marker in read-only mode", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-env-"));
+    process.env.KIT_READ_ONLY = "1";
+    try {
+      const state = await writeActiveEnv("prod", dir, "tester");
+      assert.equal(state.env, "prod"); // returns the would-be state
+      assert.equal(existsSync(join(dir, ".kit", "active-env.json")), false); // but never wrote
+      assert.equal(await readActiveEnv(dir), null); // disk marker unchanged
+    } finally {
+      delete process.env.KIT_READ_ONLY;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("ignores invalid env values in the marker", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kit-env-"));
     try {

--- a/src/env-switch.ts
+++ b/src/env-switch.ts
@@ -51,6 +51,15 @@ export async function writeActiveEnv(
     switchedAt: new Date().toISOString(),
     switchedBy,
   };
+  // Read-only mode: switching the active env writes .kit/active-env.json. Refuse
+  // + audit; persist nothing. Returns the would-be state (the marker is unchanged
+  // on disk, so a later read still sees the prior env).
+  const { isReadOnlyMode, refuseWrite } = await import("./read-only-mode.js");
+  if (isReadOnlyMode()) {
+    await refuseWrite("env-switch", { env });
+    console.error(`[kit] read-only mode active — not switching active env to "${env}".`);
+    return state;
+  }
   const path = resolve(cwd, ACTIVE_ENV_FILE);
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, JSON.stringify(state, null, 2) + "\n", "utf-8");

--- a/src/fix.ts
+++ b/src/fix.ts
@@ -233,6 +233,16 @@ export async function cmdFix(): Promise<boolean> {
       metadata: {},
     },
     async () => {
+      // Read-only mode: fix installs tools and writes .env.template / .gitignore.
+      // Refuse the whole pipeline up front + audit, so no sink runs (matches
+      // installHooks). withGovernance never consults read-only, so guard here.
+      const { isReadOnlyMode, refuseWrite } = await import("./read-only-mode.js");
+      if (isReadOnlyMode()) {
+        const refusal = await refuseWrite("fix");
+        console.log(`  ${c.yellow}!${c.reset} ${refusal.reason}`);
+        return false;
+      }
+
       // 1. Check and fix missing tools
       if (config.tools && Object.keys(config.tools).length > 0) {
         console.log(`${c.bold}[1/6] Tools${c.reset}`);

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -188,3 +188,29 @@ describe("miseErrorDetail", () => {
     assert.equal(detail, "error parsing config file: ~/repo/.mise.toml");
   });
 });
+
+describe("installTools read-only mode", () => {
+  it("refuses without touching any dep when KIT_READ_ONLY=1", async () => {
+    let touched = false;
+    const deps = makeDeps({
+      checkTools: async () => {
+        touched = true;
+        return [{ name: "deno", required: "2", installed: null, ok: false }];
+      },
+      miseInstall: async () => {
+        touched = true;
+        return { ok: true, detail: "" };
+      },
+    });
+    process.env.KIT_READ_ONLY = "1";
+    try {
+      const results = await installTools({ deno: "2" }, deps);
+      assert.equal(results.length, 1);
+      assert.equal(results[0].action, "blocked");
+      assert.match(results[0].detail, /read-only mode active/);
+      assert.equal(touched, false); // no check / no install ran
+    } finally {
+      delete process.env.KIT_READ_ONLY;
+    }
+  });
+});

--- a/src/install.ts
+++ b/src/install.ts
@@ -43,6 +43,12 @@ async function miseInstall(
   tool: string,
   version: string,
 ): Promise<{ ok: boolean; detail: string }> {
+  // Read-only mode: `mise install`/`mise use` mutate the toolchain. Refuse + audit.
+  const { isReadOnlyMode, refuseWrite } = await import("./read-only-mode.js");
+  if (isReadOnlyMode()) {
+    const refusal = await refuseWrite("mise-install", { tool, version });
+    return { ok: false, detail: refusal.reason };
+  }
   const versionArg = version === "latest" ? "latest" : version;
   try {
     await exec("mise", ["install", `${tool}@${versionArg}`], {
@@ -86,6 +92,16 @@ export async function installTools(
   deps: InstallDeps = defaultDeps,
   opts: { skipTriage?: boolean } = {},
 ): Promise<InstallResult[]> {
+  // Read-only mode: installing tools is a write. Refuse before any check/install
+  // so the guard matches installHooks (no mutating sink bypasses --read-only).
+  const { isReadOnlyMode, refuseWrite } = await import("./read-only-mode.js");
+  if (isReadOnlyMode()) {
+    const refusal = await refuseWrite("install-tools", {
+      tool_count: Object.keys(tools).length,
+    });
+    return [{ name: "read-only-refusal", action: "blocked", detail: refusal.reason }];
+  }
+
   const statuses = await deps.checkTools(tools);
   const results: InstallResult[] = [];
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -28,11 +28,28 @@ import { generateToml } from "./toml-generator.js";
 import { writeFile, access } from "node:fs/promises";
 import { executeCommand } from "./run.js";
 import { gatherProjectContext } from "./context.js";
+import { isReadOnlyMode } from "./read-only-mode.js";
 
 const KIT_FILE = ".kit.toml";
 
 function configPath(cwd?: string): string {
   return resolve(cwd ?? process.cwd(), KIT_FILE);
+}
+
+/** Refusal result for a mutating tool invoked while in read-only mode. */
+function readOnlyRefusal(tool: string): {
+  content: { type: "text"; text: string }[];
+  isError: true;
+} {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `Error: read-only mode active — refusing "${tool}". This tool performs writes and is disabled while KIT_READ_ONLY is set.`,
+      },
+    ],
+    isError: true,
+  };
 }
 
 export function createMcpServer(): McpServer {
@@ -137,6 +154,7 @@ function register_kit_install(server: McpServer): void {
     "Install missing tools defined in .kit.toml using mise.",
     { cwd: z.string().optional().describe("Working directory") },
     async ({ cwd }) => {
+      if (isReadOnlyMode()) return readOnlyRefusal("kit_install");
       try {
         const config = await loadConfig(configPath(cwd));
         if (!config.tools || Object.keys(config.tools).length === 0) {
@@ -219,6 +237,7 @@ function register_kit_secrets(server: McpServer): void {
     "Generate .env.local by resolving secrets defined in .kit.toml. Returns the list of written keys.",
     { cwd: z.string().optional().describe("Working directory") },
     async ({ cwd }) => {
+      if (isReadOnlyMode()) return readOnlyRefusal("kit_secrets");
       try {
         const config = await loadConfig(configPath(cwd));
         if (!config.secrets) {
@@ -238,11 +257,19 @@ function register_kit_secrets(server: McpServer): void {
         );
         const ok = results.every((r) => r.resolved);
         const writtenKeys = results.filter((r) => r.resolved).map((r) => r.name);
+        // Never serialize `value` — it carries the resolved plaintext secret.
+        // Project to metadata only.
+        const safeResults = results.map((r) => ({
+          name: r.name,
+          resolved: r.resolved,
+          detail: r.detail,
+          ...(r.managed !== undefined && { managed: r.managed }),
+        }));
         return {
           content: [
             {
               type: "text" as const,
-              text: JSON.stringify({ ok, written, writtenKeys, results }, null, 2),
+              text: JSON.stringify({ ok, written, writtenKeys, results: safeResults }, null, 2),
             },
           ],
         };
@@ -263,6 +290,7 @@ function register_kit_fix(server: McpServer): void {
     "Auto-fix issues found by kit check (install missing tools, generate missing lock files). Returns actions taken.",
     { cwd: z.string().optional().describe("Working directory") },
     async ({ cwd }) => {
+      if (isReadOnlyMode()) return readOnlyRefusal("kit_fix");
       try {
         const config = await loadConfig(configPath(cwd));
         const actions: Array<{ name: string; action: string; detail: string }> = [];
@@ -351,6 +379,7 @@ function register_kit_add(server: McpServer): void {
       cwd: z.string().optional().describe("Working directory"),
     },
     async ({ service, project_name, cwd }) => {
+      if (isReadOnlyMode()) return readOnlyRefusal("kit_add");
       try {
         const workDir = cwd ?? process.cwd();
         const result = await provisionService(service, workDir, project_name);
@@ -451,6 +480,8 @@ function register_kit_init(server: McpServer): void {
         .describe("Return generated config without writing to disk (default: false)"),
     },
     async ({ cwd, dry_run }) => {
+      // dry_run is a read-only preview; a real write is refused in read-only mode.
+      if (!dry_run && isReadOnlyMode()) return readOnlyRefusal("kit_init");
       try {
         const workDir = cwd ?? process.cwd();
         const cfgPath = resolve(workDir, KIT_FILE);
@@ -656,6 +687,7 @@ function register_kit_run(server: McpServer): void {
       cwd: z.string().optional().describe("Working directory (defaults to process.cwd())"),
     },
     async ({ command, cwd }) => {
+      if (isReadOnlyMode()) return readOnlyRefusal("kit_run");
       try {
         const workDir = cwd ?? process.cwd();
         const commandArgs = command.split(/\s+/);
@@ -666,7 +698,13 @@ function register_kit_run(server: McpServer): void {
           inheritEnv: true,
         });
 
-        const status = result.exitCode === 0 ? "success" : "failed";
+        const status = result.timedOut
+          ? "timed_out"
+          : result.truncated
+            ? "truncated"
+            : result.exitCode === 0
+              ? "success"
+              : "failed";
         const output = result.stdout
           ? `stdout:\n${result.stdout}${result.stderr ? `\n\nstderr:\n${result.stderr}` : ""}`
           : result.stderr

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -51,8 +51,11 @@ function ensureMemoryDir(): void {
   const dir = getMemoryDir();
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true, mode: 0o700 });
-    secureDir(dir); // enforce owner-only on Windows too (NTFS ignores mode bits) — #43
   }
+  // Enforce owner-only unconditionally: a pre-existing dir (created before this
+  // hardening, or with a looser umask) would otherwise stay world-readable. Also
+  // covers Windows, where NTFS ignores the mkdir mode bits — #43.
+  secureDir(dir);
 }
 
 const SCHEMA_SQL = `
@@ -207,6 +210,11 @@ export function openMemoryDb(path?: string): DatabaseSync {
   if (dbPath !== ":memory:" && existsSync(dbPath)) {
     try {
       secureFile(dbPath); // 0o600 on POSIX, icacls owner-only on Windows — #43
+      // WAL mode spills the secret-dense content into -wal/-shm sidecars; secure
+      // those too or the data leaks through a world-readable side channel.
+      for (const sidecar of [`${dbPath}-wal`, `${dbPath}-shm`]) {
+        if (existsSync(sidecar)) secureFile(sidecar);
+      }
     } catch {
       // best-effort: non-POSIX filesystems may not support chmod
     }

--- a/src/plugin-loader-security.test.ts
+++ b/src/plugin-loader-security.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadPluginAdapters } from "./plugin-loader.js";
+
+// Path-traversal hardening: kitPlugins entries are attacker-influenced (project
+// package.json). A name like "../../tmp/evil" used to escape node_modules and get
+// import()ed → RCE. These tests prove malicious names are rejected before import.
+
+let tmpProject: string;
+
+before(async () => {
+  tmpProject = join(tmpdir(), `sandstream-kit-plugin-sec-test-${process.pid}`);
+  await mkdir(join(tmpProject, "node_modules"), { recursive: true });
+});
+
+after(async () => {
+  await rm(tmpProject, { recursive: true, force: true });
+});
+
+async function writeKitPlugins(kitPlugins: unknown[]) {
+  await writeFile(
+    join(tmpProject, "package.json"),
+    JSON.stringify({ name: "test-project", kitPlugins }),
+    "utf-8",
+  );
+}
+
+function withWarnCapture<T>(fn: () => Promise<T>): Promise<{ result: T; warnings: string[] }> {
+  const warnings: string[] = [];
+  const orig = console.warn;
+  console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+  return fn()
+    .then((result) => ({ result, warnings }))
+    .finally(() => {
+      console.warn = orig;
+    });
+}
+
+describe("loadPluginAdapters path-traversal hardening", () => {
+  it("does NOT import a module outside node_modules and does not execute it (RCE guard)", async () => {
+    // Plant an evil module OUTSIDE the project's node_modules that, if imported,
+    // writes a marker file (stand-in for arbitrary code execution).
+    const evilName = `kit-evil-${process.pid}`;
+    const evilDir = join(tmpdir(), evilName);
+    const marker = join(tmpdir(), `kit-pwned-${process.pid}.txt`);
+    await mkdir(evilDir, { recursive: true });
+    await writeFile(
+      join(evilDir, "index.js"),
+      `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(marker)}, "pwned"); export const adapter = { name: "evil", description: "evil", getRequiredTools: () => [], check: async () => false, provision: async () => ({ success: true, message: "" }) };`,
+      "utf-8",
+    );
+    try {
+      // node_modules/<payload> resolves up-and-over into evilDir.
+      const payload = `../${evilName}`;
+      await writeKitPlugins([payload]);
+
+      const { result, warnings } = await withWarnCapture(() => loadPluginAdapters(tmpProject));
+
+      assert.deepEqual(result, {}, "traversal payload must not register any adapter");
+      assert.equal(existsSync(marker), false, "evil module must NOT have been imported/executed");
+      assert.ok(
+        warnings.some((w) => w.includes(payload)),
+        `expected a warning naming the rejected payload, got: ${JSON.stringify(warnings)}`,
+      );
+    } finally {
+      await rm(evilDir, { recursive: true, force: true });
+      await rm(marker, { force: true });
+    }
+  });
+
+  it("rejects assorted malicious / non-package names without throwing", async () => {
+    const malicious = [
+      "../../etc/passwd",
+      "..",
+      "./relative",
+      "/abs/path",
+      "foo/../bar",
+      "name\\with\\backslash",
+      "@scope/sub/too/deep",
+      "@/missing-scope",
+    ];
+    await writeKitPlugins(malicious);
+
+    const { result, warnings } = await withWarnCapture(() => loadPluginAdapters(tmpProject));
+
+    assert.deepEqual(result, {}, "no malicious name should register an adapter");
+    for (const name of malicious) {
+      assert.ok(
+        warnings.some((w) => w.includes(name) && /[Ii]nvalid plugin name/.test(w)),
+        `expected "Invalid plugin name" warning for ${JSON.stringify(name)}, got: ${JSON.stringify(warnings)}`,
+      );
+    }
+  });
+
+  it("still accepts valid scoped and unscoped package names", async () => {
+    // Valid names pass validation; they fail later only because they aren't installed,
+    // which is the normal "missing plugin" path (warns, never throws).
+    await writeKitPlugins(["@acme/kit-railway", "sandstream-kit-plugin-aws-s3"]);
+
+    const { result, warnings } = await withWarnCapture(() => loadPluginAdapters(tmpProject));
+
+    assert.deepEqual(result, {});
+    // These must NOT be rejected as invalid names — only fail to import (not found).
+    assert.ok(
+      !warnings.some((w) => /[Ii]nvalid plugin name/.test(w)),
+      `valid names must not be rejected as invalid, got: ${JSON.stringify(warnings)}`,
+    );
+  });
+});

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -1,6 +1,22 @@
 import { readFile } from "node:fs/promises";
-import { resolve, join } from "node:path";
+import { resolve, join, relative } from "node:path";
 import type { AdapterRegistry, ServiceAdapter } from "./adapters/types.js";
+
+// npm package-name grammar: optional single @scope/ prefix, then name.
+// Rejects path-traversal payloads (`..`, `/`, `\`, leading `.`) because none of
+// those bytes are in the allowed character class (only one scope slash permitted).
+const PLUGIN_NAME_RE = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+
+/**
+ * Validate a plugin name as a safe npm package specifier. Rejects anything that
+ * could escape node_modules via path traversal (RCE vector).
+ */
+function isValidPluginName(name: string): boolean {
+  if (typeof name !== "string" || name.length === 0 || name.length > 214) return false;
+  if (name.includes("..") || name.includes("\\")) return false;
+  if (name.startsWith(".") || name.startsWith("/")) return false;
+  return PLUGIN_NAME_RE.test(name);
+}
 
 /**
  * Load plugin adapters from kitPlugins listed in the project's package.json.
@@ -61,20 +77,33 @@ async function loadSinglePlugin(
   pluginName: string,
   projectPath: string,
 ): Promise<ServiceAdapter[]> {
+  // Reject path-traversal / non-package names before they reach import() (RCE guard)
+  if (!isValidPluginName(pluginName)) {
+    throw new Error(`Invalid plugin name "${pluginName}" — not a valid npm package name`);
+  }
+
   // Resolve the plugin from the project's node_modules (not kit's own node_modules)
+  const nodeModules = resolve(projectPath, "node_modules");
   const candidates = [
-    join(projectPath, "node_modules", pluginName, "kit-adapter.js"),
-    join(projectPath, "node_modules", pluginName, "kit-adapter.cjs"),
-    join(projectPath, "node_modules", pluginName, "index.js"),
-    join(projectPath, "node_modules", pluginName),
+    join(nodeModules, pluginName, "kit-adapter.js"),
+    join(nodeModules, pluginName, "kit-adapter.cjs"),
+    join(nodeModules, pluginName, "index.js"),
+    join(nodeModules, pluginName),
   ];
 
   let mod: unknown;
   let lastError: unknown;
 
   for (const candidate of candidates) {
+    // Defense in depth: never import anything that resolves outside node_modules
+    const resolved = resolve(candidate);
+    const rel = relative(nodeModules, resolved);
+    if (rel.startsWith("..") || rel === "") {
+      lastError = new Error(`Refusing to import "${candidate}" outside node_modules`);
+      continue;
+    }
     try {
-      mod = await import(candidate);
+      mod = await import(resolved);
       break;
     } catch (err) {
       lastError = err;

--- a/src/provision.ts
+++ b/src/provision.ts
@@ -2,6 +2,7 @@ import { writeFile, readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { adapters } from "./adapters/index.js";
 import { loadPluginAdapters } from "./plugin-loader.js";
+import { secureFile } from "./utils/secure-perms.js";
 import type { AdapterContext, ProvisionResult } from "./adapters/types.js";
 
 /**
@@ -46,6 +47,7 @@ async function updateEnvFile(projectPath: string, secrets: Record<string, string
   }
 
   await writeFile(envPath, lines.join("\n") + "\n", "utf-8");
+  secureFile(envPath); // plaintext secrets — restrict to owner (0o600 / icacls)
 }
 
 /**

--- a/src/revocation.ts
+++ b/src/revocation.ts
@@ -10,6 +10,15 @@ export interface RevocationStatus {
 let lastRevocationCheck = 0;
 let cachedRevocationStatus: RevocationStatus | null = null;
 
+// Internal fetch result. `cacheable` is false for fail-closed results derived
+// from ambiguous/erroring responses — those must NOT be cached as a verdict,
+// otherwise a single bad response would pin the agent into a state until the
+// cache TTL expires (and an ambiguous "revoked" would survive a recovery).
+interface FetchResult {
+  status: RevocationStatus;
+  cacheable: boolean;
+}
+
 /**
  * Check if agent access has been revoked
  */
@@ -31,10 +40,12 @@ export async function checkRevocationStatus(
   }
 
   // Check revocation endpoint
-  const status = await fetchRevocationStatus(fullConfig);
+  const { status, cacheable } = await fetchRevocationStatus(fullConfig);
 
-  cachedRevocationStatus = status;
-  lastRevocationCheck = now;
+  if (cacheable) {
+    cachedRevocationStatus = status;
+    lastRevocationCheck = now;
+  }
 
   return status.revoked;
 }
@@ -42,11 +53,15 @@ export async function checkRevocationStatus(
 /**
  * Fetch revocation status from endpoint
  */
-async function fetchRevocationStatus(
-  config: Required<GovernanceConfig>,
-): Promise<RevocationStatus> {
+async function fetchRevocationStatus(config: Required<GovernanceConfig>): Promise<FetchResult> {
   if (!config.revocation.revocation_endpoint || !config.agent.id) {
-    return { revoked: false };
+    // Revocation is enabled (callers gate on revocation.enabled) but the
+    // endpoint or agent id is missing — we cannot prove access is still valid.
+    // Fail CLOSED. Don't cache: this is a misconfiguration, not a verdict.
+    console.warn(
+      "Revocation enabled but revocation_endpoint/agent.id is missing — failing closed (assume revoked)",
+    );
+    return { status: { revoked: true }, cacheable: false };
   }
 
   try {
@@ -66,15 +81,30 @@ async function fetchRevocationStatus(
       console.warn(
         `Revocation check failed (${response.statusText}) — failing closed (assume revoked)`,
       );
-      return { revoked: true };
+      return { status: { revoked: true }, cacheable: false };
     }
 
-    const data = (await response.json()) as RevocationStatus;
-    return data;
+    const data = (await response.json()) as unknown;
+
+    // Validate shape: a 200 with no boolean `revoked` ({}, {revoked:"no"}, …) is
+    // ambiguous. Treating it as not-revoked is fail-OPEN and would be cached as a
+    // verdict. Fail CLOSED and don't cache the ambiguous result.
+    if (
+      typeof data !== "object" ||
+      data === null ||
+      typeof (data as Record<string, unknown>).revoked !== "boolean"
+    ) {
+      console.warn(
+        "Revocation response missing boolean `revoked` field — failing closed (assume revoked)",
+      );
+      return { status: { revoked: true }, cacheable: false };
+    }
+
+    return { status: data as RevocationStatus, cacheable: true };
   } catch (error) {
     // Network/parse failure — fail CLOSED (see above).
     console.warn(`Revocation check failed (${error}) — failing closed (assume revoked)`);
-    return { revoked: true };
+    return { status: { revoked: true }, cacheable: false };
   }
 }
 
@@ -90,10 +120,12 @@ export async function forceRevocationCheck(
     return { revoked: false };
   }
 
-  const status = await fetchRevocationStatus(fullConfig);
+  const { status, cacheable } = await fetchRevocationStatus(fullConfig);
 
-  cachedRevocationStatus = status;
-  lastRevocationCheck = Date.now();
+  if (cacheable) {
+    cachedRevocationStatus = status;
+    lastRevocationCheck = Date.now();
+  }
 
   return status;
 }

--- a/src/run-limits.test.ts
+++ b/src/run-limits.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { executeCommand } from "./run.js";
+
+let tmpDir: string;
+
+before(async () => {
+  tmpDir = join(tmpdir(), `kit-run-limits-test-${process.pid}`);
+  await mkdir(tmpDir, { recursive: true });
+});
+
+after(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("executeCommand resource limits", () => {
+  it("kills a subprocess that exceeds timeoutMs", async () => {
+    const result = await executeCommand({
+      // Sleep far longer than the timeout — should be SIGKILLed.
+      commandArgs: [process.execPath, "-e", "setTimeout(() => {}, 60000)"],
+      cwd: tmpDir,
+      timeoutMs: 200,
+    });
+
+    assert.equal(result.timedOut, true, "Should mark result as timed out");
+    assert.notEqual(result.exitCode, 0, "Timed-out process should not report success");
+    assert(result.stderr.includes("timed out"), "Should surface timeout in stderr");
+  });
+
+  it("truncates and kills a subprocess that exceeds maxOutputBytes", async () => {
+    const result = await executeCommand({
+      // Emit far more than the cap in a tight loop.
+      commandArgs: [
+        process.execPath,
+        "-e",
+        "for (let i = 0; i < 100000; i++) process.stdout.write('x'.repeat(1000))",
+      ],
+      cwd: tmpDir,
+      maxOutputBytes: 4096,
+    });
+
+    assert.equal(result.truncated, true, "Should mark result as truncated");
+    assert(result.stdout.length <= 4096, "Captured stdout must not exceed the cap");
+    assert(result.stderr.includes("truncated"), "Should surface truncation in stderr");
+  });
+
+  it("does not flag short, fast commands", async () => {
+    const result = await executeCommand({
+      commandArgs: ["echo", "ok"],
+      cwd: tmpDir,
+      timeoutMs: 5000,
+      maxOutputBytes: 1024,
+    });
+
+    assert.equal(result.exitCode, 0, "Should succeed");
+    assert.equal(result.timedOut, undefined, "Should not be flagged as timed out");
+    assert.equal(result.truncated, undefined, "Should not be flagged as truncated");
+    assert(result.stdout.includes("ok"), "Should capture output");
+  });
+});

--- a/src/run.ts
+++ b/src/run.ts
@@ -11,13 +11,26 @@ export interface RunOptions {
   envOverrides?: Record<string, string>;
   /** Inherit parent process environment */
   inheritEnv?: boolean;
+  /** Kill the subprocess after this many ms (default 120000). 0 disables. */
+  timeoutMs?: number;
+  /** Cap captured stdout+stderr; kill once exceeded (default 10 MiB). 0 disables. */
+  maxOutputBytes?: number;
 }
 
 export interface RunResult {
   exitCode: number;
   stdout: string;
   stderr: string;
+  /** True when the subprocess was killed for exceeding timeoutMs. */
+  timedOut?: boolean;
+  /** True when output was capped at maxOutputBytes and the process killed. */
+  truncated?: boolean;
 }
+
+/** Default wall-clock limit for a subprocess (2 minutes). */
+const DEFAULT_TIMEOUT_MS = 120_000;
+/** Default cap on combined captured output (10 MiB). */
+const DEFAULT_MAX_OUTPUT_BYTES = 10 * 1024 * 1024;
 
 /**
  * Execute a command with project environment variables loaded.
@@ -25,7 +38,14 @@ export interface RunResult {
  * The subprocess inherits parent process env + .env.local + overrides.
  */
 export async function executeCommand(opts: RunOptions): Promise<RunResult> {
-  const { commandArgs, cwd = process.cwd(), envOverrides = {}, inheritEnv = true } = opts;
+  const {
+    commandArgs,
+    cwd = process.cwd(),
+    envOverrides = {},
+    inheritEnv = true,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    maxOutputBytes = DEFAULT_MAX_OUTPUT_BYTES,
+  } = opts;
 
   if (commandArgs.length === 0) {
     throw new Error("No command provided");
@@ -72,33 +92,75 @@ export async function executeCommand(opts: RunOptions): Promise<RunResult> {
 
     let stdout = "";
     let stderr = "";
+    let captured = 0;
+    let timedOut = false;
+    let truncated = false;
+    let settled = false;
+
+    // Wall-clock timeout — kill a runaway/hung subprocess.
+    const timer =
+      timeoutMs > 0
+        ? setTimeout(() => {
+            timedOut = true;
+            child.kill("SIGKILL");
+          }, timeoutMs)
+        : null;
+    timer?.unref();
+
+    const append = (target: "stdout" | "stderr", chunk: Buffer): void => {
+      if (truncated) return;
+      const remaining = maxOutputBytes > 0 ? maxOutputBytes - captured : Infinity;
+      const slice = chunk.length > remaining ? chunk.subarray(0, remaining) : chunk;
+      const text = slice.toString();
+      if (target === "stdout") {
+        stdout += text;
+        process.stdout.write(slice);
+      } else {
+        stderr += text;
+        process.stderr.write(slice);
+      }
+      captured += slice.length;
+      if (maxOutputBytes > 0 && captured >= maxOutputBytes) {
+        truncated = true;
+        child.kill("SIGKILL");
+      }
+    };
 
     if (child.stdout) {
-      child.stdout.on("data", (chunk) => {
-        stdout += chunk.toString();
-        process.stdout.write(chunk);
-      });
+      child.stdout.on("data", (chunk: Buffer) => append("stdout", chunk));
     }
 
     if (child.stderr) {
-      child.stderr.on("data", (chunk) => {
-        stderr += chunk.toString();
-        process.stderr.write(chunk);
-      });
+      child.stderr.on("data", (chunk: Buffer) => append("stderr", chunk));
     }
 
+    const finish = (result: RunResult): void => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      resolve(result);
+    };
+
     child.on("close", (exitCode) => {
-      resolve({
-        exitCode: exitCode ?? 1,
+      if (timedOut) {
+        stderr += `\n[kit] command timed out after ${timeoutMs}ms — killed`;
+      } else if (truncated) {
+        stderr += `\n[kit] output exceeded ${maxOutputBytes} bytes — killed, output truncated`;
+      }
+      finish({
+        // A killed process reports null exitCode; surface as non-zero failure.
+        exitCode: exitCode ?? (timedOut || truncated ? 124 : 1),
         stdout,
         stderr,
+        ...(timedOut && { timedOut }),
+        ...(truncated && { truncated }),
       });
     });
 
     child.on("error", (err) => {
       // Command not found or spawn error
       console.error(`Failed to execute command: ${err.message}`);
-      resolve({
+      finish({
         exitCode: 127,
         stdout: "",
         stderr: err.message,

--- a/src/secrets-perms.test.ts
+++ b/src/secrets-perms.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { statSync } from "node:fs";
+import { unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { generateSecrets } from "./secrets.js";
+import { syncSecrets } from "./secrets-sync.js";
+import type { SecretsConfig } from "./config.js";
+
+// Plaintext-secret files must be owner-only (0o600). POSIX mode bits are
+// directly assertable; the Windows icacls path is covered by the #43 probe.
+const posix = process.platform !== "win32";
+
+const tmpOut = join(tmpdir(), `.kit-perms-${process.pid}.env`);
+
+afterEach(async () => {
+  try {
+    await unlink(tmpOut);
+  } catch {
+    /* ignore */
+  }
+});
+
+describe("secret-file perms (POSIX 0o600)", { skip: !posix }, () => {
+  it("generateSecrets writes .env.local as 0o600", async () => {
+    process.env._KIT_PERMS = "topsecret";
+    try {
+      const config: SecretsConfig = { keys: { _KIT_PERMS: { source: "env" } } };
+      const { written } = await generateSecrets(config, tmpOut);
+      assert.equal(written, true);
+      assert.equal(statSync(tmpOut).mode & 0o777, 0o600);
+    } finally {
+      delete process.env._KIT_PERMS;
+    }
+  });
+
+  it("syncSecrets dotenv-ci writes .env.ci as 0o600", async () => {
+    process.env._KIT_CI_PERMS = "cisecret";
+    try {
+      const config: SecretsConfig = { keys: { _KIT_CI_PERMS: { source: "env" } } };
+      const res = await syncSecrets(config, { target: "dotenv-ci", projectPath: tmpdir() });
+      const ciPath = join(tmpdir(), ".env.ci");
+      try {
+        assert.ok(res.synced.includes("_KIT_CI_PERMS"));
+        assert.equal(statSync(ciPath).mode & 0o777, 0o600);
+      } finally {
+        await unlink(ciPath).catch(() => {});
+      }
+    } finally {
+      delete process.env._KIT_CI_PERMS;
+    }
+  });
+});

--- a/src/secrets-sync.ts
+++ b/src/secrets-sync.ts
@@ -4,6 +4,7 @@ import { devNull } from "node:os";
 import type { SecretsConfig } from "./config.js";
 import { generateSecrets } from "./secrets.js";
 import { exec } from "./utils/exec.js";
+import { secureFile } from "./utils/secure-perms.js";
 import { safeErrorMessage } from "./secrets-migrate.js";
 
 export interface SyncResult {
@@ -57,7 +58,9 @@ export async function syncSecrets(
       const outPath = resolve(projectPath, ".env.ci");
       const lines = Object.entries(resolved).map(([k, v]) => `${k}=${v}`);
       if (!dryRun) {
-        await writeFile(outPath, lines.join("\n") + "\n", "utf8");
+        // Plaintext secrets — owner-only on create, then enforce (umask race).
+        await writeFile(outPath, lines.join("\n") + "\n", { encoding: "utf8", mode: 0o600 });
+        secureFile(outPath);
         synced.push(...Object.keys(resolved));
       } else {
         skipped.push(...Object.keys(resolved));

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -1,6 +1,8 @@
 import { readFile, writeFile, access } from "node:fs/promises";
+import { devNull } from "node:os";
 import type { SecretsConfig } from "./config.js";
 import { resolveViaBackend, resetInfisicalCache } from "./secret-backends.js";
+import { secureFile } from "./utils/secure-perms.js";
 
 export interface SecretResolveResult {
   name: string;
@@ -110,6 +112,12 @@ export async function generateSecrets(
     }
   }
 
-  await writeFile(outputPath, content, "utf-8");
+  // Create owner-only from the start (mode applies only on creation), then
+  // enforce 0o600 / icacls on the existing file too (handles pre-existing files
+  // and the umask race) — plaintext secrets must never be world-readable.
+  // Skip the platform null device (secrets-sync discards output there): chmod on
+  // the root-owned /dev/null throws EPERM and there's nothing to secure anyway.
+  await writeFile(outputPath, content, { encoding: "utf-8", mode: 0o600 });
+  if (outputPath !== devNull) secureFile(outputPath);
   return { results, written: true, fromTemplate };
 }

--- a/src/supply-chain-findings.test.ts
+++ b/src/supply-chain-findings.test.ts
@@ -1,0 +1,75 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildSupplyChainFindingLines, SUPPLY_CHAIN_FINDINGS_FILE } from "./check-security.js";
+import { verifyAuditChain } from "./audit.js";
+import type { BumblebeeFinding } from "./bumblebee.js";
+
+function finding(over: Partial<BumblebeeFinding> = {}): BumblebeeFinding {
+  return {
+    severity: "high",
+    catalogId: "shai-hulud",
+    catalogName: "Shai-Hulud worm",
+    ecosystem: "npm",
+    packageName: "evil-pkg",
+    version: "1.2.3",
+    sourceFile: "package-lock.json",
+    evidence: "matches known-compromise hash",
+    ...over,
+  };
+}
+
+describe("buildSupplyChainFindingLines", () => {
+  it("emits one JSON line per finding with the expected shape", () => {
+    const now = new Date("2026-01-02T03:04:05.000Z");
+    const out = buildSupplyChainFindingLines(
+      [finding(), finding({ packageName: "p2" })],
+      "deep",
+      now,
+    );
+    const lines = out.split("\n");
+    assert.equal(lines.length, 2);
+    const obj = JSON.parse(lines[0]);
+    assert.equal(obj.event_type, "supply_chain_finding");
+    assert.equal(obj.source, "bumblebee");
+    assert.equal(obj.profile, "deep");
+    assert.equal(obj.package, "evil-pkg");
+    assert.equal(obj.timestamp, "2026-01-02T03:04:05.000Z");
+    assert.equal(JSON.parse(lines[1]).package, "p2");
+  });
+
+  it("returns empty string for no findings (nothing to append)", () => {
+    assert.equal(buildSupplyChainFindingLines([], "baseline"), "");
+  });
+
+  it("falls back to 'unknown' package and null fields when absent", () => {
+    const obj = JSON.parse(
+      buildSupplyChainFindingLines(
+        [finding({ packageName: "", version: "", ecosystem: "", sourceFile: "", evidence: "" })],
+        "baseline",
+      ),
+    );
+    assert.equal(obj.package, "unknown");
+    assert.equal(obj.version, null);
+    assert.equal(obj.ecosystem, null);
+    assert.equal(obj.source_file, null);
+    assert.equal(obj.evidence, null);
+  });
+
+  it("produces UNCHAINED lines that must NOT go in the audit log (no prev/hash)", () => {
+    // The whole point of the fix: these raw lines have no hash chain. If they
+    // were appended to .kit-audit.jsonl, verifyAuditChain would report BROKEN.
+    const out = buildSupplyChainFindingLines([finding()], "baseline");
+    const obj = JSON.parse(out);
+    assert.equal(obj.prev, undefined);
+    assert.equal(obj.hash, undefined);
+
+    const verdict = verifyAuditChain(out + "\n");
+    assert.equal(verdict.ok, false, "raw findings must break the audit hash chain");
+    assert.match(verdict.reason ?? "", /unchained|missing hash/i);
+  });
+
+  it("targets a separate sink file, not the chained audit log", () => {
+    assert.equal(SUPPLY_CHAIN_FINDINGS_FILE, ".kit-findings.jsonl");
+    assert.notEqual(SUPPLY_CHAIN_FINDINGS_FILE, ".kit-audit.jsonl");
+  });
+});

--- a/src/triage-sandbox.test.ts
+++ b/src/triage-sandbox.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isRegistrySpec, isUnsafeEntry } from "./triage-sandbox.js";
+
+describe("isRegistrySpec (reject non-registry npm pack specs)", () => {
+  it("accepts plain and scoped registry names", () => {
+    assert.equal(isRegistrySpec("left-pad"), true);
+    assert.equal(isRegistrySpec("left-pad@1.3.0"), true);
+    assert.equal(isRegistrySpec("@scope/pkg"), true);
+    assert.equal(isRegistrySpec("@scope/pkg@2.0.0-beta.1"), true);
+    assert.equal(isRegistrySpec("@scope/pkg@latest"), true);
+  });
+
+  it("rejects git / http / file / protocol specs (would run prepare scripts)", () => {
+    assert.equal(isRegistrySpec("git+https://github.com/a/b.git"), false);
+    assert.equal(isRegistrySpec("git@github.com:a/b.git"), false);
+    assert.equal(isRegistrySpec("https://example.com/x.tgz"), false);
+    assert.equal(isRegistrySpec("http://example.com/x"), false);
+    assert.equal(isRegistrySpec("file:../local-pkg"), false);
+    assert.equal(isRegistrySpec("github:a/b"), false);
+  });
+
+  it("rejects local paths and tarball files", () => {
+    assert.equal(isRegistrySpec("/abs/path"), false);
+    assert.equal(isRegistrySpec("./rel/path"), false);
+    assert.equal(isRegistrySpec("../up"), false);
+    assert.equal(isRegistrySpec("pkg.tgz"), false);
+    assert.equal(isRegistrySpec("pkg.tar"), false);
+  });
+
+  it("rejects empty and overlong specs", () => {
+    assert.equal(isRegistrySpec(""), false);
+    assert.equal(isRegistrySpec("a".repeat(300)), false);
+  });
+});
+
+describe("isUnsafeEntry (reject escaping / link tarball entries)", () => {
+  const file = (mode: string, path: string) =>
+    `${mode}  0 user group  123 2020-01-01 00:00 ${path}`;
+
+  it("allows normal files under package/", () => {
+    assert.equal(isUnsafeEntry(file("-rw-r--r--", "package/index.js")), false);
+    assert.equal(isUnsafeEntry(file("drwxr-xr-x", "package/lib/")), false);
+    assert.equal(isUnsafeEntry(""), false);
+  });
+
+  it("rejects path traversal and absolute entries", () => {
+    assert.equal(isUnsafeEntry(file("-rw-r--r--", "package/../../etc/cron.d/x")), true);
+    assert.equal(isUnsafeEntry(file("-rw-r--r--", "/etc/passwd")), true);
+    assert.equal(isUnsafeEntry(file("-rw-r--r--", "C:\\windows\\evil")), true);
+  });
+
+  it("rejects symlinks and hardlinks regardless of target", () => {
+    assert.equal(
+      isUnsafeEntry("lrwxr-xr-x  0 user group  0 2020-01-01 00:00 package/evil -> /etc/passwd"),
+      true,
+    );
+    assert.equal(
+      isUnsafeEntry("hrw-r--r--  0 user group  0 2020-01-01 00:00 package/link link to package/x"),
+      true,
+    );
+  });
+});

--- a/src/triage-sandbox.ts
+++ b/src/triage-sandbox.ts
@@ -39,6 +39,50 @@ export interface SandboxResult {
   tarballSize: number;
 }
 
+/**
+ * Registry spec allow-list: `name` or `name@version`, optionally scoped
+ * (`@scope/name`). Anything else — git/http/file URLs, local dirs, .tgz paths —
+ * is rejected before `npm pack` so a non-registry spec can't trigger arbitrary
+ * code execution via prepare/prepack lifecycle scripts.
+ */
+const REGISTRY_SPEC = /^(@[a-z0-9][\w.-]*\/)?[a-z0-9][\w.-]*(@[\w.\-+]+)?$/i;
+
+/** Reject any spec npm would resolve to a non-registry source. */
+export function isRegistrySpec(spec: string): boolean {
+  if (!spec || spec.length > 214) return false;
+  // No protocol (git+, http(s):, file:, git@host:), no leading path or dot.
+  if (spec.includes(":") || spec.startsWith("/") || spec.startsWith(".")) return false;
+  // No local tarball / git url / explicit protocol words.
+  if (/\.tgz$|\.tar$|^git\b|^https?\b|^file\b/i.test(spec)) return false;
+  return REGISTRY_SPEC.test(spec);
+}
+
+/**
+ * Reject a tarball entry that would escape the package root or is a link.
+ * Input is a single line from a verbose `tar -tvzf` listing, e.g.
+ *   -rw-r--r--  0 u g  123 2020-01-01 00:00 package/index.js
+ *   lrwxr-xr-x  0 u g    0 2020-01-01 00:00 package/evil -> /etc/passwd
+ * The mode column's first char gives the entry type (l = symlink); the path is
+ * the trailing field (before ` -> ` for links).
+ */
+export function isUnsafeEntry(line: string): boolean {
+  const e = line.trim();
+  if (!e) return false;
+
+  // Symlink / hardlink: GNU and bsdtar both put the type flag first ('l' for
+  // symlink, 'h' for hardlink). A link can repoint outside the package root.
+  const typeFlag = e[0];
+  if (typeFlag === "l" || typeFlag === "h") return true;
+
+  // The archived path is the last field; for links, strip the ` -> target`.
+  const path = (e.split(" -> ")[0].trim().split(/\s+/).pop() ?? "").trim();
+  if (!path) return false;
+  if (path.startsWith("/")) return true; // absolute
+  if (path.split("/").some((seg) => seg === "..")) return true; // traversal
+  if (/^[a-zA-Z]:[\\/]/.test(path)) return true; // windows drive-absolute
+  return false;
+}
+
 /** Patterns that frequently appear in malicious lifecycle scripts. */
 const SUSPICIOUS_SCRIPT_PATTERNS: Array<[RegExp, string]> = [
   [/curl|wget|https?:\/\//i, "network call in install script"],
@@ -58,59 +102,90 @@ export async function triageNpmSandbox(
   const findings: SandboxFinding[] = [];
   const spec = version ? `${packageName}@${version}` : packageName;
 
+  // Build a terminating result that surfaces accumulated findings (used by the
+  // early-exit guards below) so the main flow stays flat.
+  const stop = (extra: SandboxFinding, size = 0): SandboxResult => ({
+    package: packageName,
+    version: version ?? null,
+    findings: [...findings, extra],
+    hasInstallScripts: false,
+    tarballSize: size,
+  });
+
+  // 0. Only registry specs are safe to pack. Git/dir/url/.tgz specs make
+  //    `npm pack` run prepare/prepack lifecycle scripts = arbitrary code exec
+  //    during the supposedly read-only inspection. Reject them outright.
+  if (!isRegistrySpec(spec)) {
+    return stop({
+      severity: "critical",
+      signal: "non-registry spec rejected",
+      detail: `refusing to pack non-registry spec (only name[@version] allowed): ${spec}`,
+    });
+  }
+
   // 1. Pull the tarball offline. npm pack writes to cwd; use a tmpdir so we
-  //    can clean up cleanly.
+  //    can clean up cleanly. --ignore-scripts (+ env var) prevents any
+  //    lifecycle script from running while npm resolves/packs the spec.
   const work = await mkdtemp(join(tmpdir(), "kit-triage-"));
   let tarballPath = "";
   let tarballSize = 0;
 
   try {
-    const { stdout } = await exec("npm", ["pack", spec, "--json", "--silent"], {
+    const { stdout } = await exec("npm", ["pack", spec, "--ignore-scripts", "--json", "--silent"], {
       cwd: work,
       timeout: 60_000,
+      env: { ...process.env, npm_config_ignore_scripts: "true" },
     });
     const meta = JSON.parse(stdout)[0] as { filename: string; size: number; version?: string };
     tarballPath = join(work, meta.filename);
     tarballSize = meta.size;
     if (meta.version) version = meta.version;
   } catch (err) {
+    return stop({
+      severity: "warn",
+      signal: "pack failed",
+      detail: `npm pack ${spec}: ${err instanceof Error ? err.message : String(err)}`,
+    });
+  }
+
+  // 2. List entries BEFORE extracting. npm packs everything under "package/";
+  //    any entry that escapes that root (absolute, "..", symlink/link) is
+  //    malicious and must never be written to the inspecting host's fs.
+  const listing = await listTarballEntries(tarballPath);
+  findings.push(...listing.findings);
+  if (!listing.ok) {
+    // Listing failed or an entry escapes the root: never extract.
     return {
       package: packageName,
       version: version ?? null,
-      findings: [
-        {
-          severity: "warn",
-          signal: "pack failed",
-          detail: `npm pack ${spec}: ${err instanceof Error ? err.message : String(err)}`,
-        },
-      ],
+      findings,
       hasInstallScripts: false,
-      tarballSize: 0,
+      tarballSize,
     };
   }
 
-  // 2. Extract into the same tmpdir for inspection.
-  // --no-same-owner/--no-same-permissions: archived ownership/mode bits must not
-  // carry over to the inspecting host (defense-in-depth).
-  await exec("tar", ["--no-same-owner", "--no-same-permissions", "xzf", tarballPath, "-C", work], {
-    timeout: 30_000,
-  });
-  const pkgRoot = join(work, "package");
-
-  // 3. Path traversal check — npm packs everything under "package/", anything
-  //    above is malicious.
-  const entries = (await exec("tar", ["tzf", tarballPath], { timeout: 10_000 })).stdout
-    .split("\n")
-    .filter(Boolean);
-  for (const entry of entries) {
-    if (entry.includes("..") || entry.startsWith("/")) {
-      findings.push({
-        severity: "critical",
-        signal: "path traversal",
-        detail: `tarball entry escapes package root: ${entry}`,
-      });
-    }
+  // 3. Only now extract into the same tmpdir for inspection. Use the dash form
+  //    `-xzf` (bsdtar on macOS rejects the bare `xzf` after long opts, which
+  //    silently disabled the sandbox there).
+  //    --no-same-owner/--no-same-permissions: archived ownership/mode bits must
+  //    not carry over to the inspecting host (defense-in-depth).
+  try {
+    await exec(
+      "tar",
+      ["--no-same-owner", "--no-same-permissions", "-xzf", tarballPath, "-C", work],
+      { timeout: 30_000 },
+    );
+  } catch (err) {
+    return stop(
+      {
+        severity: "warn",
+        signal: "extract failed",
+        detail: `tar -xzf ${tarballPath}: ${err instanceof Error ? err.message : String(err)}`,
+      },
+      tarballSize,
+    );
   }
+  const pkgRoot = join(work, "package");
 
   // 4. Parse package.json for install scripts.
   let hasInstallScripts = false;
@@ -158,6 +233,47 @@ export async function triageNpmSandbox(
     hasInstallScripts,
     tarballSize,
   };
+}
+
+/**
+ * List a tarball's entries (verbose, so the symlink/hardlink type flag is
+ * visible) and flag any that escape the package root. Returns ok=false — with a
+ * structured finding instead of throwing — when listing fails or an entry is
+ * unsafe, so the caller can refuse to extract.
+ */
+async function listTarballEntries(
+  tarballPath: string,
+): Promise<{ ok: boolean; findings: SandboxFinding[] }> {
+  const findings: SandboxFinding[] = [];
+  let entries: string[];
+  try {
+    entries = (await exec("tar", ["-tvzf", tarballPath], { timeout: 10_000 })).stdout
+      .split("\n")
+      .filter(Boolean);
+  } catch (err) {
+    return {
+      ok: false,
+      findings: [
+        {
+          severity: "warn",
+          signal: "tar list failed",
+          detail: `tar -tvzf ${tarballPath}: ${err instanceof Error ? err.message : String(err)}`,
+        },
+      ],
+    };
+  }
+  let ok = true;
+  for (const entry of entries) {
+    if (isUnsafeEntry(entry)) {
+      ok = false;
+      findings.push({
+        severity: "critical",
+        signal: "path traversal",
+        detail: `tarball entry escapes package root: ${entry}`,
+      });
+    }
+  }
+  return { ok, findings };
 }
 
 async function walkAndCheck(dir: string, findings: SandboxFinding[]): Promise<void> {

--- a/src/upgrade-self-error.test.ts
+++ b/src/upgrade-self-error.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isNpmPermissionError, npmPermissionRemediation } from "./cli.js";
+
+describe("isNpmPermissionError — npm -g EACCES detection", () => {
+  it("detects a classic EACCES global-prefix failure", () => {
+    const stderr =
+      "npm ERR! code EACCES\n" +
+      "npm ERR! syscall mkdir\n" +
+      "npm ERR! path /usr/local/lib/node_modules/sandstream-kit\n" +
+      "npm ERR! errno -13\n" +
+      "npm ERR! Error: EACCES: permission denied, mkdir '/usr/local/lib/node_modules/sandstream-kit'";
+    assert.equal(isNpmPermissionError(stderr), true);
+  });
+
+  it("detects EPERM / operation not permitted", () => {
+    assert.equal(isNpmPermissionError("npm ERR! Error: EPERM: operation not permitted"), true);
+    assert.equal(isNpmPermissionError("permission denied"), true);
+  });
+
+  it("does NOT misfire on an unrelated network failure", () => {
+    const stderr =
+      "npm ERR! code ENOTFOUND\nnpm ERR! network request to https://registry.npmjs.org failed";
+    assert.equal(isNpmPermissionError(stderr), false);
+  });
+
+  it("does NOT misfire on a generic version-conflict failure", () => {
+    assert.equal(isNpmPermissionError("npm ERR! ETARGET No matching version found"), false);
+  });
+});
+
+describe("npmPermissionRemediation — actionable, sudo-free guidance", () => {
+  const lines = npmPermissionRemediation();
+  const joined = lines.join("\n");
+
+  it("recommends a user-owned prefix, not sudo", () => {
+    assert.match(joined, /npm config set prefix ~\/\.npm-global/);
+    assert.match(joined, /\.npm-global\/bin/);
+    assert.ok(!/\bsudo npm\b/.test(joined), "must not tell the user to sudo npm");
+  });
+
+  it("tells the user to re-run the upgrade", () => {
+    assert.match(joined, /kit upgrade --self/);
+  });
+});


### PR DESCRIPTION
Fail-closed + least-privilege fixes from an exhaustive line-by-line review (the "paranoid, bulletproof" pass). **None were known-exploited**; all close latent gaps before anything gates on them.

## Hardening (9 lanes)
- **CI dep-triage gate fails CLOSED** — `triage-deps.yml` ran a stale script path with `|| true`; now verifies script presence, drops `|| true`, captures the real exit code, and treats non-zero exit **or** a missing `PASSED`/`WARNING` verdict as hard `FAILED`.
- **Publish supply-chain gate forceable fail-closed** — `KIT_BUMBLEBEE_REQUIRED=1` promotes scanner-unavailable `warn` → `fail`.
- **Audit hash-chain protected** — supply-chain findings now write to `.kit-findings.jsonl`, not the tamper-evident `.kit-audit.jsonl`. Pure `buildSupplyChainFindingLines()` extracted.
- **MCP `kit_secrets` never returns plaintext** — sanitized projection only; all mutating MCP tools gated behind read-only mode.
- **MCP `kit_run` bounded** — execution timeout + bounded output buffer.
- **Triage sandbox hardened** — `--ignore-scripts`, reject non-registry specs, reject `..`/leading-`/`/symlink archive entries before extraction, `tar -xzf` dash form (fixes silent macOS bsdtar failure).
- **Plugin loader** — npm-name regex + path-containment assertion before `import()`.
- **Revocation fails closed** — requires boolean `revoked`; enabled-but-misconfigured (blank endpoint/agent id) also fails closed.
- **Secret/state files owner-locked** — `secureFile`/`secureDir` (0600/0700; icacls on Windows) on `.env.local`, `.env.ci`, provisioned tokens, `memory.db`(+wal/shm).
- **CI output escaped** — GitHub annotations / GitLab JUnit / step-summary via `escData`/`xmlEscape`; `cmdTriageCheckDeps` treats NaN/invalid cache timestamp as expired.
- **Read-only mode enforced** on `kit install` (mise), `context use`, `env` switch, `fix`.

## Fixed
- `kit upgrade --self` prints actionable EACCES remediation (`npm config set prefix ~/.npm-global`) instead of a bare "command failed".

## Tests
New: ci-escaping, plugin-loader-security, run-limits, secrets-perms, supply-chain-findings, triage-sandbox, upgrade-self-error (+ context-lock, env-switch, install). **Full suite 1612/1612 green, `tsc` clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)