### PR TITLE
feat(config): versioned .kit.toml schema + kit config migrate (1.41.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.41.0] - 2026-06-27
+
+kit 2.0 Phase 1 (frozen contracts), the first move: give `.kit.toml` a versioned schema + deterministic migration, so a future breaking config change can be migrated rather than silently corrupting every existing config.
+
+### Added
+
+- **`.kit.toml` schema version + `kit config migrate`.** A new optional top-level `version` field (`CONFIG_SCHEMA_VERSION = 1`; an absent field is treated as legacy v0). `kit config migrate` runs an ordered, pure, fixture-tested migration registry from the detected version to the current one: `--dry-run` (prints the plan + a value-level diff, writes nothing), a real run writes `.kit.toml.backup` first (refuses to clobber an existing backup without `--force`) then re-parses + Zod-validates the result and **restores the original on any failure** (never leaves a corrupt config), and `--check` exits non-zero on a stale config for CI. The v0→v1 migration only stamps the version (v1 is the baseline), but the framework is real and extensible — a future field rename is a single data row. `kit config` is a new top-level command.
+
 ## [1.40.0] - 2026-06-26
 
 kit 2.0 Phase 0 (auditable core) — internal hygiene that lets the public surface be frozen in Phase 1. No behavior change.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "1.40.0",
+      "version": "1.41.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -114,6 +114,7 @@ import { KIT_FILE, resolveConfigPath } from "./cli-shared.js";
 import { gatherLive, suggestContextToml, hasLockableContext } from "./context-lock.js";
 import { cmdEnv } from "./commands/env.js";
 import { cmdContext } from "./commands/context.js";
+import { cmdConfig } from "./commands/config.js";
 import { cmdAirgap } from "./commands/airgap.js";
 import { cmdScan } from "./commands/scan.js";
 import { cmdVerifyProvenance } from "./commands/verify-provenance.js";
