### PR TITLE
feat(policy): org-distributed policy verification — trust anchor (3.0 Phase 2 starter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **Org-distributed policy verification** (`kit policy trust`) — 3.0 Phase 2
+  starter. A committed `.kit-policy.signers` trust anchor lists the org public
+  key(s) allowed to sign the policy; `verifyPolicy` resolves the signer in trust
+  order (a pinned `--key` → this machine's identity → the org anchor), so ONE
+  policy signed by a central org key verifies authentically on every clone — no
+  shared secret, only public keys distributed. `kit policy trust <pubkey.pem>
+[--label]` / `--list` / `--remove <id>` manage it. Fail-CLOSED once an anchor
+  exists: a signer that isn't in it fails `kit policy check` / `kit ci` (same
+  discipline as the HMAC audit anchor), not just a warn. New `src/policy-trust.ts`;
+  `PolicyVerifyResult` gains `via` (key|local|org) + `anchored`. This is the model
+  the major bump needs — identity signs the org standard, any repo verifies it.
 - **`kit ci` enforces the signed policy.** `kit ci` now folds `evaluatePolicy`
   into its gate: a present `.kit-policy.toml`'s requirements appear as `policy/*`
   checks in the report (text/GitHub/JSON), so a tampered/revoked signature, unmet

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -81,7 +81,31 @@ It is **opt-in**: with no `.kit-policy.toml` it is a no-op (exit 0). A hard fail
 `min_kit_version`, or — under `--strict` — a missing required scanner. Run it as a
 CI step (`kit policy check --strict`) to gate on the signed org standard.
 
+## Org distribution: `.kit-policy.signers` (the trust anchor)
+
+A locally-signed policy only verifies on the machine that signed it. To distribute
+ONE org standard across MANY repos, commit a **trust anchor** — `.kit-policy.signers`
+— listing the org public key(s) allowed to sign the policy:
+
+```
+kit identity show --public > org.pub          # on the org's signing machine
+kit policy trust org.pub --label acme-security # in each repo (commit the result)
+kit policy trust --list                        # show trusted signers
+kit policy trust --remove <kid>                # revoke trust in a signer
+```
+
+`verifyPolicy` resolves the signer key in trust order: a pinned `--key` → this
+machine's own identity → the committed org anchor. So a policy signed by the org
+key verifies as `valid (org trust anchor)` on any clone — asymmetric, no shared
+secret, only public keys distributed.
+
+**Fail-closed once anchored.** With a `.kit-policy.signers` present, a policy whose
+signer is NOT in it is a hard **fail** in `kit policy check` / `kit ci` (not a
+warn) — distribution must mean enforcement, the same discipline as the HMAC audit
+anchor. Without an anchor, an unknown signer stays a warn (trust-absence ≠ forgery).
+
 ## What's next
 
-Folding the policy verdict into `kit check` / `kit ci`'s aggregate gate, then signed
-org **bundles** + RBAC (Phase 2).
+Signed org **bundles** (packaging the policy + signer manifest for drop-in) and
+RBAC keyed to identity (which role may read/write/elevate/install/deploy) —
+Phase 2 depth.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5194,7 +5194,7 @@ export const COMMAND_HELP: Record<string, string> = {
   panic:
     "Compromise response: rotate identity + emit a signed revocation + audit it + print the platform-revocation checklist (experimental)",
   policy:
-    "Signable org policy-as-code in .kit-policy.toml (init/show/validate/sign/verify/check) — identity-signed standard, enforced + verifiable offline (experimental)",
+    "Signable org policy-as-code in .kit-policy.toml (init/show/validate/sign/verify/check/trust) — identity-signed standard, org-distributable + enforced offline (experimental)",
   design: "Check design quality (a11y, design tokens) against the baseline",
   baseline:
     "Freeze current warnings into .kit-baseline.json so future runs gate only net-new findings",

--- a/src/commands/policy.ts
+++ b/src/commands/policy.ts
@@ -4,10 +4,16 @@
 // a `kit identity` (Phase 0) so an org's standard is cryptographically attributable
 // and offline-verifiable. Distinct from `.kit.toml [policy.agent_writes]` (the 2.x
 // per-repo agent-write pre-approval) — this is the org-level standard.
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, writeFileSync, readFileSync } from "node:fs";
 import { c } from "../utils/colors.js";
 import { hasFlag, flagValue } from "../utils/flags.js";
 import { getCurrentProjectRoot } from "../memory/project.js";
+import {
+  addPolicySigner,
+  loadPolicySigners,
+  removePolicySigner,
+  getSignersPath,
+} from "../policy-trust.js";
 import {
   getPolicyPath,
   getPolicySigPath,
@@ -39,8 +45,12 @@ export async function cmdPolicy(): Promise<boolean> {
       return policyVerify(root);
     case "check":
       return policyCheck(root);
+    case "trust":
+      return policyTrust(root);
     default:
-      console.error(`${c.red}usage: kit policy <init|show|validate|sign|verify|check>${c.reset}`);
+      console.error(
+        `${c.red}usage: kit policy <init|show|validate|sign|verify|check|trust>${c.reset}`,
+      );
       return false;
   }
 }
@@ -154,6 +164,64 @@ function policyVerify(root: string): boolean {
         `${c.red}✗ policy signed by a REVOKED key${c.reset} ${c.dim}(${r.detail}) — re-sign with the current identity${c.reset}`,
       );
       return false;
+  }
+}
+
+function policyTrust(root: string): boolean {
+  // List the org trust anchor.
+  if (
+    hasFlag(process.argv, "--list") ||
+    (!process.argv[4] && !flagValue(process.argv, "--remove"))
+  ) {
+    const signers = loadPolicySigners(root);
+    if (!signers.length) {
+      console.log(
+        `${c.dim}no org trust anchor — add one with ${c.reset}${c.bold}kit policy trust <pubkey.pem> [--label <name>]${c.reset}`,
+      );
+      return true;
+    }
+    console.log(
+      `${c.bold}${signers.length}${c.reset} trusted policy signer(s) ${c.dim}(${getSignersPath(root)})${c.reset}`,
+    );
+    for (const s of signers) {
+      console.log(`  ${c.bold}${s.id}${c.reset}${s.label ? ` ${c.dim}${s.label}${c.reset}` : ""}`);
+    }
+    return true;
+  }
+  // Remove a signer by id.
+  const removeId = flagValue(process.argv, "--remove");
+  if (removeId) {
+    const ok = removePolicySigner(root, removeId);
+    console.log(
+      ok
+        ? `${c.green}✓${c.reset} removed ${removeId} from the trust anchor`
+        : `${c.dim}${removeId} not in the trust anchor${c.reset}`,
+    );
+    return ok;
+  }
+  // Add a signer from an SPKI-PEM file (e.g. produced by `kit identity show --public`).
+  const file = process.argv[4];
+  if (!existsSync(file)) {
+    console.error(`${c.red}no such public-key file: ${file}${c.reset}`);
+    return false;
+  }
+  try {
+    const pem = readFileSync(file, "utf-8");
+    const r = addPolicySigner(root, pem, flagValue(process.argv, "--label") ?? undefined);
+    if (r.added) {
+      console.log(
+        `${c.green}✓${c.reset} trusted org policy signer ${c.bold}${r.signer.id}${c.reset}${r.signer.label ? ` ${c.dim}(${r.signer.label})${c.reset}` : ""}`,
+      );
+      console.log(
+        `${c.dim}commit .kit-policy.signers — any clone now verifies a policy this org key signed; an untrusted signer fails ${c.reset}${c.bold}kit policy check${c.reset}${c.dim}/${c.reset}${c.bold}kit ci${c.reset}`,
+      );
+    } else {
+      console.log(`${c.dim}${r.signer.id} ${r.reason}${c.reset}`);
+    }
+    return true;
+  } catch (err) {
+    console.error(`${c.red}not a valid public key: ${(err as Error).message}${c.reset}`);
+    return false;
   }
 }
 

