### PR TITLE
feat(policy): kit ci enforces the signed policy (3.0 Phase 1 — complete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`kit ci` enforces the signed policy.** `kit ci` now folds `evaluatePolicy`
+  into its gate: a present `.kit-policy.toml`'s requirements appear as `policy/*`
+  checks in the report (text/GitHub/JSON), so a tampered/revoked signature, unmet
+  `min_kit_version`, or (under `--strict`) a missing required scanner fails CI like
+  any other check. Opt-in and backward-compatible — no policy ⇒ no `policy/*`
+  checks ⇒ the verdict is unchanged. Completes Phase 1's "kit ci consumes the
+  policy".
 - **`kit policy check`** (experimental) — enforce the signed `.kit-policy.toml`
   against this machine's deterministic state (3.0 Phase 1, part 2). Verifies the
   signature (the trust anchor: warn on unsigned/unknown signer, **fail** on

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -127,6 +127,7 @@ import { cmdGhaAudit } from "./commands/gha-audit.js";
 import { cmdIdentity } from "./commands/identity.js";
 import { cmdPanic } from "./commands/panic.js";
 import { cmdPolicy } from "./commands/policy.js";
+import { evaluatePolicy } from "./policy-check.js";
 import { cmdSbom } from "./commands/sbom.js";
 import { cmdAuth } from "./commands/auth.js";
 import { cmdAudit } from "./commands/audit.js";
@@ -3265,6 +3266,14 @@ async function cmdCi(): Promise<boolean> {
         : [];
       const securityResults = await step("security scan", () => checkSecurity());
       const lockResults = await step("lock files", () => checkLockFiles(config));
+      // Signed org policy (.kit-policy.toml) — opt-in (absent ⇒ present:false ⇒ no
+      // items ⇒ no effect on the verdict). Folds the same evaluatePolicy() the
+      // `kit policy check` command uses into the CI gate, so a tampered/revoked
+      // signature, unmet min_kit_version, or (under --strict) a missing required
+      // scanner fails CI like any other check.
+      const policyReport = await step("policy", () => evaluatePolicy(process.cwd(), { strict }));
+      const policyStatus = (s: "pass" | "warn" | "fail" | "n/a"): JsonCheck["status"] =>
+        s === "n/a" ? "skip" : s;
 
       const checks: JsonCheck[] = [
         ...toolResults.map((t) => ({
@@ -3311,6 +3320,26 @@ async function cmdCi(): Promise<boolean> {
           detail: s.detail,
           category: `security/${s.category}`,
         })),
+        ...(policyReport.present
+          ? [
+              ...(policyReport.signature
+                ? [
+                    {
+                      name: "signature",
+                      status: policyStatus(policyReport.signature.status),
+                      detail: policyReport.signature.detail,
+                      category: "policy",
+                    },
+                  ]
+                : []),
+              ...policyReport.items.map((i) => ({
+                name: i.requirement,
+                status: policyStatus(i.status),
+                detail: i.detail,
+                category: "policy",
+              })),
+            ]
+          : []),
       ];
 
       const summary = checks.reduce(


### PR DESCRIPTION
## Description

Completes 3.0 **Phase 1**: the signed org policy now gates the pipeline agents and CI actually run. `kit ci` folds the same `evaluatePolicy()` that `kit policy check` uses into its check aggregation — a present `.kit-policy.toml`'s requirements appear as `policy/*` checks in the report (text / GitHub summary / JSON), so a **tampered/revoked signature**, an unmet **`min_kit_version`**, or (under `--strict`) a **missing required scanner** fails CI exactly like any other check.

- One injection point in `cmdCi`: `evaluatePolicy(cwd, {strict})` → its signature verdict + per-requirement items are spread into the existing `checks[]` (with `n/a → skip` for the `JsonCheck` status union). The existing summary / `allOk` / exit logic does the rest.
- **Opt-in + backward-compatible**: no `.kit-policy.toml` ⇒ `present:false` ⇒ zero `policy/*` checks ⇒ the verdict is byte-for-byte what it was before.

## Type of Change
- [x] New feature (non-breaking)

## Testing
- [x] All tests pass (`npm test`) — **1914 pass / 0 fail**; `run-security-check.mjs` PASS (19 ok)

Verified live: a repo with a signed `.kit-policy.toml` → `kit ci --json` shows `policy/signature`, `policy/min_kit_version`, `policy/require_triage` all `pass`; editing the policy after signing → `policy/signature` becomes `fail` and contributes to the verdict. A repo with no policy → no `policy/*` checks.

## Breaking Changes
None / N/A — opt-in; absent policy ⇒ unchanged behavior.

## Follow-up
Phase 2: signed org **bundles** (one policy signed by an org key, distributed to many repos) + RBAC keyed to identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_