@@ -5148,6 +5149,9 @@ export const COMMAND_HELP: Record<string, string> = {
     "Verify each CLI's live account+project matches .kit.toml [context] (exits non-zero on mismatch)",
   "context use": "Activate the declared context: gcloud config + repo git identity",
   "context --prompt": "Print a compact active-gcloud indicator for your shell prompt (PS1)",
+  config: "Inspect + migrate the .kit.toml schema version",
+  "config migrate":
+    "Migrate .kit.toml to the current schema version (--dry-run inspect, --check CI gate, --force overwrite backup)",
   mcp: "MCP server over stdio (Claude Code/Cursor/Codex); 'kit mcp list|auth|set-token|clear' manages declared servers",
   whoami: "Show current agent / user identity",
   version: "Print kit version",
@@ -5637,6 +5641,7 @@ export const COMMANDS: Record<string, () => boolean | Promise<boolean>> = {
   run: cmdRun,
   open: cmdOpen,
   context: cmdContext,
+  config: cmdConfig,
   triage: cmdTriage,
   baseline: cmdBaseline,
   design: cmdDesign,

--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile, readFile, access } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parse } from "smol-toml";
+import { migrateConfigFile } from "./config.js";
+
+const LEGACY_TOML = `[tools]
+node = "22"
+pnpm = "latest"
+
+[services.github]
+login = "gh auth login"
+check = "gh auth status"
+`;
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("migrateConfigFile", () => {
+  let dir: string;
+  let cfgPath: string;
+  let backupPath: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "kit-config-migrate-"));
+    cfgPath = join(dir, ".kit.toml");
+    backupPath = `${cfgPath}.backup`;
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("migrates a legacy config: stamps version=1, backs up original, re-validates", async () => {
+    await writeFile(cfgPath, LEGACY_TOML, "utf-8");
+
+    const outcome = await migrateConfigFile(cfgPath);
+    assert.equal(outcome.status, "migrated");
+    assert.equal(outcome.ok, true);
+    assert.equal(outcome.fromVersion, 0);
+    assert.equal(outcome.toVersion, 1);
+    assert.equal(outcome.wrote, true);
+
+    // Migrated file now declares version = 1 and keeps existing data.
+    const written = parse(await readFile(cfgPath, "utf-8")) as Record<string, unknown>;
+    assert.equal(written.version, 1);
+    assert.deepEqual(written.tools, { node: "22", pnpm: "latest" });
+
+    // Original backed up verbatim.
+    assert.ok(await exists(backupPath));
+    assert.equal(await readFile(backupPath, "utf-8"), LEGACY_TOML);
+  });
+
+  it("--dry-run writes nothing", async () => {
+    await writeFile(cfgPath, LEGACY_TOML, "utf-8");
+
+    const outcome = await migrateConfigFile(cfgPath, { dryRun: true });
+    assert.equal(outcome.status, "dry-run");
+    assert.equal(outcome.ok, true);
+    assert.equal(outcome.wrote, false);
+
+    // File unchanged, no backup created.
+    assert.equal(await readFile(cfgPath, "utf-8"), LEGACY_TOML);
+    assert.equal(await exists(backupPath), false);
+  });
+
+  it("refuses to clobber an existing backup without --force", async () => {
+    await writeFile(cfgPath, LEGACY_TOML, "utf-8");
+    await writeFile(backupPath, "PRE-EXISTING BACKUP", "utf-8");
+
+    const outcome = await migrateConfigFile(cfgPath);
+    assert.equal(outcome.status, "error");
+    assert.equal(outcome.ok, false);
+    assert.equal(outcome.wrote, false);
+    assert.match(outcome.message, /already exists/);
+
+    // Backup untouched, config unchanged.
+    assert.equal(await readFile(backupPath, "utf-8"), "PRE-EXISTING BACKUP");
+    assert.equal(await readFile(cfgPath, "utf-8"), LEGACY_TOML);
+  });
+
+  it("overwrites the backup with --force", async () => {
+    await writeFile(cfgPath, LEGACY_TOML, "utf-8");
+    await writeFile(backupPath, "PRE-EXISTING BACKUP", "utf-8");
+
+    const outcome = await migrateConfigFile(cfgPath, { force: true });
+    assert.equal(outcome.status, "migrated");
+    assert.equal(outcome.ok, true);
+    assert.equal(await readFile(backupPath, "utf-8"), LEGACY_TOML);
+  });
+
+  it("reports 'already current' and exits ok for a v1 config", async () => {
+    await writeFile(cfgPath, `version = 1\n${LEGACY_TOML}`, "utf-8");
+
+    const outcome = await migrateConfigFile(cfgPath);
+    assert.equal(outcome.status, "already-current");
+    assert.equal(outcome.ok, true);
+    assert.equal(outcome.wrote, false);
+    assert.equal(await exists(backupPath), false);
+  });
+
+  it("--check exits non-zero on a legacy config without writing", async () => {
+    await writeFile(cfgPath, LEGACY_TOML, "utf-8");
+
+    const outcome = await migrateConfigFile(cfgPath, { check: true });
+    assert.equal(outcome.status, "stale");
+    assert.equal(outcome.ok, false);
+    assert.equal(outcome.wrote, false);
+    assert.equal(await readFile(cfgPath, "utf-8"), LEGACY_TOML);
+    assert.equal(await exists(backupPath), false);
+  });
+
+  it("--check passes for a current config", async () => {
+    await writeFile(cfgPath, `version = 1\n${LEGACY_TOML}`, "utf-8");
+
+    const outcome = await migrateConfigFile(cfgPath, { check: true });
+    assert.equal(outcome.status, "already-current");
+    assert.equal(outcome.ok, true);
+  });
+
+  it("errors (no write) when the config is newer than this kit", async () => {
+    await writeFile(cfgPath, `version = 99\n${LEGACY_TOML}`, "utf-8");
+
+    const outcome = await migrateConfigFile(cfgPath);
+    assert.equal(outcome.status, "error");
+    assert.equal(outcome.ok, false);
+    assert.match(outcome.message, /newer than this kit/);
+    assert.equal(await exists(backupPath), false);
+  });
+});

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,356 @@
+// `kit config` commands — config-file inspection + schema migration.
+//
+// Migration is a one-way door done safely: --dry-run (the inspection default for
+// a stale config) writes nothing; a real run backs the original up to
+// .kit.toml.backup (refusing to clobber an existing backup without --force),
+// writes the migrated file, then RE-PARSES + VALIDATES it under the Zod schema
+// and restores the original if validation fails. A corrupt config is never left
+// on disk.
+import { readFile, writeFile, access } from "node:fs/promises";
+import { parse, stringify } from "smol-toml";
+import { CONFIG_SCHEMA_VERSION, kitConfigSchema } from "../config.js";
+import {
+  detectConfigVersion,
+  migrateConfig,
+  diffConfigs,
+  type ConfigDiffEntry,
+  type RawConfig,
+} from "../config-migrate.js";
+import { c } from "../utils/colors.js";
+import { hasFlag } from "../utils/flags.js";
+import { resolveConfigPath, KIT_FILE } from "../cli-shared.js";
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export type MigrateStatus =
+  | "already-current" // config is at CONFIG_SCHEMA_VERSION
+  | "dry-run" // a migration is needed; nothing written (--dry-run)
+  | "stale" // --check: config is behind, no write (CI gate)
+  | "migrated" // a migration ran and was written + re-validated
+  | "error"; // could not migrate (parse failure, backup clash, validation failure)
+
+export interface MigrateFileOptions {
+  dryRun?: boolean;
+  check?: boolean;
+  force?: boolean;
+}
+
+export interface MigrateStep {
+  from: number;
+  to: number;
+  describe: string;
+}
+
+export interface MigrateFileOutcome {
+  status: MigrateStatus;
+  /** Process should exit 0 when true. */
+  ok: boolean;
+  fromVersion: number;
+  toVersion: number;
+  steps: MigrateStep[];
+  diff: ConfigDiffEntry[];
+  backupPath?: string;
+  wrote: boolean;
+  message: string;
+}
+
+/**
+ * Migrate a .kit.toml file at `configPath`. Pure of argv/cwd so it is directly
+ * testable with temp files. Honors dry-run / check / force. Never leaves a
+ * corrupt config: on a failed post-write validation the original is restored.
+ */
+export async function migrateConfigFile(
+  configPath: string,
+  opts: MigrateFileOptions = {},
+): Promise<MigrateFileOutcome> {
+  let content: string;
+  try {
+    content = await readFile(configPath, "utf-8");
+  } catch (err) {
+    return {
+      status: "error",
+      ok: false,
+      fromVersion: 0,
+      toVersion: CONFIG_SCHEMA_VERSION,
+      steps: [],
+      diff: [],
+      wrote: false,
+      message: `Could not read ${configPath}: ${(err as Error).message}`,
+    };
+  }
+
+  let raw: RawConfig;
+  try {
+    raw = parse(content) as RawConfig;
+  } catch (err) {
+    return {
+      status: "error",
+      ok: false,
+      fromVersion: 0,
+      toVersion: CONFIG_SCHEMA_VERSION,
+      steps: [],
+      diff: [],
+      wrote: false,
+      message: `Could not parse ${configPath} as TOML: ${(err as Error).message}`,
+    };
+  }
+
+  const fromVersion = detectConfigVersion(raw);
+
+  // Already current — nothing to do (exit 0).
+  if (fromVersion === CONFIG_SCHEMA_VERSION) {
+    return {
+      status: "already-current",
+      ok: true,
+      fromVersion,
+      toVersion: CONFIG_SCHEMA_VERSION,
+      steps: [],
+      diff: [],
+      wrote: false,
+      message: `Already at v${CONFIG_SCHEMA_VERSION}, nothing to do.`,
+    };
+  }
+
+  let result;
+  try {
+    result = migrateConfig(raw);
+  } catch (err) {
+    // e.g. a config NEWER than this kit (downgrade), or a gap in the registry.
+    return {
+      status: "error",
+      ok: false,
+      fromVersion,
+      toVersion: CONFIG_SCHEMA_VERSION,
+      steps: [],
+      diff: [],
+      wrote: false,
+      message: (err as Error).message,
+    };
+  }
+
+  const steps: MigrateStep[] = result.steps.map((s) => ({
+    from: s.from,
+    to: s.to,
+    describe: s.describe,
+  }));
+  const diff = diffConfigs(raw, result.migrated);
+
+  // --check: CI gate. A behind-version config is a non-zero exit, no write.
+  if (opts.check) {
+    return {
+      status: "stale",
+      ok: false,
+      fromVersion,
+      toVersion: CONFIG_SCHEMA_VERSION,
+      steps,
+      diff,
+      wrote: false,
+      message: `Config is at v${fromVersion}; current is v${CONFIG_SCHEMA_VERSION}. Run \`kit config migrate\`.`,
+    };
+  }
+
+  // --dry-run: report the plan + diff, write nothing.
+  if (opts.dryRun) {
+    return {
+      status: "dry-run",
+      ok: true,
+      fromVersion,
+      toVersion: CONFIG_SCHEMA_VERSION,
+      steps,
+      diff,
+      wrote: false,
+      message: `Would migrate v${fromVersion} -> v${CONFIG_SCHEMA_VERSION} (${steps.length} step(s)). Nothing written (--dry-run).`,
+    };
+  }
+
+  // Real run. Back up + write + re-validate, with restore-on-failure.
+  const base = {
+    fromVersion,
+    toVersion: CONFIG_SCHEMA_VERSION,
+    steps,
+    diff,
+    backupPath: `${configPath}.backup`,
+  };
+  return performMigration(configPath, content, result.migrated, base, opts.force === true);
+}
+
+/**
+ * Re-parse + validate written config under the Zod schema. Returns an error
+ * string on any problem, else null.
+ */
+function validateWritten(reparsed: RawConfig): string | null {
+  const parsed = kitConfigSchema.safeParse(reparsed);
+  if (!parsed.success) {
+    return parsed.error.issues
+      .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+      .join("; ");
+  }
+  if (detectConfigVersion(reparsed) !== CONFIG_SCHEMA_VERSION) {
+    return `written config did not land at v${CONFIG_SCHEMA_VERSION}`;
+  }
+  return null;
+}
+
+type MigrationBase = Pick<
+  MigrateFileOutcome,
+  "fromVersion" | "toVersion" | "steps" | "diff" | "backupPath"
+>;
+
+/**
+ * The real-run write path: back up the original (refusing to clobber an existing
+ * backup without force), write the migrated TOML, re-parse + validate, and
+ * restore the original if validation fails. Never leaves a corrupt config.
+ */
+async function performMigration(
+  configPath: string,
+  original: string,
+  migrated: RawConfig,
+  base: MigrationBase,
+  force: boolean,
+): Promise<MigrateFileOutcome> {
+  const err = (message: string): MigrateFileOutcome => ({
+    ...base,
+    status: "error",
+    ok: false,
+    wrote: false,
+    message,
+  });
+
+  const backupPath = base.backupPath as string;
+  if ((await fileExists(backupPath)) && !force) {
+    return err(`Backup ${backupPath} already exists. Re-run with --force to overwrite it.`);
+  }
+
+  let migratedToml: string;
+  try {
+    migratedToml = stringify(migrated);
+  } catch (e) {
+    return err(`Could not serialize migrated config: ${(e as Error).message}`);
+  }
+
+  await writeFile(backupPath, original, "utf-8");
+  await writeFile(configPath, migratedToml, "utf-8");
+
+  let validationError: string | null;
+  try {
+    validationError = validateWritten(parse(await readFile(configPath, "utf-8")) as RawConfig);
+  } catch (e) {
+    validationError = `re-parse failed: ${(e as Error).message}`;
+  }
+
+  if (validationError) {
+    await writeFile(configPath, original, "utf-8"); // restore — never leave a corrupt config
+    return err(`Migrated config failed validation and was rolled back: ${validationError}`);
+  }
+
+  return {
+    ...base,
+    status: "migrated",
+    ok: true,
+    wrote: true,
+    message: `Migrated v${base.fromVersion} -> v${CONFIG_SCHEMA_VERSION}. Original saved to ${backupPath}.`,
+  };
+}
+
+function printDiff(diff: ConfigDiffEntry[]): void {
+  if (diff.length === 0) {
+    console.log(`  ${c.dim}(no value-level changes)${c.reset}`);
+    return;
+  }
+  for (const entry of diff) {
+    if (entry.before === undefined) {
+      console.log(`  ${c.green}+ ${entry.path} = ${entry.after}${c.reset}`);
+    } else if (entry.after === undefined) {
+      console.log(`  ${c.red}- ${entry.path} = ${entry.before}${c.reset}`);
+    } else {
+      console.log(`  ${c.yellow}~ ${entry.path}: ${entry.before} -> ${entry.after}${c.reset}`);
+    }
+  }
+}
+
+async function cmdConfigMigrate(): Promise<boolean> {
+  const dryRun = hasFlag(process.argv, "--dry-run");
+  const check = hasFlag(process.argv, "--check");
+  const force = hasFlag(process.argv, "--force");
+
+  const outcome = await migrateConfigFile(resolveConfigPath(), { dryRun, check, force });
+
+  switch (outcome.status) {
+    case "already-current":
+      console.log(`${c.green}✓${c.reset} ${outcome.message}`);
+      break;
+    case "stale":
+      console.log(`${c.red}✗${c.reset} ${outcome.message}`);
+      break;
+    case "dry-run":
+      console.log(`${c.bold}Planned migration${c.reset} (dry run)\n`);
+      for (const step of outcome.steps) {
+        console.log(`  v${step.from} -> v${step.to}: ${c.dim}${step.describe}${c.reset}`);
+      }
+      console.log(`\n${c.bold}Changes:${c.reset}`);
+      printDiff(outcome.diff);
+      console.log(`\n${c.dim}${outcome.message}${c.reset}`);
+      break;
+    case "migrated":
+      console.log(`${c.green}✓${c.reset} ${outcome.message}\n`);
+      console.log(`${c.bold}Applied:${c.reset}`);
+      for (const step of outcome.steps) {
+        console.log(`  v${step.from} -> v${step.to}: ${c.dim}${step.describe}${c.reset}`);
+      }
+      console.log(`\n${c.bold}Changes:${c.reset}`);
+      printDiff(outcome.diff);
+      break;
+    case "error":
+      console.error(`${c.red}Error: ${outcome.message}${c.reset}`);
+      break;
+  }
+
+  return outcome.ok;
+}
+
+export async function cmdConfig(): Promise<boolean> {
+  const sub = process.argv[3];
+
+  if (sub === "migrate") return cmdConfigMigrate();
+
+  // Default / help: show the current config version + available subcommands.
+  if (!sub || sub === "--help" || sub === "-h") {
+    try {
+      const content = await readFile(resolveConfigPath(), "utf-8");
+      const raw = parse(content) as RawConfig;
+      const version = detectConfigVersion(raw);
+      const tag =
+        version === CONFIG_SCHEMA_VERSION
+          ? `${c.green}(current)${c.reset}`
+          : `${c.yellow}(behind v${CONFIG_SCHEMA_VERSION} — run \`kit config migrate\`)${c.reset}`;
+      console.log(`${c.bold}${KIT_FILE}${c.reset} schema version: v${version} ${tag}`);
+    } catch (err) {
+      console.log(`${c.dim}No readable ${KIT_FILE}: ${(err as Error).message}${c.reset}`);
+    }
+    console.log(`\n${c.bold}Subcommands:${c.reset}`);
+    console.log(
+      `  ${c.cyan}kit config migrate${c.reset}             Migrate ${KIT_FILE} to v${CONFIG_SCHEMA_VERSION}`,
+    );
+    console.log(
+      `  ${c.cyan}kit config migrate --dry-run${c.reset}   Show the plan + diff, write nothing`,
+    );
+    console.log(
+      `  ${c.cyan}kit config migrate --check${c.reset}     Exit non-zero if behind (CI gate)`,
+    );
+    console.log(
+      `  ${c.cyan}kit config migrate --force${c.reset}     Overwrite an existing ${KIT_FILE}.backup`,
+    );
+    return true;
+  }
+
+  console.error(`${c.red}Unknown config subcommand: ${sub}${c.reset}`);
+  console.error(`Run \`kit config\` to see subcommands.`);
+  return false;
+}

