### PR TITLE
fix(memory): harden cross-device sync transport (git option injection + env leak)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   validates the `KIT_DEVICE_ID` override against `[A-Za-z0-9_-]{1,64}` (a
   malformed value is ignored rather than trusted). The hostname hash remains only
   as a last-resort fallback when the id file can't be written.
+- **Memory-sync git transport hardened against option injection.** The
+  `remote`/`branch` from `~/.kit/sync.toml` are passed to `git` as positional
+  argv (no shell — OS metacharacters were already inert), but a value starting
+  with `-` is parsed as an *option* (a `remote` of `--upload-pack=<cmd>` turns
+  `git clone` into command execution) and `ext::`/`fd::` remote helpers run
+  commands by design. `loadSyncConfig` now rejects both, call sites pass
+  `--end-of-options` before positional operands, and `git` runs with
+  `protocol.ext`/`protocol.fd` disabled. (Config is operator-owned, so this is
+  defense-in-depth — and future-proofs any `sync init` that ingests a remote.)
+- **The `transport = "command"` child no longer inherits kit secrets.** It moves
+  only the already-encrypted blob, so it never needs `KIT_MEMORY_PASSPHRASE` —
+  yet the whole `process.env` (passphrase included) was handed to it, so a
+  transport that logged its environment (`aws --debug`, a `set -x` shell) would
+  spill the passphrase right next to the ciphertext it protects. The child env is
+  now stripped of every kit-managed passphrase/secret/token/key; the operator's
+  own provider credentials still pass through.
 
 ## [3.0.0] - 2026-06-30
 

--- a/src/memory/remote-sync.test.ts
+++ b/src/memory/remote-sync.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -71,6 +71,31 @@ describe("remote-sync — loadSyncConfig (LOCAL, ~/.kit only)", () => {
         '[memory.sync]\nremote = "git@h:me/mem.git"\nfile = "../escape"\n',
       );
       assert.throws(() => loadSyncConfig(), /bare filename/);
+    } finally {
+      if (prev === undefined) delete process.env.KIT_MEMORY_DIR;
+      else process.env.KIT_MEMORY_DIR = prev;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a git-option-injecting remote/branch (leading '-', ext::/fd:: helpers)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-cfg-"));
+    const prev = process.env.KIT_MEMORY_DIR;
+    process.env.KIT_MEMORY_DIR = dir;
+    const write = (toml: string) => writeFileSync(getSyncConfigPath(), toml);
+    try {
+      // a "remote" git would parse as an option → arbitrary command execution
+      write('[memory.sync]\nremote = "--upload-pack=touch /tmp/pwned"\n');
+      assert.throws(() => loadSyncConfig(), /must not start with '-'/);
+      // ext:: / fd:: remote helpers run commands by design
+      write('[memory.sync]\nremote = "ext::sh -c id"\n');
+      assert.throws(() => loadSyncConfig(), /ext::\/fd:: remote helpers/);
+      // a branch starting with '-' is likewise rejected
+      write('[memory.sync]\nremote = "git@h:me/mem.git"\nbranch = "--output=/tmp/x"\n');
+      assert.throws(() => loadSyncConfig(), /must not start with '-'/);
+      // a normal config still loads
+      write('[memory.sync]\nremote = "git@h:me/mem.git"\nbranch = "main"\n');
+      assert.equal(loadSyncConfig()?.remote, "git@h:me/mem.git");
     } finally {
       if (prev === undefined) delete process.env.KIT_MEMORY_DIR;
       else process.env.KIT_MEMORY_DIR = prev;
@@ -254,6 +279,42 @@ describe("remote-sync — command transport (bring-your-own move: S3/rclone/scp/
       for (const d of [store, machineA, machineB, proj]) {
         rmSync(d, { recursive: true, force: true });
       }
+    }
+  });
+
+  it("does NOT leak KIT_MEMORY_PASSPHRASE into the transport command's environment", () => {
+    const store = mkdtempSync(join(tmpdir(), "kit-envstore-"));
+    const envDump = join(store, "child-env.txt");
+    const machine = mkdtempSync(join(tmpdir(), "kit-envM-"));
+    const proj = mkdtempSync(join(tmpdir(), "kit-envproj-"));
+    const prevDir = process.env.KIT_MEMORY_DIR;
+    const prevPass = process.env.KIT_MEMORY_PASSPHRASE;
+    // the push command records its own environment, exactly as a logging/`set -x`
+    // transport would incidentally expose it
+    const cfg: SyncConfig = {
+      transport: "command",
+      file: "memory.enc",
+      pushCmd: `env > "${envDump}"`,
+      pullCmd: "true",
+    };
+    try {
+      process.env.KIT_MEMORY_DIR = machine;
+      process.env.KIT_MEMORY_PASSPHRASE = PASS; // present in the parent env
+      const dbA = openMemoryDb();
+      upsertSession(dbA, { sessionId: "s-env", harness: "claude-code", project: "p" });
+      dbA.close();
+
+      pushMemory(cfg, PASS, proj);
+      const childEnv = readFileSync(envDump, "utf8");
+      assert.ok(!childEnv.includes("KIT_MEMORY_PASSPHRASE"), "passphrase must be stripped");
+      assert.ok(!childEnv.includes(PASS), "passphrase value must not appear in any var");
+      assert.ok(childEnv.includes("KIT_MEMORY_BLOB="), "blob path is still provided");
+    } finally {
+      if (prevDir === undefined) delete process.env.KIT_MEMORY_DIR;
+      else process.env.KIT_MEMORY_DIR = prevDir;
+      if (prevPass === undefined) delete process.env.KIT_MEMORY_PASSPHRASE;
+      else process.env.KIT_MEMORY_PASSPHRASE = prevPass;
+      for (const d of [store, machine, proj]) rmSync(d, { recursive: true, force: true });
     }
   });
 

