### PR TITLE
chore: dogfood the kit agent-config block (CLAUDE.md + AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+<!-- BEGIN kit (managed block — edit outside the markers, not inside) -->
+
+## kit
+
+This project uses [kit](https://github.com/sandstream/kit) to manage tools, secrets, and environment setup. As the agent working here:
+
+- At session start run `kit statusline` and surface it — it shows the setup score for the active mode, whether a kit update is available, and the open "blocked-on-you" (PAL) count.
+- Run `kit check` before starting; if it reports `fail`, run `kit fix` then re-check.
+- Recall prior decisions with `kit memory search "<query>"` (cross-session, cross-agent); keep the local store current with `kit memory index`.
+- Before installing ANY dependency, run `kit triage npm|pip|docker|repo <target>` and only install if it passes.
+- Never write secrets to `.env*` in plaintext — resolve them with `kit secrets` (vault-backed).
+- After a batch of edits, run `kit check --category security`; halt and surface findings on `fail`.
+- Destructive secret ops require `kit auth elevate` first.
+
+<!-- END kit -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+<!-- BEGIN kit (managed block — edit outside the markers, not inside) -->
+
+## kit
+
+This project uses [kit](https://github.com/sandstream/kit) to manage tools, secrets, and environment setup. As the agent working here:
+
+- At session start run `kit statusline` and surface it — it shows the setup score for the active mode, whether a kit update is available, and the open "blocked-on-you" (PAL) count.
+- Run `kit check` before starting; if it reports `fail`, run `kit fix` then re-check.
+- Recall prior decisions with `kit memory search "<query>"` (cross-session, cross-agent); keep the local store current with `kit memory index`.
+- Before installing ANY dependency, run `kit triage npm|pip|docker|repo <target>` and only install if it passes.
+- Never write secrets to `.env*` in plaintext — resolve them with `kit secrets` (vault-backed).
+- After a batch of edits, run `kit check --category security`; halt and surface findings on `fail`.
+- Destructive secret ops require `kit auth elevate` first.
+
+<!-- END kit -->


### PR DESCRIPTION
kit injects a managed "use kit" block into *other* projects' rules files but didn't carry one itself — the repo had no `CLAUDE.md`/`AGENTS.md`, so agents working in the kit repo never received kit's own standing instructions (run `kit check` before starting, triage before install, vault secrets, etc.).

Generated by running kit's own **`kit agent-config`** on the repo (true dogfooding). `AGENTS.md` mirrors the identical block so Codex / OpenCode contributors get it too. Marker-delimited and regenerates in place — edit outside the markers freely. The `.claude/settings.json` read-only allowlist that `agent-config` also writes stays local (gitignored).

Docs/config only — no code change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_