### PR TITLE
feat(memory): sync onboarding — `sync init`, opt-in auto pull/push, one-time nudge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   project tree, so a cloned repo can't inject it), the payload is encrypted, and
   it's opt-in. The blob is the real unit; git and command are just two ways to
   move it.
+- **Memory sync onboarding: `kit memory sync init` + opt-in auto-pull/push + a
+  one-time nudge.** Closes the usability gaps in gap #4 (you previously had to
+  hand-write `~/.kit/sync.toml`, and nothing synced automatically):
+  - `kit memory sync init` writes the local `~/.kit/sync.toml` template
+    (`--remote <url>` for git, or `--command` with `--push-cmd`/`--pull-cmd`;
+    `--auto` enables the hooks; `--force` overwrites). It won't clobber an existing
+    config and reminds you to set `KIT_MEMORY_PASSPHRASE` + create the private repo.
+  - `[memory.sync] pull_on_start = true` / `push_on_end = true` wire sync into the
+    SessionStart/SessionEnd hooks: pull+merge before "where you left off", and
+    index+push when the session ends — the missing piece for **ephemeral
+    containers** (memory reaches your durable store before the box is reclaimed).
+    Both are fail-soft: a session is never blocked by sync.
+  - A one-time tip suggests `kit memory sync init` when you have a non-trivial
+    memory store but sync isn't configured yet (suppressed after the first show).
 
 ### Security
 

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -26,6 +26,11 @@ import {
   pushMemory,
   pullMemory,
   getSyncConfigPath,
+  initSyncConfig,
+  tryAutoPull,
+  tryAutoPush,
+  maybeSyncNudge,
+  type SyncTransport,
 } from "../memory/remote-sync.js";
 import {
   shareEntry,
@@ -234,6 +239,9 @@ async function memHelp(): Promise<boolean> {
     "  kit memory sync <file>      Sync from a memory export/backup (decrypts encrypted blobs)",
   );
   console.log(
+    "  kit memory sync init        Write ~/.kit/sync.toml (--remote <url> | --command, --auto for hook sync)",
+  );
+  console.log(
     "  kit memory push             Encrypt + push your store to your private remote (~/.kit/sync.toml)",
   );
   console.log(
@@ -314,6 +322,7 @@ async function memMerge(): Promise<boolean> {
 }
 
 async function memSync(): Promise<boolean> {
+  if (process.argv[4] === "init") return memSyncInit();
   const src = process.argv[4];
   if (!src) {
     console.error(
@@ -340,6 +349,47 @@ async function memSync(): Promise<boolean> {
     return false;
   } finally {
     db.close();
+  }
+  return true;
+}
+
+async function memSyncInit(): Promise<boolean> {
+  const transport: SyncTransport = hasFlag(process.argv, "--command") ? "command" : "git";
+  const { path, created } = initSyncConfig({
+    transport,
+    remote: flagValue(process.argv, "--remote"),
+    branch: flagValue(process.argv, "--branch"),
+    pushCmd: flagValue(process.argv, "--push-cmd"),
+    pullCmd: flagValue(process.argv, "--pull-cmd"),
+    auto: hasFlag(process.argv, "--auto"),
+    force: hasFlag(process.argv, "--force"),
+  });
+  if (!created) {
+    console.log(
+      `${c.yellow}!${c.reset} ${path} already exists ${c.dim}(use --force to overwrite)${c.reset}`,
+    );
+    return true;
+  }
+  console.log(
+    `${c.green}✓${c.reset} wrote ${c.bold}${path}${c.reset} ${c.dim}(LOCAL — never committed)${c.reset}`,
+  );
+  console.log(
+    `${c.dim}edit the ${transport === "command" ? "push_cmd/pull_cmd" : "remote"} to your PRIVATE store, then:${c.reset}`,
+  );
+  console.log(
+    `  export KIT_MEMORY_PASSPHRASE="…"   ${c.dim}# never stored; the blob is encrypted with it${c.reset}`,
+  );
+  console.log(`  kit memory push   ${c.dim}# from one machine${c.reset}`);
+  console.log(`  kit memory pull   ${c.dim}# on another${c.reset}`);
+  if (transport === "git") {
+    console.log(
+      `${c.dim}note: create the private repo first — e.g. \`git init --bare /srv/kit-memory.git\` on your server, or an empty private repo on GitHub. kit creates the branch + blob, not the repo.${c.reset}`,
+    );
+  }
+  if (hasFlag(process.argv, "--auto")) {
+    console.log(
+      `${c.dim}auto-sync ON: pull at session start + push at session end (run \`kit memory install\`; KIT_MEMORY_PASSPHRASE must be in the hook env).${c.reset}`,
+    );
   }
   return true;
 }
@@ -613,11 +663,23 @@ async function memHook(): Promise<boolean> {
   }
   if (event === "session-end") {
     runSessionEndIndex();
+    // Opt-in: push this session's memory to your durable store before an
+    // (ephemeral) container is reclaimed. Fail-soft; notes go to stderr.
+    const pushed = tryAutoPush(getCurrentProjectRoot());
+    if (pushed.note) console.error(`${c.dim}${pushed.note}${c.reset}`);
     return true;
   }
   if (event === "session-start") {
+    // Opt-in auto-pull BEFORE recovery so "where you left off" reflects the
+    // freshly-merged store. Fail-soft; the sync note goes to stderr (the recovery
+    // text on stdout is what gets injected as context).
+    const pulled = tryAutoPull(getCurrentProjectRoot());
+    if (pulled.note) console.error(`${c.dim}${pulled.note}${c.reset}`);
     const text = sessionStartRecovery();
     if (text) console.log(text);
+    // One-time upgrade nudge when sync isn't configured yet.
+    const nudge = maybeSyncNudge();
+    if (nudge) console.error(`${c.dim}${nudge}${c.reset}`);
     return true;
   }
   console.error(`${c.red}Unknown hook event: ${event ?? "(none)"}${c.reset}`);

--- a/src/memory/remote-sync.test.ts
+++ b/src/memory/remote-sync.test.ts
@@ -11,6 +11,10 @@ import {
   assertRemoteNotProjectOrigin,
   pushMemory,
   pullMemory,
+  initSyncConfig,
+  tryAutoPull,
+  tryAutoPush,
+  maybeSyncNudge,
   type SyncConfig,
 } from "./remote-sync.js";
 import { openMemoryDb, searchMessages, upsertSession, insertMessage } from "./db.js";
@@ -270,5 +274,102 @@ describe("remote-sync — command transport (bring-your-own move: S3/rclone/scp/
       else process.env.KIT_MEMORY_DIR = prevDir;
       for (const d of [machine, proj]) rmSync(d, { recursive: true, force: true });
     }
+  });
+});
+
+describe("remote-sync — init + auto-sync wiring + nudge", () => {
+  const withDir = (fn: (dir: string) => void) => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-init-"));
+    const prev = process.env.KIT_MEMORY_DIR;
+    process.env.KIT_MEMORY_DIR = dir;
+    try {
+      fn(dir);
+    } finally {
+      if (prev === undefined) delete process.env.KIT_MEMORY_DIR;
+      else process.env.KIT_MEMORY_DIR = prev;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  };
+
+  it("initSyncConfig writes a template, won't clobber without force, round-trips --auto flags", () => {
+    withDir(() => {
+      const a = initSyncConfig({ remote: "git@h:me/m.git", auto: true });
+      assert.equal(a.created, true);
+      const cfg = loadSyncConfig();
+      assert.equal(cfg?.transport, "git");
+      assert.equal(cfg?.remote, "git@h:me/m.git");
+      assert.equal(cfg?.pullOnStart, true);
+      assert.equal(cfg?.pushOnEnd, true);
+      // no clobber without force
+      assert.equal(initSyncConfig({ remote: "other" }).created, false);
+      // force overwrites — and to a command transport
+      assert.equal(
+        initSyncConfig({ transport: "command", pushCmd: "true", pullCmd: "true", force: true })
+          .created,
+        true,
+      );
+      assert.equal(loadSyncConfig()?.transport, "command");
+    });
+  });
+
+  it("tryAutoPull / tryAutoPush are no-ops without the opt-in flags (and never throw)", () => {
+    withDir(() => {
+      assert.equal(tryAutoPull("/tmp").ran, false); // no config
+      assert.equal(tryAutoPush("/tmp").ran, false);
+      initSyncConfig({ transport: "command", pushCmd: "true", pullCmd: "true" }); // no --auto
+      assert.equal(tryAutoPull("/tmp").ran, false);
+      assert.equal(tryAutoPush("/tmp").ran, false);
+    });
+  });
+
+  it("push_on_end pushes via the command transport (the ephemeral-container path)", () => {
+    const store = mkdtempSync(join(tmpdir(), "kit-store2-"));
+    const storeBlob = join(store, "memory.enc");
+    const machine = mkdtempSync(join(tmpdir(), "kit-em-"));
+    const proj = mkdtempSync(join(tmpdir(), "kit-eproj-"));
+    const prevDir = process.env.KIT_MEMORY_DIR;
+    const prevPass = process.env.KIT_MEMORY_PASSPHRASE;
+    try {
+      process.env.KIT_MEMORY_DIR = machine;
+      process.env.KIT_MEMORY_PASSPHRASE = PASS;
+      const dbA = openMemoryDb();
+      upsertSession(dbA, { sessionId: "s-auto", harness: "claude-code" });
+      insertMessage(dbA, { uuid: "u-auto", sessionId: "s-auto", type: "message", content: "x" });
+      dbA.close();
+      initSyncConfig({
+        transport: "command",
+        pushCmd: `cp "$KIT_MEMORY_BLOB" "${storeBlob}"`,
+        pullCmd: `cp "${storeBlob}" "$KIT_MEMORY_BLOB"`,
+        auto: true,
+        force: true,
+      });
+      const r = tryAutoPush(proj);
+      assert.equal(r.ran, true);
+      assert.ok(existsSync(storeBlob), "blob deposited by push_on_end");
+    } finally {
+      if (prevDir === undefined) delete process.env.KIT_MEMORY_DIR;
+      else process.env.KIT_MEMORY_DIR = prevDir;
+      if (prevPass === undefined) delete process.env.KIT_MEMORY_PASSPHRASE;
+      else process.env.KIT_MEMORY_PASSPHRASE = prevPass;
+      for (const d of [store, machine, proj]) rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  it("maybeSyncNudge: null when configured / no store; shows once then suppressed", () => {
+    withDir((dir) => {
+      // no store → no nudge
+      assert.equal(maybeSyncNudge(), null);
+      // a non-trivial store (a >64 KB file at the db path; nudge only stats size)
+      writeFileSync(join(dir, "memory.db"), Buffer.alloc(70 * 1024));
+      const first = maybeSyncNudge();
+      assert.match(first ?? "", /kit memory sync init/);
+      assert.equal(maybeSyncNudge(), null, "suppressed after the first show (marker)");
+    });
+    // and null when sync IS already configured
+    withDir((dir) => {
+      writeFileSync(join(dir, "memory.db"), Buffer.alloc(70 * 1024));
+      initSyncConfig({ remote: "git@h:me/m.git" });
+      assert.equal(maybeSyncNudge(), null);
+    });
   });
 });

--- a/src/memory/remote-sync.ts
+++ b/src/memory/remote-sync.ts
@@ -20,7 +20,15 @@
  * Deterministic, zero-LLM, zero new dependencies (node:child_process + git).
  */
 import { execFileSync, execSync } from "node:child_process";
-import { existsSync, readFileSync, mkdtempSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  statSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parse } from "smol-toml";
@@ -46,6 +54,11 @@ export interface SyncConfig {
   pushCmd?: string;
   /** Shell command that DOWNLOADS the blob to $KIT_MEMORY_BLOB from your store. */
   pullCmd?: string;
+  // opt-in automation (off by default) — wired into the SessionStart/SessionEnd hooks.
+  /** Pull + merge the store at the start of each session. */
+  pullOnStart?: boolean;
+  /** Index + push the store at the end of each session (key for ephemeral containers). */
+  pushOnEnd?: boolean;
 }
 
 const DEFAULT_BRANCH = "main";
@@ -81,6 +94,10 @@ export function loadSyncConfig(): SyncConfig | null {
     throw new Error(`invalid [memory.sync] file "${file}" — must be a bare filename`);
   }
 
+  const bool = (v: unknown): boolean => v === true;
+  const pullOnStart = bool(s.pull_on_start);
+  const pushOnEnd = bool(s.push_on_end);
+
   const transport: SyncTransport = s.transport === "command" ? "command" : "git";
   if (transport === "command") {
     const pushCmd = str(s.push_cmd);
@@ -88,13 +105,13 @@ export function loadSyncConfig(): SyncConfig | null {
     if (!pushCmd || !pullCmd) {
       throw new Error('[memory.sync] transport = "command" requires both push_cmd and pull_cmd');
     }
-    return { transport, file, pushCmd, pullCmd };
+    return { transport, file, pushCmd, pullCmd, pullOnStart, pushOnEnd };
   }
 
   const remote = str(s.remote);
   if (!remote) return null; // git transport with no remote → treat as unconfigured
   const branch = str(s.branch) || DEFAULT_BRANCH;
-  return { transport, file, remote, branch };
+  return { transport, file, remote, branch, pullOnStart, pushOnEnd };
 }
 
 /**
@@ -265,6 +282,132 @@ export function pullMemory(
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+}
+
+export interface InitSyncOptions {
+  transport?: SyncTransport;
+  remote?: string;
+  branch?: string;
+  pushCmd?: string;
+  pullCmd?: string;
+  /** Enable pull-on-start + push-on-end. */
+  auto?: boolean;
+  /** Overwrite an existing sync.toml. */
+  force?: boolean;
+}
+
+/**
+ * Write a starter `~/.kit/sync.toml` (LOCAL, never committed). Returns created:false
+ * (without touching the file) when one already exists and `force` isn't set.
+ */
+export function initSyncConfig(opts: InitSyncOptions = {}): { path: string; created: boolean } {
+  const path = getSyncConfigPath();
+  if (existsSync(path) && !opts.force) return { path, created: false };
+  const transport: SyncTransport = opts.transport ?? "git";
+  const lines = ["[memory.sync]"];
+  if (transport === "command") {
+    lines.push('transport = "command"');
+    lines.push(
+      `push_cmd = ${JSON.stringify(opts.pushCmd ?? 'aws s3 cp "$KIT_MEMORY_BLOB" s3://YOUR-BUCKET/kit-memory.enc')}`,
+    );
+    lines.push(
+      `pull_cmd = ${JSON.stringify(opts.pullCmd ?? 'aws s3 cp s3://YOUR-BUCKET/kit-memory.enc "$KIT_MEMORY_BLOB"')}`,
+    );
+  } else {
+    lines.push(
+      `remote = ${JSON.stringify(opts.remote ?? "git@github.com:YOU/your-private-memory.git")}`,
+    );
+    if (opts.branch) lines.push(`branch = ${JSON.stringify(opts.branch)}`);
+  }
+  if (opts.auto) {
+    lines.push("pull_on_start = true");
+    lines.push("push_on_end = true");
+  }
+  mkdirSync(getMemoryDir(), { recursive: true, mode: 0o700 });
+  writeFileSync(path, lines.join("\n") + "\n", { mode: 0o600 });
+  return { path, created: true };
+}
+
+export interface AutoSyncResult {
+  ran: boolean;
+  /** A short human note for stderr (a sync happened, or why it was skipped). */
+  note?: string;
+}
+
+/**
+ * Pull + merge at session start when `[memory.sync] pull_on_start = true`. Always
+ * fail-soft: a missing config, missing passphrase, or transport error never throws
+ * (a session must never be blocked by sync). No-op unless the flag is set.
+ */
+export function tryAutoPull(projectRoot: string): AutoSyncResult {
+  let cfg: SyncConfig | null;
+  try {
+    cfg = loadSyncConfig();
+  } catch {
+    return { ran: false };
+  }
+  if (!cfg || !cfg.pullOnStart) return { ran: false };
+  try {
+    const r = pullMemory(cfg, process.env.KIT_MEMORY_PASSPHRASE, projectRoot);
+    return { ran: true, note: r.found ? `memory synced from ${r.target}` : undefined };
+  } catch (e) {
+    return { ran: false, note: `memory pull skipped: ${(e as Error).message}` };
+  }
+}
+
+/**
+ * Index-and-push at session end when `[memory.sync] push_on_end = true`. The key
+ * piece for EPHEMERAL containers: the session's memory reaches your durable store
+ * before the container is reclaimed. Fail-soft; needs KIT_MEMORY_PASSPHRASE.
+ */
+export function tryAutoPush(projectRoot: string): AutoSyncResult {
+  let cfg: SyncConfig | null;
+  try {
+    cfg = loadSyncConfig();
+  } catch {
+    return { ran: false };
+  }
+  if (!cfg || !cfg.pushOnEnd) return { ran: false };
+  if (!process.env.KIT_MEMORY_PASSPHRASE) {
+    return { ran: false, note: "memory push skipped: KIT_MEMORY_PASSPHRASE not set" };
+  }
+  try {
+    const r = pushMemory(cfg, process.env.KIT_MEMORY_PASSPHRASE, projectRoot);
+    return { ran: true, note: r.pushed ? `memory pushed to ${r.target}` : undefined };
+  } catch (e) {
+    return { ran: false, note: `memory push skipped: ${(e as Error).message}` };
+  }
+}
+
+const NUDGE_MARKER = ".sync-nudge-shown";
+
+/**
+ * One-time upgrade nudge: if sync is NOT configured but there's a memory store
+ * worth syncing, suggest `kit memory sync init` — once (a marker under ~/.kit
+ * suppresses it thereafter). Returns null when nothing should be shown.
+ */
+export function maybeSyncNudge(): string | null {
+  try {
+    if (loadSyncConfig()) return null; // already configured
+  } catch {
+    return null;
+  }
+  const marker = join(getMemoryDir(), NUDGE_MARKER);
+  if (existsSync(marker)) return null;
+  let worthIt = false;
+  try {
+    const p = getMemoryDbPath();
+    worthIt = existsSync(p) && statSync(p).size > 64 * 1024; // a non-trivial store
+  } catch {
+    worthIt = false;
+  }
+  if (!worthIt) return null;
+  try {
+    writeFileSync(marker, "", { mode: 0o600 });
+  } catch {
+    /* best-effort — if we can't write the marker, worst case we nudge again */
+  }
+  return "tip: sync your memory across machines (and back it up) — run `kit memory sync init`";
 }
 
 /** Give the throwaway clone a commit identity if the environment has none. */


### PR DESCRIPTION
## Description

Closes the three onboarding gaps in gap #4 (#176/#178) — confirmed missing in review: you had to hand-write `~/.kit/sync.toml`, there was no setup command, no upgrade hint, and **nothing pulled/pushed automatically** (which made the ephemeral-container flow a manual chore).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

**A — `kit memory sync init`** writes the LOCAL `~/.kit/sync.toml` template:
- `--remote <url>` (git, default) or `--command` with `--push-cmd`/`--pull-cmd`; `--auto` turns on the hooks; `--force` overwrites.
- Won't clobber an existing config; prints next steps (set `KIT_MEMORY_PASSPHRASE`, and **create the private repo** — kit makes the branch + blob, not the repo).

**B — opt-in auto-sync wired into the memory hooks:**
- `[memory.sync] pull_on_start = true` → pull+merge at **SessionStart**, *before* the "where you left off" recovery (so it reflects the merged store).
- `[memory.sync] push_on_end = true` → index+push at **SessionEnd** — the missing piece for **ephemeral containers** (memory reaches your durable store before the box is reclaimed).
- Both are **fail-soft** (`tryAutoPull`/`tryAutoPush` never throw): a session is never blocked by sync. Notes go to stderr; the injected recovery stays on stdout.

**C — one-time upgrade nudge:** when sync isn't configured but a non-trivial memory store exists, suggest `kit memory sync init` once (a `~/.kit` marker suppresses it thereafter).

New exports in `remote-sync.ts`: `initSyncConfig`, `tryAutoPull`, `tryAutoPush`, `maybeSyncNudge`; `SyncConfig` gains `pullOnStart`/`pushOnEnd`.

## Testing

### Test Coverage
- [x] Added new tests (init round-trip + no-clobber + flag round-trip; auto-sync gating; `push_on_end` via command transport; nudge shows-once)
- [x] All tests pass (`npm test`) — 1952 pass, 0 fail

### Manual Testing
1. `kit memory sync init --remote … --auto` writes a config with `pull_on_start`/`push_on_end`; re-run without `--force` → no clobber.
2. `tryAutoPush` with `push_on_end` + a `cp`-based command transport deposits the encrypted blob (the ephemeral path).
3. `tryAutoPull`/`tryAutoPush` are no-ops (never throw) without the flags.
4. `maybeSyncNudge` returns the tip once for a non-trivial store, then null; null once configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_