### PR TITLE
feat(ux): `kit config knobs` — discoverable reference for hidden env/config knobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`kit config knobs` — a discoverable reference for the power-user env vars +
+  `.kit.toml` fields kit honors.** A review found capabilities like air-gapped
+  SAST (`KIT_SEMGREP_CONFIG`), capture-time secret redaction (`KIT_MEMORY_REDACT`),
+  read-only lockdown (`[policy].default_mode`), monorepo triage whitelisting
+  (`[supply_chain].internal_scopes`) and the CI escape hatches (`KIT_ELEVATED`,
+  `KIT_PROD_OK`, `KIT_NON_INTERACTIVE`) were only findable in source. `kit config
+  knobs` lists them grouped, with `env`/`cfg` tags and a ⚠ on the ones that bypass
+  a safety gate (`--json` for tooling). Listed in `kit config` help + the main
+  command list. (Companion to the deterministic hint engine.)
 - **Smart, deterministic hints — kit surfaces the right opt-in capability at the
   right moment (zero LLM).** A review found many powerful features (signed policy,
   audit anchoring, container/IaC scanning, malware heuristics) were only

--- a/contracts/public-surface.json
+++ b/contracts/public-surface.json
@@ -117,6 +117,7 @@
     "clone",
     "completions",
     "config",
