### PR TITLE
feat(agent-config): wire GitHub Copilot (.github/copilot-instructions.md)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`kit agent-config` now wires GitHub Copilot** — the managed "use kit" rules
+  block is written to `.github/copilot-instructions.md`, Copilot's canonical
+  custom-instructions file (VS Code / Visual Studio). Detected when a `.vscode/`
+  dir is present or the file already exists; `writeAgentConfig` creates the
+  nested parent dir (`.github/`) as needed. Fifth rules-file target alongside
+  CLAUDE.md / AGENTS.md / .cursorrules / .clinerules (Antigravity is already
+  covered via its `AGENTS.md` support). Advisory only — memory indexing and a
+  blocking install-gate for Copilot still need its transcript format + pre-tool
+  hook surface verified against primary sources; the git-hook floor and the MCP
+  server (`kit mcp`) apply to Copilot today regardless.
 - **Memory sync blobs are now gzip-compressed before encryption (~3× smaller).** A
   SQLite store compresses well (a real store: 6.3 MB → 2.1 MB; large stores
   ~139 MB → ~30 MB), which keeps the blob under a git host's 100 MB file limit and

--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ adapters for the surfaces each agent exposes. Support today, per agent:
 | **OpenCode**     |      ✅       |     ✅ `AGENTS.md`     | ✅ `opencode.json` + `.opencode/plugin` |        —        |          —          |   ✅ plugin    |
 | **Cursor**       |      ✅       |   ✅ `.cursorrules`    |          ✅ `.cursor/mcp.json`          |        —        |          —          |    ✅ hook     |
 | **Cline**        |      ✅       |    ✅ `.clinerules`    |                    —                    |        —        |          —          |    ✅ hook     |
+| **Copilot**      |      —        | ✅ `copilot-instructions.md` |               —                   |        —        |          —          |      —⁸        |
 | **Gemini CLI**   |      ✅       |           —            |                    —                    |        —        |          —          |    ✅ hook     |
 | **Continue**     |      ✅       |           —            |                    —                    |        —        |          —          |      n/a⁷      |
 | **Amazon Q**     |      ✅       |           —            |                    —                    |        —        |          —          |    ✅ hook     |