--- a/src/policy-check.ts
+++ b/src/policy-check.ts
@@ -63,12 +63,18 @@ export async function evaluatePolicy(
   // Signature is the trust anchor — an unsigned/unknown signer is a warn (the
   // policy still reads), a tampered/revoked one is a hard fail.
   const v = verifyPolicy(root);
+  // valid → pass; tamper/revoked → fail; unsigned → warn. An UNVERIFIABLE signer
+  // is normally a warn (trust-absence ≠ forgery), but once a committed org trust
+  // anchor exists, a signer that isn't in it is fail-CLOSED — distribution must
+  // mean enforcement (same discipline as the HMAC audit anchor).
   const sigStatus: PolicyEvalStatus =
     v.status === "valid"
       ? "pass"
       : v.status === "invalid" || v.status === "revoked"
         ? "fail"
-        : "warn";
+        : v.status === "unverifiable" && v.anchored
+          ? "fail"
+          : "warn";
   const signature: PolicyEvalItem = {
     requirement: "signature",
     status: sigStatus,

--- a/src/policy-doc.ts
+++ b/src/policy-doc.ts
@@ -28,6 +28,7 @@ import { join } from "node:path";
 import { createHash } from "node:crypto";
 import { parse } from "smol-toml";
 import { localPublicKeys, verifySignature, isRevoked } from "./identity.js";
+import { policySignersMap, hasPolicyAnchor } from "./policy-trust.js";
 
 export const POLICY_FILE = ".kit-policy.toml";
 export const POLICY_SIG_FILE = ".kit-policy.sig";
@@ -161,6 +162,10 @@ export interface PolicyVerifyResult {
   detail: string;
   kid?: string;
   fingerprint?: string;
+  /** Where the verifying key came from: a pinned --key, the local identity, or the org trust anchor. */
+  via?: "key" | "local" | "org";
+  /** True when a committed org trust anchor (.kit-policy.signers) is present. */
+  anchored?: boolean;
 }
 
 /**
@@ -182,17 +187,32 @@ export function verifyPolicy(root: string, opts: { key?: string } = {}): PolicyV
     return { status: "unsigned", detail: "no .kit-policy.sig (run kit policy sign)" };
   }
   const fingerprint = policyFingerprint(doc);
-  const pubkey = opts.key
-    ? existsSync(opts.key)
-      ? readFileSync(opts.key, "utf-8")
-      : opts.key
-    : (localPublicKeys().get(record.kid) ?? null);
+  const anchored = hasPolicyAnchor(root);
+  // Resolve the signer key, in trust order: an explicit --key pin, then this
+  // machine's own identity (the author verifying their own policy), then the
+  // committed org trust anchor (.kit-policy.signers) — which is what makes an
+  // ORG-distributed policy verify on a fresh clone.
+  let pubkey: string | null = null;
+  let via: PolicyVerifyResult["via"] = undefined;
+  if (opts.key) {
+    pubkey = existsSync(opts.key) ? readFileSync(opts.key, "utf-8") : opts.key;
+    via = "key";
+  } else if (localPublicKeys().get(record.kid)) {
+    pubkey = localPublicKeys().get(record.kid)!;
+    via = "local";
+  } else if (policySignersMap(root).get(record.kid)) {
+    pubkey = policySignersMap(root).get(record.kid)!;
+    via = "org";
+  }
   if (!pubkey) {
     return {
       status: "unverifiable",
-      detail: `signer ${record.kid} unknown (pin it with --key <spki-pem|file>)`,
+      detail: anchored
+        ? `signer ${record.kid} is not in the org trust anchor (.kit-policy.signers)`
+        : `signer ${record.kid} unknown (pin with --key, or add it to .kit-policy.signers)`,
       kid: record.kid,
       fingerprint,
+      anchored,
     };
   }
   const fpMatches = record.fingerprint === fingerprint;
@@ -205,6 +225,8 @@ export function verifyPolicy(root: string, opts: { key?: string } = {}): PolicyV
       detail: fpMatches ? "signature mismatch" : "policy changed since signing — re-sign",
       kid: record.kid,
       fingerprint,
+      via,
+      anchored,
     };
   }
   if (isRevoked(record.kid)) {
@@ -213,9 +235,18 @@ export function verifyPolicy(root: string, opts: { key?: string } = {}): PolicyV
       detail: `signer ${record.kid} is revoked`,
       kid: record.kid,
       fingerprint,
+      via,
+      anchored,
     };
   }
-  return { status: "valid", detail: `signed by ${record.kid}`, kid: record.kid, fingerprint };
+  return {
+    status: "valid",
+    detail: `signed by ${record.kid}${via === "org" ? " (org trust anchor)" : ""}`,
+    kid: record.kid,
+    fingerprint,
+    via,
+    anchored,
+  };
 }
 
 /** A ready-to-edit starter policy (written by `kit policy init`). */

--- a/src/policy-trust.test.ts
+++ b/src/policy-trust.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { generateKeyPairSync, sign as edSign, type KeyObject } from "node:crypto";
+import { identityId } from "./identity.js";
+import {
+  canonicalPolicyBytes,
+  policyFingerprint,
+  verifyPolicy,
+  getPolicyPath,
+  getPolicySigPath,
+} from "./policy-doc.js";
+import {
+  addPolicySigner,
+  loadPolicySigners,
+  removePolicySigner,
+  hasPolicyAnchor,
+} from "./policy-trust.js";
+import { evaluatePolicy } from "./policy-check.js";
+
+function orgKey(): { priv: KeyObject; pubPem: string; id: string } {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const pubPem = publicKey.export({ type: "spki", format: "pem" }) as string;
+  return { priv: privateKey, pubPem, id: identityId(pubPem) };
+}
+
+function writeSignedPolicy(
+  root: string,
+  doc: Record<string, unknown>,
+  key: { priv: KeyObject; pubPem: string; id: string },
+): void {
+  // Serialize the doc as TOML matching the object we sign (so fingerprints align).
+  const toml = Object.entries(doc)
+    .map(([k, v]) => `${k} = ${typeof v === "string" ? `"${v}"` : v}`)
+    .join("\n");
+  writeFileSync(getPolicyPath(root), toml + "\n");
+  const sig = edSign(null, Buffer.from(canonicalPolicyBytes(doc)), key.priv).toString("base64");
+  writeFileSync(
+    getPolicySigPath(root),
+    JSON.stringify({ kid: key.id, sig, ts: "t", fingerprint: policyFingerprint(doc) }),
+  );
+}
+
+describe("policy-trust — the org trust anchor", () => {
+  // Point identity at an EMPTY dir so localPublicKeys() is empty — forcing
+  // resolution to fall through to the committed .kit-policy.signers anchor.
+  let idDir: string;
+  const prev = process.env.KIT_IDENTITY_DIR;
+  before(() => {
+    idDir = mkdtempSync(join(tmpdir(), "kit-trust-id-"));
+    process.env.KIT_IDENTITY_DIR = idDir;
+  });
+  after(() => {
+    if (prev === undefined) delete process.env.KIT_IDENTITY_DIR;
+    else process.env.KIT_IDENTITY_DIR = prev;
+    rmSync(idDir, { recursive: true, force: true });
+  });
+
+  it("add/load/dedupe/remove roundtrip; malformed key throws", () => {
+    const root = mkdtempSync(join(tmpdir(), "kit-trust-"));
+    try {
+      const k = orgKey();
+      assert.equal(hasPolicyAnchor(root), false);
+      const added = addPolicySigner(root, k.pubPem, "acme-sec");
+      assert.equal(added.added, true);
+      assert.equal(added.signer.id, k.id);
+      assert.equal(loadPolicySigners(root).length, 1);
+      assert.equal(hasPolicyAnchor(root), true);
+      // idempotent
+      assert.equal(addPolicySigner(root, k.pubPem).added, false);
+      // remove
+      assert.equal(removePolicySigner(root, k.id), true);
+      assert.equal(hasPolicyAnchor(root), false);
+      // malformed
+      assert.throws(() => addPolicySigner(root, "not a key"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("verifies an ORG-signed policy via the anchor (not the local identity)", () => {
+    const root = mkdtempSync(join(tmpdir(), "kit-trust-v-"));
+    try {
+      const org = orgKey();
+      writeSignedPolicy(root, { version: 1, require_triage: true }, org);
+      // No anchor yet, and the signer is not a local key → unverifiable.
+      const before = verifyPolicy(root);
+      assert.equal(before.status, "unverifiable");
+      assert.equal(before.anchored, false);
+      // Trust the org key → now it verifies, sourced from the org anchor.
+      addPolicySigner(root, org.pubPem, "acme-sec");
+      const after = verifyPolicy(root);
+      assert.equal(after.status, "valid", after.detail);
+      assert.equal(after.via, "org");
+      assert.equal(after.anchored, true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fail-CLOSED: once an anchor exists, a signer not in it fails the gate", async () => {
+    const root = mkdtempSync(join(tmpdir(), "kit-trust-fc-"));
+    try {
+      const signer = orgKey();
+      const otherTrusted = orgKey();
+      writeSignedPolicy(root, { version: 1, require_triage: true }, signer);
+      // Anchor contains a DIFFERENT org key, not the one that signed.
+      addPolicySigner(root, otherTrusted.pubPem, "someone-else");
+      const v = verifyPolicy(root);
+      assert.equal(v.status, "unverifiable");
+      assert.equal(v.anchored, true);
+      // evaluatePolicy turns that into a hard fail (not a warn) because an anchor exists.
+      const report = await evaluatePolicy(root);
+      assert.equal(report.signature?.status, "fail", JSON.stringify(report.signature));
+      assert.equal(report.ok, false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/policy-trust.ts
+++ b/src/policy-trust.ts
@@ -1,0 +1,97 @@
+/**
+ * kit policy trust anchor — org-distributed policy verification (3.0 Phase 2 starter).
+ *
+ * Phase 1 signs a policy with the LOCAL identity, so `verifyPolicy` could only
+ * resolve the signer via this machine's own keys (or a per-invocation `--key`).
+ * That can't express the org case: ONE policy signed by a central org key,
+ * dropped into MANY repos, verified everywhere. This adds a committed,
+ * repo-resident trust anchor — `.kit-policy.signers` — listing the org public
+ * key(s) allowed to sign the policy. `verifyPolicy` consults it after the local
+ * store, so a distributed org-signed policy verifies authentically on any clone,
+ * with no shared secret (asymmetric: only public keys are distributed).
+ *
+ * Committed + reviewed like the rest of the governance surface; deterministic,
+ * zero-LLM. Once an anchor is present, an un-anchored signer is fail-CLOSED in the
+ * gate (see policy-check.ts) — the same "fail-closed once anchored" discipline as
+ * the HMAC audit anchor.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { identityId } from "./identity.js";
+
+export const POLICY_SIGNERS_FILE = ".kit-policy.signers";
+
+export interface PolicySigner {
+  /** kid derived from the public key (stable, non-secret). */
+  id: string;
+  /** SPKI PEM — the org public key allowed to sign the policy. */
+  publicKey: string;
+  /** Human label (e.g. "acme-security"). */
+  label?: string;
+}
+
+export function getSignersPath(root: string): string {
+  return join(root, POLICY_SIGNERS_FILE);
+}
+
+/** Read the committed trust anchor. Best-effort: [] when absent/malformed. */
+export function loadPolicySigners(root: string): PolicySigner[] {
+  try {
+    const raw = JSON.parse(readFileSync(getSignersPath(root), "utf-8")) as {
+      signers?: unknown;
+    };
+    if (!raw || !Array.isArray(raw.signers)) return [];
+    return raw.signers.filter(
+      (s): s is PolicySigner =>
+        !!s &&
+        typeof (s as PolicySigner).id === "string" &&
+        typeof (s as PolicySigner).publicKey === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+/** kid → public-key (PEM) map of the org-trusted policy signers. */
+export function policySignersMap(root: string): Map<string, string> {
+  return new Map(loadPolicySigners(root).map((s) => [s.id, s.publicKey]));
+}
+
+/** True when a non-empty trust anchor is present (⇒ gate is fail-closed on an untrusted signer). */
+export function hasPolicyAnchor(root: string): boolean {
+  return loadPolicySigners(root).length > 0;
+}
+
+export interface AddSignerResult {
+  added: boolean;
+  signer: PolicySigner;
+  reason?: string;
+}
+
+/**
+ * Add an org public key (SPKI PEM) to the trust anchor. Idempotent on the derived
+ * id. Throws if the PEM is not a valid public key. Writes pretty JSON (diffable).
+ */
+export function addPolicySigner(
+  root: string,
+  publicKeyPem: string,
+  label?: string,
+): AddSignerResult {
+  const id = identityId(publicKeyPem); // throws on a malformed key — fail loud
+  const signers = loadPolicySigners(root);
+  const existing = signers.find((s) => s.id === id);
+  if (existing) return { added: false, signer: existing, reason: "already trusted" };
+  const signer: PolicySigner = { id, publicKey: publicKeyPem, ...(label ? { label } : {}) };
+  signers.push(signer);
+  writeFileSync(getSignersPath(root), JSON.stringify({ signers }, null, 2) + "\n", "utf-8");
+  return { added: true, signer };
+}
+
+/** Remove a signer by id. Returns true if one was removed. */
+export function removePolicySigner(root: string, id: string): boolean {
+  const signers = loadPolicySigners(root);
+  const next = signers.filter((s) => s.id !== id);
+  if (next.length === signers.length) return false;
+  writeFileSync(getSignersPath(root), JSON.stringify({ signers: next }, null, 2) + "\n", "utf-8");
+  return true;
+}


### PR DESCRIPTION
## Description

The one piece a 3.0-readiness review flagged as the remaining gap for an honest 3.0.0: letting **one org-signed policy verify across many repos** (not just a locally-signed one). This is the model-change the major needs — *identity signs the org standard; any repo verifies it offline.*

- **`src/policy-trust.ts`** — a committed `.kit-policy.signers` **trust anchor** (the org public key(s) allowed to sign the policy). `loadPolicySigners` / `policySignersMap` / `hasPolicyAnchor` / `addPolicySigner` (dedupes; throws on a malformed key) / `removePolicySigner`.
- **`verifyPolicy`** now resolves the signer in trust order: a pinned `--key` → this machine's own identity → the **org anchor**. Result gains `via` (`key`|`local`|`org`) + `anchored`. A distributed org-signed policy verifies as `valid (org trust anchor)` on a fresh clone instead of `unverifiable`.
- **Fail-CLOSED once anchored** — with `.kit-policy.signers` present, a signer not in it fails `kit policy check` / `kit ci` (not just a warn), same discipline as the HMAC audit anchor. No anchor ⇒ an unknown signer stays a warn (trust-absence ≠ forgery).
- **`kit policy trust <pubkey.pem> [--label] | --list | --remove <id>`**.

## Type of Change
- [x] New feature (non-breaking)
- [x] Documentation update

## Testing
- [x] Added new tests
- [x] All tests pass (`npm test`) — **1917 pass / 0 fail**; `run-security-check.mjs` PASS (19 ok)

Verified live (two-machine simulation): an identity on machine A signs a policy; on machine B (different local identity) it's `unverifiable` until `kit policy trust A.pub`, then verifies `valid (org trust anchor)`.

## Breaking Changes
None / N/A — additive; opt-in (no `.kit-policy.signers` ⇒ prior behavior).

## Context — 3.0 readiness
A multi-agent review this session confirmed Phase 0 (identity) + Phase 1 (policy sign/verify/check + `kit ci` enforcement) are shipped, and named this org trust anchor as the single remaining gap for the 3.0.0 minimum. With this merged, **identity + policy = the contract** is end-to-end. (A separate PR will follow with promise-keeping fixes the review surfaced: air-gap-aware update check, deterministic catalog-staleness, and an additive-only contract test.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_