### PR TITLE
fix(memory): run SessionEnd capture detached so the exit hook can't be cancelled

### DIFF
--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -47,6 +47,7 @@ import {
 import {
   userPromptSubmitReminder,
   maybeStartMidSessionIndex,
+  startDetachedSessionEnd,
   runSessionEndIndex,
   sessionStartRecovery,
 } from "../memory/hook.js";
@@ -683,6 +684,15 @@ async function memHook(): Promise<boolean> {
     return true;
   }
   if (event === "session-end") {
+    // Return instantly: a SessionEnd hook that blocks on the index (or the
+    // opt-in network push) gets cancelled by Claude Code on exit ("Hook
+    // cancelled"). The real work runs in a detached worker below.
+    startDetachedSessionEnd();
+    return true;
+  }
+  if (event === "session-end-run") {
+    // Internal: the detached SessionEnd worker. No hook is waiting on it, so the
+    // (potentially slow / networked) capture can run synchronously here.
     runSessionEndIndex();
     // Opt-in: push this session's memory to your durable store before an
     // (ephemeral) container is reclaimed. Fail-soft; notes go to stderr.

--- a/src/memory/hook.test.ts
+++ b/src/memory/hook.test.ts
@@ -10,6 +10,7 @@ import {
   recentDecisions,
   dueForHarnessSweep,
   dueForMidSessionIndex,
+  startDetachedSessionEnd,
 } from "./hook.js";
 import { getCurrentProjectRoot } from "./project.js";
 import { shareEntry } from "./shared.js";
@@ -225,5 +226,43 @@ describe("memory hook — mid-session index debounce", () => {
     const mtime = statSync(marker).mtimeMs;
     assert.equal(dueForMidSessionIndex(mtime + 60_000), false, "1 min later → not due");
     assert.equal(dueForMidSessionIndex(mtime + 11 * 60 * 1000), true, "11 min later → due");
+  });
+});
+
+describe("memory hook — detached SessionEnd", () => {
+  let tmp: string;
+  const prevDir = process.env.KIT_MEMORY_DIR;
+  const prevDb = process.env.KIT_MEMORY_DB;
+
+  before(() => {
+    tmp = mkdtempSync(join(tmpdir(), "kit-sessionend-"));
+    process.env.KIT_MEMORY_DIR = tmp;
+    process.env.KIT_MEMORY_DB = join(tmp, "memory.db");
+  });
+
+  after(() => {
+    if (prevDir === undefined) delete process.env.KIT_MEMORY_DIR;
+    else process.env.KIT_MEMORY_DIR = prevDir;
+    if (prevDb === undefined) delete process.env.KIT_MEMORY_DB;
+    else process.env.KIT_MEMORY_DB = prevDb;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  // The happy path spawns a detached child, which is environment-dependent and
+  // would fork the test runner; we assert the fail-safe branch instead: with no
+  // re-exec entry path, it must index inline rather than throw, and report that
+  // it did NOT detach. A SessionEnd hook must never throw.
+  it("falls back to an inline index (no throw) when there is no entry to re-exec", () => {
+    const prevEntry = process.argv[1];
+    try {
+      process.argv[1] = "";
+      let detached: boolean | undefined;
+      assert.doesNotThrow(() => {
+        detached = startDetachedSessionEnd();
+      });
+      assert.equal(detached, false, "no entry path → did not detach, ran inline");
+    } finally {
+      process.argv[1] = prevEntry;
+    }
   });
 });

--- a/src/memory/hook.ts
+++ b/src/memory/hook.ts
@@ -257,6 +257,41 @@ export function maybeStartMidSessionIndex(): boolean {
   }
 }
 
+/**
+ * Run the SessionEnd capture in a DETACHED background process so the exit hook
+ * returns instantly. The foreground SessionEnd hook is on a short leash — Claude
+ * Code cancels it if it doesn't finish promptly ("Hook cancelled") — but the
+ * capture can be slow (the periodic all-harness sweep) or do network I/O (the
+ * opt-in memory push). So, exactly like {@link maybeStartMidSessionIndex}, we
+ * fire-and-forget a `kit memory hook session-end-run` worker (stdio ignored,
+ * unref'd) that does the real work where blocking is harmless. Returns true iff
+ * it launched the worker; on failure it falls back to an inline index so a
+ * session is never lost. The just-ended transcript is already on disk, so the
+ * detached worker captures it the same as a synchronous run would.
+ */
+export function startDetachedSessionEnd(): boolean {
+  try {
+    const entry = process.argv[1];
+    if (!entry) {
+      runSessionEndIndex(); // no entry path to re-exec → at least index inline
+      return false;
+    }
+    const child = spawn(process.execPath, [resolve(entry), "memory", "hook", "session-end-run"], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+    return true;
+  } catch {
+    try {
+      runSessionEndIndex(); // fail-safe: capture inline rather than not at all
+    } catch {
+      /* fail-open: a SessionEnd hook must never throw */
+    }
+    return false;
+  }
+}
+
 /** Index the just-ended session. Returns count of newly indexed messages (fail-open). */
 export function runSessionEndIndex(): { messages: number } {
   try {


### PR DESCRIPTION
## Description

On exit, Claude Code reports:

```
SessionEnd hook [.../kit memory hook session-end] failed: Hook cancelled
```

The `session-end` branch of `memHook()` does its work **synchronously in the foreground**: `runSessionEndIndex()` (which once per 6h sweeps *every* harness — codex/cursor/gemini/cline/amazon-q/opencode) plus the opt-in `tryAutoPush()` (a network push when `pushOnEnd` + `KIT_MEMORY_PASSPHRASE` are set). Claude Code keeps a SessionEnd hook on a short leash and cancels it if it doesn't return promptly — so a slow index or a hanging push surfaces as "Hook cancelled".

The mid-session index already sidesteps this by spawning a detached, unref'd worker (`maybeStartMidSessionIndex`); SessionEnd did not. This PR makes SessionEnd follow the same pattern.

No memory is lost today (mid-session indexing runs every ~10 min detached), but the exit-time capture/push was unreliable and noisy.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

- Reported in the wild: `SessionEnd hook [...kit memory hook session-end] failed: Hook cancelled`.

## Changes Made

- `src/memory/hook.ts`: add `startDetachedSessionEnd()` — fire-and-forget `kit memory hook session-end-run` (detached, `stdio: "ignore"`, `unref`'d), mirroring `maybeStartMidSessionIndex`. Fail-safe: if there's no `process.argv[1]` to re-exec, it indexes inline instead of skipping, and never throws.
- `src/commands/memory.ts`: the `session-end` event now calls `startDetachedSessionEnd()` and returns instantly; a new **internal** `session-end-run` event runs the real (slow / networked) capture — `runSessionEndIndex()` + `tryAutoPush()` — in the detached worker where nothing is waiting on it. Behavior is otherwise identical (same index logic, same 6h sweep debounce, same opt-in push gate).
- `src/memory/hook.test.ts`: cover the inline-fallback branch (no entry path → does not detach, does not throw).

The just-ended transcript is already on disk when SessionEnd fires, so the detached worker captures the same session a synchronous run would.

## Testing

### Test Coverage
- [x] Added new tests (inline-fallback branch of `startDetachedSessionEnd`)
- [x] All tests pass (`npm test`) — **1977 passed, 0 failed**

### Manual Testing
1. `npm run build` → exit 0.
2. `node --test dist/memory/hook.test.js` → 13 pass (incl. the new SessionEnd test).
3. Full suite: 1977 pass / 0 fail.

## Breaking Changes

None / N/A — `session-end-run` is an internal, undocumented hook event; the installed hooks (`UserPromptSubmit` / `SessionEnd` / `SessionStart`) are unchanged.

## Checklist

- [x] My code follows the project's style guidelines (mirrors the existing `maybeStartMidSessionIndex` detached pattern)
- [x] I've updated documentation as needed (n/a — internal behavior)
- [x] All new code has test coverage
- [x] All tests pass locally (`npm test`)
- [x] No new warnings or errors introduced
- [x] Commit messages follow conventions
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

## Performance Impact

- [x] Improves performance — the exit hook returns immediately instead of blocking on an index / network push.

## Migration Guide

N/A

## Reviewer Notes

Two judgment calls worth a look: (1) detaching at SessionEnd relies on the unref'd child outliving the parent (same assumption the mid-session index already makes); (2) the opt-in `tryAutoPush` now runs in the detached worker, so its stderr note is no longer surfaced to the foreground — acceptable since the foreground is exiting, but flagging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_