### PR TITLE
docs(changelog): add the [3.0.0] heading (release notes were under [Unreleased])

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   command configured, a non-zero exit, non-JSON output, or a missing `token` all
   hard-error rather than silently degrading to HMAC-only.
 
+## [3.0.0] - 2026-06-30
+
 kit 3.0 — from a provable local floor to an org-governed control plane: machine
 **identity** (Ed25519) + **signable, distributable policy-as-code**, **governed
 cross-device memory** (encrypted sync + device-coupled action items),


### PR DESCRIPTION
## Description

The 3.0.0 release notes shipped under `## [Unreleased]` without a `## [3.0.0] - <date>` heading. As a result, the section documenting the **released** 3.0.0 was indistinguishable from genuinely-unreleased work, and README's "see CHANGELOG.md for the full 3.0.0 entry" had no heading to resolve to.

This adds the missing `## [3.0.0] - 2026-06-30` heading (dated to match the `v3.0.0` tag) immediately before the `kit 3.0 — …` summary, leaving only the post-release work (the external-timestamp-anchor entries added after the release tag) under `## [Unreleased]`.

## Type of Change

- [x] Documentation update

## Related Issues

- Follows the 3.0.0 release (#184).

## Changes Made

- Insert `## [3.0.0] - 2026-06-30` in `CHANGELOG.md`, between the `[Unreleased]` post-release entries and the `kit 3.0 — …` release summary.
- No content was moved or reworded; the `### Security` / `### Added` blocks that follow now sit under `[3.0.0]` instead of `[Unreleased]`.

## Testing

### Test Coverage
- [x] All tests pass (`npm test`) — docs-only change, no code touched.

### Manual Testing
1. `grep -nE '^## \[' CHANGELOG.md` → headings now read `[Unreleased]`, `[3.0.0] - 2026-06-30`, `[2.2.0] - 2026-06-28`, … in order.
2. Confirmed only the external-timestamp-anchor entries remain under `[Unreleased]`.

## Breaking Changes

None / N/A

## Checklist

- [x] My code follows the project's style guidelines (matches the existing `## [X.Y.Z] - YYYY-MM-DD` convention)
- [x] I've updated documentation as needed
- [x] No new warnings or errors introduced
- [x] Commit messages follow conventions
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

## Performance Impact

- [x] No performance impact

## Migration Guide

N/A

## Reviewer Notes

Docs-only. Verify the release date (`2026-06-30`, from the `v3.0.0` tag) is the intended one; everything else is purely the missing heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_