### PR TITLE
chore(deps): pin the 7 ranged deps exactly (kit's own pinned-versions gate)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@upstash/redis": "^1.37.0",
+        "@upstash/redis": "1.37.0",
         "smol-toml": "1.6.1",
         "zod": "4.3.6"
       },
@@ -21,14 +21,14 @@
         "kit": "dist/cli.js"
       },
       "devDependencies": {
-        "@eslint/js": "^9.39.4",
+        "@eslint/js": "9.39.4",
         "@types/node": "22.19.15",
-        "eslint": "^9.39.4",
-        "globals": "^17.6.0",
-        "prettier": "^3.8.4",
-        "tsx": "^4.22.4",
+        "eslint": "9.39.4",
+        "globals": "17.6.0",
+        "prettier": "3.8.4",
+        "tsx": "4.22.4",
         "typescript": "5.9.3",
-        "typescript-eslint": "^8.61.1"
+        "typescript-eslint": "8.61.1"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -3000,7 +3000,7 @@
     },
     "packages/adapter-sdk": {
       "name": "sandstream-kit-adapter-sdk",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "devDependencies": {
         "typescript": "5.9.3"
       }

--- a/package.json
+++ b/package.json
@@ -37,19 +37,19 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.29.0",
-    "@upstash/redis": "^1.37.0",
+    "@upstash/redis": "1.37.0",
     "smol-toml": "1.6.1",
     "zod": "4.3.6"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.4",
+    "@eslint/js": "9.39.4",
     "@types/node": "22.19.15",
-    "eslint": "^9.39.4",
-    "globals": "^17.6.0",
-    "prettier": "^3.8.4",
-    "tsx": "^4.22.4",
+    "eslint": "9.39.4",
+    "globals": "17.6.0",
+    "prettier": "3.8.4",
+    "tsx": "4.22.4",
     "typescript": "5.9.3",
-    "typescript-eslint": "^8.61.1"
+    "typescript-eslint": "8.61.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Dogfooding: kit's own `kit check` flagged the kit repo. Of the 4 findings, **one was a genuine repo defect** — this fixes it; the other three are tooling-absence in a bare environment, not defects.

## Fixed — `pinned versions` (CWE-1104)
kit warns on range-specced deps, but kit's own `package.json` carried `^` on 7: `@upstash/redis` + six devDeps (`@eslint/js`, `eslint`, `globals`, `prettier`, `tsx`, `typescript-eslint`). Pinned each to the version **already resolved in `package-lock.json`** (lockfile floor == resolved, so no installed-version change). `kit check --category security` → **`pinned versions: pass`**. Full suite **1833/0**.

## Not defects (no change) — verified honestly
- **secrets scan (11 hits / 8 files):** all confirmed **false positives** — test fixtures (`sk_test_invalid_for_test`, `not_a_resend_key`, JWT test strings, `my-existing-token-12345`) and one config field *name* (`SOCKET_SECURITY_API_TOKEN`). The warn only appears because **trufflehog isn't installed** → kit falls back to a broad `git grep`. Not touching the scan heuristic (would risk false negatives for all users).
- **trivy config (IaC) + trivy container scan:** "trivy not installed" — tooling-absence, green/assessed in CI where trivy runs.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_