### PR TITLE
release: kit 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-07-01
+
 ### Added
 
 - **`sandstream-kit-plugin-sentrux` — architecture-decay findings.** A read-only

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
Cut **3.2.0** from `[Unreleased]`. Minor bump — new features, backward-compatible.

## Highlights (all zero-LLM, local, no new external deps)
- **`kit-plugin-sentrux`** — read-only architecture-decay scan ingestion; `kit check --security` can now gate on architectural regressions (#200)
- **`kit memory pal claim` / `release`** — atomic take so parallel agents don't both work the same PAL item; schema v6 (#198)
- **`kit memory learn`** — surface user instructions repeated 3+ times (candidates for a memory rule) (#199)
- **fix: `kit memory search`** — OR-fallback + bm25 so multi-term queries stop returning nothing (#197 / #164)

## Release checklist
- [x] `[Unreleased]` → `[3.2.0] - 2026-07-01`
- [x] `package.json` + `package-lock.json` → 3.2.0
- [ ] CI green
- [ ] Squash-merge
- [ ] **Peter signs the tag** (`export GPG_TTY=$(tty); git tag -s v3.2.0`) → `publish.yml` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)