### PR TITLE
feat(memory): surface recall adoption in kit memory stats (R6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`kit memory stats` now surfaces recall adoption.** A new
+  `~N recalls/active session (7d)` line (and `recalls.perActiveSession7d` /
+  `recalls.activeSessions7d` in `--json`) shows whether agents actually follow the
+  "run `kit memory search`" nudge — a near-zero rate (highlighted) means the loop
+  has silently degraded to capture-only. Deterministic, computed from `query_log`
+  vs sessions active in the last 7 days; no schema change.
+
 ### Security — memory as attack surface (the store is replayed into the prompt)
 
 - **The update-check version string can no longer carry a prompt-injection payload.**

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -671,6 +671,14 @@ async function memStats(): Promise<boolean> {
   console.log(
     `  recalls    ${s.recalls.total} ${c.dim}(${s.recalls.last7d} last 7d · ${s.recalls.distinctQueries} distinct queries)${c.reset}`,
   );
+  // Adoption: are agents actually following the "run kit memory search" nudge?
+  {
+    const rate = s.recalls.perActiveSession7d;
+    const adoptionDim = rate < 0.5 ? c.yellow : c.dim;
+    console.log(
+      `             ${adoptionDim}~${rate.toFixed(1)} recalls/active session (7d, ${s.recalls.activeSessions7d} active)${c.reset}`,
+    );
+  }
   console.log(`  pending    ${s.pendingOpen} ${c.dim}(open action items)${c.reset}`);
   console.log(`  size       ${Math.round(s.sizeBytes / 1024)} KB`);
   console.log(

--- a/src/memory/db.test.ts
+++ b/src/memory/db.test.ts
@@ -245,6 +245,20 @@ describe("memory db", () => {
     db.close();
   });
 
+  it("getStats computes recall adoption (recalls per active session, 7d)", () => {
+    const db = fresh();
+    const now = new Date().toISOString();
+    upsertSession(db, { sessionId: "a", harness: "claude-code", lastMessageAt: now });
+    upsertSession(db, { sessionId: "b", harness: "claude-code", lastMessageAt: now });
+    recordQuery(db, { query: "one", hitCount: 1 });
+    recordQuery(db, { query: "two", hitCount: 1 });
+    recordQuery(db, { query: "three", hitCount: 1 });
+    const s = getStats(db);
+    assert.equal(s.recalls.activeSessions7d, 2);
+    assert.equal(s.recalls.perActiveSession7d, 1.5); // 3 recalls / 2 active sessions
+    db.close();
+  });
+
   it("getStats splits logical vs sidechain sessions", () => {
     const db = fresh();
     upsertSession(db, { sessionId: "main", harness: "claude-code", isAgentSidechain: false });

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -513,6 +513,15 @@ export function getStats(db: DatabaseSync): MemoryStats {
     "SELECT COUNT(*) AS n FROM query_log WHERE executed_at >= datetime('now', '-7 days')",
   );
   const distinctQueries = count("SELECT COUNT(DISTINCT query) AS n FROM query_log");
+  // Recall adoption: recalls in the last 7d over sessions active in the last 7d.
+  // query_log has no session_id, so this is a per-active-session rate (near 0 ⇒
+  // the agent is ignoring the "run kit memory search" nudge), not a
+  // distinct-sessions-with-recall count. Honest, deterministic, no schema change.
+  const activeSessions7d = count(
+    "SELECT COUNT(*) AS n FROM sessions WHERE last_message_at >= datetime('now', '-7 days')",
+  );
+  const perActiveSession7d =
+    activeSessions7d > 0 ? Math.round((recall7d / activeSessions7d) * 10) / 10 : 0;
   const topTerms = (
     db
       .prepare(
@@ -541,6 +550,8 @@ export function getStats(db: DatabaseSync): MemoryStats {
       last7d: recall7d,
       distinctQueries,
       topTerms,
+      activeSessions7d,
+      perActiveSession7d,
     },
     sessionsBreakdown: {
       logical: count("SELECT COUNT(*) AS n FROM sessions WHERE is_agent_sidechain = 0"),

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -75,6 +75,11 @@ export interface MemoryStats {
     last7d: number;
     distinctQueries: number;
     topTerms: { query: string; count: number }[];
+    /** Sessions with activity in the last 7 days (denominator for adoption). */
+    activeSessions7d: number;
+    /** recalls last 7d ÷ active sessions last 7d, rounded to 1 dp — the
+     *  "is the recall nudge actually landing" signal (near 0 ⇒ agent ignores it). */
+    perActiveSession7d: number;
   };
   /** Logical vs sidechain session split + raw transcript files indexed.
    *  Exposes the "N files → M logical sessions" collapse. */


### PR DESCRIPTION
## Description

R6 from the self-play security plan. The loop's weakest link is the **advisory** layer: the agent is *nudged* to run `kit memory search`, but nothing measured whether it does — so a silently-degraded loop (capture-only, nudge ignored) was invisible. `getStats` already had raw recall counts; this adds an **adoption rate**.

## Changes
- `getStats`: `recalls.activeSessions7d` + `recalls.perActiveSession7d` (recalls in last 7d ÷ sessions active in last 7d). Deterministic, from `query_log` vs `sessions.last_message_at`; **no schema change**.
- `kit memory stats`: a `~N.N recalls/active session (7d, M active)` line, yellow when the rate is under 0.5.
- Type + test (3 recalls / 2 active → 1.5).

## Type of Change
- [x] New feature (observability)

## Testing
- [x] Added db.test case; **full suite green, 0 fail**; prettier clean.

## Breaking Changes
None / N/A — additive stats fields + one output line.

## Reviewer Notes
Honest limit noted in code: `query_log` has no `session_id`, so this is a per-active-session *rate*, not a distinct-sessions-with-recall count. Part of the self-play plan; remaining: R5 (hook-liveness), R4 (Ed25519-signed shared tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_