### PR TITLE
chore: declare trivy + trufflehog as managed tools

### DIFF
--- a/.kit.toml
+++ b/.kit.toml
@@ -1,6 +1,11 @@
 [tools]
 node = "22"
 pnpm = "latest"
+# Security scanners kit's own `kit check` resolves mise-first. Declaring them here
+# means `kit install` provisions them so the trivy/secrets scans actually run
+# (otherwise they warn "not installed"). Names resolve via the mise registry.
+trivy = "latest"
+trufflehog = "latest"
 
 [hooks]
 pre-commit = ["kit security scan-staged", "npm run build", "npm test"]

--- a/.kit/cli-lock.json
+++ b/.kit/cli-lock.json
@@ -10,6 +10,16 @@
       "version": "latest",
       "source": "mise",
       "installedAt": "2026-03-30T15:48:16.532Z"
+    },
+    "trivy": {
+      "version": "latest",
+      "source": "mise",
+      "installedAt": "2026-06-27T20:56:16.000Z"
+    },
+    "trufflehog": {
+      "version": "latest",
+      "source": "mise",
+      "installedAt": "2026-06-27T20:56:16.000Z"
     }
   }
 }


### PR DESCRIPTION
## What

Declare `trivy` and `trufflehog` in `.kit.toml [tools]` (and lock them in `.kit/cli-lock.json`) so `kit install` provisions them via mise.

## Why

kit's own `kit check` resolves these mise-first — `trivy` for the container-CVE + IaC-config scans, `trufflehog` for the deep secrets scan — but today it only **suggests** installing them when they're absent. The result: on any machine without them, all three scans warn `not installed` indefinitely (the recurring "blocked-on-you" items). kit is a security-first CLI; its scanners should be first-class managed deps, not optional suggestions. Declaring them here means `kit install` provisions them and the scans actually run.

## Verification

- `git check-ignore` / `git ls-files`: `.kit/cli-lock.json` is **tracked** (committed by design, like `package-lock.json`), so the lock is updated in lockstep — `kit check --category lock` → **cli-lock.json: in sync**.
- **No CI impact:** CI runs the security category (`scripts/run-security-check.mjs`) + `kit self-audit`; neither exercises the `tools` or `lock` categories (CI deliberately avoids full `kit check` — see the comment in `security.yml`). Confirmed by reading the workflow.
- `npm test` — 1852/0 (no test depends on the tool list).
- Tool-name resolution is via the mise registry short names (`trivy`, `trufflehog`), matching how `resolveToolBin` looks them up.

## Honest caveats

- This only changes **local** `kit check` and what `kit install` provisions. In an environment without mise/the tools (e.g. a bare container), `kit check --category tools` will now show them as declared-but-`not installed` until `kit install` runs — that's the intended explicit-dependency semantics.
- mise registry resolution for the two short names couldn't be exercised in-session (mise isn't on PATH in the build container); the worst case is `kit install` needing the backend-qualified form (`aqua:aquasecurity/trivy`), which is a follow-up, not a CI break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_