### PR TITLE
docs(env): zero-touch environment fueling guide (memory design gap #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **Zero-touch environment fueling guide** (`docs/ENV_FUELING.md`). Documents the
+  setup-script pattern — `kit setup --recommended` (config: tools, vault-backed
+  secrets, agent gates, verify) + `kit memory sync`/`restore` (recall) — so a fresh
+  or ephemeral environment (cloud container, Claude Code on the web, CI, new
+  laptop) fuels itself with no manual steps. Covers non-interactive setup, where
+  the script lives (devcontainer/Dockerfile/CI/web), the memory bridge, and the
+  guardrails (secrets never plaintext, private memory never committed, idempotent,
+  zero-LLM). Linked from the README quick start.
 - **Path→cluster push-surfacing for shared decisions** (`kit memory context`).
   Pull recall can't _guarantee_ you see a settled decision (a bad query misses
   it); the guardrail is now PUSH — touch files under an area and kit

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ kit setup          # install tools (via mise), git hooks, logins, secrets
 kit context check  # lock each CLI to the declared account + project (no wrong-org pushes)
 ```
 
+Fresh or ephemeral environment (cloud container, Claude Code on the web, CI, new
+laptop)? Wire `kit setup` + `kit memory sync` into the environment's setup script
+so it fuels itself — config, secrets (vault-backed), agent gates, identity, and
+recall — with zero manual steps. See [docs/ENV_FUELING.md](docs/ENV_FUELING.md).
+
 ## Problem
 
 Every time you (or an agent) starts on a new project:
@@ -257,16 +262,16 @@ The block is regenerated in place on re-run; edit outside its markers freely.
 kit is **agent-agnostic** — it's a CLI that any coding agent can run, plus opt-in
 adapters for the surfaces each agent exposes. Support today, per agent:
 
-| Agent | Memory index¹ | "use kit" rules block² | Agent/MCP config audit³ | Perm allowlist⁴ | Auto-capture hooks⁵ | Blocking gate⁶ |
-| :--- | :---: | :---: | :---: | :---: | :---: | :---: |
-| **Claude Code** | ✅ | ✅ `CLAUDE.md` | ✅ + commands/agents/skills/plugins | ✅ | ✅ | ✅ hook |
-| **OpenAI Codex** | ✅ | ✅ `AGENTS.md` | ✅ `.codex/config` | — | — | ✅ hook |
-| **OpenCode** | ✅ | ✅ `AGENTS.md` | ✅ `opencode.json` + `.opencode/plugin` | — | — | ✅ plugin |
-| **Cursor** | ✅ | ✅ `.cursorrules` | ✅ `.cursor/mcp.json` | — | — | ✅ hook |
-| **Cline** | ✅ | ✅ `.clinerules` | — | — | — | ✅ hook |
-| **Gemini CLI** | ✅ | — | — | — | — | ✅ hook |
-| **Continue** | ✅ | — | — | — | — | n/a⁷ |
-| **Amazon Q** | ✅ | — | — | — | — | ✅ hook |
+| Agent            | Memory index¹ | "use kit" rules block² |         Agent/MCP config audit³         | Perm allowlist⁴ | Auto-capture hooks⁵ | Blocking gate⁶ |
+| :--------------- | :-----------: | :--------------------: | :-------------------------------------: | :-------------: | :-----------------: | :------------: |
+| **Claude Code**  |      ✅       |     ✅ `CLAUDE.md`     |   ✅ + commands/agents/skills/plugins   |       ✅        |         ✅          |    ✅ hook     |
+| **OpenAI Codex** |      ✅       |     ✅ `AGENTS.md`     |           ✅ `.codex/config`            |        —        |          —          |    ✅ hook     |
+| **OpenCode**     |      ✅       |     ✅ `AGENTS.md`     | ✅ `opencode.json` + `.opencode/plugin` |        —        |          —          |   ✅ plugin    |
+| **Cursor**       |      ✅       |   ✅ `.cursorrules`    |          ✅ `.cursor/mcp.json`          |        —        |          —          |    ✅ hook     |
+| **Cline**        |      ✅       |    ✅ `.clinerules`    |                    —                    |        —        |          —          |    ✅ hook     |
+| **Gemini CLI**   |      ✅       |           —            |                    —                    |        —        |          —          |    ✅ hook     |
+| **Continue**     |      ✅       |           —            |                    —                    |        —        |          —          |      n/a⁷      |
+| **Amazon Q**     |      ✅       |           —            |                    —                    |        —        |          —          |    ✅ hook     |
 
 ✅ supported · — not yet · n/a not applicable (no surface) ([#146](https://github.com/sandstream/kit/issues/146))
 

--- a/docs/ENV_FUELING.md
+++ b/docs/ENV_FUELING.md
@@ -1,0 +1,106 @@
+# Zero-touch environment fueling
+
+A fresh or ephemeral environment — a cloud dev container, Claude Code on the web,
+a CI runner, a new laptop, a teammate's clone — starts **blank**. Re-establishing
+tools, secrets, agent gates, identity, and recall by hand every time is the tax
+this guide removes: wire two commands into the environment's **setup script** and
+every new environment fuels itself.
+
+The whole pattern is:
+
+```sh
+kit setup --recommended   # config: tools, secrets (vault-backed), agent gates, verify
+kit memory sync <export>  # recall: bring this developer's memory across (optional)
+```
+
+Switching environment then never resets your configuration or your memory.
+
+## 1. What each step establishes
+
+| Step     | Command                                  | Establishes                                                                                                                   |
+| -------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Config   | `kit setup`                              | tools (mise/aqua per `.kit.toml`), `kit login`, secrets resolved from the vault, agent install-gates, then `kit check` verify |
+| Recall   | `kit memory sync` / `kit memory restore` | this developer's conversation memory (private tier)                                                                           |
+| Identity | `kit identity init`                      | a per-environment Ed25519 signing identity (or restore an existing one)                                                       |
+
+`.kit.toml` is committed, so the **config contract travels with the repo** — `kit
+setup` just realizes it. Secrets are never committed; they are resolved at setup
+time from the vault (`kit secrets`), so the environment only needs vault auth, not
+plaintext `.env` files.
+
+## 2. `kit setup` is non-interactive-safe
+
+`kit setup` detects a non-interactive context (CI, an agent runner, no TTY) and
+runs the **core** setup without prompting — it will never silently wire global
+`~/.claude` hooks or git hooks without an explicit yes. Make the choice explicit
+in a script:
+
+- `kit setup --recommended` — core + the recommended profile (memory hooks, git
+  hooks).
+- `kit setup --minimal` — core only.
+- `kit setup --mode <name>` — a named preset over the individual knobs (see
+  `kit setup --help` for the modes).
+- Air-gapped enclave: the network posture is written to `[air_gap]` in `.kit.toml`
+  (idempotent); a mode can force it so an enclave setup never reaches for the
+  network.
+
+## 3. Where the setup script lives
+
+Put the two commands wherever the environment runs its provisioning hook:
+
+- **Claude Code on the web / remote execution environments** — the environment's
+  configured **setup script** (see the environment docs:
+  <https://code.claude.com/docs/en/claude-code-on-the-web>).
+- **Dev containers** — `postCreateCommand` in `devcontainer.json`.
+- **Dockerfile** — a `RUN kit setup --minimal` layer (config only; do memory at
+  run time, not build time).
+- **CI** — a step before the gates run; pair with `kit check` / `kit ci`.
+
+A minimal, idempotent example (safe to re-run):
+
+```sh
+#!/usr/bin/env sh
+set -eu
+
+# 1. Config from the committed .kit.toml (non-interactive core + recommended).
+kit setup --recommended
+
+# 2. Per-environment signing identity (no-op if one already exists).
+kit identity init
+
+# 3. Recall — restore this developer's encrypted memory backup, if provided.
+#    KIT_MEMORY_PASSPHRASE comes from the environment's secret store, never inline.
+if [ -n "${KIT_MEMORY_BACKUP:-}" ]; then
+  kit memory restore "$KIT_MEMORY_BACKUP"
+fi
+```
+
+## 4. Memory across environments
+
+Recall lives in the **private tier** (`~/.kit/memory.db`, never committed). To
+carry it into a new environment today:
+
+- **Encrypted backup → restore**: `kit memory backup <file>` on the source (with
+  `KIT_MEMORY_PASSPHRASE`), `kit memory restore <file>` on the target
+  (AES-256-GCM with scrypt; the passphrase is never stored).
+- **Export → sync**: `kit memory sync <export.db|backup>` last-write-wins on
+  sessions; this machine's index state is left untouched.
+
+The **shared / curated tier** (`.kit/shared/memory.jsonl`) is committed, so team
+decisions arrive with the clone — no sync step needed. Automatic private-remote
+sync (a private git repo / object store, with a guard that the remote is never the
+project's own repo) is planned; until then the backup/restore bridge above is the
+supported path.
+
+## 5. Guardrails (why this is safe to automate)
+
+- **Secrets never land in plaintext** — `kit setup` resolves them from the vault;
+  the environment supplies vault auth, kit supplies the values at use time.
+- **Private memory is never committed** — it syncs only via the encrypted
+  backup/export bridge above; the committed tier is the curated, secret-scanned
+  decisions only.
+- **Idempotent + fail-open** — re-running `kit setup` re-realizes the contract
+  without clobbering; a missing memory backup just means a blank-but-working
+  environment, never a failed setup.
+- **Deterministic, zero-LLM** — every step is a deterministic command; nothing
+  here calls a model.


### PR DESCRIPTION
## Description

Documents the **zero-touch environment fueling** pattern (memory design gap #6): wire `kit setup --recommended` (config — tools, vault-backed secrets, agent gates, verify) + `kit memory sync`/`restore` (recall) into an environment's setup script so a fresh/ephemeral environment (cloud container, Claude Code on the web, CI, new laptop) fuels itself with no manual steps.

New `docs/ENV_FUELING.md` covers:
- what each step establishes (config / recall / identity),
- `kit setup` non-interactive safety (CI/agent-safe; explicit `--recommended` / `--minimal` / `--mode`),
- where the script lives (Claude Code on the web / devcontainer / Dockerfile / CI) with a minimal idempotent example,
- the memory bridge (encrypted backup→restore; the curated shared tier arrives with the clone; private-remote sync noted as planned = gap #4),
- guardrails: secrets never plaintext, private memory never committed, idempotent, fail-open, zero-LLM.

Linked from the README quick start.

## Type of Change
- [x] Documentation update

## Testing
- [x] Docs-only; prettier-clean. No code changed.

## Breaking Changes
None / N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_