### PR TITLE
feat(scan,airgap): provable-green pt1 — scanner-health gate + provable air-gap (1.38.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.38.0] - 2026-06-26
+
+First step toward kit 2.0 ("the floor you can prove and build on"): close two fail-open holes in the "green = honest" promise. Both default to backward-compatible behavior; the stricter posture is opt-in.
+
+### Security
+
+- **Scanner-health gate — a crashed or missing scanner can no longer pass silently.** `kit scan`'s exit verdict was findings-only (`bad === 0`), so a scanner that errored / wasn't installed / lacked its token still exited 0 (a false green). A new pure `scanHealthGate(runs, {requiredScanners, strict})` now also accounts for scanner _health_. Default stays a loud warn (no existing green CI breaks); opt in to hard-fail via `[governance.scan].required_scanners` (a scanner in this list that didn't run fails) or `kit ci --strict` / `KIT_CI_STRICT=1` (any non-running scanner fails). `kit ci` gains the same `--strict` lever. New `[governance.scan].required_scanners` config key.
+- **Provable air-gap — no silent egress, and local rulesets can finally run offline.** Added `kit airgap verify`: asserts every scanner that would run in air-gap mode resolves to a local artifact (no cloud-only, no registry config) and prints a pass/fail table. In air-gap mode a registry (`p/…`) `KIT_SEMGREP_CONFIG` is now refused with a loud message in **both** scan paths (`kit scan` and `kit ci`'s `checkSemgrep`) because it would egress to the semgrep registry — while a **local** ruleset path is now correctly _kept_ (previously semgrep was dropped wholesale in air-gap, so it could never run even fully offline). New pure helpers `isLocalSemgrepConfig` + `verifyAirGapScanners`.
+
 ## [1.37.0] - 2026-06-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "1.37.0",
+      "version": "1.38.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/audit.test.ts
+++ b/src/audit.test.ts
@@ -34,6 +34,7 @@ describe("logAuditEvent", () => {
       approval: {},
       secrets: {},
       revocation: {},
+      scan: {},
     };
 
     await logAuditEvent(config, {
@@ -65,6 +66,7 @@ describe("logAuditEvent", () => {
       approval: {},
       secrets: {},
       revocation: {},
+      scan: {},
     };
 
     await logAuditEvent(config, {
@@ -102,6 +104,7 @@ describe("logAuditEvent", () => {
       approval: {},
       secrets: {},
       revocation: {},
+      scan: {},
     };
 
     await logAuditEvent(config, {
@@ -139,6 +142,7 @@ describe("logAuditEvent", () => {
       approval: {},
       secrets: {},
       revocation: {},
+      scan: {},
     };
 
     await logAuditEvent(config, {
@@ -172,6 +176,7 @@ describe("logAuditEvent", () => {
       approval: {},
       secrets: {},
       revocation: {},
+      scan: {},
     };
 
     await logAuditEvent(config, {
@@ -236,6 +241,7 @@ describe("readAuditLog", () => {
       approval: {},
       secrets: {},
       revocation: {},
+      scan: {},
     };
 
     // Write some events
@@ -270,6 +276,7 @@ describe("readAuditLog", () => {
       approval: {},
       secrets: {},
       revocation: {},
+      scan: {},
     };
 
     // Write multiple events
@@ -420,6 +427,7 @@ describe("logAuditEvent return value (fail-closed signal)", () => {
       approval: {},
       secrets: {},
       revocation: {},
+      scan: {},
     };
   }
 

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -6,7 +6,7 @@ import { homedir } from "node:os";
 import { execFileNoThrow } from "./utils/execFileNoThrow.js";
 import { resolveToolBin } from "./utils/resolveTool.js";
 import { classifyGuardDog } from "./guarddog.js";
-import { buildSemgrepArgs, semgrepConfig } from "./scanners.js";
+import { buildSemgrepArgs, semgrepConfig, isAirGap, isLocalSemgrepConfig } from "./scanners.js";
 import { ruleForCheck, type RuleRef } from "./rules/catalog.js";
 import {
   ensureBumblebee,
@@ -1308,6 +1308,20 @@ async function checkSemgrep(): Promise<SecurityCheckResult> {
   }
 
   const semgrepCfg = semgrepConfig(process.env);
+
+  // Provable air-gap: a registry ('p/...') ruleset egresses to the semgrep
+  // registry on first run. In air-gap mode refuse it (only a LOCAL ruleset path
+  // may run) — an honest skip, never a silent egress. Mirrors the scanner-runner
+  // air-gap path so `kit ci` cannot leak where `kit scan` would not.
+  if (isAirGap(process.env) && !isLocalSemgrepConfig(semgrepCfg)) {
+    return {
+      category: "supply-chain",
+      name: "semgrep SAST",
+      status: "skip",
+      detail: `air-gap: refusing registry semgrep config '${semgrepCfg}' (would egress) — set KIT_SEMGREP_CONFIG to a local ruleset path`,
+    };
+  }
+
   const result = await execFileNoThrow(
     semgrepBin,
     buildSemgrepArgs({ mode: "json", config: semgrepCfg }),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,7 @@ import { check1PasswordStatus, detect1PasswordMode } from "./onepassword.js";
 import { isNonInteractive } from "./environment.js";
 import { spawn as spawnChild } from "node:child_process";
 import { promptSelect } from "./utils/promptSelect.js";
-import { hasFlag, flagValue } from "./utils/flags.js";
+import { hasFlag, flagValue, envTruthy } from "./utils/flags.js";
 import { scanPlaintextSecrets } from "./scan-plaintext.js";
 import {
   planMigration,
@@ -3106,7 +3106,12 @@ async function cmdCi(): Promise<boolean> {
   const formatArg = args.find((a) => a.startsWith("--format="))?.split("=")[1] as
     | CiFormat
     | undefined;
-  const failOnWarning = hasFlag(args, "--fail-on-warning");
+  // Strict CI: a scanner that could not run (not installed / no token / crashed)
+  // surfaces as a WARN in the security checks, so strict promotes warnings to
+  // failures — a non-running critical scanner can no longer exit 0. Opt-in via
+  // --strict or KIT_CI_STRICT so existing green CIs are unaffected.
+  const strict = hasFlag(args, "--strict") || envTruthy(process.env.KIT_CI_STRICT);
+  const failOnWarning = hasFlag(args, "--fail-on-warning") || strict;
   const jsonMode = hasFlag(args, "--json");
   const format: CiFormat = formatArg ?? (jsonMode ? "json" : detectCiFormat());
 
@@ -5035,7 +5040,8 @@ async function cmdVerifyProvenance(): Promise<boolean> {
 
 async function cmdScan(): Promise<boolean> {
   const jsonMode = hasFlag(process.argv, "--json");
-  const { runScanners, suppressBaselined, dedupKey } = await import("./scanners.js");
+  const { runScanners, suppressBaselined, dedupKey, scanHealthGate, isLocalSemgrepConfig } =
+    await import("./scanners.js");
   const { resolveToolBin } = await import("./utils/resolveTool.js");
   const { execFileNoThrow } = await import("./utils/execFileNoThrow.js");
   const { loadBaseline, baselineGet, baselineSet, saveBaseline } = await import("./baseline.js");
@@ -5057,6 +5063,15 @@ async function cmdScan(): Promise<boolean> {
     console.log(
       `${c.dim}air-gap mode: offline scanners only${airgap.dropped.length ? ` (skipping cloud-only: ${airgap.dropped.join(", ")})` : ""}${c.reset}`,
     );
+    // Loud rejection: a registry KIT_SEMGREP_CONFIG (p/<pack>, r/<rule>, auto)
+    // would fetch rules from semgrep.dev = egress, so semgrep is NOT run
+    // air-gapped. Only a LOCAL ruleset path enables semgrep offline.
+    const semCfg = process.env.KIT_SEMGREP_CONFIG?.trim();
+    if (semCfg && !isLocalSemgrepConfig(semCfg)) {
+      console.error(
+        `${c.yellow}! air-gap: KIT_SEMGREP_CONFIG='${semCfg}' is a registry config (would fetch from the semgrep registry = egress) — semgrep is NOT run air-gapped. Point KIT_SEMGREP_CONFIG at a local ruleset path to enable it offline.${c.reset}`,
+      );
+    }
     // Verified offline threat-data bundle (optional): point scanners at a
     // signed, integrity-checked local DB set. Fail-closed — never scan against
     // unverified threat data.
@@ -5140,14 +5155,29 @@ async function cmdScan(): Promise<boolean> {
   const { kept: findings, suppressed } = suppressBaselined(merged, accepted);
   const bad = findings.filter((m) => m.severity === "critical" || m.severity === "high").length;
 
+  // Scanner-HEALTH gate (separate from findings): a scanner that did not actually
+  // run (crashed/absent/no-token) must be able to force a non-zero exit so a green
+  // verdict never hides a broken scanner. Backward-compatible — a non-running
+  // scanner stays a loud WARN unless strict or a required scanner missed.
+  const strict = hasFlag(process.argv, "--strict") || envTruthy(process.env.KIT_CI_STRICT);
+  const requiredScanners = config.governance?.scan?.required_scanners ?? [];
+  const gate = scanHealthGate(runs, { strict, requiredScanners });
+  const overallOk = bad === 0 && gate.ok;
+
   if (hasFlag(process.argv, "--sarif")) {
     const { toSarif } = await import("./sbom.js");
     console.log(JSON.stringify(toSarif(findings), null, 2));
-    return bad === 0;
+    return overallOk;
   }
   if (jsonMode) {
-    console.log(JSON.stringify({ runs, findings, suppressed }, null, 2));
-    return bad === 0;
+    console.log(
+      JSON.stringify(
+        { runs, findings, suppressed, ok: overallOk, scannerGate: gate, strict },
+        null,
+        2,
+      ),
+    );
+    return overallOk;
   }
 
   const suppressNote = suppressed > 0 ? `  ${c.dim}(${suppressed} baselined)${c.reset}` : "";
@@ -5180,7 +5210,89 @@ async function cmdScan(): Promise<boolean> {
     }
   }
   if (bad > 0) console.log(`${c.red}${bad} high/critical${c.reset}`);
-  return bad === 0;
+  // Honest scanner-health reporting: name WHICH scanner did not run and why.
+  for (const w of gate.warnings) {
+    console.log(`  ${c.yellow}! ${w}${c.reset}`);
+  }
+  for (const fmsg of gate.failures) {
+    console.log(`  ${c.red}✗ ${fmsg}${c.reset}`);
+  }
+  if (gate.warnings.length > 0 && gate.ok) {
+    console.log(
+      `${c.dim}  (a non-running scanner is a warn; use --strict or [governance.scan] required_scanners to hard-fail)${c.reset}`,
+    );
+  }
+  return overallOk;
+}
+
+/**
+ * `kit airgap verify` — prove the air-gap posture is egress-free: assert that
+ * every scanner that WOULD run in air-gap mode resolves to a local artifact (no
+ * cloud-only scanner, no registry/`auto` semgrep config). Read-only + deterministic.
+ */
+async function cmdAirgap(): Promise<boolean> {
+  const sub = process.argv[3];
+  const jsonMode = hasFlag(process.argv, "--json");
+  if (sub !== "verify") {
+    console.error(`${c.red}usage: kit airgap verify${c.reset}`);
+    process.exitCode = 1;
+    return false;
+  }
+
+  const { SCANNERS, airGapScanners, verifyAirGapScanners, semgrepConfig } =
+    await import("./scanners.js");
+  const { resolveAirGap } = await import("./airgap/config.js");
+  const configPath = resolveConfigPath();
+  const config = existsSync(configPath) ? await loadConfig(configPath) : ({} as kitConfig);
+  const ag = resolveAirGap(config.air_gap, process.env);
+
+  // Evaluate the air-gap plan (what WOULD run with no egress), regardless of
+  // whether air-gap is currently enabled — the point is to PROVE the posture.
+  const plan = airGapScanners(SCANNERS, true, process.env);
+  const cfg = semgrepConfig(process.env);
+  const report = verifyAirGapScanners(plan.scanners, { semgrepConfig: cfg });
+
+  if (jsonMode) {
+    console.log(
+      JSON.stringify(
+        { ok: report.ok, enabled: ag.enabled, rows: report.rows, dropped: plan.dropped },
+        null,
+        2,
+      ),
+    );
+    return report.ok;
+  }
+
+  console.log(
+    `${c.bold}kit airgap verify${c.reset}  ${c.dim}every runnable scanner must be local (no egress)${c.reset}`,
+  );
+  if (!ag.enabled) {
+    console.log(
+      `${c.dim}  air-gap not enabled in .kit.toml / env — verifying what air-gap mode WOULD run${c.reset}`,
+    );
+  }
+  for (const row of report.rows) {
+    const mark = row.ok ? `${c.green}✓${c.reset}` : `${c.red}✗${c.reset}`;
+    console.log(`  ${mark} ${row.id}  ${c.dim}${row.detail}${c.reset}`);
+  }
+  for (const id of plan.dropped) {
+    console.log(
+      `  ${c.dim}− ${id}  dropped (cloud-only / registry — excluded from air-gap)${c.reset}`,
+    );
+  }
+  console.log("");
+  if (report.ok) {
+    console.log(
+      `  ${c.green}air-gap clean: all runnable scanners resolve to local artifacts${c.reset}`,
+    );
+  } else {
+    const bad = report.rows
+      .filter((r) => !r.ok)
+      .map((r) => r.id)
+      .join(", ");
+    console.log(`  ${c.red}air-gap NOT provable: ${bad} would egress${c.reset}`);
+  }
+  return report.ok;
 }
 
 async function cmdGhaAudit(): Promise<boolean> {
@@ -5323,7 +5435,10 @@ export const COMMAND_HELP: Record<string, string> = {
     "Compact one-line status (mode score · update · open PAL) for any agent's info bar — wire into Claude Code statusLine / a shell PS1",
   check: "Check status of all tools, services, secrets, and lock files",
   health: "Deep environment health diagnostics — granular pass/fail across tools, services, config",
-  scan: "Run external scanners (snyk/trivy/grype/semgrep/osv) and merge them into one local verdict",
+  scan: "Run external scanners (snyk/trivy/grype/semgrep/osv) and merge them into one local verdict (--strict / [governance.scan] required_scanners gate non-running scanners)",
+  airgap: "Air-gap posture tools (verify)",
+  "airgap verify":
+    "Prove zero-egress: assert every scanner that would run air-gapped resolves to a local artifact (no cloud-only, no registry semgrep config)",
   sentinel: "Autonomous redline watcher — propose/apply guarded remediations (run|install|status)",
   "supply-chain":
     "Install-time supply-chain triage: install-scripts, lockfile-drift, dep-confusion, slopsquat",
@@ -6159,6 +6274,7 @@ export const COMMANDS: Record<string, () => boolean | Promise<boolean>> = {
   "agent-audit": cmdAgentAudit,
   sentinel: cmdSentinel,
   scan: cmdScan,
+  airgap: cmdAirgap,
   "verify-provenance": cmdVerifyProvenance,
   "gha-audit": cmdGhaAudit,
   sbom: cmdSbom,

--- a/src/config.ts
+++ b/src/config.ts
@@ -225,6 +225,21 @@ export interface GovernanceConfig {
   approval?: GovernanceApprovalConfig;
   secrets?: GovernanceSecretsConfig;
   revocation?: GovernanceRevocationConfig;
+  /**
+   * Scan-gate policy. `required_scanners` lists scanner ids (snyk/trivy/grype/
+   * semgrep/osv-scanner/socket) that MUST actually run — if a required scanner
+   * crashed, is absent, or is missing its token, the scan exits non-zero instead
+   * of false-greening on findings alone. Parsed from [governance.scan].
+   */
+  scan?: GovernanceScanConfig;
+}
+
+/**
+ * Scan-gate policy.
+ * Parsed from [governance.scan]
+ */
+export interface GovernanceScanConfig {
+  required_scanners?: string[];
 }
 
 /**
@@ -485,6 +500,12 @@ const GovernanceConfigSchema = z
         enabled: z.boolean().optional(),
         check_interval: z.number().optional(),
         revocation_endpoint: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    scan: z
+      .object({
+        required_scanners: z.array(z.string()).optional(),
       })
       .passthrough()
       .optional(),

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -53,6 +53,9 @@ export const DEFAULT_GOVERNANCE: Required<GovernanceConfig> = {
     check_interval: 300,
     revocation_endpoint: undefined,
   },
+  scan: {
+    required_scanners: [],
+  },
 };
 
 /**
@@ -89,6 +92,10 @@ export function mergeGovernanceConfig(userConfig?: GovernanceConfig): Required<G
     revocation: {
       ...DEFAULT_GOVERNANCE.revocation,
       ...userConfig.revocation,
+    },
+    scan: {
+      ...DEFAULT_GOVERNANCE.scan,
+      ...userConfig.scan,
     },
   };
 }

--- a/src/scanners.test.ts
+++ b/src/scanners.test.ts
@@ -10,10 +10,14 @@ import {
   SCANNERS,
   buildSemgrepArgs,
   semgrepConfig,
+  isLocalSemgrepConfig,
+  scanHealthGate,
+  verifyAirGapScanners,
   DEFAULT_SEMGREP_CONFIG,
   SEMGREP_EXCLUDES,
   type ScanDeps,
   type ScannerDef,
+  type ScannerRun,
 } from "./scanners.js";
 import type { SecurityCheckResult } from "./check-security.js";
 
@@ -293,5 +297,104 @@ describe("semgrep invocation (privacy + config, no `--config auto`)", () => {
     // SAST is opt-in: gated on KIT_SEMGREP_CONFIG so it never runs (slow + networked)
     // by default. The runner skips a needsToken scanner whose env var is unset.
     assert.equal(semgrep!.needsToken, "KIT_SEMGREP_CONFIG", "semgrep gated on KIT_SEMGREP_CONFIG");
+  });
+});
+
+describe("isLocalSemgrepConfig (air-gap egress gate)", () => {
+  it("registry/auto configs are NOT local (would egress)", () => {
+    assert.equal(isLocalSemgrepConfig("p/default"), false);
+    assert.equal(isLocalSemgrepConfig("auto"), false);
+    assert.equal(isLocalSemgrepConfig("r/x"), false);
+    assert.equal(isLocalSemgrepConfig(""), false);
+    assert.equal(isLocalSemgrepConfig("  "), false);
+  });
+  it("filesystem ruleset paths are local (run air-gapped)", () => {
+    assert.equal(isLocalSemgrepConfig("./rules.yml"), true);
+    assert.equal(isLocalSemgrepConfig("/abs/rules"), true);
+    assert.equal(isLocalSemgrepConfig(" ./local-rules.yml "), true);
+  });
+});
+
+describe("airGapScanners — local semgrep is allowed offline, registry dropped", () => {
+  it("keeps semgrep when KIT_SEMGREP_CONFIG is a local ruleset path", () => {
+    const plan = airGapScanners(SCANNERS, true, { KIT_SEMGREP_CONFIG: "./rules.yml" });
+    assert.ok(!plan.dropped.includes("semgrep"), "local-config semgrep must not be dropped");
+    const semgrep = plan.scanners.find((s) => s.id === "semgrep");
+    assert.ok(semgrep, "semgrep present in air-gap plan");
+    const i = semgrep!.args.indexOf("--config");
+    assert.equal(semgrep!.args[i + 1], "./rules.yml", "args rebuilt against the local ruleset");
+  });
+  it("drops semgrep when the config is a registry pack (egress)", () => {
+    const plan = airGapScanners(SCANNERS, true, { KIT_SEMGREP_CONFIG: "p/default" });
+    assert.ok(plan.dropped.includes("semgrep"));
+    assert.ok(!plan.scanners.some((s) => s.id === "semgrep"));
+  });
+});
+
+describe("scanHealthGate (reduce scanner health to exit)", () => {
+  const runs = (entries: [string, ScannerRun["status"]][]): ScannerRun[] =>
+    entries.map(([id, status]) => ({ id, status, findings: 0 }));
+
+  it("required scanner that ran => ok", () => {
+    const gate = scanHealthGate(runs([["trivy", "ran"]]), { requiredScanners: ["trivy"] });
+    assert.equal(gate.ok, true);
+    assert.deepEqual(gate.failures, []);
+  });
+  it("required scanner that errored => not ok, names the scanner", () => {
+    const gate = scanHealthGate(runs([["trivy", "error"]]), { requiredScanners: ["trivy"] });
+    assert.equal(gate.ok, false);
+    assert.ok(gate.failures.some((f) => f.includes("trivy")));
+  });
+  it("required scanner absent from the run set => not ok", () => {
+    const gate = scanHealthGate(runs([["grype", "ran"]]), { requiredScanners: ["trivy"] });
+    assert.equal(gate.ok, false);
+    assert.ok(gate.failures.some((f) => f.includes("trivy") && f.includes("not in scan plan")));
+  });
+  it("strict + any non-running scanner => not ok", () => {
+    const gate = scanHealthGate(runs([["trivy", "not-installed"]]), { strict: true });
+    assert.equal(gate.ok, false);
+    assert.ok(gate.failures.some((f) => f.includes("trivy")));
+  });
+  it("default (no strict, no required) + non-running scanner => ok but warns", () => {
+    const gate = scanHealthGate(runs([["trivy", "error"]]));
+    assert.equal(gate.ok, true);
+    assert.equal(gate.failures.length, 0);
+    assert.ok(gate.warnings.some((w) => w.includes("trivy")));
+  });
+  it("not-applicable is a legitimate skip — never a failure even when strict", () => {
+    const gate = scanHealthGate(runs([["snyk", "not-applicable"]]), { strict: true });
+    assert.equal(gate.ok, true);
+    assert.equal(gate.warnings.length, 0);
+  });
+});
+
+describe("verifyAirGapScanners (provable zero-egress reducer)", () => {
+  it("all-local plan => pass", () => {
+    const local: ScannerDef[] = [
+      { id: "trivy", bin: "trivy", args: [], format: "sarif" },
+      { id: "osv-scanner", bin: "osv-scanner", args: [], format: "osv" },
+      { id: "semgrep", bin: "semgrep", args: [], format: "sarif", cloudOnly: true },
+    ];
+    const report = verifyAirGapScanners(local, { semgrepConfig: "./rules.yml" });
+    assert.equal(report.ok, true);
+    assert.ok(report.rows.every((r) => r.ok));
+  });
+  it("a cloud-only scanner present => fail, names that id", () => {
+    const leaked: ScannerDef[] = [
+      { id: "trivy", bin: "trivy", args: [], format: "sarif" },
+      { id: "snyk", bin: "snyk", args: [], format: "sarif", cloudOnly: true },
+    ];
+    const report = verifyAirGapScanners(leaked);
+    assert.equal(report.ok, false);
+    const snyk = report.rows.find((r) => r.id === "snyk")!;
+    assert.equal(snyk.ok, false);
+  });
+  it("a registry semgrep config => fail, names semgrep", () => {
+    const withSemgrep: ScannerDef[] = [
+      { id: "semgrep", bin: "semgrep", args: [], format: "sarif", cloudOnly: true },
+    ];
+    const report = verifyAirGapScanners(withSemgrep, { semgrepConfig: "p/default" });
+    assert.equal(report.ok, false);
+    assert.ok(report.rows.find((r) => r.id === "semgrep" && !r.ok));
   });
 });

--- a/src/scanners.ts
+++ b/src/scanners.ts
@@ -45,6 +45,21 @@ export function semgrepConfig(env?: Record<string, string | undefined>): string 
 }
 
 /**
+ * True when a semgrep config points at a LOCAL filesystem ruleset (runs with no
+ * network). The registry forms FETCH rules from semgrep.dev (egress) and are NOT
+ * local: `p/<pack>` (rule packs), `r/<rule>` (single registry rules), and `auto`
+ * (which also forces telemetry). Anything else (a relative or absolute path) is a
+ * local ruleset. This is the air-gap gate for semgrep — only a local config may
+ * run air-gapped. Pure.
+ */
+export function isLocalSemgrepConfig(config: string): boolean {
+  const c = config.trim();
+  if (!c || c === "auto") return false;
+  if (/^[pr]\//.test(c)) return false; // p/<pack>, r/<rule> — registry fetch = egress
+  return true;
+}
+
+/**
  * Build semgrep CLI args with privacy + noise hardening:
  *   - explicit `--config <config>` (never `auto`, which forces telemetry on),
  *   - `--metrics off` so nothing is reported to the registry,
@@ -173,22 +188,92 @@ export interface AirGapPlan {
  * Transform the registry for air-gap mode: drop `cloudOnly` scanners and fold
  * each remaining scanner's `offline` args/env in so it runs against a local DB
  * with no network. A no-op (returns the input) when `enabled` is false.
+ *
+ * semgrep is the one exception to the blanket `cloudOnly` drop: it is cloudOnly
+ * because `p/<pack>`, `r/<rule>` and `auto` configs FETCH rules from the registry
+ * (egress), but a LOCAL ruleset path runs fully offline. So when air-gapped, kept
+ * ONLY if KIT_SEMGREP_CONFIG (via `env`) is a local path; a registry config gets
+ * dropped (it would egress).
  */
-export function airGapScanners(defs: ScannerDef[], enabled: boolean): AirGapPlan {
+export function airGapScanners(
+  defs: ScannerDef[],
+  enabled: boolean,
+  env: Record<string, string | undefined> = process.env,
+): AirGapPlan {
   if (!enabled) return { scanners: defs, env: {}, dropped: [] };
   const scanners: ScannerDef[] = [];
-  const env: Record<string, string> = {};
+  const injectEnv: Record<string, string> = {};
   const dropped: string[] = [];
   for (const d of defs) {
+    if (d.id === "semgrep") {
+      const cfg = semgrepConfig(env);
+      if (isLocalSemgrepConfig(cfg)) {
+        // Local ruleset → safe to run air-gapped; rebuild args against that config.
+        scanners.push({ ...d, args: buildSemgrepArgs({ mode: "sarif", config: cfg }) });
+      } else {
+        dropped.push(d.id);
+      }
+      continue;
+    }
     if (d.cloudOnly) {
       dropped.push(d.id);
       continue;
     }
-    if (d.offline?.env) Object.assign(env, d.offline.env);
+    if (d.offline?.env) Object.assign(injectEnv, d.offline.env);
     const extra = d.offline?.args ?? [];
     scanners.push(extra.length ? { ...d, args: [...d.args, ...extra] } : d);
   }
-  return { scanners, env, dropped };
+  return { scanners, env: injectEnv, dropped };
+}
+
+export interface AirGapVerifyRow {
+  id: string;
+  ok: boolean;
+  detail: string;
+}
+export interface AirGapVerifyReport {
+  ok: boolean;
+  rows: AirGapVerifyRow[];
+}
+
+/**
+ * Prove that every scanner that WOULD run in air-gap mode resolves to a LOCAL
+ * artifact — no `cloudOnly` scanner and no registry/`auto` semgrep config (both
+ * would egress). The caller passes the post-`airGapScanners` plan plus the
+ * resolved semgrep config; this RE-CHECKS each remaining scanner rather than
+ * trusting the drop, so a cloud/registry scanner that slipped through is named +
+ * fails. Read-only, pure + deterministic.
+ */
+export function verifyAirGapScanners(
+  scanners: ScannerDef[],
+  opts: { semgrepConfig?: string } = {},
+): AirGapVerifyReport {
+  const rows: AirGapVerifyRow[] = [];
+  for (const s of scanners) {
+    if (s.id === "semgrep") {
+      const cfg = (opts.semgrepConfig ?? "").trim();
+      rows.push(
+        isLocalSemgrepConfig(cfg)
+          ? { id: s.id, ok: true, detail: `local ruleset ${cfg} (no registry fetch)` }
+          : {
+              id: s.id,
+              ok: false,
+              detail: `registry config '${cfg || DEFAULT_SEMGREP_CONFIG}' would fetch rules from the registry (egress)`,
+            },
+      );
+      continue;
+    }
+    if (s.cloudOnly) {
+      rows.push({
+        id: s.id,
+        ok: false,
+        detail: "cloud-only scanner (needs a hosted backend) — must be dropped in air-gap",
+      });
+      continue;
+    }
+    rows.push({ id: s.id, ok: true, detail: "local scanner (offline DB)" });
+  }
+  return { ok: rows.every((r) => r.ok), rows };
 }
 
 const RANK: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1 };
@@ -245,6 +330,57 @@ export interface ScannerRun {
   id: string;
   status: ScannerStatus;
   findings: number;
+}
+
+/**
+ * Statuses that mean the scanner did NOT actually execute a scan, so its verdict
+ * is unknown (a green result hides the gap). `ran` succeeded; `not-applicable` is
+ * a legitimate skip (the scanner does not apply to this project) and is NOT a gap.
+ */
+export const NON_RUNNING_STATUSES: ScannerStatus[] = ["not-installed", "no-token", "error"];
+
+export interface ScanGateOptions {
+  /** Scanner ids that MUST run; if one did not, the gate fails (even without strict). */
+  requiredScanners?: string[];
+  /** Strict: ANY non-running scanner fails the gate (opt-in via --strict / KIT_CI_STRICT). */
+  strict?: boolean;
+}
+
+export interface ScanGate {
+  ok: boolean;
+  /** Hard-fail reasons — each names WHICH scanner did not run and why. */
+  failures: string[];
+  /** Non-fatal: a scanner did not run but is not required and strict is off. */
+  warnings: string[];
+}
+
+/**
+ * Reduce scanner-run HEALTH (did each scanner actually run?) to an exit verdict —
+ * separate from, and combined with, the findings gate. The honest default is
+ * fail-open-but-loud: a scanner that did not run is a WARN, so existing green CIs
+ * keep passing (backward-compatible). Opt in to a hard fail two ways: list the
+ * scanner under `requiredScanners` (that one must run), or set `strict` (ANY
+ * non-running scanner fails). A required scanner that is absent from the run set
+ * entirely (e.g. dropped in air-gap, not in the registry) also fails. Pure +
+ * deterministic.
+ */
+export function scanHealthGate(runs: ScannerRun[], opts: ScanGateOptions = {}): ScanGate {
+  const required = new Set(opts.requiredScanners ?? []);
+  const failures: string[] = [];
+  const warnings: string[] = [];
+  const seen = new Set<string>();
+  for (const r of runs) {
+    seen.add(r.id);
+    if (!NON_RUNNING_STATUSES.includes(r.status)) continue; // ran or not-applicable
+    const why = `${r.id} did not run (${r.status})`;
+    if (required.has(r.id)) failures.push(`required scanner ${why}`);
+    else if (opts.strict) failures.push(`${why} [strict]`);
+    else warnings.push(why);
+  }
+  for (const id of required) {
+    if (!seen.has(id)) failures.push(`required scanner ${id} did not run (not in scan plan)`);
+  }
+  return { ok: failures.length === 0, failures, warnings };
 }
 
 export interface ScanDeps {

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -23,6 +23,11 @@ export function flagValue(argv: readonly string[], name: string): string | undef
   return argv[i + 1];
 }
 
+/** True for the usual truthy env-flag spellings (1/true/yes/on); false otherwise. */
+export function envTruthy(value: string | undefined): boolean {
+  return ["1", "true", "yes", "on"].includes((value ?? "").trim().toLowerCase());
+}
+
 /**
  * Integer value for a flag, or `fallback` when absent / non-numeric.
  * Mirrors the common `const n = idx >= 0 ? parseInt(args[idx+1]) : default` idiom.


### PR DESCRIPTION
First step toward **kit 2.0** ("the floor you can prove and build on") — close two fail-open holes in `green = honest`. Both default to backward-compatible behavior; the stricter posture is opt-in, so no existing green CI breaks.

## Scanner-health gate
`kit scan`'s exit verdict was findings-only (`bad === 0`), so a scanner that errored / wasn't installed / lacked its token still exited **0** — a false green. New pure `scanHealthGate(runs, {requiredScanners, strict})` accounts for scanner *health*:
- **Default:** non-running scanner = loud warn (unchanged exit behavior).
- **Opt-in hard-fail:** `[governance.scan].required_scanners` (a listed scanner that didn't run fails) or `kit ci --strict` / `KIT_CI_STRICT=1` (any non-running scanner fails).

## Provable air-gap
- New **`kit airgap verify`** — asserts every scanner that would run in air-gap resolves to a local artifact (no cloud-only / no registry config) + prints a pass/fail table.
- In air-gap, a registry (`p/…`) `KIT_SEMGREP_CONFIG` is now **refused** (would egress to the semgrep registry) in **both** scan paths (`kit scan` *and* `kit ci`'s `checkSemgrep`), while a **local** ruleset path is correctly **kept** (semgrep was dropped wholesale before, so it could never run even fully offline).
- New pure helpers `isLocalSemgrepConfig` + `verifyAirGapScanners`.

## Verification
Build clean, **1693/1693 tests pass** (Node 22), `kit self-audit` 0 fail, `kit airgap verify` smoke-verified.

Part of the kit 2.0 roadmap (Pillar 1 · Provable Green). Next: attested audit trail (external HMAC anchor + signed check-receipt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)