### PR TITLE
feat(install-gate): deterministic core for triage-before-install in auto-mode

### DIFF
--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -1,0 +1,153 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseInstallCommand, decideBashGate } from "./install-gate.js";
+import type { GateDeps } from "./triage-gate.js";
+import type { TriageType } from "./triage.js";
+
+describe("parseInstallCommand — detection", () => {
+  const refs = (cmd: string) => parseInstallCommand(cmd).refs;
+
+  it("npm install / i / add → npm refs", () => {
+    assert.deepEqual(refs("npm install express"), ["npm:express"]);
+    assert.deepEqual(refs("npm i express"), ["npm:express"]);
+    assert.deepEqual(refs("npm add express"), ["npm:express"]);
+  });
+
+  it("skips flags (npm i -g typescript)", () => {
+    assert.deepEqual(refs("npm i -g typescript"), ["npm:typescript"]);
+    assert.deepEqual(refs("npm install --save-dev jest"), ["npm:jest"]);
+  });
+
+  it("pnpm / yarn / bun add", () => {
+    assert.deepEqual(refs("pnpm add react react-dom"), ["npm:react", "npm:react-dom"]);
+    assert.deepEqual(refs("yarn add lodash@4.17.21"), ["npm:lodash"]); // version stripped
+    assert.deepEqual(refs("bun add zod"), ["npm:zod"]);
+  });
+
+  it("scoped packages keep the scope, drop the version", () => {
+    assert.deepEqual(refs("npm install @modelcontextprotocol/sdk@1.2.3"), [
+      "npm:@modelcontextprotocol/sdk",
+    ]);
+  });
+
+  it("npx / bunx execution is gated (first non-flag token)", () => {
+    assert.deepEqual(refs("npx create-react-app"), ["npm:create-react-app"]);
+    assert.deepEqual(refs("npx -y cowsay"), ["npm:cowsay"]);
+    assert.deepEqual(refs("bunx vite"), ["npm:vite"]);
+  });
+
+  it("pip / pip3 / pipx / uv / python -m pip", () => {
+    assert.deepEqual(refs("pip install requests"), ["pip:requests"]);
+    assert.deepEqual(refs("pip3 install Flask>=2.0"), ["pip:Flask"]); // version spec stripped
+    assert.deepEqual(refs("pipx install black"), ["pip:black"]);
+    assert.deepEqual(refs("uv add httpx"), ["pip:httpx"]);
+    assert.deepEqual(refs("uv pip install numpy"), ["pip:numpy"]);
+    assert.deepEqual(refs("python -m pip install pandas"), ["pip:pandas"]);
+    assert.deepEqual(refs("python3 -m pip install scipy"), ["pip:scipy"]);
+  });
+
+  it("pip extras keep just the name", () => {
+    assert.deepEqual(refs("pip install 'requests[security]'".replace(/'/g, "")), ["pip:requests"]);
+  });
+
+  it("bare reinstall (no package args) is NOT an install", () => {
+    assert.equal(parseInstallCommand("npm install").isInstall, false);
+    assert.equal(parseInstallCommand("yarn").isInstall, false);
+    assert.equal(parseInstallCommand("pnpm install").isInstall, false);
+    assert.equal(parseInstallCommand("npm ci").isInstall, false);
+  });
+
+  it("local targets are ignored (user's own code)", () => {
+    assert.deepEqual(parseInstallCommand("npm i ./local-pkg").refs, []);
+    assert.deepEqual(parseInstallCommand("pip install -e .").refs, []);
+    assert.deepEqual(parseInstallCommand("pip install ./dist/foo.whl").refs, []);
+    assert.deepEqual(parseInstallCommand("npm i ../sibling").refs, []);
+  });
+
+  it("chained commands gate every install", () => {
+    const p = parseInstallCommand("npm i a && pip install b ; npx c");
+    assert.deepEqual(p.refs.sort(), ["npm:a", "npm:c", "pip:b"]);
+  });
+
+  it("dedups repeated targets", () => {
+    assert.deepEqual(refs("npm i express express"), ["npm:express"]);
+  });
+
+  it("out-of-scope ecosystems pass through (not flagged)", () => {
+    assert.equal(parseInstallCommand("cargo add serde").isInstall, false);
+    assert.equal(parseInstallCommand("go install x@latest").isInstall, false);
+    assert.equal(parseInstallCommand("gem install rails").isInstall, false);
+    assert.equal(parseInstallCommand("brew install jq").isInstall, false);
+  });
+
+  it("non-install commands are ignored", () => {
+    assert.equal(parseInstallCommand("git status").isInstall, false);
+    assert.equal(parseInstallCommand("ls -la && echo hi").isInstall, false);
+    assert.equal(parseInstallCommand("npm run build").isInstall, false);
+    assert.equal(parseInstallCommand("npm test").isInstall, false);
+  });
+
+  it("fail-closed: an in-scope install with an unreducible target is unverifiable", () => {
+    const p = parseInstallCommand("npm install git+https://github.com/evil/pkg");
+    assert.equal(p.isInstall, true);
+    assert.equal(p.refs.length, 0);
+    assert.equal(p.unverifiable.length, 1);
+  });
+
+  it("handles empty / garbage input", () => {
+    assert.equal(parseInstallCommand("").isInstall, false);
+    // @ts-expect-error intentional bad input
+    assert.equal(parseInstallCommand(undefined).isInstall, false);
+  });
+});
+
+// Fake triage: pass everything except names in `blocklist`.
+function fakeDeps(blocklist: string[] = []): GateDeps {
+  return {
+    runTriage: async (type: TriageType, target: string) => ({
+      type,
+      target,
+      passed: !blocklist.includes(target),
+      output: blocklist.includes(target) ? "TRIAGE FAILED" : "TRIAGE PASSED",
+    }),
+  };
+}
+
+describe("decideBashGate — decision", () => {
+  it("allows a non-install command without triaging", async () => {
+    const v = await decideBashGate("git status", fakeDeps());
+    assert.equal(v.block, false);
+    assert.equal(v.checked.length, 0);
+  });
+
+  it("allows when every target triages PASS", async () => {
+    const v = await decideBashGate("npm i express && pip install requests", fakeDeps());
+    assert.equal(v.block, false);
+    assert.equal(v.checked.length, 2);
+  });
+
+  it("BLOCKS when any target fails triage (fail-closed)", async () => {
+    const v = await decideBashGate("npm i express evil-pkg", fakeDeps(["evil-pkg"]));
+    assert.equal(v.block, true);
+    assert.match(v.reason, /triage did not pass|evil-pkg/);
+  });
+
+  it("BLOCKS an unverifiable in-scope install without calling triage", async () => {
+    let called = false;
+    const deps: GateDeps = {
+      runTriage: async (type, target) => {
+        called = true;
+        return { type, target, passed: true, output: "" };
+      },
+    };
+    const v = await decideBashGate("npm install git+https://github.com/x/y", deps);
+    assert.equal(v.block, true);
+    assert.equal(called, false, "must not triage when target is unverifiable — block outright");
+    assert.match(v.reason, /cannot reduce to a triage target/);
+  });
+
+  it("local-only install neither blocks nor triages", async () => {
+    const v = await decideBashGate("pip install -e .", fakeDeps());
+    assert.equal(v.block, false);
+  });
+});

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -80,7 +80,10 @@ const MATCHERS: Matcher[] = [
     argStart: (t) => {
       const bin = t[0];
       if (bin === "npm" && /^(install|i|add)$/.test(t[1] ?? "")) return 2;
-      if ((bin === "pnpm" || bin === "yarn" || bin === "bun") && /^(add|install|i)$/.test(t[1] ?? ""))
+      if (
+        (bin === "pnpm" || bin === "yarn" || bin === "bun") &&
+        /^(add|install|i)$/.test(t[1] ?? "")
+      )
         return 2;
       return -1;
     },
@@ -157,10 +160,7 @@ export interface BashGateVerdict {
  * target via `gateInstall`. Fail-closed — any blocked target, or any
  * unverifiable in-scope arg, blocks the whole command.
  */
-export async function decideBashGate(
-  command: string,
-  deps?: GateDeps,
-): Promise<BashGateVerdict> {
+export async function decideBashGate(command: string, deps?: GateDeps): Promise<BashGateVerdict> {
   const probe = parseInstallCommand(command);
   if (!probe.isInstall) {
     return { block: false, reason: "no in-scope package install detected", checked: [] };

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -1,0 +1,191 @@
+/**
+ * Install-gate — make "installs nothing untriaged" true even in agent auto-mode.
+ *
+ * A rules-file instruction ("run kit triage before installing") only ADVISES; an
+ * agent in auto/bypass mode can run `npm install evil` directly and the malicious
+ * postinstall fires immediately — before any commit, so git hooks are too late.
+ * The only real gate is a Claude Code (or Codex / Amazon Q) `PreToolUse` hook that
+ * inspects the pending Bash command and BLOCKS it (exit 2) unless the package is
+ * triaged.
+ *
+ * This module is the deterministic core: `parseInstallCommand` turns a raw Bash
+ * string into kit triage refs (npm:/pip:), and `decideBashGate` triages each via
+ * the existing `gateInstall` and returns a block/allow verdict. Pure + injectable
+ * (no I/O here); the CLI wires it to stdin/exit-codes.
+ *
+ * Scope: the ecosystems kit can actually triage — npm (npm/pnpm/yarn/bun + npx)
+ * and PyPI (pip/pip3/pipx/uv). Ecosystems kit has no triage for (cargo/go/gem/
+ * brew) are passed through, NOT blocked, so the gate stays usable; that is an
+ * honest scope limit, documented as such. Within scope it is FAIL-CLOSED: an
+ * install whose target we cannot reduce to a clean registry name is blocked.
+ */
+import { gateInstall, type GateVerdict, type GateDeps } from "./triage-gate.js";
+
+export interface InstallProbe {
+  /** A package-manager add/install in a covered ecosystem was detected. */
+  isInstall: boolean;
+  /** kit triage refs to gate, e.g. ["npm:express", "pip:requests"]. */
+  refs: string[];
+  /** Covered-ecosystem install args we could not reduce to a clean ref (fail-closed → block). */
+  unverifiable: string[];
+}
+
+/** Shell operators that separate independent commands in one Bash string. */
+const SEGMENT_SPLIT = /\s*(?:&&|\|\||;|\||\n)\s*/;
+
+/** A token is a flag (skip it) — `-g`, `--save-dev`, etc. */
+function isFlag(tok: string): boolean {
+  return tok.startsWith("-");
+}
+
+/**
+ * A token is a LOCAL target (the user's own code / a file), not a registry
+ * package — skip it (there is no reputation to triage). Covers `.`/`..`, relative
+ * and absolute paths, home-relative, tarballs/wheels.
+ */
+function isLocalTarget(tok: string): boolean {
+  if (tok === "." || tok === "..") return true;
+  if (/^[./~]/.test(tok)) return true; // ./x  ../x  /abs  ~/x
+  if (/\.(tgz|tar\.gz|whl)$/i.test(tok)) return true;
+  return false;
+}
+
+/** A clean npm package name (optionally scoped, optionally @version) → bare name. */
+function npmName(tok: string): string | null {
+  // @scope/name(@version)?  or  name(@version)?
+  const m = tok.match(/^(@[a-z0-9][\w.-]*\/[a-z0-9][\w.-]*|[a-z0-9][\w.-]*)(@[^/\s]+)?$/i);
+  return m ? m[1] : null;
+}
+
+/** A clean PyPI requirement (name plus optional extras/version spec) → bare name. */
+function pipName(tok: string): string | null {
+  // requests , requests==1.2 , requests[extra] , Flask>=2 — name is the leading run.
+  const m = tok.match(/^([a-z0-9][\w.-]*)(\[[\w,.-]*\])?\s*([<>=!~].*)?$/i);
+  return m ? m[1] : null;
+}
+
+interface Matcher {
+  /** Does this segment's leading tokens start an in-scope install? Returns the index of the first ARG token, or -1. */
+  argStart(tokens: string[]): number;
+  scheme: "npm" | "pip";
+  toName(tok: string): string | null;
+}
+
+/** Recognized package-manager invocations, by leading-token shape. */
+const MATCHERS: Matcher[] = [
+  // npm install|i|add <pkg...>, pnpm add|install, yarn add, bun add
+  {
+    scheme: "npm",
+    toName: npmName,
+    argStart: (t) => {
+      const bin = t[0];
+      if (bin === "npm" && /^(install|i|add)$/.test(t[1] ?? "")) return 2;
+      if ((bin === "pnpm" || bin === "yarn" || bin === "bun") && /^(add|install|i)$/.test(t[1] ?? ""))
+        return 2;
+      return -1;
+    },
+  },
+  // npx <pkg> — executes a package immediately (high risk)
+  {
+    scheme: "npm",
+    toName: npmName,
+    argStart: (t) => (t[0] === "npx" || t[0] === "bunx" ? 1 : -1),
+  },
+  // pip/pip3 install, pipx install, uv pip install, uv add, python -m pip install
+  {
+    scheme: "pip",
+    toName: pipName,
+    argStart: (t) => {
+      if ((t[0] === "pip" || t[0] === "pip3" || t[0] === "pipx") && t[1] === "install") return 2;
+      if (t[0] === "uv" && t[1] === "pip" && t[2] === "install") return 3;
+      if (t[0] === "uv" && t[1] === "add") return 2;
+      if (
+        (t[0] === "python" || t[0] === "python3") &&
+        t[1] === "-m" &&
+        t[2] === "pip" &&
+        t[3] === "install"
+      )
+        return 4;
+      return -1;
+    },
+  },
+];
+
+/**
+ * Parse a raw Bash command for in-scope package installs. Pure. Conservative:
+ * bare `npm install` (no package args, i.e. reinstall declared deps) is NOT an
+ * add and is ignored; local paths are ignored; a covered-ecosystem add whose
+ * target is neither a clean name nor a local path is `unverifiable` (→ block).
+ */
+export function parseInstallCommand(command: string): InstallProbe {
+  const probe: InstallProbe = { isInstall: false, refs: [], unverifiable: [] };
+  if (!command || typeof command !== "string") return probe;
+
+  for (const segment of command.split(SEGMENT_SPLIT)) {
+    const tokens = segment.trim().split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) continue;
+    for (const m of MATCHERS) {
+      const start = m.argStart(tokens);
+      if (start < 0) continue;
+      const args = tokens.slice(start).filter((t) => !isFlag(t));
+      // No package args → reinstall of already-declared deps (or a runner with no
+      // pkg). Not an "add"; don't gate.
+      if (args.length === 0) break;
+      probe.isInstall = true;
+      for (const arg of args) {
+        if (isLocalTarget(arg)) continue; // user's own code — nothing to triage
+        const name = m.toName(arg);
+        if (name) probe.refs.push(`${m.scheme}:${name}`);
+        else probe.unverifiable.push(arg); // fail-closed: can't reduce to a ref
+      }
+      break; // one matcher per segment
+    }
+  }
+  // De-dup refs (npm i a a, or a && a)
+  probe.refs = [...new Set(probe.refs)];
+  return probe;
+}
+
+export interface BashGateVerdict {
+  block: boolean;
+  reason: string;
+  checked: GateVerdict[];
+}
+
+/**
+ * Decide whether a Bash command should be blocked: triage every in-scope install
+ * target via `gateInstall`. Fail-closed — any blocked target, or any
+ * unverifiable in-scope arg, blocks the whole command.
+ */
+export async function decideBashGate(
+  command: string,
+  deps?: GateDeps,
+): Promise<BashGateVerdict> {
+  const probe = parseInstallCommand(command);
+  if (!probe.isInstall) {
+    return { block: false, reason: "no in-scope package install detected", checked: [] };
+  }
+  if (probe.unverifiable.length > 0) {
+    return {
+      block: true,
+      reason: `cannot reduce to a triage target: ${probe.unverifiable.join(", ")} — run \`kit triage\` manually, or install via \`kit pkg\` (fail-closed)`,
+      checked: [],
+    };
+  }
+  const checked: GateVerdict[] = [];
+  for (const ref of probe.refs) {
+    const v = deps ? await gateInstall(ref, deps) : await gateInstall(ref);
+    checked.push(v);
+    if (v.decision === "blocked") {
+      return { block: true, reason: v.reason, checked };
+    }
+  }
+  return {
+    block: false,
+    reason:
+      checked.length > 0
+        ? `triage PASS: ${checked.map((c) => c.tool).join(", ")}`
+        : "no registry targets to triage",
+    checked,
+  };
+}


### PR DESCRIPTION
**Phase 1 of 2 for #146** — makes "installs nothing untriaged" true even in agent **auto-mode**.

## The problem
The "use kit" rules-file block only **advises**. An agent in auto/bypass mode can run `npm install evil` directly via Bash — and the malicious `postinstall` fires **immediately**, before any commit, so git hooks are too late. The only real gate is a **PreToolUse hook** that inspects the pending Bash command and blocks it (exit 2) unless the target is triaged. The deep research (#146) verified Claude Code, Codex, and Amazon Q all support this.

## This PR — the deterministic core (`src/install-gate.ts`)
Pure, injectable, zero I/O, **no CLI-surface change**:
- **`parseInstallCommand(cmd)`** → kit triage refs (`npm:`/`pip:`). Covers npm/pnpm/yarn/bun + npx/bunx (npm) and pip/pip3/pipx/uv/`python -m pip` (PyPI). Skips flags, **local paths** (the user's own code), and **bare reinstalls** (`npm install` with no args). **Fail-closed:** an in-scope install whose target can't be reduced to a clean registry name is `unverifiable` → block. **Out-of-scope ecosystems** (cargo/go/gem/brew — kit has no triage for them) pass through (honest, documented scope limit).
- **`decideBashGate(cmd, deps)`** → triages each ref via the existing `gateInstall`; any blocked or unverifiable target blocks the command.

## Tests — 20, covering
detection (scoped/versioned names, `npx` execution, `&&`/`;` chains, dedup, local-path & bare-reinstall negatives, out-of-scope pass-through, unverifiable fail-closed) and decision (pass / fail / unverifiable-without-triaging / local-only). Full suite **1826/0**; public-surface snapshot untouched.

## Phase 2 (follow-up PR, touches the frozen CLI surface)
- `kit`-side PreToolUse **handler** (reads the hook's JSON on stdin → `decideBashGate` → exit 2 on block) — a new command, so it needs `contracts/public-surface.json` regen + command-surface parity.
- **Installer** that writes the PreToolUse hook into `.claude/settings.json` (mirrors `installKitPermissions`), opt-in.
- Codex (`config.toml`) + Amazon Q (`preToolUse`) adapters reuse the same core.

Split deliberately so the security-critical detector lands provably-correct without rushing a frozen-contract change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_