### PR TITLE
feat(audit): attested audit trail — HMAC anchor + signed check-receipt (1.39.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ sandstream-kit-*.tgz
 # Internal runtime state — never publish
 .kit/elevation.json
 .kit-audit.jsonl
+.kit-check-attestation.json
 .kit-baseline.json
 .kit-budget.json
 .kit-escalation.txt
@@ -23,3 +24,12 @@ opencode.json
 *\ 2.ts
 *\ 2.js
 *\ 2.md
+
+# ── kit security check-gitignore ── do not edit ──
+.kit/*  # kit local state (elevation, env, runtime)
+!.kit/shared/  # keep curated shared memory tracked (committed by design)
+*.key  # private keys
+id_ed25519  # SSH ed25519 private key
+*.p12  # PKCS#12 bundle (TLS certs + keys)
+*-service-account*.json  # GCP service-account JSON keys
+# ── /kit ──

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.39.0] - 2026-06-26
+
+kit 2.0 Pillar 1 (Provable Green), part 2: make the audit trail attestable, and be honest about exactly how far that goes.
+
+### Security
+
+- **Audit chain gains an external HMAC anchor.** The `.kit-audit.jsonl` chain was tamper-_evident_ but fully recomputable by any writer (keyless SHA-256 from a public genesis). A machine-local anchor key (`~/.kit/audit-anchor.key`, 0600, reusing the `elevation.ts` pattern) now seals the chain into a separate 0600 anchor record (HMAC tip + sealed entry count). `kit audit verify` detects a keyless prefix rewrite (tip mismatch) and truncation/rollback (count), and `kit audit anchor` seals a log. The append path stays keyless (so a sandboxed agent with no key access keeps logging); the key is only needed to seal/verify. **Honest by design:** this raises forgery from "anyone who can write the log" to "someone who can read the 0600 key" — it is **not** tamper-proof against a same-UID local principal (that needs the documented, stubbed external TSA anchor). Key rotation reports as a distinct `anchor-key-changed` status (not a false tamper alarm), and a tampered/rotated prefix is never silently re-sealed.
+- **`kit audit verify --strict` / `[governance.audit].require_anchor` — fail-closed.** By default an unanchored log / unreadable key / unsealed tail is a warn (backward-compatible). Strict mode (or once the machine has anchored any log) makes them hard failures, so a project-writable `[governance.audit].log_file` cannot repoint verification at a forged, never-anchored file and pass. An unsealed tail past the seal is unauthenticated and surfaced loudly.
+- **Signed check-attestation receipt** (`kit check --attest` / `kit ci --attest` / `KIT_ATTEST=1`) — opt-in, fail-soft (never blocks or alters the verdict). Writes `.kit-check-attestation.json` recording which scanners actually ran + the verdict, signed with the machine-local HMAC anchor key (authoritative — the verifier needs that key). An Ed25519 receipt is a portable fallback whose **embedded public key is untrusted**: `kit check verify-attestation` reports `unverified-authenticity` (not green) unless the key is pinned (TOFU in `~/.kit`, refuses silent overwrite) or passed via `--key`; a non-matching key fails. No "forgery requires the key" overclaim for the Ed25519 path.
+
+### Fixed
+
+- Hardened a key-file create race (a lost `wx` race could re-read a partial/empty key) — `reReadHexKey` now enforces the length guard with bounded backoff and never returns a short key; applied to both the audit anchor and `elevation.ts`.
+
 ## [1.38.0] - 2026-06-26
 
 First step toward kit 2.0 ("the floor you can prove and build on"): close two fail-open holes in the "green = honest" promise. Both default to backward-compatible behavior; the stricter posture is opt-in.

--- a/docs/AUDIT_ATTESTATION.md
+++ b/docs/AUDIT_ATTESTATION.md
@@ -1,0 +1,152 @@
+# Attested audit trail
+
+kit 1.39.0 adds two layers on top of the `.kit-audit.jsonl` hash chain: an
+external HMAC anchor for the audit log, and a signed check-attestation receipt.
+This document states precisely what each layer does and, just as important, what
+it does NOT guarantee.
+
+## 1. The starting point: a tamper-evident, not tamper-proof, chain
+
+Each line in `.kit-audit.jsonl` carries `prev` (the previous line's hash) and
+`hash` (sha256 over the line's pre-hash JSON). `kit audit verify` re-walks the
+chain and catches any edit, insertion, deletion, or reorder.
+
+The chain is **keyless**: the hashes seed from a public genesis constant
+(`"0".repeat(64)`) and use plain sha256. So a writer who can rewrite the log can
+also recompute `prev` + `hash` for every line and produce a chain that
+`verifyAuditChain` accepts. There is no key, no stored tip, and no stored entry
+count, so a full rewrite (or a truncation/rollback) is invisible to the keyless
+check. The chain is tamper-EVIDENT against accidental or naive edits; it is not
+tamper-PROOF against a writer who recomputes it.
+
+## 2. External HMAC anchor (`kit audit anchor` / `kit audit verify`)
+
+A machine-local key lives at `~/.kit/audit-anchor.key` (0600, created on first
+use, `icacls` owner-only on Windows). An anchor record at
+`~/.kit/audit-anchor.json` (0600) stores, per log path, an HMAC `tip` over the
+sealed prefix and the `count` of entries it covers.
+
+- `kit audit anchor` seals the current log: it verifies the keyless chain, then
+  folds an HMAC chain over every line hash with the anchor key and records the
+  resulting tip + count.
+- `kit audit verify` re-checks the keyless chain, then (when an anchor exists and
+  the key is readable) recomputes the tip over the first `count` line hashes and
+  compares it to the stored tip, and checks that at least `count` entries remain.
+- The append path stays KEYLESS. A project-sandboxed agent that cannot read
+  `~/.kit` still appends audit entries; anchoring is best-effort and fail-soft on
+  the write path and never blocks an append. Set `KIT_AUDIT_ANCHOR=0` to disable
+  append-time anchoring; set `KIT_AUDIT_ANCHOR_DIR` to relocate the key + record
+  (used by the test suite for isolation).
+
+Detection properties:
+
+| Attack                                                       | Keyless chain | HMAC anchor (default)                                             | HMAC anchor (`--strict` / `require_anchor`) |
+| ------------------------------------------------------------ | ------------- | ----------------------------------------------------------------- | ------------------------------------------- |
+| Edit one line, leave the rest                                | detected      | detected                                                          | detected                                    |
+| Rewrite + re-chain the whole log without the key             | NOT detected  | detected (tip-mismatch)                                           | detected                                    |
+| Truncate / roll back to fewer entries                        | NOT detected  | detected (count)                                                  | detected                                    |
+| Append forged NEW entries beyond the seal (keyless re-chain) | NOT detected  | surfaced LOUDLY as unsealed tail                                  | FAIL (unsealed entries are unauthenticated) |
+| Repoint `log_file` at a forged, never-anchored log           | n/a           | warn (no-anchor)                                                  | FAIL once any log is anchored / required    |
+| Rotate / replace the anchor key                              | n/a           | reported as `anchor-key-changed` (distinct from a content tamper) | FAIL                                        |
+
+### Fail-closed mode (`--strict` / `require_anchor`)
+
+By default an unanchored log, an unreadable key, an unsealed tail, and a rotated
+key are warnings, so existing logs stay compatible. Turn them into hard failures
+(non-zero exit) with `kit audit verify --strict` or `[governance.audit]
+require_anchor = true`. Fail-closed is ALSO implicitly active once this machine
+has anchored ANY log: a no-key writer must not be able to repoint the
+project-writable `log_file` at a forged, never-anchored file and have verify pass
+green.
+
+An unsealed tail (entries appended after the last `kit audit anchor`) is
+unauthenticated: a writer without the key can append keyless-rechained entries.
+The keyless chain accepts them; the anchor surfaces them loudly and, under
+strict mode, fails. Re-run `kit audit anchor` to seal them.
+
+A key rotation (the current key no longer matches the one that sealed the
+record) is reported as `anchor-key-changed`, NOT a content tamper. Old anchors
+are invalid by design after a key change; re-anchor to re-establish the seal.
+The append-time auto-advance will NOT silently re-seal a prefix that no longer
+verifies under the current key, so a real tamper/rotation alarm cannot be erased
+by the next audited write.
+
+### Threat boundary (read before claiming anything)
+
+The anchor raises the bar from "anyone who can WRITE the log can forge it" to
+"only someone who can READ the 0600 anchor key can forge it". It is **NOT**
+tamper-proof against a same-UID local principal: an attacker running as the same
+user can read `~/.kit/audit-anchor.key` AND the anchor record, recompute the tip,
+and re-seal a forged log. Do not describe this as tamper-proof.
+
+## 3. Signed check-attestation receipt (`kit check --attest`)
+
+With `--attest` (or `KIT_ATTEST=1`), `kit check` / `kit ci` writes
+`.kit-check-attestation.json`: `{ schema, command, timestamp, kit_version,
+overall_ok, results summary, scanners_ran[], signature }`. `scanners_ran`
+records which security gates actually ran versus were skipped/errored, so the
+receipt proves which gates ran and that none failed open.
+
+Emission is **opt-in** because writing a new file into the repo on every run
+would surprise scripted users. The sign step is fail-soft: a signing failure
+never blocks the check from completing, and at worst the receipt is emitted
+unsigned (`sig_alg: "none"`) with a reason.
+
+Signing precedence:
+
+1. **HMAC-SHA256** with the machine-local audit anchor key. DEFAULT and
+   authoritative: the verifier needs the same machine-local key, so a valid MAC
+   genuinely binds the receipt to a key-holder (real authenticity).
+2. **Ed25519** keypair at `~/.kit/attestation-ed25519.key` (portable fallback,
+   or when explicitly requested). The receipt embeds its SPKI public key, but
+   that embedded key is **UNTRUSTED**: anyone can mint a keypair, sign
+   `overall_ok: true`, and embed their own public key. Authenticity therefore
+   requires the verifier to authenticate the key.
+
+Verify with `kit check verify-attestation [file] [--key <spki|fingerprint>]
+[--pin]`.
+
+### Ed25519 authenticity (do NOT trust the embedded key)
+
+A self-signed Ed25519 receipt proves **integrity of its own claims only** - that
+the payload was not altered after signing. It does NOT prove WHO produced it: the
+public key travels inside the receipt, so a forger simply embeds their own. The
+old framing that "forgery requires reading the key" is FALSE for the Ed25519
+path and has been removed.
+
+To authenticate an Ed25519 receipt the verifier must compare the embedded key
+against an expected one:
+
+- `--key <spki-pem | fingerprint>` - the operator pins the expected key inline.
+- a **TOFU pin** in `~/.kit/attestation-ed25519.pin` (0600) - `verify --pin`
+  records the current key as trusted-on-first-use; later receipts must match.
+  Pinning a key you have not independently verified trusts whoever produced that
+  first receipt.
+
+With no `--key` and no pin, an Ed25519 receipt verifies as
+`unverified-authenticity`: the signature is mathematically valid but the signer
+is unauthenticated. This is **NOT** a green pass. A receipt whose key does not
+match the pin/expected key FAILS (possible forgery). Verify output surfaces the
+key fingerprint (`sha256:…`) so it can be pinned.
+
+### Threat boundary
+
+A same-UID attacker who can read the signing key (the HMAC anchor key or an
+Ed25519 private key) can forge a receipt. An HMAC receipt (or an Ed25519 receipt
+matching a pinned key) proves "the gates ran and passed on a host holding this
+key", not "the gates ran on an untampered host". An unpinned self-signed Ed25519
+receipt proves only the integrity of its own claims, nothing about authenticity.
+Same same-UID boundary as the audit anchor.
+
+## 4. Closing the same-UID gap (external anchor, not shipped)
+
+Both layers above fall to a same-UID attacker who can read the local key. The
+only way to close that is an anchor the local principal cannot rewrite: an
+RFC3161 Time-Stamping Authority over the tip, or a remote append-only log.
+
+kit ships a documented extension point (`ExternalTimestampAnchor` /
+`resolveExternalAnchor` in `src/audit-anchor.ts`) but no network TSA client,
+because a default network call would break the local-first / no-egress posture.
+An enclave wires its own implementation and treats a missing or failed external
+anchor as a verification failure, the same fail-closed contract as the air-gap
+provenance path (`docs/AIR_GAP.md`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "1.38.0",
+      "version": "1.39.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -12,6 +12,9 @@ const env = {
   KIT_BUMBLEBEE: "0",
   KIT_NO_FAILURE_SIM: "1",
   KIT_NO_UPDATE_CHECK: "1",
+  // Keep incidental audit appends from touching the real ~/.kit anchor. Tests
+  // that exercise anchoring opt back in with an explicit KIT_AUDIT_ANCHOR_DIR.
+  KIT_AUDIT_ANCHOR: "0",
 };
 
 if (!existsSync("dist")) {

--- a/src/audit-anchor.test.ts
+++ b/src/audit-anchor.test.ts
@@ -1,0 +1,441 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { appendAuditEventDirect } from "./audit.js";
+import { randomBytes, createHash } from "node:crypto";
+import {
+  computeAnchorTip,
+  anchorKeyFingerprint,
+  lineHashes,
+  anchorAuditLog,
+  readAnchorRecord,
+  verifyAgainstAnchor,
+  decideAnchorVerdict,
+  hasAnyAnchoredLogs,
+  getAuditAnchorKey,
+  tryReadAuditAnchorKey,
+  tryAdvanceAnchorOnAppend,
+  resolveExternalAnchor,
+  type AnchorVerifyResult,
+} from "./audit-anchor.js";
+
+// Build a real hash-chained log without auto-anchoring (KIT_AUDIT_ANCHOR=0 is
+// set by the test runner) so each test controls anchoring explicitly.
+async function buildChain(cwd: string, n: number): Promise<string> {
+  for (let i = 0; i < n; i++) {
+    const ok = await appendAuditEventDirect(
+      { operation: `op-${i}`, environment: "dev", success: true },
+      { cwd },
+    );
+    assert.equal(ok, true);
+  }
+  return readFileSync(join(cwd, ".kit-audit.jsonl"), "utf-8");
+}
+
+describe("audit anchor - pure helpers", () => {
+  it("computeAnchorTip is deterministic and key-dependent", () => {
+    const k1 = Buffer.alloc(32, 1);
+    const k2 = Buffer.alloc(32, 2);
+    const hashes = ["aa", "bb", "cc"];
+    assert.equal(computeAnchorTip(k1, hashes), computeAnchorTip(k1, hashes));
+    assert.notEqual(computeAnchorTip(k1, hashes), computeAnchorTip(k2, hashes));
+  });
+
+  it("computeAnchorTip changes when any hash changes (order-sensitive)", () => {
+    const k = Buffer.alloc(32, 7);
+    assert.notEqual(computeAnchorTip(k, ["a", "b"]), computeAnchorTip(k, ["b", "a"]));
+    assert.notEqual(computeAnchorTip(k, ["a", "b"]), computeAnchorTip(k, ["a", "b", "c"]));
+  });
+
+  it("lineHashes returns null for an unchained (legacy) line", () => {
+    const legacy = JSON.stringify({ operation: "x", environment: "dev", success: true });
+    assert.equal(lineHashes(legacy + "\n"), null);
+  });
+});
+
+describe("audit anchor - key file", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "kit-anchor-key-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("creates the key on first use (0600) and re-reads the same key", async () => {
+    const k1 = await getAuditAnchorKey(dir);
+    const k2 = await tryReadAuditAnchorKey(dir);
+    assert.ok(k2);
+    assert.ok(k1.equals(k2!));
+  });
+
+  it("tryReadAuditAnchorKey returns null when no key exists", async () => {
+    const empty = mkdtempSync(join(tmpdir(), "kit-anchor-empty-"));
+    try {
+      assert.equal(await tryReadAuditAnchorKey(empty), null);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("audit anchor - sign + verify round-trip", () => {
+  let cwd: string;
+  let dir: string;
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), "kit-anchor-log-"));
+    dir = mkdtempSync(join(tmpdir(), "kit-anchor-home-"));
+  });
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("anchors a chain and verifies it as anchored-ok", async () => {
+    const content = await buildChain(cwd, 5);
+    const logPath = join(cwd, ".kit-audit.jsonl");
+    const rec = await anchorAuditLog(logPath, content, dir);
+    assert.equal(rec.count, 5);
+
+    const key = await tryReadAuditAnchorKey(dir);
+    const stored = await readAnchorRecord(logPath, dir);
+    const r = verifyAgainstAnchor(content, stored, key);
+    assert.equal(r.status, "anchored-ok");
+    assert.equal(r.newSinceAnchor, 0);
+  });
+
+  it("reports new unanchored entries appended after the seal (not a failure)", async () => {
+    const content = await buildChain(cwd, 3);
+    const logPath = join(cwd, ".kit-audit.jsonl");
+    await anchorAuditLog(logPath, content, dir);
+    const grown = await buildChain(cwd, 0); // re-read
+    void grown;
+    await appendAuditEventDirect(
+      { operation: "later", environment: "dev", success: true },
+      { cwd },
+    );
+    const after = readFileSync(logPath, "utf-8");
+
+    const key = await tryReadAuditAnchorKey(dir);
+    const stored = await readAnchorRecord(logPath, dir);
+    const r = verifyAgainstAnchor(after, stored, key);
+    assert.equal(r.status, "anchored-ok");
+    assert.equal(r.newSinceAnchor, 1);
+  });
+});
+
+describe("audit anchor - tamper detection", () => {
+  let cwd: string;
+  let dir: string;
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), "kit-anchor-t-"));
+    dir = mkdtempSync(join(tmpdir(), "kit-anchor-th-"));
+  });
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("a chain recomputed WITHOUT the key fails on tip-mismatch", async () => {
+    const content = await buildChain(cwd, 4);
+    const logPath = join(cwd, ".kit-audit.jsonl");
+    await anchorAuditLog(logPath, content, dir);
+    const key = await tryReadAuditAnchorKey(dir);
+    const stored = await readAnchorRecord(logPath, dir);
+
+    // Tamperer rewrites entry 1 and re-chains the keyless hashes from genesis.
+    // verifyAuditChain would PASS (no key), but the HMAC anchor catches it.
+    const lines = content.trim().split("\n");
+    const obj = JSON.parse(lines[1]);
+    obj.operation = "tampered";
+    // Recompute the keyless chain so the per-line chain stays internally valid.
+    const { createHash } = await import("node:crypto");
+    const GENESIS = "0".repeat(64);
+    const rebuilt: string[] = [];
+    let prev = GENESIS;
+    const parsed = lines.map((l) => JSON.parse(l));
+    parsed[1].operation = "tampered";
+    for (const p of parsed) {
+      const { hash: _h, prev: _p, ...rest } = p;
+      void _h;
+      void _p;
+      const pre = JSON.stringify({ ...rest, prev });
+      const hash = createHash("sha256").update(pre).digest("hex");
+      rebuilt.push(JSON.stringify({ ...rest, prev, hash }));
+      prev = hash;
+    }
+    const forged = rebuilt.join("\n") + "\n";
+
+    // Sanity: the forged chain is internally consistent (keyless verify passes).
+    const { verifyAuditChain } = await import("./audit.js");
+    assert.equal(verifyAuditChain(forged).ok, true);
+
+    // But the anchor catches it.
+    const r = verifyAgainstAnchor(forged, stored, key);
+    assert.equal(r.status, "tip-mismatch");
+  });
+
+  it("a truncated chain fails on the count check", async () => {
+    const content = await buildChain(cwd, 6);
+    const logPath = join(cwd, ".kit-audit.jsonl");
+    await anchorAuditLog(logPath, content, dir);
+    const key = await tryReadAuditAnchorKey(dir);
+    const stored = await readAnchorRecord(logPath, dir);
+
+    const lines = content.trim().split("\n").slice(0, 3); // drop the last 3
+    const truncated = lines.join("\n") + "\n";
+    const r = verifyAgainstAnchor(truncated, stored, key);
+    assert.equal(r.status, "truncated");
+    assert.equal(r.expected, 6);
+    assert.equal(r.entries, 3);
+  });
+
+  it("legacy unanchored log verifies as no-anchor (warn, not error)", async () => {
+    const content = await buildChain(cwd, 3);
+    const key = await tryReadAuditAnchorKey(dir); // null - never created
+    const r = verifyAgainstAnchor(content, null, key);
+    assert.equal(r.status, "no-anchor");
+  });
+
+  it("anchor present but key unavailable downgrades to key-unavailable (warn)", async () => {
+    const content = await buildChain(cwd, 2);
+    const logPath = join(cwd, ".kit-audit.jsonl");
+    const rec = await anchorAuditLog(logPath, content, dir);
+    const r = verifyAgainstAnchor(content, rec, null);
+    assert.equal(r.status, "key-unavailable");
+    assert.equal(r.expected, 2);
+  });
+});
+
+describe("audit anchor - append-path advance", () => {
+  it("tryAdvanceAnchorOnAppend is a no-op when KIT_AUDIT_ANCHOR=0", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "kit-anchor-off-"));
+    const dir = mkdtempSync(join(tmpdir(), "kit-anchor-offh-"));
+    const prev = process.env.KIT_AUDIT_ANCHOR;
+    process.env.KIT_AUDIT_ANCHOR = "0";
+    try {
+      await buildChain(cwd, 2);
+      await tryAdvanceAnchorOnAppend(join(cwd, ".kit-audit.jsonl"), dir);
+      assert.equal(await readAnchorRecord(join(cwd, ".kit-audit.jsonl"), dir), null);
+    } finally {
+      if (prev === undefined) delete process.env.KIT_AUDIT_ANCHOR;
+      else process.env.KIT_AUDIT_ANCHOR = prev;
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("tryAdvanceAnchorOnAppend seals the log when enabled", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "kit-anchor-on-"));
+    const dir = mkdtempSync(join(tmpdir(), "kit-anchor-onh-"));
+    const prev = process.env.KIT_AUDIT_ANCHOR;
+    const prevDir = process.env.KIT_AUDIT_ANCHOR_DIR;
+    delete process.env.KIT_AUDIT_ANCHOR; // enabled by default
+    // Redirect the DEFAULT anchor dir to temp so the append-path auto-anchor
+    // inside buildChain cannot touch the real ~/.kit.
+    process.env.KIT_AUDIT_ANCHOR_DIR = dir;
+    try {
+      await buildChain(cwd, 2);
+      const logPath = join(cwd, ".kit-audit.jsonl");
+      await tryAdvanceAnchorOnAppend(logPath, dir);
+      const rec = await readAnchorRecord(logPath, dir);
+      assert.ok(rec);
+      assert.equal(rec!.count, 2);
+    } finally {
+      if (prev === undefined) delete process.env.KIT_AUDIT_ANCHOR;
+      else process.env.KIT_AUDIT_ANCHOR = prev;
+      if (prevDir === undefined) delete process.env.KIT_AUDIT_ANCHOR_DIR;
+      else process.env.KIT_AUDIT_ANCHOR_DIR = prevDir;
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("audit anchor - key rotation (FIX 4)", () => {
+  let cwd: string;
+  let dir: string;
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), "kit-anchor-rot-"));
+    dir = mkdtempSync(join(tmpdir(), "kit-anchor-roth-"));
+  });
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("anchorAuditLog records the key fingerprint (v2)", async () => {
+    const content = await buildChain(cwd, 3);
+    const logPath = join(cwd, ".kit-audit.jsonl");
+    const rec = await anchorAuditLog(logPath, content, dir);
+    const key = await tryReadAuditAnchorKey(dir);
+    assert.equal(rec.keyFingerprint, anchorKeyFingerprint(key!));
+    assert.equal(rec.version, 2);
+  });
+
+  it("a rotated key reports 'anchor-key-changed', NOT content tip-mismatch", async () => {
+    const content = await buildChain(cwd, 3);
+    const logPath = join(cwd, ".kit-audit.jsonl");
+    const rec = await anchorAuditLog(logPath, content, dir);
+    // Same (untampered) content, but verify under a DIFFERENT key = rotation.
+    const rotatedKey = randomBytes(32);
+    const r = verifyAgainstAnchor(content, rec, rotatedKey);
+    assert.equal(r.status, "anchor-key-changed");
+  });
+
+  it("tryAdvanceAnchorOnAppend does NOT silently re-seal a non-verifying prefix", async () => {
+    const content = await buildChain(cwd, 3);
+    const logPath = join(cwd, ".kit-audit.jsonl");
+    const rec = await anchorAuditLog(logPath, content, dir);
+    const originalTip = rec.tip;
+    const originalCount = rec.count;
+
+    // Forge: rewrite entry 1 and re-chain the keyless hashes (verifyAuditChain
+    // would pass, but the anchored prefix no longer matches under the key).
+    const GENESIS = "0".repeat(64);
+    const parsed = content
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    parsed[1].operation = "tampered";
+    let prev = GENESIS;
+    const rebuilt: string[] = [];
+    for (const p of parsed) {
+      const { hash: _h, prev: _p, ...rest } = p;
+      void _h;
+      void _p;
+      const pre = JSON.stringify({ ...rest, prev });
+      const hash = createHash("sha256").update(pre).digest("hex");
+      rebuilt.push(JSON.stringify({ ...rest, prev, hash }));
+      prev = hash;
+    }
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(logPath, rebuilt.join("\n") + "\n", "utf-8");
+
+    // Enable append-time anchoring for this call only.
+    const prevEnv = process.env.KIT_AUDIT_ANCHOR;
+    delete process.env.KIT_AUDIT_ANCHOR;
+    try {
+      await tryAdvanceAnchorOnAppend(logPath, dir);
+    } finally {
+      if (prevEnv === undefined) delete process.env.KIT_AUDIT_ANCHOR;
+      else process.env.KIT_AUDIT_ANCHOR = prevEnv;
+    }
+
+    // The stored anchor MUST be unchanged: re-sealing would erase the alarm.
+    const after = await readAnchorRecord(logPath, dir);
+    assert.equal(after!.tip, originalTip);
+    assert.equal(after!.count, originalCount);
+  });
+});
+
+describe("audit anchor - verdict policy (FIX 2 + FIX 3)", () => {
+  const mk = (over: Partial<AnchorVerifyResult>): AnchorVerifyResult => ({
+    status: "anchored-ok",
+    entries: 3,
+    expected: 3,
+    ...over,
+  });
+
+  it("ATTACK: no-anchor + machine has anchored logs => FAIL (path-repoint)", () => {
+    const v = decideAnchorVerdict({
+      result: mk({ status: "no-anchor" }),
+      strict: false,
+      machineHasAnchors: true,
+    });
+    assert.equal(v.ok, false);
+    assert.equal(v.level, "error");
+  });
+
+  it("no-anchor + no strict + no anchored logs => warn (backward compat)", () => {
+    const v = decideAnchorVerdict({
+      result: mk({ status: "no-anchor" }),
+      strict: false,
+      machineHasAnchors: false,
+    });
+    assert.equal(v.ok, true);
+    assert.equal(v.level, "warn");
+  });
+
+  it("ATTACK: forged unsealed tail => FAIL under strict", () => {
+    const v = decideAnchorVerdict({
+      result: mk({ status: "anchored-ok", entries: 5, expected: 3, newSinceAnchor: 2 }),
+      strict: true,
+      machineHasAnchors: true,
+    });
+    assert.equal(v.ok, false);
+    assert.equal(v.level, "error");
+    assert.match(v.message, /UNSEALED|UNAUTHENTICATED/);
+  });
+
+  it("unsealed tail without strict => surfaced loudly as warn (exit 0)", () => {
+    const v = decideAnchorVerdict({
+      result: mk({ status: "anchored-ok", entries: 5, expected: 3, newSinceAnchor: 2 }),
+      strict: false,
+      machineHasAnchors: false,
+    });
+    assert.equal(v.ok, true);
+    assert.equal(v.level, "warn");
+    assert.match(v.message, /UNSEALED|UNAUTHENTICATED/);
+  });
+
+  it("anchored-ok with no tail => ok", () => {
+    const v = decideAnchorVerdict({
+      result: mk({ newSinceAnchor: 0 }),
+      strict: true,
+      machineHasAnchors: true,
+    });
+    assert.equal(v.ok, true);
+    assert.equal(v.level, "ok");
+  });
+
+  it("anchor-key-changed: warn by default, FAIL under strict (distinct from tamper)", () => {
+    const warn = decideAnchorVerdict({
+      result: mk({ status: "anchor-key-changed", reason: "rotated" }),
+      strict: false,
+      machineHasAnchors: true,
+    });
+    assert.equal(warn.ok, true);
+    assert.equal(warn.level, "warn");
+    const strict = decideAnchorVerdict({
+      result: mk({ status: "anchor-key-changed", reason: "rotated" }),
+      strict: true,
+      machineHasAnchors: true,
+    });
+    assert.equal(strict.ok, false);
+  });
+
+  it("tip-mismatch / truncated / unparseable always FAIL", () => {
+    for (const status of ["tip-mismatch", "truncated", "unparseable"] as const) {
+      const v = decideAnchorVerdict({
+        result: mk({ status, reason: status }),
+        strict: false,
+        machineHasAnchors: false,
+      });
+      assert.equal(v.ok, false, status);
+      assert.equal(v.level, "error", status);
+    }
+  });
+});
+
+describe("audit anchor - hasAnyAnchoredLogs", () => {
+  it("is false on a fresh dir and true after anchoring", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "kit-anchor-has-"));
+    const dir = mkdtempSync(join(tmpdir(), "kit-anchor-hash-"));
+    try {
+      assert.equal(await hasAnyAnchoredLogs(dir), false);
+      const content = await buildChain(cwd, 2);
+      await anchorAuditLog(join(cwd, ".kit-audit.jsonl"), content, dir);
+      assert.equal(await hasAnyAnchoredLogs(dir), true);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("audit anchor - external anchor extension point", () => {
+  it("resolveExternalAnchor returns null until an enclave wires one up", () => {
+    assert.equal(resolveExternalAnchor(), null);
+  });
+});

--- a/src/audit-anchor.ts
+++ b/src/audit-anchor.ts
@@ -1,0 +1,515 @@
+/**
+ * External HMAC anchor for the `.kit-audit.jsonl` hash chain.
+ *
+ * WHY THIS EXISTS (the gap it closes)
+ * -----------------------------------
+ * The per-line hash chain in audit.ts is tamper-EVIDENT but not tamper-PROOF:
+ * the chain hashes are keyless and seed from a PUBLIC genesis constant
+ * (`"0".repeat(64)`), so a writer who can rewrite `.kit-audit.jsonl` can also
+ * recompute `prev` + `hash` for every line and produce a chain that
+ * `verifyAuditChain` accepts. There is no key, no stored tip, and no stored
+ * entry count, so a full rewrite (or a truncation/rollback) is invisible.
+ *
+ * This module adds a machine-local HMAC anchor kept OUTSIDE the project dir
+ * (`~/.kit/audit-anchor.key`, 0600) plus an anchor record
+ * (`~/.kit/audit-anchor.json`, 0600) holding, per log path, the latest HMAC
+ * `tip` over the sealed prefix and the `count` of entries it covers.
+ *
+ *   - A tamperer who rewrites the log WITHOUT the key cannot recompute a tip
+ *     that matches the stored one  -> `kit audit verify` reports tip-mismatch.
+ *   - A tamperer who TRUNCATES or rolls back the log to fewer entries than the
+ *     anchored count is caught by the count check -> reports truncated.
+ *
+ * HONEST THREAT BOUNDARY (read this before claiming anything)
+ * -----------------------------------------------------------
+ * This raises the bar from "anyone who can WRITE the log can forge it" to
+ * "only someone who can READ the 0600 anchor key can forge it". It is NOT
+ * tamper-proof against a same-UID local principal: an attacker running as the
+ * same user can read `~/.kit/audit-anchor.key` AND the anchor record, recompute
+ * the tip, and re-seal a forged log. Closing THAT gap requires an EXTERNAL
+ * anchor the local principal cannot rewrite (an RFC3161 TSA or a remote
+ * append-only log) - see the ExternalTimestampAnchor extension point below.
+ *
+ * The append path stays KEYLESS so a project-sandboxed agent (which cannot read
+ * `~/.kit`) can still append audit entries; anchoring is layered on top and is
+ * best-effort / fail-soft on the write path. A log that was never anchored
+ * verifies as "legacy (unanchored)" - a warning, not a hard failure.
+ */
+import { readFile, writeFile, mkdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { createHmac, timingSafeEqual, randomBytes } from "node:crypto";
+import { secureFile } from "./utils/secure-perms.js";
+import { reReadHexKey } from "./utils/key-file.js";
+
+const ANCHOR_KEY_FILE = "audit-anchor.key";
+const ANCHOR_RECORD_FILE = "audit-anchor.json";
+const ANCHOR_ALGO = "hmac-sha256";
+// Domain-separation seed so the anchor HMAC chain can never collide with any
+// other HMAC use of the same key.
+const ANCHOR_SEED = "kit-audit-anchor/v1";
+
+/** Resolve the directory that holds the anchor key + record (default ~/.kit). */
+export function anchorDir(override?: string): string {
+  if (override) return override;
+  if (process.env.KIT_AUDIT_ANCHOR_DIR) return process.env.KIT_AUDIT_ANCHOR_DIR;
+  return join(homedir(), ".kit");
+}
+
+export function anchorKeyPath(dir?: string): string {
+  return join(anchorDir(dir), ANCHOR_KEY_FILE);
+}
+
+export function anchorRecordPath(dir?: string): string {
+  return join(anchorDir(dir), ANCHOR_RECORD_FILE);
+}
+
+/**
+ * Machine-local HMAC key, created once (0600). Create is atomic (flag "wx"):
+ * on a lost create race the winner's key is re-read so all callers agree.
+ * Mirrors elevation.ts:getElevationSigningKey. Creating the key is a WRITE to
+ * `~/.kit`, so a project-sandboxed principal that cannot write there will throw
+ * here - callers on the append path must treat that as "anchoring unavailable",
+ * never as a hard error.
+ */
+export async function getAuditAnchorKey(dir?: string): Promise<Buffer> {
+  const keyPath = anchorKeyPath(dir);
+  try {
+    const hex = (await readFile(keyPath, "utf-8")).trim();
+    if (hex.length >= 64) return Buffer.from(hex, "hex");
+  } catch {
+    /* fall through to create */
+  }
+  const key = randomBytes(32);
+  await mkdir(anchorDir(dir), { recursive: true });
+  try {
+    await writeFile(keyPath, key.toString("hex") + "\n", {
+      encoding: "utf-8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    secureFile(keyPath); // owner-only on Windows (NTFS ignores mode)
+    return key;
+  } catch {
+    // Lost the create race. Re-read the winner's key WITH the same length guard
+    // as the happy path (+ retry) so a mid-write read can never hand back a
+    // short/empty key (which would later look like a tip-mismatch). #fix5
+    return reReadHexKey(keyPath);
+  }
+}
+
+/**
+ * Read the anchor key WITHOUT creating it. Returns null when the key is absent
+ * or unreadable (e.g. a sandboxed principal). Verify uses this so that a missing
+ * key downgrades to "cannot check the anchor" rather than minting a fresh key.
+ */
+export async function tryReadAuditAnchorKey(dir?: string): Promise<Buffer | null> {
+  try {
+    const hex = (await readFile(anchorKeyPath(dir), "utf-8")).trim();
+    if (hex.length >= 64) return Buffer.from(hex, "hex");
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract the per-line `hash` field from raw `.kit-audit.jsonl` content.
+ * Returns null if any non-empty line is unparseable or lacks a string hash -
+ * such a log cannot be anchored (the keyless chain check catches it first).
+ */
+export function lineHashes(content: string): string[] | null {
+  const lines = content.split("\n").filter((l) => l.trim().length > 0);
+  const hashes: string[] = [];
+  for (const line of lines) {
+    let obj: { hash?: unknown };
+    try {
+      obj = JSON.parse(line) as { hash?: unknown };
+    } catch {
+      return null;
+    }
+    if (typeof obj.hash !== "string") return null;
+    hashes.push(obj.hash);
+  }
+  return hashes;
+}
+
+/**
+ * Fold an HMAC chain over the supplied line hashes and return the final tip
+ * (hex). Pure: same key + hashes always yield the same tip. Only a holder of
+ * the key can reproduce this value, which is what makes a key-less rewrite
+ * detectable.
+ */
+export function computeAnchorTip(key: Buffer, hashes: string[]): string {
+  let tip = createHmac("sha256", key).update(ANCHOR_SEED).digest("hex");
+  for (const h of hashes) {
+    tip = createHmac("sha256", key)
+      .update(tip + "\n" + h)
+      .digest("hex");
+  }
+  return tip;
+}
+
+// Domain-separated key-id label. The fingerprint is an HMAC of a FIXED label
+// keyed by the anchor key, so it identifies the key (lets verify tell "the key
+// rotated" apart from "the content was tampered") WITHOUT revealing key bytes.
+const ANCHOR_KEY_FP_LABEL = "kit-anchor-key-fingerprint/v1";
+/** Stable, non-reversible identifier for an anchor key. */
+export function anchorKeyFingerprint(key: Buffer): string {
+  return createHmac("sha256", key).update(ANCHOR_KEY_FP_LABEL).digest("hex").slice(0, 32);
+}
+
+/** Current schema version of the anchor record. */
+export const ANCHOR_RECORD_VERSION = 2;
+
+export interface AnchorRecord {
+  /** HMAC tip over the sealed prefix of `count` entries. */
+  tip: string;
+  /** Number of entries the tip covers. */
+  count: number;
+  /** Signature algorithm identifier. */
+  algo: string;
+  /** ISO-8601 time the anchor was last advanced. */
+  updatedAt: string;
+  /**
+   * Non-reversible fingerprint of the key that sealed this record (v2+). Lets
+   * verify report a key rotation distinctly from a content tamper. Absent on
+   * legacy (v1) records, which fall back to the tip check.
+   */
+  keyFingerprint?: string;
+  /** Anchor record schema version. */
+  version?: number;
+}
+
+type AnchorStore = Record<string, AnchorRecord>;
+
+async function readStore(dir?: string): Promise<AnchorStore> {
+  try {
+    const raw = await readFile(anchorRecordPath(dir), "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object") return parsed as AnchorStore;
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Persist the store, pruning entries whose log file no longer exists so the
+ * record self-heals after temp/ephemeral logs disappear (also keeps it bounded).
+ */
+async function writeStore(store: AnchorStore, dir?: string): Promise<void> {
+  const pruned: AnchorStore = {};
+  for (const [logPath, rec] of Object.entries(store)) {
+    try {
+      await stat(logPath);
+      pruned[logPath] = rec;
+    } catch {
+      // log file gone -> drop the stale anchor entry
+    }
+  }
+  await mkdir(anchorDir(dir), { recursive: true });
+  const recordPath = anchorRecordPath(dir);
+  await writeFile(recordPath, JSON.stringify(pruned, null, 2) + "\n", {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+  secureFile(recordPath);
+}
+
+export async function readAnchorRecord(
+  logPath: string,
+  dir?: string,
+): Promise<AnchorRecord | null> {
+  const store = await readStore(dir);
+  return store[logPath] ?? null;
+}
+
+/**
+ * True when this machine has sealed ANY audit log. Used by `kit audit verify`
+ * to fail closed: once anchoring is in use, a log that presents as unanchored
+ * (e.g. a project config repointed `log_file` at a forged, never-anchored file)
+ * is suspicious rather than benign-legacy. #fix2
+ */
+export async function hasAnyAnchoredLogs(dir?: string): Promise<boolean> {
+  const store = await readStore(dir);
+  return Object.keys(store).length > 0;
+}
+
+/**
+ * Seal the current log: compute the HMAC tip over ALL current entries and
+ * persist it as the anchor for `logPath`. Needs the key (creates it on first
+ * use). Returns the written record. Throws if the content cannot be anchored
+ * (unparseable / unchained) so the caller can surface it.
+ */
+export async function anchorAuditLog(
+  logPath: string,
+  content: string,
+  dir?: string,
+): Promise<AnchorRecord> {
+  const hashes = lineHashes(content);
+  if (hashes === null) {
+    throw new Error("audit log is unparseable or unchained - cannot anchor");
+  }
+  const key = await getAuditAnchorKey(dir);
+  const rec: AnchorRecord = {
+    tip: computeAnchorTip(key, hashes),
+    count: hashes.length,
+    algo: ANCHOR_ALGO,
+    updatedAt: new Date().toISOString(),
+    keyFingerprint: anchorKeyFingerprint(key),
+    version: ANCHOR_RECORD_VERSION,
+  };
+  const store = await readStore(dir);
+  store[logPath] = rec;
+  await writeStore(store, dir);
+  return rec;
+}
+
+export type AnchorVerifyStatus =
+  | "anchored-ok"
+  | "no-anchor"
+  | "key-unavailable"
+  | "anchor-key-changed"
+  | "tip-mismatch"
+  | "truncated"
+  | "unparseable";
+
+export interface AnchorVerifyResult {
+  status: AnchorVerifyStatus;
+  /** Entries currently present in the log. */
+  entries: number;
+  /** Entries the anchor expects (when an anchor exists). */
+  expected?: number;
+  /** Entries appended since the last anchor (status "anchored-ok"). */
+  newSinceAnchor?: number;
+  reason?: string;
+}
+
+/**
+ * Verify a log body against its anchor record. Pure given (content, anchor,
+ * key) so it is fully testable. Fail-closed semantics live in the caller; this
+ * returns a precise status:
+ *
+ *   - no-anchor          : legacy/unanchored log - warn, not an error
+ *   - key-unavailable    : anchor exists but the key cannot be read here - warn
+ *   - anchor-key-changed : the current key is not the one that sealed the anchor
+ *                          (rotation / lost key) - distinct from a content tamper
+ *   - truncated          : fewer entries than the anchored count (rollback)
+ *   - tip-mismatch       : the sealed prefix was rewritten under the SAME key
+ *   - anchored-ok        : the sealed prefix reproduces the stored tip
+ */
+export function verifyAgainstAnchor(
+  content: string,
+  anchor: AnchorRecord | null,
+  key: Buffer | null,
+): AnchorVerifyResult {
+  const hashes = lineHashes(content);
+  const entries = hashes?.length ?? 0;
+  if (!anchor) return { status: "no-anchor", entries };
+  if (!key) return { status: "key-unavailable", entries, expected: anchor.count };
+  // Key-rotation check FIRST so a changed key reports as a rotation, never as a
+  // false content-tamper alarm. Only for v2+ records that carry a fingerprint;
+  // legacy records fall through to the tip check (best effort). #fix4
+  if (anchor.keyFingerprint && anchorKeyFingerprint(key) !== anchor.keyFingerprint) {
+    return {
+      status: "anchor-key-changed",
+      entries,
+      expected: anchor.count,
+      reason:
+        "the current anchor key differs from the one that sealed this log (rotated/replaced key); old anchors are invalid by design - re-run 'kit audit anchor'",
+    };
+  }
+  if (hashes === null) {
+    return {
+      status: "unparseable",
+      entries,
+      expected: anchor.count,
+      reason: "log is unparseable - cannot reconcile with the anchor",
+    };
+  }
+  if (hashes.length < anchor.count) {
+    return {
+      status: "truncated",
+      entries,
+      expected: anchor.count,
+      reason: `log has ${hashes.length} entries but the anchor sealed ${anchor.count} (truncated/rolled back)`,
+    };
+  }
+  const recomputed = computeAnchorTip(key, hashes.slice(0, anchor.count));
+  const a = Buffer.from(recomputed, "hex");
+  const b = Buffer.from(anchor.tip, "hex");
+  const matches = a.length === b.length && timingSafeEqual(a, b);
+  if (!matches) {
+    return {
+      status: "tip-mismatch",
+      entries,
+      expected: anchor.count,
+      reason: "anchored prefix HMAC does not match - the log was rewritten without the anchor key",
+    };
+  }
+  return {
+    status: "anchored-ok",
+    entries,
+    expected: anchor.count,
+    newSinceAnchor: entries - anchor.count,
+  };
+}
+
+export interface AnchorVerdictInput {
+  result: AnchorVerifyResult;
+  /**
+   * Fail-closed mode: `kit audit verify --strict` OR
+   * `[governance.audit].require_anchor = true`. In strict mode an unanchored
+   * log, an unreadable key, and an unsealed tail are FAILURES, not warnings.
+   */
+  strict: boolean;
+  /**
+   * This machine has sealed at least one log. Even without --strict, a log that
+   * presents as unanchored is then treated as a failure: a no-key writer must
+   * not be able to repoint `log_file` at a forged, never-anchored file and have
+   * it pass green. #fix2
+   */
+  machineHasAnchors: boolean;
+}
+
+export interface AnchorVerdict {
+  /** Whether the command should exit 0. */
+  ok: boolean;
+  level: "ok" | "warn" | "error";
+  message: string;
+}
+
+/**
+ * Map a raw anchor-verify result to a pass/fail verdict given the fail-closed
+ * inputs. Pure + exported so the exact exit-code policy is unit-testable and the
+ * three review attacks (path-repoint, forged tail, key-rotation) have a single
+ * authoritative decision point. #fix2 #fix3 #fix4
+ */
+export function decideAnchorVerdict(input: AnchorVerdictInput): AnchorVerdict {
+  const { result, strict, machineHasAnchors } = input;
+  const failClosed = strict || machineHasAnchors;
+  switch (result.status) {
+    case "anchored-ok": {
+      const tail = result.newSinceAnchor ?? 0;
+      if (tail > 0) {
+        // Unsealed tail = unauthenticated entries appended past the seal. Loud
+        // by default; a hard failure under --strict / require_anchor. #fix3
+        const msg = `HMAC anchor verified ${result.expected} sealed entries, but ${tail} entry(ies) BEYOND the seal are UNSEALED and UNAUTHENTICATED (anyone who can write the log can append keyless-rechained entries). Run 'kit audit anchor' to re-seal.`;
+        return strict
+          ? { ok: false, level: "error", message: msg }
+          : { ok: true, level: "warn", message: msg };
+      }
+      return {
+        ok: true,
+        level: "ok",
+        message: `HMAC anchor verified (${result.expected} sealed entries).`,
+      };
+    }
+    case "no-anchor": {
+      const msg = failClosed
+        ? "log is NOT anchored but this machine has anchored logs (or anchoring is required); refusing to treat an unanchored log as verified. A repointed/forged log_file would land here."
+        : "legacy (unanchored) audit log, keyless chain only. Run 'kit audit anchor' to seal it with the machine-local key.";
+      return failClosed
+        ? { ok: false, level: "error", message: msg }
+        : { ok: true, level: "warn", message: msg };
+    }
+    case "key-unavailable": {
+      const msg = failClosed
+        ? "anchor present but the anchor key is unreadable here; cannot verify the HMAC seal (strict/require_anchor -> failing closed)."
+        : "anchor present but the anchor key is unreadable here; cannot check the HMAC seal (keyless chain still intact).";
+      return failClosed
+        ? { ok: false, level: "error", message: msg }
+        : { ok: true, level: "warn", message: msg };
+    }
+    case "anchor-key-changed":
+      // Distinct from content tamper. Default warn (rotation needs a re-seal),
+      // hard failure under strict so a CI gate cannot drift unnoticed. #fix4
+      return {
+        ok: !strict,
+        level: strict ? "error" : "warn",
+        message:
+          result.reason ?? "anchor key changed (rotated/replaced); re-run 'kit audit anchor'.",
+      };
+    case "truncated":
+    case "tip-mismatch":
+    case "unparseable":
+      return {
+        ok: false,
+        level: "error",
+        message: result.reason ?? `HMAC anchor FAILED (${result.status}).`,
+      };
+  }
+}
+
+/**
+ * Best-effort, fail-soft anchor advance for the append path. Re-seals the log
+ * to cover all current entries. NEVER throws and NEVER blocks the append:
+ *
+ *   - disabled when KIT_AUDIT_ANCHOR=0 (the test suite sets this so incidental
+ *     appends don't touch the real ~/.kit);
+ *   - a sandboxed principal that cannot read/write ~/.kit simply does not
+ *     anchor - the entry stays keyless-chain-protected and verifies later as
+ *     "new unanchored entries since last anchor", which is honest, not a lie.
+ */
+export async function tryAdvanceAnchorOnAppend(logPath: string, dir?: string): Promise<void> {
+  if (process.env.KIT_AUDIT_ANCHOR === "0") return;
+  try {
+    const content = await readFile(logPath, "utf-8");
+    // CRITICAL: never silently re-seal over a prefix that no longer verifies.
+    // Re-sealing a tampered / key-rotated log would erase a real alarm that
+    // `kit audit verify` should have raised. Only advance when an existing
+    // anchor's sealed prefix still verifies anchored-ok under the current key
+    // (or when there is no anchor yet -> first seal). #fix4
+    const existing = await readAnchorRecord(logPath, dir);
+    if (existing) {
+      const key = await tryReadAuditAnchorKey(dir);
+      if (!key) return; // cannot verify the prefix -> do not re-seal
+      const v = verifyAgainstAnchor(content, existing, key);
+      if (v.status !== "anchored-ok") return; // preserve the alarm; do not re-seal
+    }
+    await anchorAuditLog(logPath, content, dir);
+  } catch {
+    // Best-effort: append must succeed even when anchoring cannot (sandbox /
+    // unwritable home / unparseable log). The keyless chain still protects the
+    // entry; verify reports the unanchored tail honestly.
+  }
+}
+
+// ── Build 3 extension point: external timestamp / append anchor ──────────────
+//
+// The HMAC anchor above only resists a tamperer who CANNOT read the 0600 key.
+// To close the same-UID gap an enclave needs an anchor the local principal
+// cannot rewrite: an RFC3161 Time-Stamping Authority over the tip, or a remote
+// append-only log. This is the documented, intentionally-unimplemented hook.
+//
+// kit does NOT ship a network TSA client (it would break the local-first /
+// no-egress posture by default). An operator wires their own implementation and
+// kit submits the tip after each seal. Fail-closed by contract: an enclave that
+// requires external anchoring must treat a missing/failed external anchor as a
+// verification failure, exactly like the air-gap provenance path.
+
+export interface ExternalAnchorReceipt {
+  /** Opaque proof bytes (e.g. an RFC3161 TimeStampToken), base64-encoded. */
+  token: string;
+  /** Authority / endpoint identifier, for audit. */
+  authority: string;
+  /** ISO-8601 time the external anchor attests. */
+  timestamp: string;
+}
+
+export interface ExternalTimestampAnchor {
+  /** Submit an anchor tip for external timestamping. Implementations MUST be
+   *  fail-closed: reject (throw / reject the promise) rather than return a
+   *  fabricated receipt when the authority is unreachable. */
+  anchor(input: { tip: string; count: number; logPath: string }): Promise<ExternalAnchorReceipt>;
+}
+
+/**
+ * Resolve a configured external anchor. Returns null until an enclave wires one
+ * up - kit ships no default network client by design. Present so call sites and
+ * docs can reference a stable extension point.
+ */
+export function resolveExternalAnchor(): ExternalTimestampAnchor | null {
+  return null;
+}

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -124,6 +124,11 @@ export async function appendAuditEventDirect(
   const logPath = resolve(opts.cwd ?? process.cwd(), logFile);
   try {
     await appendChained(logPath, auditEvent);
+    // Best-effort external HMAC anchor advance. Fail-soft by contract: never
+    // blocks the (keyless) append, so a sandboxed agent still logs even when it
+    // cannot reach ~/.kit. See audit-anchor.ts for the threat boundary.
+    const { tryAdvanceAnchorOnAppend } = await import("./audit-anchor.js");
+    await tryAdvanceAnchorOnAppend(logPath);
     return true;
   } catch (error) {
     console.error(`[kit] audit-log append failed: ${error}`);
@@ -292,6 +297,14 @@ export async function logAuditEvent(
   try {
     await appendChained(logPath, auditEvent);
     wroteLocal = true;
+    // Best-effort external HMAC anchor advance (see audit-anchor.ts). Fail-soft
+    // so it never converts a successful append into a failure.
+    try {
+      const { tryAdvanceAnchorOnAppend } = await import("./audit-anchor.js");
+      await tryAdvanceAnchorOnAppend(logPath);
+    } catch (anchorErr) {
+      console.error(`[kit] audit anchor advance skipped: ${anchorErr}`);
+    }
   } catch (error) {
     console.error(`Failed to write audit log: ${error}`);
   }

--- a/src/check-attestation.test.ts
+++ b/src/check-attestation.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { generateKeyPairSync, createPublicKey, sign as cryptoSign } from "node:crypto";
+import {
+  buildAttestationPayload,
+  canonicalPayloadBytes,
+  signAttestation,
+  verifyAttestation,
+  emitAttestation,
+  ed25519Fingerprint,
+  pinEd25519Fingerprint,
+  ATTESTATION_FILE,
+  type Attestation,
+  type AttestationPayload,
+  type BuildAttestationInput,
+} from "./check-attestation.js";
+
+const SAMPLE: BuildAttestationInput = {
+  command: "check",
+  kitVersion: "1.39.0",
+  overallOk: true,
+  results: { passed: 10, failed: 0, warnings: 1, skipped: 2 },
+  scannersRan: [
+    { id: "gitleaks", status: "ran" },
+    { id: "semgrep", status: "not-installed" },
+  ],
+  timestamp: "2026-06-26T00:00:00.000Z",
+};
+
+describe("check-attestation - payload + canonicalization", () => {
+  it("canonical bytes are stable regardless of field insertion order", () => {
+    const p1 = buildAttestationPayload(SAMPLE);
+    const p2 = buildAttestationPayload({ ...SAMPLE });
+    assert.ok(canonicalPayloadBytes(p1).equals(canonicalPayloadBytes(p2)));
+  });
+
+  it("canonical bytes change when a result count changes", () => {
+    const a = canonicalPayloadBytes(buildAttestationPayload(SAMPLE));
+    const b = canonicalPayloadBytes(
+      buildAttestationPayload({ ...SAMPLE, results: { ...SAMPLE.results, failed: 1 } }),
+    );
+    assert.ok(!a.equals(b));
+  });
+});
+
+describe("check-attestation - HMAC is the authoritative default", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "kit-att-hmac-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("signs with HMAC by default and verifies via the machine-local anchor key", async () => {
+    const att = await signAttestation(buildAttestationPayload(SAMPLE), { dir });
+    assert.equal(att.sig_alg, "hmac-sha256");
+    const r = await verifyAttestation(att, { dir });
+    assert.equal(r.ok, true);
+    assert.equal(r.status, "ok");
+    assert.equal(r.sig_alg, "hmac-sha256");
+  });
+
+  it("a tampered HMAC receipt fails verification", async () => {
+    const att = await signAttestation(buildAttestationPayload(SAMPLE), { dir });
+    const tampered: Attestation = { ...att, overall_ok: false };
+    const r = await verifyAttestation(tampered, { dir });
+    assert.equal(r.ok, false);
+    assert.equal(r.status, "failed");
+  });
+
+  it("an HMAC receipt with a wrong signature fails", async () => {
+    const { getAuditAnchorKey } = await import("./audit-anchor.js");
+    await getAuditAnchorKey(dir); // ensure a key exists to verify against
+    const att: Attestation = {
+      ...buildAttestationPayload(SAMPLE),
+      sig_alg: "hmac-sha256",
+      signature: Buffer.from("not-the-real-mac").toString("base64"),
+    };
+    const r = await verifyAttestation(att, { dir });
+    assert.equal(r.ok, false);
+    assert.equal(r.status, "failed");
+  });
+});
+
+describe("check-attestation - Ed25519 authenticity (FIX 1: embedded key is untrusted)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "kit-att-ed-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  /** Mint a fully self-signed, green Ed25519 receipt (the forgery attack). */
+  function forgeGreenEd25519Receipt(payload: AttestationPayload): {
+    att: Attestation;
+    fingerprint: string;
+  } {
+    const { privateKey } = generateKeyPairSync("ed25519");
+    const bytes = canonicalPayloadBytes(payload);
+    const signature = cryptoSign(null, bytes, privateKey).toString("base64");
+    const publicKey = createPublicKey(privateKey)
+      .export({ type: "spki", format: "pem" })
+      .toString();
+    return {
+      att: { ...payload, sig_alg: "ed25519", signature, public_key: publicKey },
+      fingerprint: ed25519Fingerprint(publicKey),
+    };
+  }
+
+  it("ATTACK: a forged fresh-keypair green receipt is NOT ok without a pin", async () => {
+    const { att } = forgeGreenEd25519Receipt(buildAttestationPayload(SAMPLE));
+    const r = await verifyAttestation(att, { dir }); // no pin, no --key
+    assert.equal(r.ok, false);
+    assert.equal(r.status, "unverified-authenticity");
+    assert.ok(r.fingerprint, "fingerprint surfaced");
+  });
+
+  it("ATTACK: a forged receipt FAILS against a pin that does not match", async () => {
+    const { att } = forgeGreenEd25519Receipt(buildAttestationPayload(SAMPLE));
+    // Pin a different (genuine) key first.
+    const { privateKey: other } = generateKeyPairSync("ed25519");
+    const otherFp = ed25519Fingerprint(
+      createPublicKey(other).export({ type: "spki", format: "pem" }).toString(),
+    );
+    await pinEd25519Fingerprint(otherFp, dir);
+
+    const r = await verifyAttestation(att, { dir });
+    assert.equal(r.ok, false);
+    assert.equal(r.status, "failed");
+    assert.match(r.reason, /does not match/);
+  });
+
+  it("verifies ok when the embedded key matches an explicit --key", async () => {
+    const att = await signAttestation(buildAttestationPayload(SAMPLE), {
+      dir,
+      preferEd25519: true,
+    });
+    assert.equal(att.sig_alg, "ed25519");
+    const fp = ed25519Fingerprint(att.public_key!);
+    const r = await verifyAttestation(att, { dir, expectedKey: fp });
+    assert.equal(r.ok, true);
+    assert.equal(r.status, "ok");
+  });
+
+  it("verifies ok against a TOFU pin of the genuine key, then a forgery fails", async () => {
+    const att = await signAttestation(buildAttestationPayload(SAMPLE), {
+      dir,
+      preferEd25519: true,
+    });
+    const fp = ed25519Fingerprint(att.public_key!);
+    await pinEd25519Fingerprint(fp, dir);
+
+    const good = await verifyAttestation(att, { dir });
+    assert.equal(good.ok, true);
+
+    // A forged receipt (different key) now fails against the established pin.
+    const { att: forged } = forgeGreenEd25519Receipt(buildAttestationPayload(SAMPLE));
+    const bad = await verifyAttestation(forged, { dir });
+    assert.equal(bad.ok, false);
+    assert.equal(bad.status, "failed");
+  });
+
+  it("a mathematically broken Ed25519 signature fails before authenticity", async () => {
+    const att = await signAttestation(buildAttestationPayload(SAMPLE), {
+      dir,
+      preferEd25519: true,
+    });
+    const tampered: Attestation = { ...att, overall_ok: false };
+    const r = await verifyAttestation(tampered, { dir });
+    assert.equal(r.ok, false);
+    assert.equal(r.status, "failed");
+    assert.match(r.reason, /does not verify/);
+  });
+
+  it("pinEd25519Fingerprint refuses to overwrite a different existing pin", async () => {
+    await pinEd25519Fingerprint("a".repeat(64), dir);
+    await assert.rejects(() => pinEd25519Fingerprint("b".repeat(64), dir), /refusing to overwrite/);
+  });
+});
+
+describe("check-attestation - emit writes the receipt file", () => {
+  it("emitAttestation writes .kit-check-attestation.json and it verifies (HMAC)", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "kit-att-emit-"));
+    const dir = mkdtempSync(join(tmpdir(), "kit-att-emith-"));
+    try {
+      const res = await emitAttestation(SAMPLE, cwd, dir);
+      assert.ok(res);
+      const onDisk = JSON.parse(
+        await readFile(join(cwd, ATTESTATION_FILE), "utf-8"),
+      ) as Attestation;
+      assert.equal(onDisk.command, "check");
+      assert.equal(onDisk.sig_alg, "hmac-sha256");
+      const r = await verifyAttestation(onDisk, { dir });
+      assert.equal(r.ok, true);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/check-attestation.ts
+++ b/src/check-attestation.ts
@@ -1,0 +1,499 @@
+/**
+ * Signed check-attestation receipt.
+ *
+ * After `kit check` / `kit ci`, kit can emit `.kit-check-attestation.json`: a
+ * signed record of WHICH gates ran and that none failed open. It is the
+ * artifact a reviewer or CI verifies to know the security gates actually
+ * executed (rather than being skipped, errored, or quietly disabled).
+ *
+ * Signing precedence (decided here, documented in docs/AUDIT_ATTESTATION.md):
+ *   1. HMAC-SHA256 with the machine-local audit anchor key - DEFAULT and
+ *      AUTHORITATIVE. The verifier needs the same machine-local key, so a valid
+ *      MAC genuinely binds the receipt to a key-holder (real authenticity).
+ *   2. Ed25519 keypair (`~/.kit/attestation-ed25519.key`, PKCS8 PEM, 0600) -
+ *      portable fallback used when the anchor key cannot be obtained, or when
+ *      explicitly requested. The receipt embeds its SPKI public key, but that
+ *      embedded key is UNTRUSTED: anyone can mint a keypair and sign
+ *      `overall_ok: true`. Authenticity therefore requires the verifier to PIN
+ *      or pass the expected key (`--key`, or a TOFU pin in `~/.kit`). With no
+ *      pin and no expected key the receipt is "unverified-authenticity": the
+ *      signature is mathematically valid but the SIGNER is unauthenticated.
+ *   3. Unsigned (`sig_alg: "none"`) - last resort. The SIGN step MUST NEVER
+ *      block the check from completing, so a total signing failure degrades to
+ *      an unsigned receipt with a loud reason rather than throwing.
+ *
+ * HONESTY: a same-UID attacker who can read the signing key (the HMAC anchor key
+ * or an Ed25519 private key) can forge a receipt. A self-signed Ed25519 receipt
+ * with no pinned key proves only "integrity of its own claims" - NOT that the
+ * gates ran on an untampered host, and NOT who produced it. Same boundary as the
+ * audit anchor (audit-anchor.ts).
+ */
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  createHmac,
+  createHash,
+  timingSafeEqual,
+  generateKeyPairSync,
+  createPrivateKey,
+  createPublicKey,
+  sign as cryptoSign,
+  verify as cryptoVerify,
+  type KeyObject,
+} from "node:crypto";
+import { anchorDir, tryReadAuditAnchorKey, getAuditAnchorKey } from "./audit-anchor.js";
+import { secureFile } from "./utils/secure-perms.js";
+
+export const ATTESTATION_FILE = ".kit-check-attestation.json";
+const ED25519_KEY_FILE = "attestation-ed25519.key";
+const ED25519_PIN_FILE = "attestation-ed25519.pin";
+
+export type SigAlg = "ed25519" | "hmac-sha256" | "none";
+
+export interface AttestationSummary {
+  passed: number;
+  failed: number;
+  warnings: number;
+  skipped: number;
+}
+
+/** The signed body - everything except the signature envelope. */
+export interface AttestationPayload {
+  schema: "kit-check-attestation/v1";
+  command: "check" | "ci";
+  timestamp: string;
+  kit_version: string;
+  overall_ok: boolean;
+  results: AttestationSummary;
+  /** Scanner ids and whether each actually ran vs was skipped/errored. */
+  scanners_ran: { id: string; status: string }[];
+}
+
+export interface Attestation extends AttestationPayload {
+  sig_alg: SigAlg;
+  signature: string;
+  /** SPKI PEM public key when sig_alg = ed25519 (lets anyone verify). */
+  public_key?: string;
+  /** Why the receipt is unsigned, when sig_alg = none. */
+  unsigned_reason?: string;
+}
+
+export interface BuildAttestationInput {
+  command: "check" | "ci";
+  kitVersion: string;
+  overallOk: boolean;
+  results: AttestationSummary;
+  scannersRan: { id: string; status: string }[];
+  /** Override for deterministic tests. */
+  timestamp?: string;
+}
+
+/** Build the unsigned payload. Pure. */
+export function buildAttestationPayload(input: BuildAttestationInput): AttestationPayload {
+  return {
+    schema: "kit-check-attestation/v1",
+    command: input.command,
+    timestamp: input.timestamp ?? new Date().toISOString(),
+    kit_version: input.kitVersion,
+    overall_ok: input.overallOk,
+    results: input.results,
+    scanners_ran: input.scannersRan,
+  };
+}
+
+/**
+ * Canonical bytes signed/verified. Stable key order so the same payload always
+ * produces the same bytes regardless of object construction order. Pure.
+ */
+export function canonicalPayloadBytes(payload: AttestationPayload): Buffer {
+  const canonical = {
+    schema: payload.schema,
+    command: payload.command,
+    timestamp: payload.timestamp,
+    kit_version: payload.kit_version,
+    overall_ok: payload.overall_ok,
+    results: {
+      passed: payload.results.passed,
+      failed: payload.results.failed,
+      warnings: payload.results.warnings,
+      skipped: payload.results.skipped,
+    },
+    scanners_ran: payload.scanners_ran.map((s) => ({ id: s.id, status: s.status })),
+  };
+  return Buffer.from(JSON.stringify(canonical), "utf-8");
+}
+
+function ed25519KeyPath(dir?: string): string {
+  return join(anchorDir(dir), ED25519_KEY_FILE);
+}
+
+function ed25519PinPath(dir?: string): string {
+  return join(anchorDir(dir), ED25519_PIN_FILE);
+}
+
+/**
+ * Stable fingerprint of an Ed25519 public key: sha256 over its SPKI DER, hex.
+ * Surfaced in verify output and used to compare against an expected/pinned key.
+ */
+export function ed25519Fingerprint(pub: KeyObject | string): string {
+  // createPublicKey() derives a public key from a PRIVATE key / PEM / JWK; it
+  // rejects an already-public KeyObject. So only convert strings; use a passed
+  // public KeyObject directly.
+  const keyObj = typeof pub === "string" ? createPublicKey(pub) : pub;
+  const der = keyObj.export({ type: "spki", format: "der" });
+  return createHash("sha256").update(der).digest("hex");
+}
+
+/** Read the TOFU-pinned Ed25519 fingerprint, or null when none is pinned. */
+export async function readPinnedEd25519Fingerprint(dir?: string): Promise<string | null> {
+  try {
+    const fp = (await readFile(ed25519PinPath(dir), "utf-8")).trim().toLowerCase();
+    return fp.length > 0 ? fp : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pin an Ed25519 fingerprint as trusted-on-first-use (0600). Later receipts must
+ * present a matching key or verify fails. Refuses to silently overwrite an
+ * existing, different pin (that would let an attacker re-pin their own key).
+ */
+export async function pinEd25519Fingerprint(fingerprint: string, dir?: string): Promise<void> {
+  const fp = fingerprint.trim().toLowerCase();
+  const existing = await readPinnedEd25519Fingerprint(dir);
+  if (existing && existing !== fp) {
+    throw new Error(
+      `an Ed25519 key is already pinned (${existing.slice(0, 16)}…) and differs from this one; refusing to overwrite`,
+    );
+  }
+  await mkdir(anchorDir(dir), { recursive: true });
+  const pinPath = ed25519PinPath(dir);
+  await writeFile(pinPath, fp + "\n", { encoding: "utf-8", mode: 0o600 });
+  secureFile(pinPath);
+}
+
+/**
+ * Normalize an operator-supplied expected key (`--key`) to a fingerprint. Accepts
+ * either an SPKI PEM public key or a raw fingerprint hex (optionally `sha256:`
+ * prefixed). Returns null when it cannot be interpreted.
+ */
+export function expectedKeyToFingerprint(expected: string): string | null {
+  const trimmed = expected.trim();
+  if (trimmed.includes("BEGIN PUBLIC KEY")) {
+    try {
+      return ed25519Fingerprint(trimmed);
+    } catch {
+      return null;
+    }
+  }
+  const hex = trimmed.replace(/^sha256:/i, "").toLowerCase();
+  return /^[0-9a-f]{16,64}$/.test(hex) ? hex : null;
+}
+
+/**
+ * Load the Ed25519 signing key, creating it on first use (0600). Returns null
+ * if it cannot be read or created (sandbox / unwritable home) so the caller can
+ * fall back to HMAC. Never throws.
+ */
+async function loadOrCreateEd25519Key(dir?: string): Promise<KeyObject | null> {
+  const keyPath = ed25519KeyPath(dir);
+  try {
+    const pem = await readFile(keyPath, "utf-8");
+    return createPrivateKey(pem);
+  } catch {
+    /* fall through to create */
+  }
+  try {
+    const { privateKey } = generateKeyPairSync("ed25519");
+    const pem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+    await mkdir(anchorDir(dir), { recursive: true });
+    await writeFile(keyPath, pem, { encoding: "utf-8", mode: 0o600, flag: "wx" });
+    secureFile(keyPath);
+    return privateKey;
+  } catch {
+    // Lost create race or unwritable home - try one more read before giving up.
+    try {
+      const pem = await readFile(keyPath, "utf-8");
+      return createPrivateKey(pem);
+    } catch {
+      return null;
+    }
+  }
+}
+
+export interface SignAttestationOptions {
+  /** Override the key directory (default ~/.kit). */
+  dir?: string;
+  /**
+   * Force the portable Ed25519 path even when the anchor key is available.
+   * Default is the authoritative HMAC path. Ed25519 receipts are only
+   * authenticatable by a verifier that pins/expects the key (see header).
+   */
+  preferEd25519?: boolean;
+}
+
+async function signEd25519(
+  payload: AttestationPayload,
+  bytes: Buffer,
+  dir?: string,
+): Promise<Attestation | null> {
+  const edKey = await loadOrCreateEd25519Key(dir);
+  if (!edKey) return null;
+  try {
+    const signature = cryptoSign(null, bytes, edKey).toString("base64");
+    const publicKey = createPublicKey(edKey).export({ type: "spki", format: "pem" }).toString();
+    return { ...payload, sig_alg: "ed25519", signature, public_key: publicKey };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Sign a payload into a full attestation. HMAC (anchor key) is the default and
+ * authoritative path; Ed25519 is the portable fallback (or when forced). The
+ * sign step is fail-soft: if no key can be produced, the receipt is emitted
+ * UNSIGNED (sig_alg "none") with a reason - completing the check is never
+ * blocked by a signing failure.
+ */
+export async function signAttestation(
+  payload: AttestationPayload,
+  options: SignAttestationOptions = {},
+): Promise<Attestation> {
+  const { dir, preferEd25519 } = options;
+  const bytes = canonicalPayloadBytes(payload);
+
+  if (preferEd25519) {
+    const ed = await signEd25519(payload, bytes, dir);
+    if (ed) return ed;
+  }
+
+  // Authoritative default: HMAC with the machine-local anchor key. A valid MAC
+  // genuinely binds the receipt to a key-holder (the verifier needs that key).
+  const hmacKey =
+    (await tryReadAuditAnchorKey(dir).catch(() => null)) ??
+    (await getAuditAnchorKey(dir).catch(() => null));
+  if (hmacKey) {
+    const signature = createHmac("sha256", hmacKey).update(bytes).digest("base64");
+    return { ...payload, sig_alg: "hmac-sha256", signature };
+  }
+
+  // Portable fallback: Ed25519 (unauthenticated unless the verifier pins it).
+  const ed = await signEd25519(payload, bytes, dir);
+  if (ed) return ed;
+
+  return {
+    ...payload,
+    sig_alg: "none",
+    signature: "",
+    unsigned_reason:
+      "no signing key available (could not read/create the ~/.kit anchor key or an Ed25519 key)",
+  };
+}
+
+/**
+ * Verify outcome.
+ *   - "ok": signature valid AND signer authenticated (HMAC, or Ed25519 matching
+ *     a pinned/expected key).
+ *   - "unverified-authenticity": Ed25519 signature is mathematically valid but
+ *     no pin/expected key exists, so the SIGNER is unauthenticated. NOT green.
+ *   - "failed": signature invalid, key mismatch, or any other failure.
+ */
+export type AttestationVerifyStatus = "ok" | "unverified-authenticity" | "failed";
+
+export interface AttestationVerifyResult {
+  ok: boolean;
+  status: AttestationVerifyStatus;
+  sig_alg: SigAlg;
+  reason: string;
+  /** Ed25519 key fingerprint (when applicable), surfaced for pinning. */
+  fingerprint?: string;
+}
+
+export interface VerifyAttestationOptions {
+  /** Override the key directory (default ~/.kit). */
+  dir?: string;
+  /** Expected Ed25519 key: an SPKI PEM or a fingerprint hex (`--key`). */
+  expectedKey?: string;
+}
+
+function splitEnvelope(att: Attestation): AttestationPayload {
+  return {
+    schema: att.schema,
+    command: att.command,
+    timestamp: att.timestamp,
+    kit_version: att.kit_version,
+    overall_ok: att.overall_ok,
+    results: att.results,
+    scanners_ran: att.scanners_ran,
+  };
+}
+
+/**
+ * Verify a receipt. Fail-closed: anything unexpected is a verification failure.
+ *
+ *   - HMAC: needs the machine-local anchor key (genuine authenticity).
+ *   - Ed25519: the embedded public key is UNTRUSTED. The math is checked against
+ *     it, then the key's fingerprint is compared to an expected key (`--key`) or
+ *     a TOFU pin in ~/.kit. No expected key + no pin => "unverified-authenticity"
+ *     (NOT ok). A mismatch => failed (possible forgery).
+ */
+export async function verifyAttestation(
+  att: Attestation,
+  options: VerifyAttestationOptions = {},
+): Promise<AttestationVerifyResult> {
+  const { dir, expectedKey } = options;
+  if (att.schema !== "kit-check-attestation/v1") {
+    return {
+      ok: false,
+      status: "failed",
+      sig_alg: att.sig_alg,
+      reason: "unknown attestation schema",
+    };
+  }
+  const bytes = canonicalPayloadBytes(splitEnvelope(att));
+
+  if (att.sig_alg === "ed25519") {
+    if (!att.public_key) {
+      return {
+        ok: false,
+        status: "failed",
+        sig_alg: "ed25519",
+        reason: "missing embedded public key",
+      };
+    }
+    let pub: KeyObject;
+    let fingerprint: string;
+    try {
+      pub = createPublicKey(att.public_key);
+      fingerprint = ed25519Fingerprint(pub);
+    } catch (err) {
+      return {
+        ok: false,
+        status: "failed",
+        sig_alg: "ed25519",
+        reason: `Ed25519 key parse error: ${(err as Error).message}`,
+      };
+    }
+    const mathOk = cryptoVerify(null, bytes, pub, Buffer.from(att.signature, "base64"));
+    if (!mathOk) {
+      return {
+        ok: false,
+        status: "failed",
+        sig_alg: "ed25519",
+        reason: "Ed25519 signature does not verify",
+        fingerprint,
+      };
+    }
+    // The signature is mathematically valid; now decide AUTHENTICITY.
+    let expectedFp: string | null = null;
+    if (expectedKey) {
+      expectedFp = expectedKeyToFingerprint(expectedKey);
+      if (!expectedFp) {
+        return {
+          ok: false,
+          status: "failed",
+          sig_alg: "ed25519",
+          reason: "could not parse the expected --key (need an SPKI PEM or a fingerprint hex)",
+          fingerprint,
+        };
+      }
+    } else {
+      expectedFp = await readPinnedEd25519Fingerprint(dir);
+    }
+    if (!expectedFp) {
+      return {
+        ok: false,
+        status: "unverified-authenticity",
+        sig_alg: "ed25519",
+        reason:
+          "Ed25519 signature is valid but the SIGNER is unauthenticated: no --key and no pinned key. The embedded key proves integrity of its own claims only - anyone can mint a keypair and sign overall_ok=true. Pin the key (verify --pin) or pass --key to authenticate.",
+        fingerprint,
+      };
+    }
+    const matches = expectedFp === fingerprint;
+    return matches
+      ? {
+          ok: true,
+          status: "ok",
+          sig_alg: "ed25519",
+          reason: "valid Ed25519 signature from the pinned/expected key",
+          fingerprint,
+        }
+      : {
+          ok: false,
+          status: "failed",
+          sig_alg: "ed25519",
+          reason: `Ed25519 key ${fingerprint.slice(0, 16)}… does not match the expected/pinned key ${expectedFp.slice(0, 16)}… (possible forgery)`,
+          fingerprint,
+        };
+  }
+
+  if (att.sig_alg === "hmac-sha256") {
+    const key = await tryReadAuditAnchorKey(dir);
+    if (!key) {
+      return {
+        ok: false,
+        status: "failed",
+        sig_alg: "hmac-sha256",
+        reason: "HMAC receipt but the anchor key is unavailable on this host",
+      };
+    }
+    const expected = createHmac("sha256", key).update(bytes).digest();
+    let actual: Buffer;
+    try {
+      actual = Buffer.from(att.signature, "base64");
+    } catch {
+      return {
+        ok: false,
+        status: "failed",
+        sig_alg: "hmac-sha256",
+        reason: "signature not valid base64",
+      };
+    }
+    const ok = expected.length === actual.length && timingSafeEqual(expected, actual);
+    return ok
+      ? { ok: true, status: "ok", sig_alg: "hmac-sha256", reason: "valid HMAC signature" }
+      : {
+          ok: false,
+          status: "failed",
+          sig_alg: "hmac-sha256",
+          reason: "HMAC signature does not match",
+        };
+  }
+
+  return {
+    ok: false,
+    status: "failed",
+    sig_alg: "none",
+    reason: "receipt is unsigned (sig_alg=none)",
+  };
+}
+
+/** Write a receipt to `.kit-check-attestation.json` in `cwd`. */
+export async function writeAttestation(att: Attestation, cwd: string): Promise<string> {
+  const path = join(cwd, ATTESTATION_FILE);
+  await writeFile(path, JSON.stringify(att, null, 2) + "\n", "utf-8");
+  return path;
+}
+
+/**
+ * Build + sign + write a receipt. Fully fail-soft: returns null and prints a
+ * warning on any error so the calling check command's verdict is never altered
+ * by attestation problems.
+ */
+export async function emitAttestation(
+  input: BuildAttestationInput,
+  cwd: string,
+  dir?: string,
+): Promise<{ path: string; att: Attestation } | null> {
+  try {
+    const payload = buildAttestationPayload(input);
+    const att = await signAttestation(payload, { dir });
+    const path = await writeAttestation(att, cwd);
+    return { path, att };
+  } catch (err) {
+    console.error(`[kit] check attestation not emitted: ${(err as Error).message}`);
+    return null;
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -238,8 +238,41 @@ async function cmdHeal(): Promise<boolean> {
   return green;
 }
 
+/**
+ * Emit a signed `.kit-check-attestation.json` receipt after a check/ci run, but
+ * only when the operator opts in (`--attest` flag or `KIT_ATTEST=1`). Writing a
+ * new file into the repo on every run would surprise scripted users, so it is
+ * gated. The signing step is fail-soft inside emitAttestation: a signing failure
+ * never alters the check verdict; at worst the receipt is unsigned.
+ */
+async function maybeEmitCheckAttestation(
+  command: "check" | "ci",
+  overallOk: boolean,
+  summary: { passed: number; failed: number; warnings: number; skipped: number },
+  scannersRan: { id: string; status: string }[],
+  quiet: boolean,
+): Promise<void> {
+  if (!hasFlag(process.argv, "--attest") && !envTruthy(process.env.KIT_ATTEST)) return;
+  const { emitAttestation } = await import("./check-attestation.js");
+  const res = await emitAttestation(
+    { command, kitVersion: KIT_VERSION, overallOk, results: summary, scannersRan },
+    process.cwd(),
+  );
+  if (res && !quiet) {
+    const signedNote =
+      res.att.sig_alg === "none"
+        ? `${c.yellow}unsigned (${res.att.unsigned_reason})${c.reset}`
+        : `${c.dim}signed ${res.att.sig_alg}${c.reset}`;
+    console.log(`${c.dim}attestation: ${res.path}${c.reset} ${signedNote}`);
+  }
+}
+
 async function cmdCheck(): Promise<boolean> {
   const jsonMode = hasFlag(process.argv, "--json");
+  // kit check verify-attestation <file> verifies a signed check receipt.
+  if (process.argv[3] === "verify-attestation") {
+    return cmdVerifyAttestation();
+  }
   const enforceTests = hasFlag(process.argv, "--enforce-tests");
   const config = await loadConfig(resolveConfigPath());
 
@@ -396,6 +429,13 @@ async function cmdCheck(): Promise<boolean> {
         );
 
         const output: JsonCheckOutput = { ok: allOk, checks, summary };
+        await maybeEmitCheckAttestation(
+          "check",
+          allOk,
+          summary,
+          securityResults.map((s) => ({ id: s.name, status: s.status })),
+          true, // quiet: never print to stdout in --json mode
+        );
         console.log(JSON.stringify(output, null, 2));
         return allOk;
       }
@@ -449,6 +489,29 @@ async function cmdCheck(): Promise<boolean> {
       }
 
       printSummary(toolResults, serviceResults, secretResults.keys, securityResults);
+
+      // Opt-in signed attestation receipt (text mode). Summary is over the
+      // security gates, consistent with scanners_ran; overall_ok is the whole
+      // check verdict. Emission is fail-soft and never changes the verdict.
+      {
+        const attSummary = securityResults.reduce(
+          (acc, s) => {
+            if (s.status === "pass") acc.passed++;
+            else if (s.status === "fail") acc.failed++;
+            else if (s.status === "warn") acc.warnings++;
+            else acc.skipped++;
+            return acc;
+          },
+          { passed: 0, failed: 0, warnings: 0, skipped: 0 },
+        );
+        await maybeEmitCheckAttestation(
+          "check",
+          allOk,
+          attSummary,
+          securityResults.map((s) => ({ id: s.name, status: s.status })),
+          false,
+        );
+      }
 
       // Surface a stale kit (a newer published version) as a warn — a stale CLI
       // can carry already-fixed bugs. Gated by [update].check; checkForUpdate
@@ -3252,9 +3315,92 @@ async function cmdCi(): Promise<boolean> {
         );
       }
 
+      // Opt-in signed attestation receipt. scanners_ran reflects the security
+      // gates (which ran vs were skipped/errored). Quiet in json/non-text so it
+      // never corrupts machine-readable output.
+      await maybeEmitCheckAttestation(
+        "ci",
+        allOk,
+        summary,
+        securityResults.map((s) => ({ id: s.name, status: s.status })),
+        format !== "text",
+      );
+
       return allOk;
     },
   );
+}
+
+async function cmdVerifyAttestation(): Promise<boolean> {
+  // kit check verify-attestation [file] [--key <spki|fingerprint>] [--pin]
+  const args = process.argv.slice(4);
+  const file = args.find((a) => !a.startsWith("-")) ?? ".kit-check-attestation.json";
+  const expectedKey = flagValue(args, "--key");
+  const doPin = hasFlag(args, "--pin");
+  const { readFile } = await import("node:fs/promises");
+  const { verifyAttestation, pinEd25519Fingerprint, ATTESTATION_FILE } =
+    await import("./check-attestation.js");
+  const path = resolve(process.cwd(), file);
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf-8");
+  } catch {
+    console.error(
+      `${c.red}✗ no attestation at ${file}${c.reset}  ${c.dim}(default: ${ATTESTATION_FILE})${c.reset}`,
+    );
+    return false;
+  }
+  let att;
+  try {
+    att = JSON.parse(raw);
+  } catch {
+    console.error(`${c.red}✗ attestation is not valid JSON: ${file}${c.reset}`);
+    return false;
+  }
+  const r = await verifyAttestation(att, { expectedKey });
+  const fpNote = r.fingerprint
+    ? `  ${c.dim}ed25519 key sha256:${r.fingerprint.slice(0, 16)}…${c.reset}`
+    : "";
+
+  if (r.status === "ok") {
+    console.log(
+      `${c.green}✓ attestation verified${c.reset}  ${c.dim}${r.sig_alg}: ${att.command} on kit ${att.kit_version}, overall_ok=${att.overall_ok}${c.reset}${fpNote}`,
+    );
+    if (r.sig_alg === "hmac-sha256") {
+      console.log(
+        `${c.dim}HMAC verified against the machine-local anchor key (a valid MAC binds the receipt to a key-holder). Does NOT prove the host was untampered - a same-UID key reader can forge.${c.reset}`,
+      );
+    } else {
+      console.log(
+        `${c.dim}Ed25519 signature matches the pinned/expected key. Does NOT prove the host was untampered - a same-UID key reader can forge.${c.reset}`,
+      );
+    }
+    return true;
+  }
+
+  if (r.status === "unverified-authenticity") {
+    // Honest, non-green outcome: valid math, unauthenticated signer.
+    if (doPin && r.fingerprint) {
+      try {
+        await pinEd25519Fingerprint(r.fingerprint);
+        console.warn(
+          `${c.yellow}! pinned Ed25519 key sha256:${r.fingerprint.slice(0, 16)}… as trusted (TOFU).${c.reset} ${c.dim}Re-run verify to authenticate against the pin. NOTE: pinning a forged receipt's key trusts the forger - only pin a key you know is genuine.${c.reset}`,
+        );
+        return false; // still not authenticated on THIS run
+      } catch (err) {
+        console.error(`${c.red}✗ could not pin key: ${(err as Error).message}${c.reset}`);
+        return false;
+      }
+    }
+    console.error(
+      `${c.yellow}! attestation UNVERIFIED-AUTHENTICITY${c.reset} ${c.dim}(${r.sig_alg})${c.reset}${fpNote}`,
+    );
+    console.error(`${c.dim}${r.reason}${c.reset}`);
+    return false;
+  }
+
+  console.error(`${c.red}✗ attestation FAILED: ${r.reason}${c.reset}${fpNote}`);
+  return false;
 }
 
 async function cmdSelfAudit(): Promise<boolean> {
@@ -5434,6 +5580,7 @@ export const COMMAND_HELP: Record<string, string> = {
   statusline:
     "Compact one-line status (mode score · update · open PAL) for any agent's info bar — wire into Claude Code statusLine / a shell PS1",
   check: "Check status of all tools, services, secrets, and lock files",
+  "check verify-attestation": "Verify a signed .kit-check-attestation.json receipt",
   health: "Deep environment health diagnostics — granular pass/fail across tools, services, config",
   scan: "Run external scanners (snyk/trivy/grype/semgrep/osv) and merge them into one local verdict (--strict / [governance.scan] required_scanners gate non-running scanners)",
   airgap: "Air-gap posture tools (verify)",
@@ -5513,7 +5660,10 @@ export const COMMAND_HELP: Record<string, string> = {
   "security prescan-diff":
     "Diff two prescan reports — surface new regressions + fixed findings since baseline",
   "audit secrets": "Forensics: who/what touched each key + when (reads audit log)",
-  "audit verify": "Verify the audit log's tamper-evident hash chain (exit 1 on break)",
+  "audit verify":
+    "Verify the audit log's keyless hash chain + the external HMAC anchor (exit 1 on break/forge/truncation)",
+  "audit anchor":
+    "Seal the audit log with the machine-local HMAC key so a key-less rewrite or truncation is detectable",
   "audit export": "Emit the audit log for a SIEM (--format cef|syslog|json)",
   auth: "TOTP-gated elevation for destructive secret ops (elevate|status|revoke|setup-totp)",
   "auth elevate": "Mint elevation marker for destructive secret ops (TOTP/yes-prompt)",

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -69,6 +69,124 @@ async function cmdAuditSecrets(): Promise<boolean> {
   return true;
 }
 
+/** Resolve the configured audit log file (absolute path), defaulting to ./.kit-audit.jsonl. */
+async function resolveAuditLogPath(): Promise<string> {
+  let logFile = ".kit-audit.jsonl";
+  try {
+    const config = await loadConfig(resolveConfigPath());
+    if (config.governance?.audit?.log_file) logFile = config.governance.audit.log_file;
+  } catch {
+    /* default */
+  }
+  return resolve(process.cwd(), logFile);
+}
+
+/**
+ * `kit audit verify` - verify the keyless hash chain, then the external HMAC
+ * anchor (key + sealed count) when one exists. See audit-anchor.ts for the
+ * threat boundary (only a reader of the 0600 key can forge; a same-UID attacker
+ * is NOT covered, which needs the external TSA anchor).
+ *
+ * Fail-closed mode (`--strict` or `[governance.audit].require_anchor = true`,
+ * and implicitly once this machine has anchored ANY log) turns an unanchored
+ * log, an unreadable key, an unsealed tail, and a rotated key into hard
+ * failures, so a project-writable `log_file` cannot silently point verify at a
+ * forged, never-anchored file and pass. #fix2 #fix3 #fix4
+ */
+async function cmdAuditVerify(): Promise<boolean> {
+  const { verifyAuditChain } = await import("../audit.js");
+  const { readFile } = await import("node:fs/promises");
+  const args = process.argv.slice(3);
+  const strictFlag = hasFlag(args, "--strict");
+  let requireAnchor = false;
+  try {
+    const config = await loadConfig(resolveConfigPath());
+    requireAnchor = config.governance?.audit?.require_anchor === true;
+  } catch {
+    /* default: not required */
+  }
+  const logPath = await resolveAuditLogPath();
+  let content = "";
+  try {
+    content = await readFile(logPath, "utf-8");
+  } catch {
+    console.log(`${c.dim}no audit log at ${logPath}${c.reset}`);
+    return true;
+  }
+  const r = verifyAuditChain(content);
+  if (!r.ok) {
+    console.error(
+      `${c.red}✗ audit chain BROKEN at entry ${r.brokenAt}: ${r.reason}${c.reset}  ${c.dim}(verified ${r.entries} entries before the break)${c.reset}`,
+    );
+    return false;
+  }
+  console.log(`${c.green}✓ audit chain intact${c.reset}  ${c.dim}${r.entries} entries${c.reset}`);
+
+  const {
+    readAnchorRecord,
+    tryReadAuditAnchorKey,
+    verifyAgainstAnchor,
+    hasAnyAnchoredLogs,
+    decideAnchorVerdict,
+  } = await import("../audit-anchor.js");
+  const anchor = await readAnchorRecord(logPath);
+  const key = await tryReadAuditAnchorKey();
+  const a = verifyAgainstAnchor(content, anchor, key);
+  const machineHasAnchors = await hasAnyAnchoredLogs();
+  const verdict = decideAnchorVerdict({
+    result: a,
+    strict: strictFlag || requireAnchor,
+    machineHasAnchors,
+  });
+  if (verdict.level === "ok") {
+    console.log(`${c.green}✓ ${verdict.message}${c.reset}`);
+  } else if (verdict.level === "warn") {
+    console.warn(`${c.yellow}! ${verdict.message}${c.reset}`);
+  } else {
+    console.error(`${c.red}✗ HMAC anchor FAILED: ${verdict.message}${c.reset}`);
+  }
+  return verdict.ok;
+}
+
+/**
+ * `kit audit anchor` - seal the current log with the machine-local HMAC key so
+ * a later key-less rewrite or truncation is detectable by `kit audit verify`.
+ */
+async function cmdAuditAnchor(): Promise<boolean> {
+  const { verifyAuditChain } = await import("../audit.js");
+  const { anchorAuditLog } = await import("../audit-anchor.js");
+  const { readFile } = await import("node:fs/promises");
+  const logPath = await resolveAuditLogPath();
+  let content = "";
+  try {
+    content = await readFile(logPath, "utf-8");
+  } catch {
+    console.error(`${c.dim}no audit log at ${logPath}; nothing to anchor${c.reset}`);
+    return true;
+  }
+  // Refuse to seal a broken chain: the anchor must vouch for a sound log.
+  const chain = verifyAuditChain(content);
+  if (!chain.ok) {
+    console.error(
+      `${c.red}✗ refusing to anchor: chain broken at entry ${chain.brokenAt} (${chain.reason})${c.reset}`,
+    );
+    return false;
+  }
+  try {
+    const rec = await anchorAuditLog(logPath, content);
+    console.log(
+      `${c.green}✓ audit log anchored${c.reset}  ${c.dim}${rec.count} entries sealed (${rec.algo})${c.reset}`,
+    );
+    console.log(
+      `${c.dim}Note: the anchor resists a tamperer who cannot read the 0600 anchor key. A same-UID attacker who can read ~/.kit can still forge; close that with an external TSA anchor.${c.reset}`,
+    );
+    return true;
+  } catch (err) {
+    console.error(`${c.red}✗ could not anchor: ${(err as Error).message}${c.reset}`);
+    return false;
+  }
+}
+
 export async function cmdAudit(): Promise<boolean> {
   const args = process.argv.slice(3);
 
@@ -77,35 +195,14 @@ export async function cmdAudit(): Promise<boolean> {
     return cmdAuditSecrets();
   }
 
-  // Sub-sub: kit audit verify — check the tamper-evident hash chain
+  // Sub-sub: kit audit verify - keyless chain + external HMAC anchor.
   if (args[0] === "verify") {
-    let logFile = ".kit-audit.jsonl";
-    try {
-      const config = await loadConfig(resolveConfigPath());
-      if (config.governance?.audit?.log_file) logFile = config.governance.audit.log_file;
-    } catch {
-      /* default */
-    }
-    const { verifyAuditChain } = await import("../audit.js");
-    const { readFile } = await import("node:fs/promises");
-    let content = "";
-    try {
-      content = await readFile(resolve(process.cwd(), logFile), "utf-8");
-    } catch {
-      console.log(`${c.dim}no audit log at ${logFile}${c.reset}`);
-      return true;
-    }
-    const r = verifyAuditChain(content);
-    if (r.ok) {
-      console.log(
-        `${c.green}✓ audit chain intact${c.reset}  ${c.dim}${r.entries} entries${c.reset}`,
-      );
-      return true;
-    }
-    console.error(
-      `${c.red}✗ audit chain BROKEN at entry ${r.brokenAt}: ${r.reason}${c.reset}  ${c.dim}(verified ${r.entries} entries before the break)${c.reset}`,
-    );
-    return false;
+    return cmdAuditVerify();
+  }
+
+  // Sub-sub: kit audit anchor - seal the log with the machine-local HMAC key.
+  if (args[0] === "anchor") {
+    return cmdAuditAnchor();
   }
 
   // Sub-sub: kit audit export [--format cef|syslog|json] — emit for a SIEM

--- a/src/config.ts
+++ b/src/config.ts
@@ -177,6 +177,14 @@ export interface GovernanceAuditConfig {
    * data is leaving the machine.
    */
   remote?: boolean;
+  /**
+   * Fail-closed anchoring for `kit audit verify`. When true, an unanchored log,
+   * an unreadable anchor key, an unsealed tail, or a rotated key are treated as
+   * verification FAILURES (non-zero exit) instead of warnings. Defaults to
+   * false for backward compatibility (and is implicitly active once this
+   * machine has anchored any log). See docs/AUDIT_ATTESTATION.md.
+   */
+  require_anchor?: boolean;
 }
 
 /**
@@ -474,6 +482,7 @@ const GovernanceConfigSchema = z
         log_file: z.string().optional(),
         log_level: z.enum(["debug", "info", "warn", "error"]).optional(),
         include_secrets: z.boolean().optional(),
+        require_anchor: z.boolean().optional(),
       })
       .passthrough()
       .optional(),

--- a/src/elevation.ts
+++ b/src/elevation.ts
@@ -20,6 +20,7 @@ import { resolve, dirname } from "node:path";
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import { appendAuditEventDirect } from "./audit.js";
 import { secureFile } from "./utils/secure-perms.js";
+import { reReadHexKey } from "./utils/key-file.js";
 
 const ELEVATION_FILE = ".kit/elevation.json";
 const DEFAULT_TTL_MINUTES = 15;
@@ -118,8 +119,10 @@ async function getElevationSigningKey(): Promise<Buffer> {
     secureFile(keyPath); // owner-only on Windows (NTFS ignores mode) — #43
     return key;
   } catch {
-    const hex = (await readFile(keyPath, "utf-8")).trim();
-    return Buffer.from(hex, "hex");
+    // Lost the create race. Re-read with the same >=64 hex guard as the happy
+    // path (+ retry) so a mid-write read never returns a short/empty signing
+    // key (which would later refuse a valid elevation marker). #fix5
+    return reReadHexKey(keyPath);
   }
 }
 

--- a/src/utils/key-file.test.ts
+++ b/src/utils/key-file.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { reReadHexKey } from "./key-file.js";
+
+describe("reReadHexKey - create-race guard (FIX 5)", () => {
+  it("returns a full 32-byte key for a valid 64-hex file", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-keyfile-ok-"));
+    try {
+      const p = join(dir, "k");
+      writeFileSync(p, "a".repeat(64) + "\n", "utf-8");
+      const buf = await reReadHexKey(p);
+      assert.equal(buf.length, 32);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ATTACK: a too-short (mid-write) hex re-read THROWS instead of returning an empty key", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-keyfile-short-"));
+    try {
+      const p = join(dir, "k");
+      writeFileSync(p, "abc", "utf-8"); // partial write, stays short
+      await assert.rejects(() => reReadHexKey(p, 64, 3), /did not become readable/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ATTACK: an empty file never yields a zero-length key", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-keyfile-empty-"));
+    try {
+      const p = join(dir, "k");
+      writeFileSync(p, "", "utf-8");
+      await assert.rejects(() => reReadHexKey(p, 64, 2), /did not become readable/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("retries and succeeds once the winner finishes writing the full key", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-keyfile-retry-"));
+    try {
+      const p = join(dir, "k");
+      writeFileSync(p, "abc", "utf-8"); // starts short
+      // Winner flushes the full key shortly after, before attempts exhaust.
+      setTimeout(() => writeFileSync(p, "b".repeat(64) + "\n", "utf-8"), 25);
+      const buf = await reReadHexKey(p, 64, 6);
+      assert.equal(buf.length, 32);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/utils/key-file.ts
+++ b/src/utils/key-file.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared hex-key file reader with a length guard + bounded retry.
+ *
+ * Machine-local HMAC keys (audit anchor, elevation) are created atomically with
+ * `flag: "wx"`. The loser of a create race must re-read the winner's file, but a
+ * naive single read can land MID-WRITE and return a partial (or empty) string.
+ * A zero/short key silently breaks every later HMAC compare (false tip-mismatch
+ * / refused elevation), so the re-read MUST enforce the same `hex.length >=
+ * minHexLen` guard the happy path uses, and retry briefly while the winner
+ * finishes its write.
+ *
+ * This NEVER returns a short/empty key: it either returns a full-length key or
+ * throws with a clear reason (no silent degrade).
+ */
+import { readFile } from "node:fs/promises";
+
+function delay(ms: number): Promise<void> {
+  return new Promise((res) => setTimeout(res, ms));
+}
+
+/**
+ * Re-read a hex key file, retrying with a small linear backoff until it holds at
+ * least `minHexLen` hex chars. Throws if it never does (e.g. the file stays
+ * truncated/absent) rather than handing back a zero-length key.
+ */
+export async function reReadHexKey(path: string, minHexLen = 64, attempts = 5): Promise<Buffer> {
+  let lastLen = -1;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const hex = (await readFile(path, "utf-8")).trim();
+      if (hex.length >= minHexLen) return Buffer.from(hex, "hex");
+      lastLen = hex.length;
+    } catch {
+      // Not yet visible (mid-write / not flushed) - fall through to backoff.
+      lastLen = -1;
+    }
+    if (i < attempts - 1) await delay(15 * (i + 1));
+  }
+  throw new Error(
+    `key file ${path} did not become readable with >=${minHexLen} hex chars after ${attempts} attempts (last observed length ${lastLen})`,
+  );
+}


### PR DESCRIPTION
kit 2.0 Pillar 1 (Provable Green) pt2 — make the audit trail attestable, and be **honest** about how far that goes. An adversarial crypto-review caught a self-vouching receipt + two verify bypasses on the first cut; **all 5 findings fixed before merge** with attack-tests-that-now-fail.

## Audit chain — external HMAC anchor
The `.kit-audit.jsonl` chain was tamper-*evident* but recomputable by any writer (keyless SHA-256 from a public genesis). A machine-local 0600 anchor key (`elevation.ts` pattern) seals it into a separate 0600 record (HMAC tip + sealed count). `kit audit verify` catches keyless prefix-rewrite (tip) + truncation (count); `kit audit anchor` seals. The append path stays keyless so sandboxed agents keep logging.
**Honest by design:** raises forgery from "anyone who can write the log" to "someone who can read the 0600 key" — **not** tamper-proof vs a same-UID principal (documented; external TSA hook stubbed). Rotation → distinct `anchor-key-changed` status; a non-verifying prefix is never silently re-sealed.

## Fail-closed verify
`kit audit verify --strict` / `[governance.audit].require_anchor`: a project-writable `log_file` can no longer repoint verify at a forged unanchored file and pass; unsealed tail past the seal is unauthenticated and fails under strict. Default stays warn (backward-compatible).

## Signed check-attestation
`kit check --attest` / `kit ci --attest` / `KIT_ATTEST=1` — opt-in, fail-soft, records which scanners ran + the verdict. HMAC anchor-key signature is authoritative. Ed25519 is a portable fallback whose **embedded pubkey is untrusted**: verify reports `unverified-authenticity` (not green) unless pinned (TOFU) or `--key`. No "forgery requires the key" overclaim.

## Verification
Build clean, **1734/1734 tests pass** (Node 22), self-audit 0 fail. All 5 crypto-review findings fixed with attack tests (forged ed25519 → not green; path-repoint+strict → fail; forged tail+strict → fail; key-rotate → distinct status + no silent re-seal; short-key race guarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)