### PR TITLE
feat(memory): atomic PAL claiming for parallel agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`kit memory pal claim` — atomic take for parallel agents.** When several
+  agents share a PAL (a durable device + ephemeral cloud sessions), two could
+  both start the same open item. `pal claim <id>` flips it to `claimed` via an
+  `UPDATE … WHERE status='open'` guard, so exactly one agent wins the race
+  (`✓ claimed` vs a no-op) and the item drops out of everyone's open list;
+  `claimed_by` records the winner (defaults to this device). `pal release <id>`
+  returns an abandoned claim to `open`. Deterministic, zero-LLM, local; schema
+  v6 (older rows have NULL claim fields — backward-compatible).
+
 ## [3.1.0] - 2026-07-01
 
 ### Added

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -73,6 +73,8 @@ import {
   palList,
   palDone,
   palSnooze,
+  palClaim,
+  palRelease,
   palAutoVerify,
   palPrune,
   importLegacyLedger,
@@ -220,6 +222,33 @@ async function memPal(): Promise<boolean> {
       );
       return true;
     }
+    if (action === "claim") {
+      const id = process.argv[5];
+      const by = process.argv[6]; // optional; defaults to this device
+      if (!id) {
+        console.error(`${c.red}usage: kit memory pal claim <id> [by]${c.reset}`);
+        return false;
+      }
+      console.log(
+        palClaim(db, id, by)
+          ? `${c.green}✓${c.reset} claimed ${c.bold}${id}${c.reset} — yours to work`
+          : `${c.dim}${id} not open (already claimed, closed, or not found)${c.reset}`,
+      );
+      return true;
+    }
+    if (action === "release") {
+      const id = process.argv[5];
+      if (!id) {
+        console.error(`${c.red}usage: kit memory pal release <id>${c.reset}`);
+        return false;
+      }
+      console.log(
+        palRelease(db, id)
+          ? `${c.green}✓${c.reset} released ${id} back to open`
+          : `${c.dim}${id} not found or not claimed${c.reset}`,
+      );
+      return true;
+    }
     if (action === "verify") {
       const r = await palAutoVerify(db);
       console.log(
@@ -244,7 +273,9 @@ async function memPal(): Promise<boolean> {
       return true;
     }
     console.error(`${c.red}Unknown pal action: ${action}${c.reset}`);
-    console.error("Use: kit memory pal [list|add|done|snooze|verify|import|prune]");
+    console.error(
+      "Use: kit memory pal [list|add|claim|release|done|snooze|verify|import|prune]",
+    );
     return false;
   } finally {
     db.close();
@@ -282,7 +313,7 @@ async function memHelp(): Promise<boolean> {
   );
   console.log("  kit memory uninstall        Remove the hooks");
   console.log(
-    "  kit memory pal [list|add|done|snooze|verify|import|prune]   Pending action ledger (list --all = every device; prune = drop dead-origin items)",
+    "  kit memory pal [list|add|claim|release|done|snooze|verify|import|prune]   Pending action ledger (claim = atomic take for parallel agents; list --all = every device; prune = drop dead-origin items)",
   );
   console.log("  kit memory save <name>      Bookmark the current session as a named copilot");
   console.log("  kit memory threads          List saved copilots (--global for all)");

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -273,9 +273,7 @@ async function memPal(): Promise<boolean> {
       return true;
     }
     console.error(`${c.red}Unknown pal action: ${action}${c.reset}`);
-    console.error(
-      "Use: kit memory pal [list|add|claim|release|done|snooze|verify|import|prune]",
-    );
+    console.error("Use: kit memory pal [list|add|claim|release|done|snooze|verify|import|prune]");
     return false;
   } finally {
     db.close();

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -21,7 +21,7 @@ import { summarizeTokens } from "./stats.js";
 import { redactSecrets } from "../utils/redactSecrets.js";
 import { secureFile, secureDir } from "../utils/secure-perms.js";
 
-export const SCHEMA_VERSION = 5;
+export const SCHEMA_VERSION = 6;
 
 /**
  * Opt-in redaction-at-capture (KIT_MEMORY_REDACT=1). The memory store is raw by
@@ -191,6 +191,12 @@ function migrate(db: DatabaseSync): void {
   // rows have NULL → treated as "this device" (always shown), backward-compatible.
   ensureColumn(db, "pending_actions", "origin_device", "TEXT");
   ensureColumn(db, "pending_actions", "origin_root", "TEXT");
+  // v6: atomic PAL claiming for parallel agents (from guild's Quests). A claim is
+  // an `UPDATE … WHERE status='open'` guard so exactly one agent wins an open
+  // item; claimed_by = the winner's id, claimed_at = when. Older rows have NULL
+  // (unclaimed) → backward-compatible.
+  ensureColumn(db, "pending_actions", "claimed_by", "TEXT");
+  ensureColumn(db, "pending_actions", "claimed_at", "TEXT");
   const row = db.prepare("SELECT version FROM schema_meta LIMIT 1").get() as
     | { version: number }
     | undefined;

--- a/src/memory/pal.test.ts
+++ b/src/memory/pal.test.ts
@@ -9,6 +9,8 @@ import {
   palList,
   palDone,
   palSnooze,
+  palClaim,
+  palRelease,
   palAutoVerify,
   palPrune,
   deviceId,
@@ -51,6 +53,47 @@ describe("PAL — pending actions", () => {
     assert.equal(palSnooze(db, id, 7), true);
     assert.equal(palList(db).length, 0);
     assert.equal(palList(db, { status: "snoozed" }).length, 1);
+    db.close();
+  });
+
+  it("claim atomically takes an open item; a concurrent second claim loses", () => {
+    const db = fresh();
+    const id = palAdd(db, { title: "flip the auth setting" });
+    assert.equal(palClaim(db, id, "agent-a"), true); // first caller wins
+    assert.equal(palClaim(db, id, "agent-b"), false); // WHERE status='open' guard: no double-claim
+    assert.equal(palList(db).length, 0); // a claimed item drops out of the open list
+    const claimed = palList(db, { status: "claimed" });
+    assert.equal(claimed.length, 1);
+    assert.equal(claimed[0]?.claimed_by, "agent-a");
+    db.close();
+  });
+
+  it("claim defaults claimed_by to this device", () => {
+    const db = fresh();
+    const id = palAdd(db, { title: "x" });
+    assert.equal(palClaim(db, id), true);
+    assert.equal(palList(db, { status: "claimed" })[0]?.claimed_by, deviceId());
+    db.close();
+  });
+
+  it("release returns a claimed item to open (and only a claimed one)", () => {
+    const db = fresh();
+    const id = palAdd(db, { title: "x" });
+    assert.equal(palRelease(db, id), false); // nothing to release — still open
+    palClaim(db, id, "agent-a");
+    assert.equal(palRelease(db, id), true);
+    const open = palList(db);
+    assert.equal(open.length, 1);
+    assert.equal(open[0]?.claimed_by, null); // claim cleared
+    db.close();
+  });
+
+  it("a claimed item can still be marked done by its claimer", () => {
+    const db = fresh();
+    const id = palAdd(db, { title: "x" });
+    palClaim(db, id, "agent-a");
+    assert.equal(palDone(db, id), true);
+    assert.equal(palList(db, { status: "closed" }).length, 1);
     db.close();
   });
 

--- a/src/memory/pal.ts
+++ b/src/memory/pal.ts
@@ -112,6 +112,10 @@ export interface PendingAction {
   origin_device: string | null;
   /** Absolute project path at creation (v5+) — used by `pal prune`. */
   origin_root: string | null;
+  /** Agent/session that atomically claimed this open item (v6+); NULL = unclaimed. */
+  claimed_by: string | null;
+  /** When the claim was taken (v6+). */
+  claimed_at: string | null;
 }
 
 export interface PalAddInput {
@@ -219,6 +223,37 @@ export function palSnooze(db: DatabaseSync, id: string, days: number): boolean {
       "UPDATE pending_actions SET status='snoozed', snooze_until=datetime('now', ?) WHERE id=?",
     )
     .run(`+${d} days`, id);
+  return Number(res.changes) > 0;
+}
+
+/**
+ * Atomically claim an OPEN item so two parallel agents don't both work it (from
+ * guild's Quests). The `WHERE status='open'` guard makes this a race-free
+ * compare-and-set: exactly one caller sees `changes === 1` and wins; every other
+ * concurrent caller gets false. The winner flips the item to 'claimed' so it
+ * drops out of the default (open) list. Returns true iff this caller won.
+ */
+export function palClaim(db: DatabaseSync, id: string, claimedBy?: string): boolean {
+  const who = claimedBy ?? deviceId();
+  const res = db
+    .prepare(
+      "UPDATE pending_actions SET status='claimed', claimed_by=?, claimed_at=datetime('now') WHERE id=? AND status='open'",
+    )
+    .run(who, id);
+  return Number(res.changes) > 0;
+}
+
+/**
+ * Release a claimed item back to 'open' (the claimer crashed, gave up, or handed
+ * it off) so another agent can pick it up. Only touches a currently-'claimed'
+ * row. Returns true iff a claimed item was released.
+ */
+export function palRelease(db: DatabaseSync, id: string): boolean {
+  const res = db
+    .prepare(
+      "UPDATE pending_actions SET status='open', claimed_by=NULL, claimed_at=NULL WHERE id=? AND status='claimed'",
+    )
+    .run(id);
   return Number(res.changes) > 0;
 }
 


### PR DESCRIPTION
Implements the strongest kit-research borrow candidate (from **guild's Quests**): an atomic PAL claim so parallel agents don't both work the same item. Relevant right now — a durable device + ephemeral cloud sessions share one PAL.

## Change
- `palClaim(db, id, claimedBy?)` — `UPDATE … SET status='claimed', claimed_by=?, claimed_at=… WHERE id=? AND status='open'`. The `WHERE status='open'` guard is a race-free compare-and-set: exactly one caller gets `changes === 1` and wins; concurrent callers get `false`. `claimedBy` defaults to `deviceId()`.
- `palRelease(db, id)` — returns a `claimed` item to `open` (abandoned/handoff).
- CLI: `kit memory pal claim <id> [by]` + `kit memory pal release <id>`.
- Schema **v6**: `claimed_by` / `claimed_at` columns (older rows NULL — backward-compatible). Claimed items drop out of the default open list; `palDone` still closes a claimed item.

## Invariants
Deterministic, zero-LLM, local. No new deps.

## Tests (44/44 green across pal.test.js + db.test.js)
- first claim wins, concurrent second claim loses (the guard)
- claimed_by defaults to this device
- release returns a claimed item to open (and only a claimed one)
- a claimed item can still be marked done

Generated with Claude Code