### PR TITLE
feat(memory): kit memory learn — recurring-instruction mining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`kit memory learn` — surface instructions you keep re-typing.** Deterministically
+  mines the local store for user messages repeated 3+ times (verbatim after casing /
+  punctuation normalization), ranked by distinct sessions then count, with a
+  `correction` flag for redirections ("no", "stop", "instead", "nej", "istället").
+  These recurring asks are candidates for a memory rule — record them with
+  `kit memory share` or in a rules file (CLAUDE.md / AGENTS.md) instead of re-typing.
+  Zero-LLM, local, no ML — kit finds the pattern; you decide the rule. `--json`
+  supported. Idea from headroom's `learn` (kit-research), done the kit way.
+
 ## [3.1.0] - 2026-07-01
 
 ### Added

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -16,6 +16,7 @@ import { sparkline, fmtTokens } from "../memory/stats.js";
 import { indexAllHarnesses } from "../memory/parser.js";
 import { mergeDb } from "../memory/merge.js";
 import { buildSuggestPrompt } from "../memory/suggest.js";
+import { learnRecurring } from "../memory/learn.js";
 import { getCurrentProjectRoot } from "../memory/project.js";
 import { scanDbForSecrets } from "../memory/scan.js";
 import {
@@ -105,6 +106,7 @@ export async function cmdMemory(): Promise<boolean> {
     stats: memStats,
     status: memStats, // common typo/alias for `stats`
     suggest: memSuggest,
+    learn: memLearn,
     search: memSearch,
     hook: memHook,
     install: memInstall,
@@ -251,6 +253,40 @@ async function memPal(): Promise<boolean> {
   }
 }
 
+async function memLearn(): Promise<boolean> {
+  const jsonMode = hasFlag(process.argv, "--json");
+  const db = openMemoryDb();
+  try {
+    const candidates = learnRecurring(db, {});
+    if (jsonMode) {
+      console.log(JSON.stringify(candidates));
+      return true;
+    }
+    if (candidates.length === 0) {
+      console.log(
+        `${c.dim}no recurring instructions found — the store is small or your asks are varied${c.reset}`,
+      );
+      return true;
+    }
+    console.log(
+      `${c.bold}${candidates.length}${c.reset} recurring instruction(s) worth a memory rule:`,
+    );
+    for (const cand of candidates) {
+      const flag = cand.correction ? ` ${c.dim}· correction${c.reset}` : "";
+      const s = cand.sessions === 1 ? "session" : "sessions";
+      console.log(
+        `  ${c.bold}${cand.count}×${c.reset} ${c.dim}(${cand.sessions} ${s})${c.reset}${flag}  ${cand.example}`,
+      );
+    }
+    console.log(
+      `\n${c.dim}You keep re-typing these. Record the ones worth keeping with ${c.reset}kit memory share${c.dim} or in your rules file (CLAUDE.md / AGENTS.md) so you stop repeating them.${c.reset}`,
+    );
+    return true;
+  } finally {
+    db.close();
+  }
+}
+
 async function memHelp(): Promise<boolean> {
   console.log("kit memory — local conversation memory (SQLite + FTS5)");
   console.log("\nUsage:");
@@ -261,6 +297,9 @@ async function memHelp(): Promise<boolean> {
     "  kit memory search <query>   Search memory + curated shared decisions (current project; --global for all)",
   );
   console.log("  kit memory stats            Show what the memory store contains");
+  console.log(
+    "  kit memory learn            Surface recurring instructions you keep re-typing (candidates for a memory rule)",
+  );
   console.log("  kit memory merge <file>     Merge another machine's memory.db into this one");
   console.log(
     "  kit memory sync <file>      Sync from a memory export/backup (decrypts encrypted blobs)",

--- a/src/memory/learn.test.ts
+++ b/src/memory/learn.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { DatabaseSync } from "node:sqlite";
+import { openMemoryDb, insertMessage } from "./db.js";
+import { learnRecurring, normalizeInstruction } from "./learn.js";
+
+describe("memory learn — recurring instruction mining", () => {
+  const fresh = () => openMemoryDb(":memory:");
+  const seed = (db: DatabaseSync, uuid: string, sessionId: string, content: string) =>
+    insertMessage(db, { uuid, sessionId, type: "user", role: "user", content });
+
+  it("normalizeInstruction lowercases, strips punctuation, collapses whitespace", () => {
+    assert.equal(normalizeInstruction("  Always use ÅÖÄ!! "), "always use åöä");
+    assert.equal(normalizeInstruction("No, don't do that."), "no don t do that");
+  });
+
+  it("surfaces a message repeated 3× across sessions; ignores one-offs + short chatter", () => {
+    const db = fresh();
+    seed(db, "a1", "s1", "always keep code quality high");
+    seed(db, "a2", "s2", "Always keep code quality high.");
+    seed(db, "a3", "s3", "always keep  code quality high");
+    seed(db, "b1", "s1", "a unique one-off request about pricing tiers");
+    seed(db, "c1", "s1", "ok"); // < 3 words — skipped
+    seed(db, "c2", "s2", "yes please"); // < 3 words — skipped
+    const cands = learnRecurring(db);
+    assert.equal(cands.length, 1);
+    assert.equal(cands[0]?.count, 3);
+    assert.equal(cands[0]?.sessions, 3);
+    assert.match(cands[0]?.example ?? "", /keep code quality high/i);
+    assert.equal(cands[0]?.correction, false);
+    db.close();
+  });
+
+  it("flags a repeated correction and ranks cross-session above a single-session nag", () => {
+    const db = fresh();
+    // correction, 3× across 3 sessions
+    seed(db, "x1", "s1", "no stop doing that");
+    seed(db, "x2", "s2", "No, stop doing that.");
+    seed(db, "x3", "s3", "no stop doing that");
+    // non-correction, 4× but all in ONE session (a nagging loop)
+    seed(db, "y1", "s9", "please add the export line");
+    seed(db, "y2", "s9", "please add the export line");
+    seed(db, "y3", "s9", "please add the export line");
+    seed(db, "y4", "s9", "please add the export line");
+    const cands = learnRecurring(db);
+    assert.equal(cands.length, 2);
+    // cross-session (3) ranks above single-session (1) even though its raw count is lower
+    assert.equal(cands[0]?.sessions, 3);
+    assert.equal(cands[0]?.correction, true);
+    assert.equal(cands[1]?.sessions, 1);
+    assert.equal(cands[1]?.count, 4);
+    db.close();
+  });
+
+  it("respects minCount / minSessions thresholds", () => {
+    const db = fresh();
+    seed(db, "a1", "s1", "twice only instruction here");
+    seed(db, "a2", "s2", "twice only instruction here");
+    assert.equal(learnRecurring(db).length, 0); // default minCount=3 → below threshold
+    assert.equal(learnRecurring(db, { minCount: 2 }).length, 1); // lowered → surfaces
+    assert.equal(learnRecurring(db, { minCount: 2, minSessions: 3 }).length, 0); // needs 3 sessions
+    db.close();
+  });
+});

--- a/src/memory/learn.ts
+++ b/src/memory/learn.ts
@@ -1,0 +1,106 @@
+/**
+ * kit memory learn — deterministically mine the store for RECURRING user
+ * instructions worth promoting to a memory rule.
+ *
+ * Zero-LLM, local, no ML: kit *finds* the pattern by counting verbatim-normalized
+ * user messages; *you* decide the rule (record it via `kit memory share` or your
+ * rules file). Idea borrowed from headroom's `learn` (kit-research), done the kit
+ * way — pure counting over the local store, no model call.
+ *
+ * The signal: a user who says the same thing 3+ times (across sessions, or over
+ * and over in one) is telling you something that belongs in memory instead of
+ * being re-typed. A message flagged `correction` (it reads like a redirection —
+ * "no", "stop", "instead", "nej", "istället") is an even stronger candidate.
+ */
+import type { DatabaseSync } from "node:sqlite";
+
+export interface LearnCandidate {
+  /** Normalized instruction text — the grouping key. */
+  normalized: string;
+  /** A representative original message (first seen, trimmed). */
+  example: string;
+  /** Total occurrences across the store. */
+  count: number;
+  /** Distinct sessions it appeared in — the cross-session recurrence signal. */
+  sessions: number;
+  /** True if it reads like a correction/redirection (bilingual sv/en). */
+  correction: boolean;
+}
+
+export interface LearnOptions {
+  /** Min total occurrences for a candidate (default 3). */
+  minCount?: number;
+  /** Min distinct sessions (default 1 — off; raise to require cross-session). */
+  minSessions?: number;
+  /** Max candidates returned (default 20). */
+  limit?: number;
+}
+
+// Correction / redirection signals — bilingual (this user works in sv + en).
+// Word-boundary anchored so "not" doesn't fire inside "notation".
+const CORRECTION_RE =
+  /\b(no|nope|don'?t|stop|actually|wrong|instead|not that|nej|sluta|fel|inte|istället|igen)\b/i;
+
+/**
+ * Normalize a user message to a grouping key: lowercase, strip markdown/punctuation,
+ * collapse whitespace. Two messages that differ only in casing or punctuation group
+ * together; substantively different messages do not.
+ */
+export function normalizeInstruction(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[`*_>#[\](){}"'.,!?;:/\\-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Rank recurring user instructions. Groups user messages by their normalized text,
+ * keeps those seen `minCount`+ times (and in `minSessions`+ distinct sessions), and
+ * ranks by distinct sessions, then raw count, then correction-first. Very short
+ * (< 3 words: "ok", "kör", "yes") and very long (> 50 words: one-off context dumps)
+ * messages are skipped — neither is a repeatable instruction.
+ */
+export function learnRecurring(db: DatabaseSync, opts: LearnOptions = {}): LearnCandidate[] {
+  const minCount = opts.minCount ?? 3;
+  const minSessions = opts.minSessions ?? 1;
+  const limit = opts.limit ?? 20;
+
+  const rows = db
+    .prepare(
+      `SELECT content, session_id FROM messages
+       WHERE type = 'user' AND content IS NOT NULL AND content != ''`,
+    )
+    .all() as { content: string; session_id: string }[];
+
+  const groups = new Map<string, { example: string; count: number; sessions: Set<string> }>();
+  for (const r of rows) {
+    const normalized = normalizeInstruction(r.content);
+    const words = normalized.split(" ").filter(Boolean);
+    if (words.length < 3 || words.length > 50) continue;
+    let g = groups.get(normalized);
+    if (!g) {
+      g = { example: r.content.replace(/\s+/g, " ").trim(), count: 0, sessions: new Set() };
+      groups.set(normalized, g);
+    }
+    g.count++;
+    g.sessions.add(r.session_id);
+  }
+
+  const candidates: LearnCandidate[] = [];
+  for (const [normalized, g] of groups) {
+    if (g.count < minCount || g.sessions.size < minSessions) continue;
+    candidates.push({
+      normalized,
+      example: g.example.slice(0, 200),
+      count: g.count,
+      sessions: g.sessions.size,
+      correction: CORRECTION_RE.test(normalized),
+    });
+  }
+  candidates.sort(
+    (a, b) =>
+      b.sessions - a.sessions || b.count - a.count || Number(b.correction) - Number(a.correction),
+  );
+  return candidates.slice(0, limit);
+}


### PR DESCRIPTION
Implements the third kit-research borrow candidate (from **headroom's `learn`**, done the kit way — no ML): surface the instructions you keep re-typing so they become a memory rule.

## What it does
`kit memory learn` deterministically mines the local store for user messages repeated **3+ times** (verbatim after casing/punctuation normalization), ranked by **distinct sessions** then raw count, with a `correction` flag for redirections ("no", "stop", "instead", "nej", "istället"). Output is a ranked list + a nudge to record the keepers via `kit memory share` or a rules file. `--json` supported.

Directly targets the failure mode where the same reminder gets re-sent over and over instead of being written down once.

## Design
- New `src/memory/learn.ts` — `learnRecurring(db, {minCount=3, minSessions=1, limit=20})` + `normalizeInstruction()`. Skips < 3-word chatter ("ok", "yes") and > 50-word one-off context dumps.
- CLI `kit memory learn` in the handler table + help.

## Invariants
Zero-LLM, local, no ML, no new deps — pure counting over the store kit already owns. kit finds the pattern; you decide the rule.

## Tests (4/4 green in learn.test.js)
- normalization (case / punctuation / whitespace, unicode preserved)
- 3× across sessions surfaces; one-offs + short chatter excluded
- correction flagged; cross-session ranks above a single-session nag
- minCount / minSessions thresholds respected

Generated with Claude Code