### PR TITLE
feat(install-gate): agent-agnostic handler + Codex & Amazon Q installers

### DIFF
--- a/src/agent-config.test.ts
+++ b/src/agent-config.test.ts
@@ -11,6 +11,8 @@ import {
   writeAgentConfig,
   installKitPermissions,
   installInstallGate,
+  installInstallGateCodex,
+  installInstallGateAmazonQ,
   READONLY_KIT_PERMISSIONS,
 } from "./agent-config.js";
 
@@ -290,6 +292,73 @@ describe("installInstallGate", () => {
     try {
       const r = await installInstallGate(dir);
       assert.equal(r.action, "skipped");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("installInstallGateCodex", () => {
+  it("appends a valid [[hooks.PreToolUse]] block to .codex/config.toml, preserving content, idempotent", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-codexgate-"));
+    try {
+      mkdirSync(join(dir, ".codex"), { recursive: true });
+      writeFileSync(join(dir, ".codex", "config.toml"), '# my codex config\nmodel = "gpt-5"\n');
+      const r1 = await installInstallGateCodex(dir);
+      assert.equal(r1.action, "updated");
+      const txt = readFileSync(join(dir, ".codex", "config.toml"), "utf-8");
+      assert.ok(txt.includes("# my codex config"), "preserves existing content/comments");
+      assert.ok(txt.includes("[[hooks.PreToolUse]]"));
+      assert.ok(txt.includes("gate-bash"));
+      const { parse } = await import("smol-toml");
+      const cfg = parse(txt) as { hooks: { PreToolUse: { matcher: string }[] } };
+      assert.ok(Array.isArray(cfg.hooks.PreToolUse), "valid TOML, array-of-tables");
+      assert.equal(cfg.hooks.PreToolUse[0].matcher, "^Bash$");
+      const r2 = await installInstallGateCodex(dir);
+      assert.equal(r2.action, "unchanged");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips when no Codex project is present", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-codexgate2-"));
+    try {
+      assert.equal((await installInstallGateCodex(dir)).action, "skipped");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("installInstallGateAmazonQ", () => {
+  it("adds hooks.preToolUse to existing agent JSONs, idempotently", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-qgate-"));
+    try {
+      mkdirSync(join(dir, ".amazonq", "cli-agents"), { recursive: true });
+      writeFileSync(
+        join(dir, ".amazonq", "cli-agents", "default.json"),
+        JSON.stringify({ name: "default", tools: ["execute_bash"] }),
+      );
+      const r1 = await installInstallGateAmazonQ(dir);
+      assert.equal(r1.action, "updated");
+      const a = JSON.parse(
+        readFileSync(join(dir, ".amazonq", "cli-agents", "default.json"), "utf-8"),
+      );
+      assert.equal(a.name, "default", "preserves existing agent fields");
+      assert.equal(a.hooks.preToolUse[0].matcher, "execute_bash");
+      assert.ok(a.hooks.preToolUse[0].command.endsWith("gate-bash"));
+      const r2 = await installInstallGateAmazonQ(dir);
+      assert.equal(r2.action, "unchanged");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips when no Amazon Q agent config is present", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-qgate2-"));
+    try {
+      assert.equal((await installInstallGateAmazonQ(dir)).action, "skipped");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agent-config.ts
+++ b/src/agent-config.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
-import { existsSync } from "node:fs";
-import { resolve, dirname } from "node:path";
+import { existsSync, readdirSync } from "node:fs";
+import { resolve, dirname, join } from "node:path";
 
 /**
  * Teach the coding agent to use kit.
@@ -334,4 +334,121 @@ export async function installInstallGate(cwd: string = process.cwd()): Promise<H
   } catch (err) {
     return { file, action: "failed", detail: err instanceof Error ? err.message : String(err) };
   }
+}
+
+/**
+ * Codex install-gate: a `[[hooks.PreToolUse]]` block in `.codex/config.toml`
+ * (matcher `^Bash$`) that runs `kit gate-bash` and exits 2 to block. We APPEND
+ * the TOML block as text rather than parse→stringify, so the user's existing
+ * config + comments are preserved; idempotent via a `gate-bash` text check.
+ */
+export async function installInstallGateCodex(
+  cwd: string = process.cwd(),
+): Promise<HookInstallResult> {
+  const file = ".codex/config.toml";
+  const path = resolve(cwd, file);
+  const { isReadOnlyMode } = await import("./read-only-mode.js");
+  if (isReadOnlyMode()) return { file, action: "skipped", detail: "read-only mode" };
+  if (!existsSync(resolve(cwd, ".codex")) && !existsSync(resolve(cwd, "AGENTS.md"))) {
+    return { file, action: "skipped", detail: "no Codex project detected" };
+  }
+
+  let existing = "";
+  let existed = false;
+  try {
+    existing = await readFile(path, "utf-8");
+    existed = true;
+  } catch {
+    existing = "";
+  }
+  if (existing.includes("gate-bash")) {
+    return { file, action: "unchanged", detail: "install-gate already wired" };
+  }
+  // Single-quoted TOML literal — the invocation is an absolute node+path, no single quotes.
+  const block = `\n[[hooks.PreToolUse]]\nmatcher = "^Bash$"\n[[hooks.PreToolUse.hooks]]\ntype = "command"\ncommand = '${kitGateInvocation()}'\n`;
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, existing + block, "utf-8");
+    return { file, action: existed ? "updated" : "created" };
+  } catch (err) {
+    return { file, action: "failed", detail: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Amazon Q install-gate: add a `hooks.preToolUse` entry (matcher `execute_bash`)
+ * to each agent config under `.amazonq/cli-agents/*.json`. Amazon Q keeps hooks
+ * per-agent, so we wire every existing agent file; if none are present we skip
+ * (honest about the per-agent layout rather than guessing a path). Idempotent.
+ */
+export async function installInstallGateAmazonQ(
+  cwd: string = process.cwd(),
+): Promise<HookInstallResult> {
+  const dir = ".amazonq/cli-agents";
+  const dirPath = resolve(cwd, dir);
+  const { isReadOnlyMode } = await import("./read-only-mode.js");
+  if (isReadOnlyMode()) return { file: dir, action: "skipped", detail: "read-only mode" };
+  let agentFiles: string[] = [];
+  try {
+    agentFiles = readdirSync(dirPath)
+      .filter((f) => f.endsWith(".json"))
+      .map((f) => join(dirPath, f));
+  } catch {
+    agentFiles = [];
+  }
+  if (agentFiles.length === 0) {
+    return { file: dir, action: "skipped", detail: "no Amazon Q agent config found" };
+  }
+
+  let wired = 0;
+  let already = 0;
+  for (const p of agentFiles) {
+    let agent: {
+      hooks?: Record<string, { matcher?: string; command: string }[]>;
+      [k: string]: unknown;
+    };
+    try {
+      agent = JSON.parse(await readFile(p, "utf-8"));
+    } catch {
+      continue; // skip unparseable agent file
+    }
+    const hooks = (agent.hooks ??= {});
+    const pre = (hooks.preToolUse ??= []);
+    if (pre.some((h) => typeof h?.command === "string" && h.command.endsWith("gate-bash"))) {
+      already++;
+      continue;
+    }
+    pre.push({ matcher: "execute_bash", command: kitGateInvocation() });
+    try {
+      await writeFile(p, JSON.stringify(agent, null, 2) + "\n", "utf-8");
+      wired++;
+    } catch {
+      /* best-effort per file */
+    }
+  }
+  if (wired === 0) {
+    return {
+      file: dir,
+      action: "unchanged",
+      detail: `install-gate already wired (${already} agent[s])`,
+    };
+  }
+  return { file: dir, action: "updated", detail: `wired ${wired} Amazon Q agent config(s)` };
+}
+
+/** Per-agent install-gate result. */
+export interface GateInstallEntry {
+  agent: "Claude Code" | "Codex" | "Amazon Q";
+  result: HookInstallResult;
+}
+
+/** Wire the PreToolUse install-gate for every supported agent present in the project. */
+export async function installAllInstallGates(
+  cwd: string = process.cwd(),
+): Promise<GateInstallEntry[]> {
+  return [
+    { agent: "Claude Code", result: await installInstallGate(cwd) },
+    { agent: "Codex", result: await installInstallGateCodex(cwd) },
+    { agent: "Amazon Q", result: await installInstallGateAmazonQ(cwd) },
+  ];
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,7 +99,7 @@ import {
   writeAgentConfig,
   detectAgentTargets,
   installKitPermissions,
-  installInstallGate,
+  installAllInstallGates,
 } from "./agent-config.js";
 import { applyRecommendedHardening } from "./recommended.js";
 import { checkHooks, isGitRepository } from "./check-hooks.js";
@@ -1486,17 +1486,19 @@ async function cmdAgentConfig(): Promise<boolean> {
   // auto-mode can't run an un-triaged `npm install` past kit. The rules block
   // above only advises; this enforces (blocks the install before it runs).
   if (hasFlag(process.argv, "--install-gate")) {
-    const gate = await installInstallGate();
-    if (gate.action === "created" || gate.action === "updated") {
-      console.log(
-        `\n  ${c.green}✓${c.reset} installed the ${c.bold}PreToolUse install-gate${c.reset} in ${c.dim}${gate.file}${c.reset} ${c.dim}(blocks un-triaged installs before they run)${c.reset}`,
-      );
-    } else if (gate.action === "unchanged") {
-      console.log(`\n  ${c.dim}= install-gate already wired in ${gate.file}${c.reset}`);
-    } else {
-      console.log(
-        `\n  ${c.yellow}!${c.reset} ${c.dim}install-gate not wired: ${gate.detail ?? gate.action}${c.reset}`,
-      );
+    console.log(
+      `\n  ${c.bold}PreToolUse install-gate${c.reset} ${c.dim}(blocks un-triaged installs before they run):${c.reset}`,
+    );
+    for (const { agent, result } of await installAllInstallGates()) {
+      if (result.action === "created" || result.action === "updated") {
+        console.log(
+          `    ${c.green}✓${c.reset} ${agent} ${c.dim}→ ${result.file}${result.detail ? ` (${result.detail})` : ""}${c.reset}`,
+        );
+      } else if (result.action === "unchanged") {
+        console.log(`    ${c.dim}= ${agent} already wired (${result.file})${c.reset}`);
+      } else {
+        console.log(`    ${c.dim}· ${agent} skipped: ${result.detail ?? result.action}${c.reset}`);
+      }
     }
   }
   console.log(
@@ -5684,9 +5686,18 @@ export async function cmdGateBash(): Promise<boolean> {
   } catch {
     return true; // unparseable hook payload → do not block (avoid breaking the agent)
   }
-  const command = payload?.tool_input?.command;
-  if (payload?.tool_name !== "Bash" || typeof command !== "string" || !command) {
-    return true; // not a Bash command → allow
+  // Agent-agnostic: Claude Code, Codex, and Amazon Q all pass the shell command in
+  // tool_input.command (only the tool_name differs — "Bash" vs "execute_bash"), so
+  // extract it regardless of tool_name. Tolerate array-form (bin + args).
+  const rawCmd = payload?.tool_input?.command;
+  const command =
+    typeof rawCmd === "string"
+      ? rawCmd
+      : Array.isArray(rawCmd)
+        ? rawCmd.filter((x): x is string => typeof x === "string").join(" ")
+        : "";
+  if (!command) {
+    return true; // no shell command in this tool call → allow
   }
   const { decideBashGate } = await import("./install-gate.js");
   const verdict = await decideBashGate(command);


### PR DESCRIPTION
**Phase 3 of #146** — extends the install-gate beyond Claude Code to the other two agents with a verified blocking `PreToolUse` hook (Codex, Amazon Q).

## Changes
- **Agent-agnostic handler:** `kit gate-bash` now extracts the shell command from `tool_input.command` **regardless of `tool_name`** (Claude "Bash" vs Amazon Q "execute_bash") and tolerates array-form. `exit 2` = deny across all three. Verified: Amazon Q `hooks.md` and Codex `config-reference` both send `{tool_name, tool_input}` and block on exit 2.
- **`installInstallGateCodex`** → appends a `[[hooks.PreToolUse]]` block (matcher `^Bash$`) to `.codex/config.toml` **as text**, preserving the user's existing config + comments (no parse→stringify clobber); idempotent.
- **`installInstallGateAmazonQ`** → adds `hooks.preToolUse {matcher: execute_bash}` to each `.amazonq/cli-agents/*.json` (Amazon Q keeps hooks per-agent); **skips honestly** when no agent config is present rather than guessing a path.
- **`installAllInstallGates`** orchestrates all three; **`kit agent-config --install-gate`** now wires every supported agent present in the project.

## Tests
Codex TOML append (valid TOML + comment-preserving + idempotent), Amazon Q agent-JSON wiring (idempotent + field-preserving), skip-when-absent for both. Full suite **1833/0**; format + lint clean (0 errors).

## Honest scope
The blocking gate is real for the **3 agents with a verified PreToolUse hook** (Claude Code, Codex, Amazon Q). The other 5 (Gemini/Continue/Cursor/Cline/OpenCode) still need the research pass (#146) before adapters. The detector's ecosystem scope (npm/pip) is unchanged.

This completes the cross-agent enforce layer for #146.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_