### PR TITLE
docs: state the repo is not pure TypeScript

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,9 @@ npm run dev -- test
 
 ### Code Style
 
-- Use TypeScript for all code
+- Use TypeScript for the CLI and library code (the `src/` tree). JavaScript is
+  only for tooling — `eslint.config.js` and the `scripts/` helpers (`.js`/`.mjs`)
+  — and the triage gate's sandboxed checker is Python (`skills/triage/`).
 - Follow the existing patterns in the codebase
 - ESM modules only (no CommonJS)
 - Include tests for new features

--- a/README.md
+++ b/README.md
@@ -847,4 +847,4 @@ See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
 - [mise-en-place](https://mise.jdx.dev): tool version management
 - [1Password CLI](https://developer.1password.com/docs/cli/): secret management
-- Node.js CLI (TypeScript)
+- Node.js CLI (primarily TypeScript; JavaScript tooling/scripts, plus a Python triage checker)


### PR DESCRIPTION
GitHub's language stats correctly show **JavaScript** (`eslint.config.js`, the `scripts/` helpers) and **Python** (the triage checker) alongside the TypeScript `src/` tree, but two docs claim it's pure TypeScript:

- `CONTRIBUTING.md`: "Use TypeScript for all code" → clarified that TypeScript is for `src/` (CLI/library), JS is tooling only, and the triage gate is Python.
- `README.md` Stack: "Node.js CLI (TypeScript)" → "primarily TypeScript; JavaScript tooling/scripts, plus a Python triage checker".

Docs-only, no code change. Built fresh against current main (2.1.1) — supersedes the stale `docs/language-accuracy` branch (cut from 1.x), which can be deleted.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_