--- a/src/config-migrate.test.ts
+++ b/src/config-migrate.test.ts
@@ -1,0 +1,92 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { CONFIG_SCHEMA_VERSION } from "./config.js";
+import {
+  detectConfigVersion,
+  planMigrations,
+  migrateConfig,
+  diffConfigs,
+  MIGRATIONS,
+} from "./config-migrate.js";
+
+describe("detectConfigVersion", () => {
+  it("treats an absent version field as legacy v0", () => {
+    assert.equal(detectConfigVersion({ tools: { node: "22" } }), 0);
+  });
+
+  it("reads an explicit integer version", () => {
+    assert.equal(detectConfigVersion({ version: 1 }), 1);
+  });
+
+  it("treats a non-integer / negative version as v0 (defensive)", () => {
+    assert.equal(detectConfigVersion({ version: 1.5 }), 0);
+    assert.equal(detectConfigVersion({ version: -3 }), 0);
+    assert.equal(detectConfigVersion({ version: "1" as unknown as number }), 0);
+  });
+});
+
+describe("planMigrations", () => {
+  it("yields the v0->v1 step for (0, 1)", () => {
+    const steps = planMigrations(0, 1);
+    assert.equal(steps.length, 1);
+    assert.equal(steps[0].from, 0);
+    assert.equal(steps[0].to, 1);
+  });
+
+  it("returns no steps when already at target", () => {
+    assert.deepEqual(planMigrations(1, 1), []);
+  });
+
+  it("throws on a downgrade (config newer than this kit)", () => {
+    assert.throws(() => planMigrations(2, 1), /newer than this kit/);
+  });
+
+  it("throws when no migration is registered for a gap", () => {
+    assert.throws(() => planMigrations(0, 99), /No migration registered/);
+  });
+
+  it("registry rows are contiguous single steps", () => {
+    for (const m of MIGRATIONS) {
+      assert.equal(m.to, m.from + 1, `migration ${m.from}->${m.to} must be a single step`);
+    }
+  });
+});
+
+describe("migrateConfig", () => {
+  it("stamps version and reports changed for a legacy config", () => {
+    const input = { tools: { node: "22" } };
+    const result = migrateConfig(input);
+    assert.equal(result.fromVersion, 0);
+    assert.equal(result.toVersion, CONFIG_SCHEMA_VERSION);
+    assert.equal(result.changed, true);
+    assert.equal(result.steps.length, 1);
+    assert.equal((result.migrated as { version?: number }).version, 1);
+    // Existing fields preserved.
+    assert.deepEqual((result.migrated as { tools?: unknown }).tools, { node: "22" });
+  });
+
+  it("does not mutate the input object", () => {
+    const input = { tools: { node: "22" } };
+    migrateConfig(input);
+    assert.equal("version" in input, false);
+  });
+
+  it("is a no-op when already at the current version", () => {
+    const input = { version: 1, tools: { node: "22" } };
+    const result = migrateConfig(input);
+    assert.equal(result.changed, false);
+    assert.deepEqual(result.steps, []);
+  });
+});
+
+describe("diffConfigs", () => {
+  it("reports the stamped version as an added path", () => {
+    const before = { tools: { node: "22" } };
+    const after = { version: 1, tools: { node: "22" } };
+    const diff = diffConfigs(before, after);
+    assert.equal(diff.length, 1);
+    assert.equal(diff[0].path, "version");
+    assert.equal(diff[0].before, undefined);
+    assert.equal(diff[0].after, "1");
+  });
+});

