### PR TITLE
feat(install-gate): Gemini CLI + Cursor adapters (5 agents now enforced)

### DIFF
--- a/src/agent-config.test.ts
+++ b/src/agent-config.test.ts
@@ -13,6 +13,8 @@ import {
   installInstallGate,
   installInstallGateCodex,
   installInstallGateAmazonQ,
+  installInstallGateGemini,
+  installInstallGateCursor,
   READONLY_KIT_PERMISSIONS,
 } from "./agent-config.js";
 
@@ -359,6 +361,55 @@ describe("installInstallGateAmazonQ", () => {
     const dir = mkdtempSync(join(tmpdir(), "kit-qgate2-"));
     try {
       assert.equal((await installInstallGateAmazonQ(dir)).action, "skipped");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("installInstallGateGemini", () => {
+  it("wires a BeforeTool hook into .gemini/settings.json, idempotently", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-geminigate-"));
+    try {
+      mkdirSync(join(dir, ".gemini"), { recursive: true });
+      const r1 = await installInstallGateGemini(dir);
+      assert.equal(r1.action, "created");
+      const s = JSON.parse(readFileSync(join(dir, ".gemini", "settings.json"), "utf-8"));
+      assert.ok(s.hooks.BeforeTool[0].hooks[0].command.endsWith("gate-bash"));
+      assert.equal((await installInstallGateGemini(dir)).action, "unchanged");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+  it("skips when no Gemini project is present", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-geminigate2-"));
+    try {
+      assert.equal((await installInstallGateGemini(dir)).action, "skipped");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("installInstallGateCursor", () => {
+  it("wires a beforeShellExecution hook into .cursor/hooks.json, idempotently", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-cursorgate-"));
+    try {
+      mkdirSync(join(dir, ".cursor"), { recursive: true });
+      const r1 = await installInstallGateCursor(dir);
+      assert.equal(r1.action, "created");
+      const c = JSON.parse(readFileSync(join(dir, ".cursor", "hooks.json"), "utf-8"));
+      assert.equal(c.version, 1);
+      assert.ok(c.hooks.beforeShellExecution[0].command.endsWith("gate-bash"));
+      assert.equal((await installInstallGateCursor(dir)).action, "unchanged");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+  it("skips when no Cursor project is present", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-cursorgate2-"));
+    try {
+      assert.equal((await installInstallGateCursor(dir)).action, "skipped");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agent-config.ts
+++ b/src/agent-config.ts
@@ -436,9 +436,92 @@ export async function installInstallGateAmazonQ(
   return { file: dir, action: "updated", detail: `wired ${wired} Amazon Q agent config(s)` };
 }
 
+/**
+ * Gemini CLI install-gate: a `BeforeTool` hook in `.gemini/settings.json` (same
+ * nested hooks > Event > matcher > hooks[] shape as Claude Code). Gemini passes
+ * the command in tool_input.command and blocks on exit 2 — so `kit gate-bash`
+ * works unchanged. Idempotent; preserves other settings/hooks.
+ */
+export async function installInstallGateGemini(
+  cwd: string = process.cwd(),
+): Promise<HookInstallResult> {
+  const file = ".gemini/settings.json";
+  const path = resolve(cwd, file);
+  const { isReadOnlyMode } = await import("./read-only-mode.js");
+  if (isReadOnlyMode()) return { file, action: "skipped", detail: "read-only mode" };
+  if (!existsSync(resolve(cwd, ".gemini"))) {
+    return { file, action: "skipped", detail: "no Gemini CLI project detected" };
+  }
+  let settings: { hooks?: Record<string, SettingsHookGroup[]>; [k: string]: unknown } = {};
+  let existed = false;
+  try {
+    settings = JSON.parse(await readFile(path, "utf-8")) as typeof settings;
+    existed = true;
+  } catch {
+    settings = {};
+  }
+  const hooks = (settings.hooks ??= {});
+  const pre = (hooks.BeforeTool ??= []);
+  if (pre.some((g) => g.hooks?.some((h) => h.command?.endsWith("gate-bash")))) {
+    return { file, action: "unchanged", detail: "install-gate already wired" };
+  }
+  pre.push({ matcher: "", hooks: [{ type: "command", command: kitGateInvocation() }] });
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, JSON.stringify(settings, null, 2) + "\n", "utf-8");
+    return { file, action: existed ? "updated" : "created" };
+  } catch (err) {
+    return { file, action: "failed", detail: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Cursor install-gate: a `beforeShellExecution` hook in `.cursor/hooks.json`.
+ * Cursor passes the shell command at top-level `command` and blocks on exit 2
+ * (equivalent to returning `{permission:"deny"}`), so `kit gate-bash` works.
+ * Idempotent; preserves other hooks.
+ */
+export async function installInstallGateCursor(
+  cwd: string = process.cwd(),
+): Promise<HookInstallResult> {
+  const file = ".cursor/hooks.json";
+  const path = resolve(cwd, file);
+  const { isReadOnlyMode } = await import("./read-only-mode.js");
+  if (isReadOnlyMode()) return { file, action: "skipped", detail: "read-only mode" };
+  if (!existsSync(resolve(cwd, ".cursor"))) {
+    return { file, action: "skipped", detail: "no Cursor project detected" };
+  }
+  let cfg: {
+    version?: number;
+    hooks?: Record<string, { command: string }[]>;
+    [k: string]: unknown;
+  } = {};
+  let existed = false;
+  try {
+    cfg = JSON.parse(await readFile(path, "utf-8")) as typeof cfg;
+    existed = true;
+  } catch {
+    cfg = {};
+  }
+  cfg.version ??= 1;
+  const hooks = (cfg.hooks ??= {});
+  const pre = (hooks.beforeShellExecution ??= []);
+  if (pre.some((h) => h.command?.endsWith("gate-bash"))) {
+    return { file, action: "unchanged", detail: "install-gate already wired" };
+  }
+  pre.push({ command: kitGateInvocation() });
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, JSON.stringify(cfg, null, 2) + "\n", "utf-8");
+    return { file, action: existed ? "updated" : "created" };
+  } catch (err) {
+    return { file, action: "failed", detail: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 /** Per-agent install-gate result. */
 export interface GateInstallEntry {
-  agent: "Claude Code" | "Codex" | "Amazon Q";
+  agent: "Claude Code" | "Codex" | "Amazon Q" | "Gemini CLI" | "Cursor";
   result: HookInstallResult;
 }
 
@@ -450,5 +533,7 @@ export async function installAllInstallGates(
     { agent: "Claude Code", result: await installInstallGate(cwd) },
     { agent: "Codex", result: await installInstallGateCodex(cwd) },
     { agent: "Amazon Q", result: await installInstallGateAmazonQ(cwd) },
+    { agent: "Gemini CLI", result: await installInstallGateGemini(cwd) },
+    { agent: "Cursor", result: await installInstallGateCursor(cwd) },
   ];
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5689,16 +5689,17 @@ export async function cmdGateBash(): Promise<boolean> {
   } catch {
     return true; // no stdin / read error → do not block
   }
-  let payload: { tool_name?: string; tool_input?: { command?: unknown } };
+  let payload: { tool_name?: string; tool_input?: { command?: unknown }; command?: unknown };
   try {
     payload = raw ? JSON.parse(raw) : {};
   } catch {
     return true; // unparseable hook payload → do not block (avoid breaking the agent)
   }
-  // Agent-agnostic: Claude Code, Codex, and Amazon Q all pass the shell command in
-  // tool_input.command (only the tool_name differs — "Bash" vs "execute_bash"), so
-  // extract it regardless of tool_name. Tolerate array-form (bin + args).
-  const rawCmd = payload?.tool_input?.command;
+  // Agent-agnostic command extraction. Claude Code / Codex / Amazon Q / Gemini put
+  // the shell command in tool_input.command (only tool_name differs — "Bash" vs
+  // "execute_bash"); Cursor's beforeShellExecution puts it at top-level `command`.
+  // Tolerate array-form (bin + args). exit 2 = deny across all of them.
+  const rawCmd = payload?.tool_input?.command ?? payload?.command;
   const command =
     typeof rawCmd === "string"
       ? rawCmd


### PR DESCRIPTION
**Track #1 (extend agent coverage)** — adds the two more agents with a **verified exit-2 blocking hook**, taking the install-gate from 3 → **5 enforced agents**.

## Research outcome (the 5 remaining agents)
| Agent | Blocking hook? | How | Wired here? |
|---|---|---|---|
| **Gemini CLI** | ✅ `BeforeTool` | exit 2, `tool_input.command` | ✅ |
| **Cursor** | ✅ `beforeShellExecution` | exit 2 / `{permission:"deny"}`, **top-level `command`** | ✅ |
| Cline | ✅ `PreToolUse` | JSON `{cancel:true}` (not exit 2) | ⏳ #146 (different output protocol) |
| OpenCode | ✅ `tool.execute.before` | JS plugin **throws** | ⏳ #146 (JS-plugin integration) |
| Continue | ❓ unverified | — | ⏳ #146 |

## Changes
- **Handler** now reads top-level `command` in addition to `tool_input.command` (Cursor puts the shell string at top level). Gemini uses `tool_input.command` like the others. `exit 2` = deny across all five.
- **`installInstallGateGemini`** → `BeforeTool` hook in `.gemini/settings.json`.
- **`installInstallGateCursor`** → `beforeShellExecution` hook in `.cursor/hooks.json`.
- `installAllInstallGates` / `kit agent-config --install-gate` now wire all five present agents.

Verified vs primary docs (geminicli.com/docs/hooks, cursor.com/docs/hooks). Tests: Gemini + Cursor wiring (create/idempotent/skip). Full suite **1837/0**, format/lint clean.

Cline/OpenCode/Continue use a different block mechanism (JSON-cancel / JS-throw / unverified) and are tracked in #146; the agent-agnostic **git-hook** layer covers them regardless.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_