### PR TITLE
feat(memory): wire the Claude Code status line on install — PAL becomes visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`kit memory install` now wires the Claude Code status line too — the setup
+  score + open-PAL (`⚠`) count become visible in your terminal.** Previously PAL
+  only reached the agent (via the hook); the human never saw it unless they
+  hand-edited `settings.json`. Install now also sets `statusLine` to `kit
+  statusline` — idempotent, and it **never clobbers a custom statusLine** (reports
+  it and leaves it as-is). `--no-statusline` skips it; `kit memory uninstall`
+  removes only kit's own. (Paired with the device-coupled PAL count, so what you
+  see in the bar is this device's real "blocked-on-you".)
 - **PAL is device-coupled — an ephemeral session's action items no longer nag your
   durable device.** Pending-action items are now stamped at creation with an
   `origin_device` (stable per machine; an ephemeral container gets its own

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -55,6 +55,8 @@ import { collectHints } from "../hints.js";
 import {
   installMemoryHooks,
   uninstallMemoryHooks,
+  installStatusline,
+  uninstallStatusline,
   getClaudeSettingsPath,
 } from "../memory/install.js";
 import {
@@ -262,7 +264,9 @@ async function memHelp(): Promise<boolean> {
   console.log(
     "  kit memory pull             Pull + merge your store from your private remote (last-write-wins)",
   );
-  console.log("  kit memory install          Wire the 2 hooks into ~/.claude/settings.json");
+  console.log(
+    "  kit memory install          Wire the hooks + status line (score + PAL ⚠) into ~/.claude/settings.json (--no-statusline to skip)",
+  );
   console.log("  kit memory uninstall        Remove the hooks");
   console.log(
     "  kit memory pal [list|add|done|snooze|verify|import|prune]   Pending action ledger (list --all = every device; prune = drop dead-origin items)",
@@ -729,6 +733,21 @@ async function memInstall(): Promise<boolean> {
   const { added, alreadyPresent, resolved } = installMemoryHooks();
   for (const e of added) console.log(`${c.green}✓${c.reset} installed ${e} hook`);
   for (const e of alreadyPresent) console.log(`${c.dim}• ${e} hook already present${c.reset}`);
+
+  // Also wire the status line (the setup score + open-PAL ⚠ count, visible in the
+  // terminal) — unless --no-statusline, and never clobbering a custom statusLine.
+  if (!hasFlag(process.argv, "--no-statusline")) {
+    const sl = installStatusline();
+    if (sl.status === "added")
+      console.log(`${c.green}✓${c.reset} wired status line ${c.dim}(kit statusline)${c.reset}`);
+    else if (sl.status === "already") console.log(`${c.dim}• status line already wired${c.reset}`);
+    else
+      console.log(
+        `${c.yellow}!${c.reset} you already have a custom statusLine — left as-is. ` +
+          `To show kit's score + PAL count, set its command to \`kit statusline\` (or run with --no-statusline to silence this).`,
+      );
+  }
+
   console.log(`${c.dim}settings: ${getClaudeSettingsPath()}${c.reset}`);
   if (!resolved) {
     console.log(
@@ -746,6 +765,9 @@ async function memUninstall(): Promise<boolean> {
     for (const e of removed) console.log(`${c.green}✓${c.reset} removed ${e} hook`);
   } else {
     console.log(`${c.dim}no kit memory hooks were installed${c.reset}`);
+  }
+  if (uninstallStatusline().removed) {
+    console.log(`${c.green}✓${c.reset} removed kit status line`);
   }
   return true;
 }

--- a/src/memory/install.test.ts
+++ b/src/memory/install.test.ts
@@ -3,7 +3,12 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { installMemoryHooks, uninstallMemoryHooks } from "./install.js";
+import {
+  installMemoryHooks,
+  uninstallMemoryHooks,
+  installStatusline,
+  uninstallStatusline,
+} from "./install.js";
 
 describe("memory hook installer", () => {
   let tmp: string;
@@ -115,5 +120,56 @@ describe("memory hook installer", () => {
     );
     assert.ok(ups.includes("some-other-tool"), "unrelated hook survives uninstall");
     assert.ok(!ups.includes("kit memory hook user-prompt-submit"));
+  });
+});
+
+describe("status-line installer", () => {
+  let tmp: string;
+  let settingsPath: string;
+  const prev = process.env.KIT_CLAUDE_SETTINGS;
+
+  before(() => {
+    tmp = mkdtempSync(join(tmpdir(), "kit-sl-"));
+    settingsPath = join(tmp, "settings.json");
+    process.env.KIT_CLAUDE_SETTINGS = settingsPath;
+  });
+  after(() => {
+    if (prev === undefined) delete process.env.KIT_CLAUDE_SETTINGS;
+    else process.env.KIT_CLAUDE_SETTINGS = prev;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("wires kit statusline when absent, idempotently", () => {
+    writeFileSync(settingsPath, "{}");
+    const r1 = installStatusline();
+    assert.equal(r1.status, "added");
+    const s = JSON.parse(readFileSync(settingsPath, "utf8"));
+    assert.equal(s.statusLine.type, "command");
+    assert.ok(s.statusLine.command.endsWith("statusline"));
+    // second run is a no-op
+    assert.equal(installStatusline().status, "already");
+  });
+
+  it("never clobbers a user's existing custom statusLine", () => {
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({ statusLine: { type: "command", command: "my-own-prompt" } }),
+    );
+    assert.equal(installStatusline().status, "foreign");
+    const s = JSON.parse(readFileSync(settingsPath, "utf8"));
+    assert.equal(s.statusLine.command, "my-own-prompt", "left as-is");
+    // and uninstall must NOT remove a foreign statusLine
+    assert.equal(uninstallStatusline().removed, false);
+    assert.equal(
+      JSON.parse(readFileSync(settingsPath, "utf8")).statusLine.command,
+      "my-own-prompt",
+    );
+  });
+
+  it("uninstall removes only our statusLine", () => {
+    writeFileSync(settingsPath, "{}");
+    installStatusline();
+    assert.equal(uninstallStatusline().removed, true);
+    assert.equal(JSON.parse(readFileSync(settingsPath, "utf8")).statusLine, undefined);
   });
 });

--- a/src/memory/install.ts
+++ b/src/memory/install.ts
@@ -104,6 +104,51 @@ export function installMemoryHooks(path: string = getClaudeSettingsPath()): {
   return { added, alreadyPresent, resolved };
 }
 
+// ── Claude Code status line (the persistent info bar) ────────────────────────
+//
+// Wiring `kit statusline` as Claude Code's `statusLine` is what makes the setup
+// score + the open-PAL ("blocked-on-you") count VISIBLE in the terminal — without
+// it, PAL only reaches the agent via the hook, never the human. We never clobber
+// a user's existing custom statusLine; we only set it when absent (or refresh our
+// own), and report a "foreign" status so the caller can tell the user.
+
+const STATUSLINE_SUFFIX = "statusline";
+
+/** True if `cmd` looks like OUR statusLine wiring (so we can refresh/remove it). */
+function isKitStatusline(cmd: string | undefined): boolean {
+  return !!cmd && cmd.trimEnd().endsWith(STATUSLINE_SUFFIX) && cmd.includes("kit");
+}
+
+export type StatuslineInstall = "added" | "already" | "foreign";
+
+export function installStatusline(path: string = getClaudeSettingsPath()): {
+  status: StatuslineInstall;
+  resolved: boolean;
+} {
+  const s = readSettings(path);
+  const prefix = kitHookInvocation();
+  const resolved = prefix !== "kit";
+  const existing = s.statusLine as { command?: string } | undefined;
+  if (existing && typeof existing === "object") {
+    // Already ours → idempotent no-op; someone else's → never clobber it.
+    return { status: isKitStatusline(existing.command) ? "already" : "foreign", resolved };
+  }
+  s.statusLine = { type: "command", command: `${prefix} ${STATUSLINE_SUFFIX}` };
+  writeSettings(path, s);
+  return { status: "added", resolved };
+}
+
+export function uninstallStatusline(path: string = getClaudeSettingsPath()): { removed: boolean } {
+  const s = readSettings(path);
+  const existing = s.statusLine as { command?: string } | undefined;
+  if (existing && isKitStatusline(existing.command)) {
+    delete s.statusLine;
+    writeSettings(path, s);
+    return { removed: true };
+  }
+  return { removed: false }; // absent, or a user's own statusLine → leave it
+}
+
 export function uninstallMemoryHooks(path: string = getClaudeSettingsPath()): {
   removed: string[];
 } {


### PR DESCRIPTION
## Description

Closes the "why don't I see PAL in the terminal?" gap. PAL's "blocked-on-you" count only reached the **agent** (via the memory hook injection); the **human** never saw it unless they hand-edited `~/.claude/settings.json`. `kit statusline` (which renders the setup score + `⚠N` PAL count) was never wired anywhere. So `kit memory install` now wires it.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `installStatusline` / `uninstallStatusline` in `memory/install.ts`:
  - Sets `settings.statusLine = { type: "command", command: "<abs kit> statusline" }` (same absolute/wrapper invocation as the hooks, so it resolves in the hook shell).
  - **Idempotent**, and **never clobbers a user's existing custom statusLine** — returns `foreign` and leaves it untouched; `uninstall` removes only kit's own.
- `kit memory install` wires it (skip with `--no-statusline`); `kit memory uninstall` removes it. Help text updated.

Pairs with the device-coupled PAL count (#182): the bar shows **this device's** real blocked-on-you, never an ephemeral session's.

## Testing

### Test Coverage
- [x] 3 new install tests: wires when absent + idempotent; never clobbers a foreign statusLine (and uninstall leaves it); uninstall removes only kit's
- [x] All tests pass (`npm test`) — 1972 pass, 0 fail

### Manual Testing
`KIT_CLAUDE_SETTINGS=… kit memory install` → writes `statusLine.command = "/…/kit statusline"` and prints `✓ wired status line`; a pre-existing custom statusLine is reported and left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_