### PR TITLE
fix(memory): OR-fallback + bm25 recall for multi-term search (#164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`kit memory search` no longer comes back empty for multi-term queries.** A
+  query whose terms don't all co-occur in a single message used to match zero
+  rows (the FTS5 expression joined terms by implicit AND). It now falls back to
+  OR when the strict AND finds nothing, bm25-ranked so the message covering the
+  most terms ranks first — relevance instead of all-or-nothing. Single-term
+  lookups and exact multi-term matches are unchanged; still zero-LLM, local,
+  no new deps. (#164)
+
 ## [3.1.0] - 2026-07-01
 
 ### Added

--- a/src/memory/db.test.ts
+++ b/src/memory/db.test.ts
@@ -54,6 +54,47 @@ describe("memory db", () => {
     it("returns empty string for blank input", () => {
       assert.equal(toFtsMatchQuery("   "), "");
     });
+    it("joins terms with OR when op is OR (graceful-recall fallback)", () => {
+      assert.equal(toFtsMatchQuery("vault secret", "OR"), '"vault"* OR "secret"*');
+    });
+  });
+
+  it("multi-term query falls back to OR + bm25 when strict AND finds nothing (#164)", () => {
+    const db = fresh();
+    // No single message holds every query term, so a strict (implicit-AND) match → 0 hits.
+    insertMessage(db, {
+      uuid: "u1",
+      sessionId: "s1",
+      type: "assistant",
+      role: "assistant",
+      content: "cline pretooluse installgate wiring",
+    });
+    insertMessage(db, {
+      uuid: "u2",
+      sessionId: "s1",
+      type: "assistant",
+      role: "assistant",
+      content: "cline adapter only",
+    });
+    // "cline pretooluse ciinit" matches no single message under AND; the OR fallback must
+    // recall both, ranking the message covering more terms (u1: cline+pretooluse) first.
+    const hits = searchMessages(db, "cline pretooluse ciinit");
+    assert.equal(hits.length, 2);
+    assert.equal(hits[0]?.uuid, "u1");
+    db.close();
+  });
+
+  it("does not OR-widen a single-term miss", () => {
+    const db = fresh();
+    insertMessage(db, {
+      uuid: "u1",
+      sessionId: "s1",
+      type: "user",
+      role: "user",
+      content: "decision about October pricing",
+    });
+    assert.equal(searchMessages(db, "november").length, 0);
+    db.close();
   });
 
   it("does not crash on queries with FTS5 special chars (regression)", () => {

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -338,12 +338,15 @@ export interface SearchOptions {
  * bare `AND`/`OR`/`NEAR` either crashes the query ("no such column: …") or acts
  * as an unintended operator. We split on whitespace, quote each term (escaping
  * embedded quotes by doubling them — the FTS5 string-literal rule), and
- * prefix-match it; terms are joined by implicit AND. Returns "" for an
- * empty/whitespace query so the caller can short-circuit.
+ * prefix-match it. `op` joins the terms: "AND" (implicit, the default — every
+ * term must match) or "OR" (any term — the graceful-recall fallback, ranked by
+ * bm25 so the message matching the most terms floats to the top). Returns "" for
+ * an empty/whitespace query so the caller can short-circuit.
  */
-export function toFtsMatchQuery(raw: string): string {
+export function toFtsMatchQuery(raw: string, op: "AND" | "OR" = "AND"): string {
   const terms = raw.trim().split(/\s+/).filter(Boolean);
-  return terms.map((t) => `"${t.replace(/"/g, '""')}"*`).join(" ");
+  const quoted = terms.map((t) => `"${t.replace(/"/g, '""')}"*`);
+  return quoted.join(op === "OR" ? " OR " : " ");
 }
 
 export function searchMessages(
@@ -351,27 +354,41 @@ export function searchMessages(
   query: string,
   opts: SearchOptions = {},
 ): SearchHit[] {
-  const match = toFtsMatchQuery(query);
-  if (!match) return [];
+  const terms = query.trim().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return [];
   const limit = opts.limit ?? 20;
-  const params: (string | number)[] = [match];
-  let where = "messages_fts MATCH ?";
-  if (opts.projectPath) {
-    where += " AND (m.cwd = ? OR m.cwd LIKE ?)";
-    params.push(opts.projectPath, `${opts.projectPath}/%`);
-  }
-  params.push(limit);
-  return db
-    .prepare(
-      `SELECT m.id AS id, m.uuid AS uuid, m.session_id AS sessionId, m.role AS role,
-              m.content AS content, m.timestamp AS timestamp
-       FROM messages_fts f
-       JOIN messages m ON m.id = f.rowid
-       WHERE ${where}
-       ORDER BY rank
-       LIMIT ?`,
-    )
-    .all(...params) as unknown as SearchHit[];
+
+  const run = (match: string): SearchHit[] => {
+    const params: (string | number)[] = [match];
+    let where = "messages_fts MATCH ?";
+    if (opts.projectPath) {
+      where += " AND (m.cwd = ? OR m.cwd LIKE ?)";
+      params.push(opts.projectPath, `${opts.projectPath}/%`);
+    }
+    params.push(limit);
+    return db
+      .prepare(
+        `SELECT m.id AS id, m.uuid AS uuid, m.session_id AS sessionId, m.role AS role,
+                m.content AS content, m.timestamp AS timestamp
+         FROM messages_fts f
+         JOIN messages m ON m.id = f.rowid
+         WHERE ${where}
+         ORDER BY rank
+         LIMIT ?`,
+      )
+      .all(...params) as unknown as SearchHit[];
+  };
+
+  // Precision first: an all-terms (implicit-AND) match. FTS5's `rank` is bm25,
+  // so results already come back relevance-ordered.
+  const strict = run(toFtsMatchQuery(query, "AND"));
+  if (strict.length > 0 || terms.length < 2) return strict;
+
+  // Graceful recall: a strict AND over a multi-term query returned nothing (no
+  // single message holds every term). Fall back to OR so partial matches still
+  // surface, bm25-ranked — the message covering the most terms ranks first.
+  // This is the "rank by relevance, not all-or-nothing" behavior (#164).
+  return run(toFtsMatchQuery(query, "OR"));
 }
 
 export interface QueryLogInput {


### PR DESCRIPTION
Fixes #164 — `kit memory search` returned **0 hits** for multi-term queries whose terms don't all co-occur in one message (FTS5 joined terms by implicit AND). Recall depended on exact phrasing — the failure mode the UserPromptSubmit reminder warns against.

## Change
- `toFtsMatchQuery(raw, op)` — new optional `op` (`"AND"` default | `"OR"`). Default unchanged, so existing behavior + tests hold.
- `searchMessages` — strict **AND first** (unchanged for precise / single-term queries), then **OR fallback** only when AND finds nothing on a 2+ term query. FTS5 `rank` is already bm25, so OR results surface the message covering the **most terms** first → relevance instead of all-or-nothing.

## Invariants
Zero-LLM, local-first, **no new deps** (pure FTS5). No embeddings.

## Tests (21/21 green in db.test.ts)
- OR query construction
- multi-term AND-miss to OR fallback recalls both, ranks higher-coverage message first
- single-term miss stays empty (no OR-widening)
- existing AND / sanitization / scoping tests unchanged

Generated with Claude Code