### PR TITLE
fix: gitignore .kit-triage.jsonl (kit's local triage audit log)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ sandstream-kit-*.tgz
 # Internal runtime state — never publish
 .kit/elevation.json
 .kit-audit.jsonl
+.kit-triage.jsonl
 .kit-check-attestation.json
 .kit-baseline.json
 .kit-budget.json

--- a/.kit-triage.jsonl
+++ b/.kit-triage.jsonl
@@ -1,2 +1,0 @@
-{"timestamp":"2026-06-27T18:30:11.622Z","type":"npm","target":"opencode-ai","sandbox":false,"granter":"unknown"}
-{"timestamp":"2026-06-27T18:32:17.563Z","type":"npm","target":"@opencode-ai/plugin","sandbox":false,"granter":"unknown"}


### PR DESCRIPTION
## What

`kit triage` appends a per-run audit log to `.kit-triage.jsonl` in the cwd (`src/commands/triage.ts:124`), exactly like `.kit-audit.jsonl` and the other `.kit-*` local-state files — but it was the **one such file missing from `.gitignore`**.

## RCA

While verifying the OpenCode work (#156) I ran `kit triage npm opencode-ai` etc. from the repo root, which wrote `.kit-triage.jsonl`. A `git add -A` then swept it into #156 and it landed on `main`. Root cause: the ignore list covers `.kit-audit.jsonl`, `.kit-baseline.json`, `.kit-budget.json`, `.kit-escalation.txt`, … but not `.kit-triage.jsonl`.

## Fix

- Untrack the stray `.kit-triage.jsonl`.
- Add the pattern to `.gitignore` next to `.kit-audit.jsonl`, so neither kit's own repo nor any kit user commits this local audit state again.

Verified `git check-ignore .kit-triage.jsonl` now matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_