--- a/src/memory/remote-sync.ts
+++ b/src/memory/remote-sync.ts
@@ -111,7 +111,32 @@ export function loadSyncConfig(): SyncConfig | null {
   const remote = str(s.remote);
   if (!remote) return null; // git transport with no remote → treat as unconfigured
   const branch = str(s.branch) || DEFAULT_BRANCH;
+  assertSafeGitRef(remote, "remote");
+  assertSafeGitRef(branch, "branch");
   return { transport, file, remote, branch, pullOnStart, pushOnEnd };
+}
+
+/**
+ * Reject a git remote/branch value that git would treat as something other than a
+ * plain operand. These reach git as positional argv (execFileSync — no shell, so
+ * OS metacharacters are already inert), but two git-level vectors remain:
+ *   - a value starting with '-' is parsed as an OPTION, e.g. a "remote" of
+ *     `--upload-pack=<cmd>` turns `git clone` into arbitrary command execution;
+ *   - `ext::`/`fd::` remote helpers run a command by design (`git clone ext::sh -c …`).
+ * Config is operator-owned (~/.kit/sync.toml, never the repo tree), so this is
+ * defense-in-depth — but it also future-proofs any `sync init` that ingests a
+ * remote from a less-trusted source. Call sites additionally pass
+ * `--end-of-options` and disable the ext/fd protocols.
+ */
+function assertSafeGitRef(value: string, what: "remote" | "branch"): void {
+  if (value.startsWith("-")) {
+    throw new Error(`invalid [memory.sync] ${what} "${value}" — must not start with '-'`);
+  }
+  if (what === "remote" && /^(ext|fd)::/i.test(value)) {
+    throw new Error(
+      `invalid [memory.sync] remote "${value}" — ext::/fd:: remote helpers are not allowed`,
+    );
+  }
 }
 
 /**
@@ -161,11 +186,18 @@ export function assertRemoteNotProjectOrigin(remote: string, root: string): void
 }
 
 function git(args: string[], cwd: string): string {
-  return execFileSync("git", args, {
-    cwd,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+  // Disable the command-running remote helpers unconditionally (harmless for the
+  // local ops too) so even a value that slipped past validation can't reach the
+  // ext::/fd:: handlers.
+  return execFileSync(
+    "git",
+    ["-c", "protocol.ext.allow=never", "-c", "protocol.fd.allow=never", ...args],
+    {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
 }
 
 /**
@@ -175,7 +207,9 @@ function git(args: string[], cwd: string): string {
  */
 function cloneOrInit(remote: string, branch: string, dir: string): void {
   try {
-    git(["clone", "--depth", "1", "--branch", branch, remote, "."], dir);
+    // --end-of-options: everything after is a positional operand, so a remote/branch
+    // can never be reinterpreted as a git option (belt-and-suspenders to assertSafeGitRef).
+    git(["clone", "--depth", "1", "--branch", branch, "--end-of-options", remote, "."], dir);
     return;
   } catch {
     // empty remote or missing branch — initialize a fresh repo targeting it
@@ -192,8 +226,18 @@ function cloneOrInit(remote: string, branch: string, dir: string): void {
  * Runs through the default shell so an operator can write `aws s3 cp …` etc.
  */
 function runTransportCmd(cmd: string, blobPath: string): void {
+  // Do NOT hand the transport our secrets. It only moves the already-encrypted
+  // blob, so it never needs KIT_MEMORY_PASSPHRASE — and a command that logs its
+  // environment (`aws --debug`, a shell with `set -x`, an error tracer) would
+  // otherwise spill the passphrase that protects the blob right next to the blob,
+  // collapsing the encryption guarantee. Strip every kit-managed secret from the
+  // child env; the operator's own provider credentials (AWS_*, etc.) pass through.
+  const env: Record<string, string | undefined> = { ...process.env, KIT_MEMORY_BLOB: blobPath };
+  for (const k of Object.keys(env)) {
+    if (/^KIT_.*(PASSPHRASE|SECRET|TOKEN|PASSWORD|KEY)$/.test(k)) delete env[k];
+  }
   execSync(cmd, {
-    env: { ...process.env, KIT_MEMORY_BLOB: blobPath },
+    env: env as NodeJS.ProcessEnv,
     stdio: ["ignore", "inherit", "inherit"],
     timeout: 120_000,
   });


### PR DESCRIPTION
## What

Track C — adversarial hardening of the 3.0 memory-sync surface (`src/memory/remote-sync.ts`). Two findings, both fixed here.

### MEDIUM — git option injection on the remote/branch

`remote`/`branch` from `~/.kit/sync.toml` reach `git` as positional argv via `execFileSync` (no shell, so OS metacharacters are already inert), but two git-level vectors remained:
- a value starting with `-` is parsed as an **option** — a `remote` of `--upload-pack=<cmd>` turns `git clone` into arbitrary command execution;
- `ext::`/`fd::` remote helpers **run commands by design** (`git clone ext::sh -c …`).

Fix:
- `loadSyncConfig` rejects a `remote`/`branch` starting with `-`, and an `ext::`/`fd::` remote;
- `cloneOrInit` passes `--end-of-options` before the positional operands;
- the `git()` helper runs with `protocol.ext.allow=never protocol.fd.allow=never`.

Config is operator-owned (read only from `~/.kit/sync.toml`, never the repo tree), so realistic severity is bounded — this is defense-in-depth, and it future-proofs any `sync init` that ingests a remote from a less-trusted source.

### LOW — kit secrets leaked into the transport command's environment

`runTransportCmd` handed the **entire `process.env`** (including `KIT_MEMORY_PASSPHRASE`) to the operator's `push_cmd`/`pull_cmd`. That command only ever moves the **already-encrypted** blob, so it never needs the passphrase — and a transport that logs its environment (`aws --debug`, a `set -x` shell, an error tracer) would spill the passphrase right next to the ciphertext it protects, collapsing the encryption guarantee.

Fix: the child env is stripped of every kit-managed `*(PASSPHRASE|SECRET|TOKEN|PASSWORD|KEY)` var; the operator's own provider credentials (`AWS_*`, etc.) still pass through, and `KIT_MEMORY_BLOB` is still provided.

## Tests

2 new tests: `loadSyncConfig` rejects an option-injecting `remote`/`branch` and `ext::` helpers (and still loads a normal config); the `transport = "command"` child env never contains `KIT_MEMORY_PASSPHRASE` (or its value) while still receiving `KIT_MEMORY_BLOB`. Full suite **1981 green**, prettier clean.

## Context

Final PR of the A→B→C hardening arc: #185 (docs) → #186 (external timestamp anchor) → #187 (PAL device-fence + device identity) → this (transport hardening). All findings came from an adversarial review of the new 3.0 surface; the memory content path itself was confirmed clean (travels as a GCM blob by path, `verify_cmd` demoted on merge, path-traversal guarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ERHw6bVUz39sAuoQZ1iyg)_