### PR TITLE
fix: declare scanner tools as aqua: refs so the triage gate installs them

### DIFF
--- a/.kit.toml
+++ b/.kit.toml
@@ -3,9 +3,11 @@ node = "22"
 pnpm = "latest"
 # Security scanners kit's own `kit check` resolves mise-first. Declaring them here
 # means `kit install` provisions them so the trivy/secrets scans actually run
-# (otherwise they warn "not installed"). Names resolve via the mise registry.
-trivy = "latest"
-trufflehog = "latest"
+# (otherwise they warn "not installed"). Scheme-qualified `aqua:` refs (matching
+# kit's own toml-generator) so the triage gate maps them to a repo triage and
+# installs on PASS — bare names are untriageable and the gate blocks them.
+"aqua:aquasecurity/trivy" = "latest"
+"aqua:trufflesecurity/trufflehog" = "latest"
 
 [hooks]
 pre-commit = ["kit security scan-staged", "npm run build", "npm test"]

--- a/.kit/cli-lock.json
+++ b/.kit/cli-lock.json
@@ -11,12 +11,12 @@
       "source": "mise",
       "installedAt": "2026-03-30T15:48:16.532Z"
     },
-    "trivy": {
+    "aqua:aquasecurity/trivy": {
       "version": "latest",
       "source": "mise",
       "installedAt": "2026-06-27T20:56:16.000Z"
     },
-    "trufflehog": {
+    "aqua:trufflesecurity/trufflehog": {
       "version": "latest",
       "source": "mise",
       "installedAt": "2026-06-27T20:56:16.000Z"


### PR DESCRIPTION
## RCA — corrects #158

#158 declared `trivy` and `trufflehog` in `.kit.toml [tools]` as **bare names**. But `kit install` runs every tool through the triage gate first, and `triageTargetFor` maps a bare, non-core-runtime name to `untriageable` → `gateInstall` fail-closes → **the install is blocked**. So #158 declared the scanners but `kit install` would have refused to provision them — the change didn't actually do what it claimed.

Root cause: I declared the tools by their bare binary name instead of kit's documented install vocabulary. kit's own `src/toml-generator.ts` emits scanners as **scheme-qualified `aqua:` refs** (`aqua:trufflesecurity/trufflehog` always; `aqua:aquasecurity/trivy` when a Dockerfile is present), and `triage-gate` maps those to a `repo` triage.

## Fix

`.kit.toml [tools]` (and the matching `.kit/cli-lock.json` keys):

```diff
-trivy = "latest"
-trufflehog = "latest"
+"aqua:aquasecurity/trivy" = "latest"
+"aqua:trufflesecurity/trufflehog" = "latest"
```

## Verification

- `triageTargetFor("aqua:aquasecurity/trivy")` → `{kind:"triage", type:"repo", target:"https://github.com/aquasecurity/trivy"}` (installable); same for trufflehog. Bare `trivy` still → `untriageable` (the bug).
- `kit check --category lock` → **cli-lock.json: in sync**.
- `npm test` — 1852/0.

No CI impact (CI runs the security + self-audit categories, not `tools`/`lock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_