@@ -311,6 +312,7 @@ adapters for the surfaces each agent exposes. Support today, per agent:
 5. kit registers lifecycle hooks so memory capture happens automatically (Claude Code `settings.json` hooks today).
 6. A **true blocking gate** (deny an un-triaged install before it runs) uses the agent's pre-tool hook — `kit agent-config --install-gate` wires it for Claude Code, Codex, Amazon Q, Gemini CLI, and Cursor (exit-2 hook commands); OpenCode via a generated `.opencode/plugin` that hooks `tool.execute.before` and throws; and Cline via an executable `.clinerules/hooks/PreToolUse` shim that blocks through Cline's `{cancel:true}` stdout contract. The agent-agnostic enforcement floor is **git hooks** (`kit hooks`, pre-commit/pre-push) — they fire in any agent or none. See [#146](https://github.com/sandstream/kit/issues/146).
 7. **Continue** exposes only a declarative tool-permission policy (`~/.continue/permissions.yaml` allow/ask/exclude) with no way to invoke an external command before a tool runs, so a kit blocking-gate adapter isn't possible there — git hooks + the rules-file block remain its floor.
+8. **GitHub Copilot** (VS Code / Visual Studio): the "use kit" rules block is written to `.github/copilot-instructions.md` (wired when a `.vscode/` dir is present or the file already exists). Memory indexing and a blocking install-gate are not yet implemented — they need Copilot's transcript format and a pre-tool-hook surface verified against primary sources first. The git-hook floor + the MCP server (`kit mcp`, added to `.vscode/mcp.json`) apply today.
 
 > The git-hook layer enforces at the VCS boundary regardless of agent; the rules-file block is **advisory** (it reminds the agent); only the blocking-gate hook **enforces** before an action runs.
 

--- a/src/agent-config.test.ts
+++ b/src/agent-config.test.ts
@@ -129,6 +129,29 @@ describe("detectAgentTargets", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("wires Copilot via a .vscode/ dir (→ .github/copilot-instructions.md)", () => {
+    const dir = tmpRepo();
+    try {
+      mkdirSync(join(dir, ".vscode"));
+      const files = detectAgentTargets(dir).map((t) => t.file);
+      assert.deepEqual(files, [".github/copilot-instructions.md"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects Copilot via an existing .github/copilot-instructions.md", () => {
+    const dir = tmpRepo();
+    try {
+      mkdirSync(join(dir, ".github"));
+      writeFileSync(join(dir, ".github", "copilot-instructions.md"), "# instructions\n");
+      const agents = detectAgentTargets(dir).map((t) => t.agent);
+      assert.deepEqual(agents, ["Copilot"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("writeAgentConfig", () => {
@@ -141,6 +164,20 @@ describe("writeAgentConfig", () => {
       assert.equal(results[0].file, "CLAUDE.md");
       assert.equal(results[0].action, "created");
       const written = readFileSync(join(dir, "CLAUDE.md"), "utf-8");
+      assert.ok(written.includes(KIT_BLOCK_BEGIN) && written.includes(KIT_BLOCK_END));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates the parent dir for a nested target (Copilot's .github/copilot-instructions.md)", async () => {
+    const dir = tmpRepo();
+    try {
+      const t = [{ agent: "Copilot", file: ".github/copilot-instructions.md" }];
+      const results = await writeAgentConfig(dir, t);
+      assert.equal(results[0].action, "created");
+      assert.ok(existsSync(join(dir, ".github", "copilot-instructions.md")), "file created");
+      const written = readFileSync(join(dir, ".github", "copilot-instructions.md"), "utf-8");
       assert.ok(written.includes(KIT_BLOCK_BEGIN) && written.includes(KIT_BLOCK_END));
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/src/agent-config.ts
+++ b/src/agent-config.ts
@@ -48,6 +48,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
   { agent: "Codex", file: "AGENTS.md" },
   { agent: "Cursor", file: ".cursorrules" },
   { agent: "Cline", file: ".clinerules" },
+  { agent: "Copilot", file: ".github/copilot-instructions.md" },
 ];
 
 /**
@@ -74,6 +75,12 @@ export function detectAgentTargets(cwd: string = process.cwd()): AgentTarget[] {
         );
       case "Cursor":
         return existsSync(resolve(cwd, ".cursor"));
+      case "Copilot":
+        // GitHub Copilot (VS Code / Visual Studio) reads
+        // `.github/copilot-instructions.md`. The file check above covers an
+        // existing one; a `.vscode/` dir marks a VS Code project where Copilot
+        // is the likely agent, so wire it there too.
+        return existsSync(resolve(cwd, ".vscode"));
       default:
         return false;
     }
@@ -153,6 +160,9 @@ export async function writeAgentConfig(
         results.push({ agent: t.agent, file: t.file, action, detail: "kit block already current" });
         continue;
       }
+      // Rules files can be nested (e.g. Copilot's `.github/copilot-instructions.md`);
+      // create the parent dir. No-op for root-level targets.
+      await mkdir(dirname(path), { recursive: true });
       await writeFile(path, next, "utf-8");
       results.push({
         agent: t.agent,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5251,7 +5251,7 @@ export const COMMAND_HELP: Record<string, string> = {
   "env current": "Show active environment marker",
   analyze: "Analyze repo + emit draft CLAUDE.md / RULES.md",
   "agent-config":
-    "Inject a managed 'use kit' block into CLAUDE.md / AGENTS.md / .cursorrules / .clinerules",
+    "Inject a managed 'use kit' block into CLAUDE.md / AGENTS.md / .cursorrules / .clinerules / .github/copilot-instructions.md",
   "gate-bash":
     "PreToolUse install-gate: read an agent's pending Bash command on stdin, block (exit 2) un-triaged installs",
   security:


### PR DESCRIPTION
## Description

`kit agent-config` now writes the managed "use kit" rules block into **GitHub Copilot's** canonical custom-instructions file, `.github/copilot-instructions.md` — the fifth rules-file target alongside `CLAUDE.md` / `AGENTS.md` / `.cursorrules` / `.clinerules`. Copilot (VS Code / Visual Studio) was the one common agent kit didn't reach for the advisory rules block. (Google Antigravity is already covered via its `AGENTS.md` support, so no separate target is needed for it.)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

- Related to #146 (per-agent adapter coverage)

## Changes Made

- `AGENT_TARGETS` gains `{ agent: "Copilot", file: ".github/copilot-instructions.md" }`.
- `detectAgentTargets` wires Copilot when a `.vscode/` dir is present or the file already exists.
- `writeAgentConfig` now `mkdir`s the parent dir before writing, so a nested target (`.github/`) is created — a no-op for the existing root-level files.
- `COMMAND_HELP`, the README agent-support table (+ footnote 8), and `CHANGELOG.md` updated.

## Scope / deliberately out

Advisory **rules block only**. Memory indexing (a Copilot transcript parser → new harness) and a **blocking install-gate** for Copilot are intentionally **not** included: they require Copilot's transcript serialization format and a verified pre-tool-hook surface, and kit's rule is to build adapters only after verifying against primary sources (never guessed). The agent-agnostic **git-hook floor** and the **MCP server** (`kit mcp`, added to `.vscode/mcp.json`) already apply to Copilot today.

## Testing

### Test Coverage
- [x] Added new tests (detectAgentTargets: `.vscode/` and existing-file detection; writeAgentConfig: nested-dir creation)
- [x] All tests pass (`npm test`) — **1989 tests, 0 fail**

### Manual Testing
1. In a repo with a `.vscode/` dir, `kit agent-config` now creates `.github/copilot-instructions.md` containing the marker-delimited kit block.
2. Re-running is idempotent (`unchanged`); editing outside the markers is preserved.
3. `public-surface` snapshot unchanged; `eslint src` reports 0 errors.

## Breaking Changes

None / N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've updated documentation as needed (README table + footnote, COMMAND_HELP, CHANGELOG)
- [x] All new code has test coverage
- [x] All tests pass locally (`npm test`)
- [x] No new warnings or errors introduced
- [x] Commit messages follow conventions
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

## Performance Impact

- [x] No performance impact

## Migration Guide

N/A — additive. Existing rules files are untouched; the Copilot file is only written when the project looks like a VS Code/Copilot project (or already has the file).

## Reviewer Notes

The `.vscode/` heuristic is intentionally permissive (a VS Code project is the best available "Copilot likely" signal); an extra marker-guarded, idempotent instructions file is harmless if Copilot isn't actually used. Open to gating it differently (e.g. only on an existing file) if you'd prefer a narrower trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_