### PR TITLE
ci: dogfood kit's scanner provisioning + scan (non-gating)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -252,6 +252,29 @@ jobs:
         # ADVISORIES (info, never gate, reported aggregated): R5, R10.
         run: node dist/cli.js self-audit --format=github
 
+  # kit dogfood — provision the scanners declared in .kit.toml [tools] via
+  # `kit install` (mise), then run kit's own security scan with them present.
+  # Proves kit's provisioning + scan path works end-to-end. INFORMATIONAL ONLY:
+  # not in the `gate` needs, and each step is continue-on-error, so a finding
+  # never blocks — the gating trivy/gitleaks live in the dedicated stages above.
+  dogfood-scan:
+    name: kit dogfood (provision + scan)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci && npm run build
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - name: Provision declared tools via kit install (triage-gated)
+        run: node dist/cli.js install
+        continue-on-error: true # kit-self-audit: allow-continue-on-error
+      - name: Run kit's security scan with trivy + trufflehog present
+        run: node scripts/run-security-check.mjs
+        continue-on-error: true # kit-self-audit: allow-continue-on-error
+
   # Aggregated gate — all stages must pass
   gate:
     name: Security gate


### PR DESCRIPTION
## What

Adds a `dogfood-scan` job to `security.yml` that provisions the scanners declared in `.kit.toml [tools]` via `kit install` (mise-action → triage-gated install), then runs kit's own security scan (`scripts/run-security-check.mjs`) with `trivy` + `trufflehog` actually present. Proves kit's end-to-end **provisioning + scan** path works in CI — the dogfood follow-up to #158/#159.

## Non-gating by design

The one real risk (raised + verified earlier) is that `trivy fs` returns `fail` on any HIGH/CRITICAL CVE, which would break a gating job. So this job is **informational only**:

- **not** in the `gate` job's `needs` → it can never block a merge (verified: `dogfood-scan not in gate.needs`)
- each step is `continue-on-error` (annotated `# kit-self-audit: allow-continue-on-error`)

Enforcement stays where it already is: the gating **Stage 4 Trivy** (on the built image) and **gitleaks** secret scan. This job just dogfoods kit driving the scanners itself, so a `trivy fs` finding is surfaced without breaking the gate.

## Verification (kit's own analyzers, run locally)

- `kit gha-audit` → **7 workflows: all actions pinned, no pwn-request** (the `jdx/mise-action` pin passes)
- `kit self-audit` → **0 fail, 0 warn**; CI script-paths: 15 refs across 7 workflows all resolve
- `jdx/mise-action` pinned to `e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d` (**v4.2.0**, confirmed via `api.github.com/.../git/refs/tags/v4.2.0` → `object.type: commit`)
- YAML parses; `dogfood-scan` present and excluded from `gate.needs`

## Note

`kit install` is triage-gated — it runs `kit triage repo` on `aquasecurity/trivy` + `trufflesecurity/trufflehog` before installing (the #159 fix made these refs installable). If a triage WARN/offline ever fail-closes the gate, the job stays green (continue-on-error) and simply reports the scanners weren't provisioned — informational, never blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_