### PR TITLE
release: kit 3.0.0 — version bump + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-06-30
+
+kit 3.0 — from a provable local floor to an org-governed control plane: machine
+**identity** (Ed25519) + **signable, distributable policy-as-code**, **governed
+cross-device memory** (encrypted sync + device-coupled action items),
+**attribution-bound tamper-evident audit**, a hardened install/scan gate, and a
+deterministic, zero-LLM "smart" UX (contextual hints + a discoverable knobs
+reference). Everything below is **additive over 2.x** — no stable command was
+removed or downgraded (enforced by the public-surface invariant).
+
 ### Security
 
 - **Audit attribution is now bound into the HMAC anchor (de-attribution of a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "2.1.1",
+      "version": "3.0.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
## Description

Stamps the **3.0.0** release so `publish.yml`'s version-guard (tag == `package.json` version) passes.

⚠️ **Context:** the `v3.0.0` tag was already pushed, but it points at a commit where `package.json` still read `2.2.0` — so publish **correctly refused** (`Tag v3.0.0 (3.0.0) does not match package.json version (2.2.0)`). This PR bumps the version; **re-tag this PR's merge commit** (steps below) and publish will pass.

## Type of Change

- [x] Release / version bump (no behavior change)

## Changes Made

- `package.json` `2.2.0` → `3.0.0`.
- `package-lock.json` root version `2.1.1` (stale) → `3.0.0` (both root fields).
- `CHANGELOG.md`: rolled `[Unreleased]` → `## [3.0.0] - 2026-06-30` with a release summary; opened a fresh empty `[Unreleased]`.

## What 3.0 ships (all additive over 2.x)

Identity + signable policy-as-code + org trust anchor · governed cross-device memory (encrypted git/command sync, device-coupled PAL, `sync init` + status-line wiring) · attribution-bound HMAC audit (anchor v3) · install-gate / ReDoS / policy-canonicalization security hardening · deterministic zero-LLM smart UX (contextual hints + `kit config knobs`).

## Testing
- [x] `npm test` — 1972 pass, 0 fail; `package.json` and `package-lock` root both `3.0.0`.

## Release steps (after this merges, on your machine)
```
git fetch origin main && git checkout main && git pull
git push origin :refs/tags/v3.0.0      # delete the stale remote tag
git tag -d v3.0.0                       # delete the stale local tag
git tag -s v3.0.0 -m "kit 3.0.0" $(git rev-parse HEAD)   # re-sign on the bumped commit
git push origin v3.0.0
```
→ publish.yml verifies tag==version (3.0.0) + GPG signature → publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_