### PR TITLE
docs(platform): note kit is Docker-engine-agnostic (OrbStack/Colima/etc.)

### DIFF
--- a/docs/PLATFORM_SUPPORT.md
+++ b/docs/PLATFORM_SUPPORT.md
@@ -45,6 +45,20 @@ Windows (Docker Desktop), macOS, and Linux — see
 docker run --rm -v "${PWD}:/work" -w /work sandstream/kit:latest check
 ```
 
+## Docker engine
+
+kit is engine-agnostic. Anywhere it touches Docker it either calls the standard
+`docker` CLI (via `execFile`, no shell), queries the Docker Hub **registry HTTP
+API** (`kit triage docker:<image>` — never the local daemon), or reads
+`Dockerfile`/Compose files on disk. It never opens the daemon socket directly or
+hard-codes Docker Desktop paths.
+
+So **any Docker-CLI-compatible engine works** — Docker Desktop, **[OrbStack](https://orbstack.dev)**,
+Colima, Rancher Desktop, or Podman with a `docker` shim. The only requirement is
+a `docker` on `PATH` (for `kit pkg docker:` / service adapters); registry triage
+needs neither a daemon nor a CLI. There is intentionally no engine-specific
+detection — pick whichever engine you prefer.
+
 ## Why native Windows is not supported yet
 
 These are the concrete blockers, not a blanket "we didn't try". Each is


### PR DESCRIPTION
Adds a short **Docker engine** section to `docs/PLATFORM_SUPPORT.md` confirming OrbStack (and any other Docker-CLI-compatible engine) is supported.

Verified against main (1.40.0): kit has **no** direct daemon-socket usage (`docker.sock` / `DOCKER_HOST` / `dockerode` — zero matches). Every Docker touchpoint is engine-agnostic:
- `kit triage docker:<image>` → Docker Hub **registry HTTP API**, not the daemon
- `kit pkg docker:` / service adapters → standard `docker` CLI via `execFile`
- `kit check`/`scan` → reads `Dockerfile`/Compose + runs trivy (no daemon)
- triage-sandbox → `npm pack` + `tar` (not Docker at all)

So Docker Desktop, **OrbStack**, Colima, Rancher Desktop, or Podman-with-shim all work unchanged — the only requirement is a `docker` on `PATH`. Documents this and notes there is deliberately no engine-specific detection (keeps kit motor-agnostic).

Docs-only, no code change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_