--- a/src/config-migrate.ts
+++ b/src/config-migrate.ts
@@ -1,0 +1,166 @@
+// Deterministic, pure .kit.toml schema migration registry.
+//
+// This is the "first move" of the config contract freeze: a major kit bump must
+// never silently re-interpret an existing user's config. Every breaking shape
+// change becomes an ordered data row below. The framework detects the config's
+// current version, plans the path of migrations up to CONFIG_SCHEMA_VERSION, and
+// applies them in order — all as pure object transforms (no IO), so the file-IO
+// layer (commands/config.ts) can back up, write, then re-validate the result.
+//
+// A config with no [version] field is legacy "v0". v1 is the baseline: the
+// v0->v1 migration stamps version=1 and changes no other field. The point is the
+// FRAMEWORK, which is real and extensible — a future field rename is one row.
+import { CONFIG_SCHEMA_VERSION } from "./config.js";
+
+/** A parsed-but-untyped config object (smol-toml output / Zod input). */
+export type RawConfig = Record<string, unknown>;
+
+export interface ConfigMigration {
+  /** Schema version this migration upgrades FROM. */
+  from: number;
+  /** Schema version this migration upgrades TO (must equal from + 1). */
+  to: number;
+  /** Human-readable summary of what this step changes. */
+  describe: string;
+  /** Pure transform: returns a NEW object, never mutates the input. */
+  apply(cfg: RawConfig): RawConfig;
+}
+
+/**
+ * Ordered migration registry. Each row upgrades exactly one version step.
+ * Keep contiguous (0->1->2->…) so planMigrations can always find a path.
+ */
+export const MIGRATIONS: ConfigMigration[] = [
+  {
+    from: 0,
+    to: 1,
+    describe: "Stamp schema version=1 (baseline; no field renames)",
+    apply(cfg) {
+      // No-op transform beyond stamping the version. v1 is the current shape.
+      return { ...cfg, version: 1 };
+    },
+  },
+];
+
+/**
+ * Detect the schema version of a parsed config. Absent / non-integer / negative
+ * version => legacy v0 (every config written before versioning existed).
+ */
+export function detectConfigVersion(cfg: RawConfig): number {
+  const v = cfg.version;
+  if (typeof v === "number" && Number.isInteger(v) && v >= 0) return v;
+  return 0;
+}
+
+/**
+ * Compute the ordered list of migration steps to get from `from` to `to`.
+ * Returns [] when already at the target. Throws on a downgrade (config newer
+ * than this kit) or a gap in the registry — fail loud, never corrupt.
+ */
+export function planMigrations(from: number, to: number): ConfigMigration[] {
+  if (from === to) return [];
+  if (from > to) {
+    throw new Error(
+      `Config is at v${from}, newer than this kit's v${to}. Upgrade kit instead of migrating down.`,
+    );
+  }
+  const steps: ConfigMigration[] = [];
+  let cursor = from;
+  while (cursor < to) {
+    const step = MIGRATIONS.find((m) => m.from === cursor);
+    if (!step) {
+      throw new Error(`No migration registered from config v${cursor} (target v${to}).`);
+    }
+    if (step.to !== cursor + 1) {
+      throw new Error(
+        `Migration from v${step.from} must go to v${step.from + 1}, not v${step.to}.`,
+      );
+    }
+    steps.push(step);
+    cursor = step.to;
+  }
+  return steps;
+}
+
+export interface MigrationResult {
+  /** The migrated config object (input unchanged when no steps applied). */
+  migrated: RawConfig;
+  /** Detected starting version. */
+  fromVersion: number;
+  /** Target version (CONFIG_SCHEMA_VERSION unless overridden). */
+  toVersion: number;
+  /** The steps that were applied, in order. */
+  steps: ConfigMigration[];
+  /** True when at least one migration step ran. */
+  changed: boolean;
+}
+
+/**
+ * Pure migration of a parsed config object from its detected version up to
+ * `target` (default CONFIG_SCHEMA_VERSION). Does not touch the filesystem and
+ * does not mutate the input.
+ */
+export function migrateConfig(
+  cfg: RawConfig,
+  target: number = CONFIG_SCHEMA_VERSION,
+): MigrationResult {
+  const fromVersion = detectConfigVersion(cfg);
+  const steps = planMigrations(fromVersion, target);
+  let migrated: RawConfig = cfg;
+  for (const step of steps) {
+    migrated = step.apply(migrated);
+  }
+  return {
+    migrated,
+    fromVersion,
+    toVersion: target,
+    steps,
+    changed: steps.length > 0,
+  };
+}
+
+export interface ConfigDiffEntry {
+  path: string;
+  before: string | undefined;
+  after: string | undefined;
+}
+
+/**
+ * Flatten a config object to dotted-path => scalar string entries, for a
+ * deterministic, value-level diff (independent of TOML key ordering).
+ */
+function flatten(
+  obj: RawConfig,
+  prefix = "",
+  out: Map<string, string> = new Map(),
+): Map<string, string> {
+  for (const [key, value] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      flatten(value as RawConfig, path, out);
+    } else {
+      out.set(path, JSON.stringify(value));
+    }
+  }
+  return out;
+}
+
+/**
+ * Value-level diff of two parsed configs (before -> after). Returns sorted
+ * entries where a path was added, removed, or changed.
+ */
+export function diffConfigs(before: RawConfig, after: RawConfig): ConfigDiffEntry[] {
+  const a = flatten(before);
+  const b = flatten(after);
+  const paths = new Set([...a.keys(), ...b.keys()]);
+  const entries: ConfigDiffEntry[] = [];
+  for (const path of paths) {
+    const bv = a.get(path);
+    const av = b.get(path);
+    if (bv !== av) {
+      entries.push({ path, before: bv, after: av });
+    }
+  }
+  entries.sort((x, y) => x.path.localeCompare(y.path));
+  return entries;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -310,7 +310,23 @@ export interface SetupConfig {
   verify?: string;
 }
 
+/**
+ * The current/baseline .kit.toml schema version. A config with no [version]
+ * field is treated as legacy "v0" (every config written before versioning
+ * existed). `kit config migrate` walks a config from its detected version up to
+ * this value. Bump this (and add a migration row in config-migrate.ts) whenever a
+ * breaking config-shape change lands — never silently re-interpret old configs.
+ */
+export const CONFIG_SCHEMA_VERSION = 1;
+
 export interface kitConfig {
+  /**
+   * Schema version of this .kit.toml. Absent => legacy v0 (migrate stamps it).
+   * Single integer (not a [meta] table): .kit.toml is entirely kit's namespace,
+   * so a top-level scalar is unambiguous and is the smallest possible addition
+   * needed to freeze the config contract.
+   */
+  version?: number;
   tools?: ToolConfig;
   services?: Record<string, ServiceConfig>;
   /** Project bootstrap commands (deps install, migrate, verify). */
@@ -540,6 +556,7 @@ const WebConfigSchema = z
 
 // Known top-level section names — used to detect typos
 const KNOWN_SECTIONS = new Set([
+  "version", // top-level schema-version scalar (kit config migrate)
   "tools",
   "services",
   "secrets",
@@ -556,8 +573,9 @@ const KNOWN_SECTIONS = new Set([
   "air_gap", // [air_gap] — no-egress / offline config (#85)
 ]);
 
-const kitConfigSchema = z
+export const kitConfigSchema = z
   .object({
+    version: z.number().int().nonnegative().optional(),
     tools: z.record(z.string(), z.string()).optional(),
     services: z.record(z.string(), ServiceConfigSchema).optional(),
     secrets: SecretsConfigSchema.optional(),


### PR DESCRIPTION
kit 2.0 **Phase 1 (frozen contracts)** — the **first move / one-way door**. A versioned config schema + deterministic migration so a future breaking config change is migrated, never silently corrupting an existing `.kit.toml`.

- New optional top-level `version` field (`CONFIG_SCHEMA_VERSION = 1`; absent = legacy v0).
- **`kit config migrate`** — ordered, pure, fixture-tested migration registry from the detected version to current:
  - `--dry-run`: prints the plan + a value-level diff, writes nothing.
  - real run: writes `.kit.toml.backup` first (refuses to clobber without `--force`), then **re-parses + Zod-validates** the result and **restores the original on any failure** — never leaves a corrupt config.
  - `--check`: exits non-zero on a stale config (CI gate).
- v0→v1 only stamps the version (v1 = baseline), but the framework is real and extensible — a future field rename is a single data row. New top-level `config` command.

**Verification:** build clean, `kit self-audit` 0 fail, 20 new migration tests (Node 22). The one local `self-audit --fail-on-warning` failure is the known iCloud `' 2'` working-tree junk tripping R12-dup-source; a clean CI checkout has none and passes — **this CI run is the authoritative clean-tree verification** (as 1.40.0 already demonstrated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)