+    "config knobs",
     "config migrate",
     "context",
     "context --prompt",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5305,6 +5305,7 @@ export const COMMAND_HELP: Record<string, string> = {
   config: "Inspect + migrate the .kit.toml schema version",
   "config migrate":
     "Migrate .kit.toml to the current schema version (--dry-run inspect, --check CI gate, --force overwrite backup)",
+  "config knobs": "List power-user env vars + .kit.toml fields kit honors (--json)",
   mcp: "MCP server over stdio (Claude Code/Cursor/Codex); 'kit mcp list|auth|set-token|clear' manages declared servers",
   whoami: "Show current agent / user identity",
   version: "Print kit version",

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -19,6 +19,7 @@ import {
 import { c } from "../utils/colors.js";
 import { hasFlag } from "../utils/flags.js";
 import { resolveConfigPath, KIT_FILE } from "../cli-shared.js";
+import { formatKnobs, knobsAsJson } from "../knobs.js";
 
 async function fileExists(path: string): Promise<boolean> {
   try {
@@ -315,10 +316,20 @@ async function cmdConfigMigrate(): Promise<boolean> {
   return outcome.ok;
 }
 
+function cmdConfigKnobs(): boolean {
+  if (hasFlag(process.argv, "--json")) {
+    console.log(JSON.stringify(knobsAsJson(), null, 2));
+    return true;
+  }
+  console.log(formatKnobs({ color: true }));
+  return true;
+}
+
 export async function cmdConfig(): Promise<boolean> {
   const sub = process.argv[3];
 
   if (sub === "migrate") return cmdConfigMigrate();
+  if (sub === "knobs") return cmdConfigKnobs();
 
   // Default / help: show the current config version + available subcommands.
   if (!sub || sub === "--help" || sub === "-h") {
@@ -346,6 +357,9 @@ export async function cmdConfig(): Promise<boolean> {
     );
     console.log(
       `  ${c.cyan}kit config migrate --force${c.reset}     Overwrite an existing ${KIT_FILE}.backup`,
+    );
+    console.log(
+      `  ${c.cyan}kit config knobs${c.reset}               List power-user env vars + ${KIT_FILE} fields (--json)`,
     );
     return true;
   }

--- a/src/knobs.test.ts
+++ b/src/knobs.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { KNOBS, knobsAsJson, formatKnobs } from "./knobs.js";
+
+const ESC = String.fromCharCode(27); // ANSI sequences start with this byte
+
+describe("knobs reference", () => {
+  it("every knob is well-formed (name, kind, desc)", () => {
+    for (const group of KNOBS) {
+      assert.ok(group.title.length > 0);
+      assert.ok(group.knobs.length > 0, `group ${group.title} is empty`);
+      for (const k of group.knobs) {
+        assert.ok(k.name.length > 0);
+        assert.ok(k.kind === "env" || k.kind === "config");
+        assert.ok(k.desc.length > 0, `${k.name} missing desc`);
+      }
+    }
+  });
+
+  it("includes the headline hidden knobs surfaced by the review", () => {
+    const names = KNOBS.flatMap((g) => g.knobs.map((k) => k.name));
+    for (const expected of [
+      "KIT_MEMORY_REDACT",
+      "KIT_SEMGREP_CONFIG",
+      "[policy].default_mode",
+      "[supply_chain].internal_scopes",
+      "KIT_NO_HINTS",
+    ]) {
+      assert.ok(names.includes(expected), `expected knob ${expected}`);
+    }
+  });
+
+  it("marks gate-bypassing knobs as dangerous", () => {
+    const danger = KNOBS.flatMap((g) => g.knobs)
+      .filter((k) => k.danger)
+      .map((k) => k.name);
+    for (const d of ["KIT_NON_INTERACTIVE", "KIT_ELEVATED", "KIT_PROD_OK"]) {
+      assert.ok(danger.includes(d), `${d} should be flagged dangerous`);
+    }
+  });
+
+  it("formatKnobs({color:false}) is plain text with no ANSI escape bytes", () => {
+    const out = formatKnobs({ color: false });
+    // knob names legitimately contain "[" so check for the ESC byte, not "[".
+    assert.ok(!out.includes(ESC), "no ANSI escape bytes in no-color mode");
+    assert.match(out, /KIT_SEMGREP_CONFIG/);
+    assert.match(out, /Scanning/);
+  });
+
+  it("formatKnobs({color:true}) emits ANSI", () => {
+    assert.ok(formatKnobs({ color: true }).includes(ESC));
+  });
+
+  it("knobsAsJson round-trips through JSON", () => {
+    const j = JSON.parse(JSON.stringify(knobsAsJson()));
+    assert.equal(j.length, KNOBS.length);
+    assert.equal(j[0].knobs[0].name, KNOBS[0].knobs[0].name);
+  });
+});

--- a/src/knobs.ts
+++ b/src/knobs.ts
@@ -1,0 +1,214 @@
+/**
+ * kit knobs — a curated reference of the power-user env vars + `.kit.toml` fields
+ * that kit honors but that aren't part of the everyday surface. Surfaced by
+ * `kit config knobs` so they're DISCOVERABLE without reading source.
+ *
+ * This is documentation-as-data: a single hand-curated list (only user-facing,
+ * genuinely useful knobs — internal/test-only env vars are intentionally left
+ * out). Pure: `formatKnobs` renders it; `knobsAsJson` returns it structured.
+ */
+import { c } from "./utils/colors.js";
+
+export interface Knob {
+  /** Env var name, or `.kit.toml` key path. */
+  name: string;
+  kind: "env" | "config";
+  /** One-line explanation. */
+  desc: string;
+  /** Bypasses a safety gate — render with a warning. */
+  danger?: boolean;
+}
+
+export interface KnobGroup {
+  title: string;
+  knobs: Knob[];
+}
+
+export const KNOBS: KnobGroup[] = [
+  {
+    title: "Scanning & supply-chain",
+    knobs: [
+      {
+        name: "KIT_SEMGREP_CONFIG",
+        kind: "env",
+        desc: "semgrep ruleset — a LOCAL path (e.g. ./rules.yaml) enables air-gapped SAST; default p/default fetches from the registry",
+      },
+      {
+        name: "KIT_BUMBLEBEE_PROFILE",
+        kind: "env",
+        desc: "supply-chain scan depth: baseline (fast, default) | project | deep",
+      },
+      {
+        name: "KIT_BUMBLEBEE_REQUIRED",
+        kind: "env",
+        desc: "fail the gate if the bumblebee scanner is unavailable (regulated/strict)",
+      },
+      {
+        name: "KIT_NO_DOWNLOAD",
+        kind: "env",
+        desc: "never download scanner binaries — use only what's already installed",
+      },
+      {
+        name: "[scan].guarddog",
+        kind: "config",
+        desc: "enable GuardDog malware heuristics (needs semgrep); off by default",
+      },
+      {
+        name: "[supply_chain].internal_scopes",
+        kind: "config",
+        desc: "npm orgs / PyPI namespaces treated as internal — skipped in triage (monorepo whitelist)",
+      },
+    ],
+  },
+  {
+    title: "Memory",
+    knobs: [
+      {
+        name: "KIT_MEMORY_REDACT",
+        kind: "env",
+        desc: "mask secret-shaped values BEFORE they're written to memory.db (spillage prevention)",
+      },
+      {
+        name: "KIT_MEMORY_DIR",
+        kind: "env",
+        desc: "relocate the store (default ~/.kit) — put it outside any repo for cross-device sync",
+      },
+      {
+        name: "KIT_MEMORY_PASSPHRASE",
+        kind: "env",
+        desc: "AES-256-GCM passphrase for `kit memory backup`/`push`/`pull` — never stored",
+      },
+      {
+        name: "[memory].track_findings",
+        kind: "config",
+        desc: "auto-track `kit check` findings as PAL items that close on re-scan (default true)",
+      },
+      {
+        name: "[memory.sync]",
+        kind: "config",
+        desc: "cross-device sync (in ~/.kit/sync.toml) — set it up with `kit memory sync init`",
+      },
+    ],
+  },
+  {
+    title: "Policy & governance",
+    knobs: [
+      {
+        name: "[policy].default_mode",
+        kind: "config",
+        desc: '"read-only" locks the repo to read-only without a CLI flag',
+      },
+      {
+        name: "[policy.agent_writes]",
+        kind: "config",
+        desc: 'pre-authorize specific agent vendor ops (e.g. sentry = ["resolve_issue"])',
+      },
+      {
+        name: "KIT_READ_ONLY",
+        kind: "env",
+        desc: "refuse all writes / mutations / elevation — agent containment",
+      },
+    ],
+  },
+  {
+    title: "Audit & attestation",
+    knobs: [
+      {
+        name: "KIT_ATTEST",
+        kind: "env",
+        desc: "emit a signed gate-attestation receipt (same as `kit check --attest`)",
+      },
+      {
+        name: "KIT_AUDIT_ANCHOR_DIR",
+        kind: "env",
+        desc: "relocate the HMAC audit-anchor key + record (default ~/.kit)",
+      },
+    ],
+  },
+  {
+    title: "CI & automation — use with care",
+    knobs: [
+      {
+        name: "KIT_CI_STRICT",
+        kind: "env",
+        desc: "fail `kit ci` if any scanner is unavailable (same as --strict)",
+      },
+      {
+        name: "KIT_NO_UPDATE_CHECK",
+        kind: "env",
+        desc: "disable the npm update check (reproducible/offline CI)",
+      },
+      {
+        name: "KIT_AIRGAP",
+        kind: "env",
+        desc: "air-gap mode: no outbound network; cloud-only scanners are dropped",
+      },
+      {
+        name: "KIT_NO_HINTS",
+        kind: "env",
+        desc: "silence the 💡 contextual tips",
+      },
+      {
+        name: "KIT_NON_INTERACTIVE",
+        kind: "env",
+        desc: "skip ALL confirmation prompts",
+        danger: true,
+      },
+      {
+        name: "KIT_ELEVATED",
+        kind: "env",
+        desc: "bypass the TTY elevation gate for destructive ops in CI (always audit-logged)",
+        danger: true,
+      },
+      {
+        name: "KIT_PROD_OK",
+        kind: "env",
+        desc: "allow production-secret operations without interactive confirmation",
+        danger: true,
+      },
+    ],
+  },
+  {
+    title: "TLS monitoring",
+    knobs: [
+      {
+        name: "KIT_TLS_HOST",
+        kind: "env",
+        desc: "comma-separated hosts → certificate-expiry monitoring in `kit check`",
+      },
+      {
+        name: "KIT_TLS_WARN_DAYS",
+        kind: "env",
+        desc: "days-to-expiry warning threshold (default 21)",
+      },
+    ],
+  },
+];
+
+/** Structured form for `--json`. */
+export function knobsAsJson(): KnobGroup[] {
+  return KNOBS;
+}
+
+/** Human-readable, grouped rendering. `color` toggles ANSI. */
+export function formatKnobs(opts: { color?: boolean } = {}): string {
+  const color = opts.color ?? true;
+  const paint = (fn: string, s: string) => (color ? `${fn}${s}${c.reset}` : s);
+  const lines: string[] = [];
+  lines.push(paint(c.bold, "kit knobs — power-user env vars + .kit.toml fields"));
+  lines.push(
+    paint(c.dim, "env = environment variable · cfg = .kit.toml key · ⚠ = bypasses a safety gate"),
+  );
+  const width = Math.max(...KNOBS.flatMap((g) => g.knobs.map((k) => k.name.length)));
+  for (const group of KNOBS) {
+    lines.push("");
+    lines.push(paint(c.cyan, group.title));
+    for (const k of group.knobs) {
+      const tag = k.kind === "env" ? "env" : "cfg";
+      const flag = k.danger ? paint(c.yellow, " ⚠") : "";
+      const name = k.name.padEnd(width);
+      lines.push(`  ${paint(c.dim, tag)} ${paint(c.bold, name)}  ${paint(c.dim, k.desc)}${flag}`);
+    }
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Description

PR 2 of the "make it feel smart" work (companion to the deterministic hint engine in #180). The hint engine surfaces capabilities *contextually* when state triggers them; this gives a **browsable reference** for the rest — the power-user env vars + `.kit.toml` fields kit honors but that were findable only in source.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `src/knobs.ts` — curated **documentation-as-data**: `KNOBS` grouped by area (scanning/supply-chain, memory, policy/governance, audit/attestation, CI/automation, TLS). Each entry tags **`env`** vs **`cfg`** and flags gate-bypassing knobs (`KIT_ELEVATED`, `KIT_PROD_OK`, `KIT_NON_INTERACTIVE`) with **⚠**. `formatKnobs` (color/no-color) + `knobsAsJson`.
- **`kit config knobs`** — a subcommand (no new top-level command), `--json` for tooling. Listed in `kit config` help and the main command descriptions so it's discoverable.

Surfaces the headliners the review flagged: `KIT_SEMGREP_CONFIG` (air-gapped SAST), `KIT_MEMORY_REDACT` (capture-time secret redaction), `[policy].default_mode` (read-only lockdown), `[supply_chain].internal_scopes` (monorepo triage whitelist), `KIT_BUMBLEBEE_PROFILE`, `KIT_NO_HINTS`, …

## Testing

### Test Coverage
- [x] Added new tests (`knobs.test.ts`): every entry well-formed, headline knobs present, danger flags set, color/no-color rendering, JSON round-trip
- [x] Regenerated `contracts/public-surface.json` — **purely additive** (`+"config knobs"`), passes the additive-only invariant
- [x] All tests pass (`npm test`) — 1964 pass, 0 fail

### Manual Testing
`kit config knobs` renders the grouped table (verified live); `--json` emits the structured groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_