### PR TITLE
release: kit 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-07-01
+
 ### Added
 
 - **`kit agent-config` now wires GitHub Copilot** — the managed "use kit" rules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
Cut **3.1.0** from `[Unreleased]`. Minor bump — new features, backward-compatible.

## Highlights
- **gzip-compress memory sync blobs before encryption** (~3× smaller; 139 MB → ~30 MB) — makes a private GitHub repo viable as a sync remote under the 100 MB file limit (#193)
- **Public-key memory sync** — `kit memory keygen` (X25519, `MAGIC_V3`); ephemeral sessions push with no secret via a `recipient` (#192)
- **`kit agent-config` wires GitHub Copilot** (`.github/copilot-instructions.md`) — 5th rules-file target (#195)
- **External timestamp anchor** via command transport (#186)
- Device-identity hardening + cross-device sync transport fixes (#187, #188, #190)

## Release checklist
- [x] `[Unreleased]` → `[3.1.0] - 2026-07-01` in CHANGELOG
- [x] `package.json` + `package-lock.json` → 3.1.0
- [ ] CI green
- [ ] Squash-merge
- [ ] **Peter signs the tag** (`export GPG_TTY=$(tty); git tag -s v3.1.0`) → `publish.yml` runs on the tag

Note: pre-commit self-skipped locally (sentinel-missing in the bump env, logged to `.kit-skipped-commits.jsonl`); full gate runs here in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)