### PR TITLE
docs(agents): explicit per-agent support matrix in README + help

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,33 @@ vault your secrets" block into the agent's rules file (`CLAUDE.md`, `AGENTS.md`,
 `.cursorrules`, `.clinerules`). Run it standalone any time with `kit agent-config`.
 The block is regenerated in place on re-run; edit outside its markers freely.
 
+## Agent support
+
+kit is **agent-agnostic** — it's a CLI that any coding agent can run, plus opt-in
+adapters for the surfaces each agent exposes. Support today, per agent:
+
+| Agent | Memory index¹ | "use kit" rules block² | Agent/MCP config audit³ | Perm allowlist⁴ | Auto-capture hooks⁵ | Blocking gate⁶ |
+| :--- | :---: | :---: | :---: | :---: | :---: | :---: |
+| **Claude Code** | ✅ | ✅ `CLAUDE.md` | ✅ + commands/agents/skills/plugins | ✅ | ✅ | 🔜 verified |
+| **OpenAI Codex** | ✅ | ✅ `AGENTS.md` | ✅ `.codex/config` | — | — | 🔜 verified |
+| **OpenCode** | ✅ | ✅ `AGENTS.md` | ✅ `opencode.json` | — | — | 🔎 research |
+| **Cursor** | ✅ | ✅ `.cursorrules` | ✅ `.cursor/mcp.json` | — | — | 🔎 research |
+| **Cline** | ✅ | ✅ `.clinerules` | — | — | — | 🔎 research |
+| **Gemini CLI** | ✅ | — | — | — | — | 🔎 research |
+| **Continue** | ✅ | — | — | — | — | 🔎 research |
+| **Amazon Q** | ✅ | — | — | — | — | 🔜 verified |
+
+✅ supported · — not yet · 🔜 planned, agent's blocking-hook capability verified · 🔎 planned, needs research ([#146](https://github.com/sandstream/kit/issues/146))
+
+1. `kit memory index` parses the agent's local transcripts into the shared store.
+2. `kit agent-config` writes the managed "run kit before installs / vault secrets" block into the agent's rules file.
+3. `kit agent-audit` flags plaintext secrets, cleartext/inline-code MCP servers, and malware-shaped hooks in the agent's config. Generic `.mcp.json` / `.claude.json` are scanned for every agent regardless.
+4. kit can pre-authorize its read-only commands so they run without a prompt (Claude Code's `permissions.allow` today).
+5. kit registers lifecycle hooks so memory capture happens automatically (Claude Code `settings.json` hooks today).
+6. A **true blocking gate** (deny an un-triaged install before it runs) requires the agent's `PreToolUse`-style hook. Verified available for Claude Code, Codex, and Amazon Q; the rest need a research pass. Until then, the agent-agnostic enforcement floor is **git hooks** (`kit hooks`, pre-commit/pre-push) — they fire in any agent or none. See [#146](https://github.com/sandstream/kit/issues/146).
+
+> The git-hook layer enforces at the VCS boundary regardless of agent; the rules-file block is **advisory** (it reminds the agent); only the blocking-gate hook **enforces** before an action runs.
+
 `kit check`, grouped status tables with a pass/fail summary:
 
 ```text

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1503,6 +1503,15 @@ async function cmdAgentConfig(): Promise<boolean> {
     `\n${c.dim}Blocks regenerate in place on re-run; edit outside the markers freely. ` +
       `Mutating kit commands (secrets/fix/hooks) still prompt by design.${c.reset}`,
   );
+  console.log(
+    `\n${c.bold}Agent support${c.reset} ${c.dim}(what kit wires up per agent):${c.reset}\n` +
+      `  ${c.dim}· Memory index: Claude Code, Codex, Cursor, Cline, Gemini, Continue, Amazon Q, OpenCode${c.reset}\n` +
+      `  ${c.dim}· "use kit" rules block: Claude Code, Codex, Cursor, Cline, OpenCode${c.reset}\n` +
+      `  ${c.dim}· Config/secret audit (kit agent-audit): Claude Code, Codex, Cursor, OpenCode (+ generic .mcp.json)${c.reset}\n` +
+      `  ${c.dim}· Permission allowlist + auto-capture hooks: Claude Code${c.reset}\n` +
+      `  ${c.dim}· Blocking install-gate (PreToolUse): planned — verified for Claude Code/Codex/Amazon Q (see issue #146)${c.reset}\n` +
+      `  ${c.dim}The agent-agnostic enforcement floor is git hooks (${c.reset}${c.bold}kit hooks${c.reset}${c.dim}); the rules block only advises.${c.reset}`,
+  );
   return !failed;
 }
 


### PR DESCRIPTION
Documents per-agent support explicitly and honestly — what kit wires up **today** vs what's planned — across the 8 supported agents.

## README — new "Agent support" section
A matrix with columns: **memory index · "use kit" rules block · agent/MCP config audit · permission allowlist · auto-capture hooks · blocking gate**, for Claude Code, Codex, OpenCode, Cursor, Cline, Gemini CLI, Continue, Amazon Q. Legend distinguishes:
- ✅ supported today
- — not yet
- 🔜 planned, agent's blocking-hook capability **verified** (Claude Code / Codex / Amazon Q)
- 🔎 planned, **needs research** (the other agents) — links to #146

Footnotes spell out what each column means and the key distinction: **rules block advises, git hooks are the agent-agnostic enforcement floor, only a `PreToolUse` hook truly blocks before an action runs.**

## `kit agent-config` help
Now prints the same per-agent support summary + the advise-vs-enforce note, so it's visible in the CLI, not just the README.

Docs/help only — no behavior change. Full suite **1806/0**, tsc + format:check clean.

Note: the marketing site (sandstre.am/kit) lives in a separate repo outside this session's scope — equivalent copy is being handed to the maintainer to paste there.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_