### PR TITLE
feat(ci): kit ci --init gitlab|bitbucket pipeline generation + host docs (#145)

### DIFF
--- a/docs/CI_AND_GIT_HOSTS.md
+++ b/docs/CI_AND_GIT_HOSTS.md
@@ -1,0 +1,69 @@
+# CI & git-host enforcement
+
+kit's gates live at four layers. **Layers 1–3 are client-side and host-agnostic**
+(a pre-commit hook or a Claude Code `PreToolUse` hook does not care whether the
+remote is GitHub, GitLab, or Bitbucket). **Layer 4 is server-side and is where
+true org-level enforcement lives — and it is host-specific.**
+
+| Layer | What | Host-agnostic? | Enforces or advises? |
+| --- | --- | :---: | --- |
+| 1. Git hooks (pre-commit/pre-push) — `kit hooks` | ✅ identical everywhere | Blocks locally, but bypassable (`--no-verify`, not installed) |
+| 2. Native agent hook (Claude Code `PreToolUse`, …) | ✅ (local) | Can truly block, where the agent supports it |
+| 3. Rules file + allowlist (`CLAUDE.md`/`AGENTS.md`/…) | ✅ | **Advises** (the agent runs the gate) |
+| 4. Server-side / CI (branch protection + pipeline + pre-receive) | ❌ host-specific | **True org-level enforce** |
+
+> Local layers are advisory or bypassable. **Only layer 4 enforces at the org
+> level**, and it differs per host. Do not present a local hook as
+> org-enforcement.
+
+## The CI job (layer 4) — `kit ci`
+
+`kit ci` is host-agnostic: it runs the checks, exits non-zero on failure, and can
+emit a host-native report (`--format github` annotations, `--format gitlab`
+JUnit). Drop it into any runner. Generate a ready pipeline snippet with:
+
+```bash
+kit ci --init gitlab        # prints a .gitlab-ci.yml job to stdout
+kit ci --init bitbucket     # prints a bitbucket-pipelines.yml step
+kit ci --init gitlab --write # writes the file (only if absent — never clobbers)
+```
+
+### GitHub
+
+kit ships its own SHA-pinned Actions; a hand-written unpinned workflow would
+(correctly) be flagged by `kit gha-audit`, so `--init` does not generate one. Run
+`kit ci` in a job and make it a **required status check** on the protected branch
+(Settings → Branches → branch protection rule → *Require status checks to pass*).
+
+### GitLab
+
+`kit ci --init gitlab` emits a `kit-ci` job (`kit ci --format gitlab` → JUnit
+artifact `kit-report.xml`). Enforce it:
+
+- **Required pipeline:** Settings → Merge requests → *Pipelines must succeed*.
+- **Protected branch:** Settings → Repository → Protected branches.
+- **Self-managed server-side (true enforce):** a [push rule] or a server
+  [pre-receive hook] rejects the push itself — not bypassable by `--no-verify`.
+  kit does not install these (platform-admin territory); run `kit ci` from them.
+
+### Bitbucket
+
+`kit ci --init bitbucket` emits a `kit ci` step. Enforce it:
+
+- **Merge checks:** Repository settings → Merge checks → *Minimum successful
+  builds* (≥1) so the pipeline must pass before merge.
+- **Branch permissions:** Repository settings → Branch restrictions.
+- **Data Center server-side (true enforce):** a pre-receive hook rejects the
+  push. Same division of labor: kit runs in it; admins install it.
+
+## What kit does and does not do
+
+- **Does:** run as a host-agnostic gate (`kit ci`), generate GitLab/Bitbucket
+  pipeline snippets, lint CI YAML for all three hosts (`kit gha-audit` covers
+  GitHub Actions + `.gitlab-ci.yml` + `bitbucket-pipelines.yml`).
+- **Does not:** install server-side/pre-receive hooks or branch-protection rules
+  — those are platform-admin actions. kit documents the path; your admin wires
+  the required check to the kit job.
+
+[push rule]: https://docs.gitlab.com/ee/user/project/repository/push_rules.html
+[pre-receive hook]: https://docs.gitlab.com/ee/administration/server_hooks.html

--- a/src/ci-audit.test.ts
+++ b/src/ci-audit.test.ts
@@ -32,6 +32,23 @@ describe("auditCiYaml — image pinning", () => {
     assert.equal(latest?.severity, "medium");
   });
 
+  it("does NOT flag a bare `name:` label (Bitbucket step / job name, not an image)", () => {
+    const yml = [
+      "image: node:20.11.1",
+      "pipelines:",
+      "  default:",
+      "    - step:",
+      "        name: kit ci", // a step label — not an image
+      "        script:",
+      "          - npx --yes sandstream-kit ci",
+    ].join("\n");
+    const findings = auditCiYaml(yml, "bitbucket-pipelines.yml");
+    assert.ok(
+      !findings.some((f) => f.name.includes("kit")),
+      "a step `name:` label must not be reported as an unpinned image",
+    );
+  });
+
   it("does not double-report the same unpinned image", () => {
     const yml = "image: node:latest\nother:\n  image: node:latest\n";
     const findings = auditCiYaml(yml, ".gitlab-ci.yml").filter((f) => f.name.includes("node"));

--- a/src/ci-audit.ts
+++ b/src/ci-audit.ts
@@ -54,10 +54,16 @@ export function auditCiYaml(content: string, file: string): SecurityCheckResult[
   const out: SecurityCheckResult[] = [];
   const seenImages = new Set<string>();
 
-  // image: <ref>  and  - name: <ref>  (services / Bitbucket image.name)
-  const imageRe = /(?:^|\n)\s*(?:image|[-\s]name):\s*['"]?([A-Za-z0-9][\w./:@-]+)/g;
+  // image: <ref>  and  name: <ref>  (services / Bitbucket image.name). Capture the
+  // key so a bare `name:` label (a Bitbucket step name, a job/stage name) isn't
+  // mistaken for an image — only treat a `name:` value as an image when it is
+  // image-shaped (has a registry path `/`, a tag `:`, or a digest `@`). `image:`
+  // is unambiguous, so an untagged `image: node` is still flagged.
+  const imageRe = /(?:^|\n)\s*(image|[-\s]?name):\s*['"]?([A-Za-z0-9][\w./:@-]+)/g;
   for (const m of content.matchAll(imageRe)) {
-    const ref = m[1];
+    const isNameKey = m[1].trim().endsWith("name");
+    const ref = m[2];
+    if (isNameKey && !/[:/@]/.test(ref)) continue; // bare `name:` label, not an image
     if (isDigestPinned(ref)) continue;
     const tag = imageTag(ref);
     if (tag && tag !== "latest") continue; // a concrete version tag is acceptable

--- a/src/ci-init.test.ts
+++ b/src/ci-init.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { pipelineSnippet, isCiHost, CI_HOSTS } from "./ci-init.js";
+import { auditCiYaml } from "./ci-audit.js";
+
+describe("ci-init pipeline snippets", () => {
+  it("isCiHost accepts gitlab/bitbucket, rejects others", () => {
+    assert.ok(isCiHost("gitlab"));
+    assert.ok(isCiHost("bitbucket"));
+    assert.ok(!isCiHost("github"));
+    assert.ok(!isCiHost("jenkins"));
+    assert.deepEqual([...CI_HOSTS], ["gitlab", "bitbucket"]);
+  });
+
+  it("gitlab snippet targets .gitlab-ci.yml and runs kit ci with a JUnit artifact", () => {
+    const s = pipelineSnippet("gitlab");
+    assert.equal(s.file, ".gitlab-ci.yml");
+    assert.match(s.content, /sandstream-kit ci --format gitlab/);
+    assert.match(s.content, /junit: kit-report\.xml/);
+  });
+
+  it("bitbucket snippet targets bitbucket-pipelines.yml and runs kit ci", () => {
+    const s = pipelineSnippet("bitbucket");
+    assert.equal(s.file, "bitbucket-pipelines.yml");
+    assert.match(s.content, /sandstream-kit ci/);
+  });
+
+  // Dogfood: the snippets kit emits must pass kit's own ci-audit (pinned image,
+  // no remote include, no pipe-to-shell).
+  for (const host of CI_HOSTS) {
+    it(`${host} snippet is clean under kit's own ci-audit`, () => {
+      const s = pipelineSnippet(host);
+      const findings = auditCiYaml(s.content, s.file).filter((f) => f.status !== "pass");
+      assert.deepEqual(
+        findings,
+        [],
+        `expected no ci-audit findings, got ${findings.map((f) => f.name)}`,
+      );
+    });
+  }
+});

--- a/src/ci-init.ts
+++ b/src/ci-init.ts
@@ -1,0 +1,66 @@
+/**
+ * CI pipeline-snippet generation for non-GitHub hosts (#145).
+ *
+ * `kit ci` is host-agnostic ("run → exit code + JUnit report"), so the only
+ * host-specific piece is the pipeline file that invokes it. This emits a ready
+ * `.gitlab-ci.yml` job and `bitbucket-pipelines.yml` step that run `kit ci`.
+ *
+ * The snippets are written to pass kit's OWN ci-audit: container images use a
+ * concrete version tag (never `:latest`/untagged), no remote `include:`, and no
+ * pipe-to-shell. Pure (host → {file, content}); the CLI handles stdout/--write.
+ *
+ * GitHub is intentionally not generated here — kit ships its own SHA-pinned
+ * Actions and the gha-audit would (correctly) flag a hand-written unpinned one;
+ * see docs/CI_AND_GIT_HOSTS.md for the GitHub path.
+ */
+export type CiHost = "gitlab" | "bitbucket";
+
+export const CI_HOSTS: readonly CiHost[] = ["gitlab", "bitbucket"];
+
+export function isCiHost(value: string): value is CiHost {
+  return (CI_HOSTS as readonly string[]).includes(value);
+}
+
+export interface PipelineSnippet {
+  /** Conventional pipeline file for the host. */
+  file: string;
+  /** The snippet to place in that file. */
+  content: string;
+}
+
+/** Node image pinned to a concrete major tag (ci-audit-clean: not :latest/untagged). */
+const NODE_IMAGE = "node:22";
+
+const GITLAB = `# kit security gate — runs \`kit ci\` and publishes a JUnit report.
+# Make this a required check on protected branches:
+#   Settings → Merge requests → "Pipelines must succeed".
+kit-ci:
+  image: ${NODE_IMAGE}
+  script:
+    - npx --yes sandstream-kit ci --format gitlab
+  artifacts:
+    when: always
+    reports:
+      junit: kit-report.xml
+`;
+
+const BITBUCKET = `# kit security gate — runs \`kit ci\`.
+# Add a required merge check in repo settings:
+#   Repository settings → Merge checks → "Minimum successful builds".
+image: ${NODE_IMAGE}
+pipelines:
+  default:
+    - step:
+        name: kit ci
+        script:
+          - npx --yes sandstream-kit ci
+`;
+
+export function pipelineSnippet(host: CiHost): PipelineSnippet {
+  switch (host) {
+    case "gitlab":
+      return { file: ".gitlab-ci.yml", content: GITLAB };
+    case "bitbucket":
+      return { file: "bitbucket-pipelines.yml", content: BITBUCKET };
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3199,6 +3199,34 @@ function emitGitlabJunit(checks: JsonCheck[], allOk: boolean): void {
 
 async function cmdCi(): Promise<boolean> {
   const args = process.argv.slice(2);
+
+  // `kit ci --init <gitlab|bitbucket>` — emit the pipeline snippet that runs
+  // `kit ci` on a non-GitHub host. Prints to stdout (copy-paste); `--write`
+  // writes the file only when absent (never clobbers an existing pipeline).
+  const initIdx = args.indexOf("--init");
+  if (initIdx !== -1) {
+    const { pipelineSnippet, isCiHost, CI_HOSTS } = await import("./ci-init.js");
+    const host = args[initIdx + 1] ?? "";
+    if (!isCiHost(host)) {
+      console.error(`kit ci --init: host must be one of ${CI_HOSTS.join(", ")}`);
+      return false;
+    }
+    const { file, content } = pipelineSnippet(host);
+    if (hasFlag(args, "--write")) {
+      const path = resolve(process.cwd(), file);
+      if (existsSync(path)) {
+        console.error(`${file} already exists — not overwriting. Snippet to merge in:\n`);
+        console.log(content);
+        return false;
+      }
+      writeFileSync(path, content, "utf8");
+      console.log(`${c.green}✓${c.reset} wrote ${file}`);
+      return true;
+    }
+    console.log(content);
+    return true;
+  }
+
   const formatArg = args.find((a) => a.startsWith("--format="))?.split("=")[1] as
     | CiFormat
     | undefined;
@@ -5217,7 +5245,7 @@ export const COMMAND_HELP: Record<string, string> = {
   audit: "View audit log of kit operations",
   doctor: "Deep diagnostics — checks environment health in detail",
   env: "Show current environment info",
-  ci: "CI-native check: GitHub Actions annotations, GitLab JUnit, JSON",
+  ci: "CI-native check: GitHub Actions annotations, GitLab JUnit, JSON (--init gitlab|bitbucket scaffolds a pipeline)",
   clone: "Clone a Git repository and run kit setup",
   run: "Execute a command with project env vars loaded",
   open: "Open service dashboard in browser (stripe, vercel, railway, etc.)",


### PR DESCRIPTION
## What

Completes the buildable half of #145 (git-host parity).

- **`kit ci --init <gitlab|bitbucket>`** emits a ready pipeline snippet that runs `kit ci` — GitLab `kit-ci` job (`--format gitlab` → JUnit `kit-report.xml`) / Bitbucket `kit ci` step. Prints to stdout by default (copy-paste); `--write` writes the file **only when absent** (never clobbers an existing pipeline). New pure module `src/ci-init.ts`.
  - GitHub is intentionally not generated: kit ships its own SHA-pinned Actions and a hand-written unpinned workflow would be (correctly) flagged by `kit gha-audit` — documented instead.
- **`docs/CI_AND_GIT_HOSTS.md`**: the 4-layer gate model, the snippets, server-side hook + branch-protection guidance per host, and the honest "local advises / layer-4 enforces" framing.

## RCA fix to ci-audit (#155), found while dogfooding

The generated Bitbucket snippet tripped kit's own `ci-audit`: its image regex treated **any** `name:` — including a Bitbucket step label like `name: kit ci` — as a service image → false positive ("unpinned image kit"). Fixed: a `name:` value is only treated as an image when it's image-shaped (has `/`, `:`, or `@`); `image:` stays unambiguous so an untagged `image: node` is still flagged. Added a regression guard, and a dogfood test that asserts the emitted snippets are clean under `ci-audit`.

## Verification

- `kit ci --init gitlab|bitbucket` → correct snippets; `--init bogus` → error; both snippets pass `kit ci-audit` (dogfood test).
- Image-detection regression-checked: `image: node:latest` / untagged `image: python` still flagged.
- `npm test` — **1866/0**; build + `format:check` clean. Only `ci` COMMAND_HELP text changed (no public-surface snapshot impact).

## Still open on #145 (not code)
Server-side/pre-receive hook *installation* and branch-protection rules are platform-admin actions — documented, not automated (out of scope by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_