### PR TITLE
feat(memory): debounced mid-session indexing so recall survives ephemeral sessions

### DIFF
--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -30,6 +30,7 @@ import {
 } from "../memory/shared.js";
 import {
   userPromptSubmitReminder,
+  maybeStartMidSessionIndex,
   runSessionEndIndex,
   sessionStartRecovery,
 } from "../memory/hook.js";
@@ -464,6 +465,7 @@ async function memHook(): Promise<boolean> {
   // Internal: invoked by Claude Code hooks. Fail-open — never block.
   const event = process.argv[4];
   if (event === "user-prompt-submit") {
+    maybeStartMidSessionIndex(); // debounced, detached — keeps recall fresh mid-session
     const text = userPromptSubmitReminder();
     if (text) console.log(text);
     return true;

--- a/src/memory/hook.test.ts
+++ b/src/memory/hook.test.ts
@@ -4,7 +4,12 @@ import { mkdtempSync, rmSync, writeFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { openMemoryDb, upsertSession, insertMessage } from "./db.js";
-import { userPromptSubmitReminder, sessionStartRecovery, dueForHarnessSweep } from "./hook.js";
+import {
+  userPromptSubmitReminder,
+  sessionStartRecovery,
+  dueForHarnessSweep,
+  dueForMidSessionIndex,
+} from "./hook.js";
 import { getCurrentProjectRoot } from "./project.js";
 
 describe("memory hook — UserPromptSubmit reminder", () => {
@@ -113,5 +118,33 @@ describe("memory hook — harness sweep debounce", () => {
     const mtime = statSync(marker).mtimeMs;
     assert.equal(dueForHarnessSweep(mtime + 60_000), false, "1 min later → not due");
     assert.equal(dueForHarnessSweep(mtime + 7 * 60 * 60 * 1000), true, "7h later → due");
+  });
+});
+
+describe("memory hook — mid-session index debounce", () => {
+  let tmp: string;
+  const prevDir = process.env.KIT_MEMORY_DIR;
+
+  before(() => {
+    tmp = mkdtempSync(join(tmpdir(), "kit-midsession-"));
+    process.env.KIT_MEMORY_DIR = tmp;
+  });
+
+  after(() => {
+    if (prevDir === undefined) delete process.env.KIT_MEMORY_DIR;
+    else process.env.KIT_MEMORY_DIR = prevDir;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("is due when no marker exists yet", () => {
+    assert.equal(dueForMidSessionIndex(), true);
+  });
+
+  it("is not due right after an index, but due once the 10-min interval elapses", () => {
+    const marker = join(tmp, ".mid-session-index");
+    writeFileSync(marker, new Date().toISOString());
+    const mtime = statSync(marker).mtimeMs;
+    assert.equal(dueForMidSessionIndex(mtime + 60_000), false, "1 min later → not due");
+    assert.equal(dueForMidSessionIndex(mtime + 11 * 60 * 1000), true, "11 min later → due");
   });
 });

--- a/src/memory/hook.ts
+++ b/src/memory/hook.ts
@@ -8,8 +8,9 @@
  * Both are FAIL-OPEN: any error yields an empty/no-op result so a hook can never
  * block a prompt or break a session. Deterministic, zero model calls.
  */
-import { basename, join } from "node:path";
+import { basename, join, resolve } from "node:path";
 import { existsSync, statSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
 import { openMemoryDb, getStats, recentMessages, getMemoryDir, ensureMemoryDir } from "./db.js";
 import { indexClaudeTranscripts, indexAllHarnesses } from "./parser.js";
 import { palList } from "./pal.js";
@@ -132,6 +133,65 @@ function markHarnessSwept(): void {
     writeFileSync(harnessSweepMarker(), new Date().toISOString(), { mode: 0o600 });
   } catch {
     /* best-effort: a missed marker just means we sweep again next time */
+  }
+}
+
+/**
+ * Mid-session recall freshness. SessionEnd indexes the session when it ends, but
+ * a long session — or one whose (ephemeral / remote) container is reclaimed before
+ * a clean SessionEnd ever fires — would leave its recent turns unsearchable. So on
+ * every prompt we cheaply check a debounce marker and, at most once per interval,
+ * kick a DETACHED `kit memory index` so recall stays fresh WITHOUT adding latency
+ * to the prompt (a full index parse is seconds; we never block on it). Shorter
+ * interval than the harness sweep because it tracks the live session.
+ */
+const MID_SESSION_INDEX_INTERVAL_MS = 10 * 60 * 1000; // 10 min
+
+function midSessionIndexMarker(): string {
+  return join(getMemoryDir(), ".mid-session-index");
+}
+
+/** True if a mid-session index is due (marker missing or older than the interval). */
+export function dueForMidSessionIndex(now: number = Date.now()): boolean {
+  try {
+    const marker = midSessionIndexMarker();
+    if (!existsSync(marker)) return true;
+    return now - statSync(marker).mtimeMs >= MID_SESSION_INDEX_INTERVAL_MS;
+  } catch {
+    return false; // can't tell → don't add work
+  }
+}
+
+function markMidSessionIndexed(): void {
+  try {
+    ensureMemoryDir();
+    writeFileSync(midSessionIndexMarker(), new Date().toISOString(), { mode: 0o600 });
+  } catch {
+    /* best-effort: a missed marker just means we index again next time */
+  }
+}
+
+/**
+ * If due, stamp the debounce marker and launch a DETACHED `kit memory index`
+ * (fire-and-forget, stdio ignored, unref'd) so the live session's recent turns
+ * become searchable without waiting for SessionEnd. Stamps BEFORE spawning so
+ * concurrent prompts don't stampede. Fail-open: any error is swallowed so a
+ * prompt is never blocked. Returns true iff it launched an index.
+ */
+export function maybeStartMidSessionIndex(): boolean {
+  try {
+    if (!dueForMidSessionIndex()) return false;
+    markMidSessionIndexed(); // stamp first → debounce holds even if the spawn races
+    const entry = process.argv[1];
+    if (!entry) return false;
+    const child = spawn(process.execPath, [resolve(entry), "memory", "index"], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+    return true;
+  } catch {
+    return false; // fail-open: never block a prompt
   }
 }
 


### PR DESCRIPTION
## Why

`SessionEnd` indexes the session when it ends — but a long session, or one whose **ephemeral/remote container is reclaimed before a clean SessionEnd ever fires**, leaves its recent turns unsearchable. Observed live this session: the store sat **297 messages behind** mid-session, and `kit memory search` missed work done minutes earlier.

## What

Adds a **debounced, detached** mid-session index on the `UserPromptSubmit` hook (which already fires every prompt):

- At most once per **10 min** it stamps a marker and launches `kit memory index` **fire-and-forget** (`detached`, `stdio: "ignore"`, `unref()`), so recall stays fresh **without adding latency** to the prompt — a full index parse is seconds and we never block on it.
- Stamps the marker **before** spawning so concurrent prompts don't stampede.
- **Fail-open**: any error is swallowed; a prompt is never blocked.
- Reuses the marker-mtime debounce idiom already used for the harness sweep (shorter interval since this tracks the live session).

## Test

- `dueForMidSessionIndex` unit-tested (marker-missing → due; 1 min later → not due; 11 min later → due), mirroring the harness-sweep debounce test.
- `npm test` — **1868/0**; build + `format:check` clean. No public-surface change (the hook is internal).

## Note on the related "(b)"

Wiring the hooks themselves (`kit memory install`) is an **environment-level** action (or `kit setup --recommended`) — it generates machine-specific absolute paths via the 2.1 self-heal wrapper, so it's deliberately **not** committed into the shared repo `.claude/settings.json`. This PR improves the hook that real user setups already wire.

## Follow-up (separate issue)
Recall is literal keyword matching (zero-LLM by design); a better local ranking (e.g. BM25, still zero-LLM) is a worthwhile enhancement — filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_