### PR TITLE
feat(memory): hook-liveness check — surface a silently-removed capture loop (R5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   "run `kit memory search`" nudge — a near-zero rate (highlighted) means the loop
   has silently degraded to capture-only. Deterministic, computed from `query_log`
   vs sessions active in the last 7 days; no schema change.
+- **`kit doctor` now detects a silently-removed memory capture loop.** If memory
+  hooks were ever installed here (a durable marker under `~/.kit`) but a hook has
+  since vanished from `~/.claude/settings.json`, `kit doctor` reports a **fail**
+  ("memory capture is silently off") instead of the loop dying in silence — the
+  worst failure mode. `memoryHooksLiveness()` is the deterministic check; the
+  marker is written by `kit memory install` and cleared by `kit memory uninstall`
+  (so a deliberate uninstall is never flagged).
 
 ### Security — memory as attack surface (the store is replayed into the prompt)
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -163,6 +163,24 @@ async function checkKitWrapper(): Promise<DoctorCheck | null> {
   return { name, status: "pass", detail: path, category };
 }
 
+async function checkMemoryHooks(): Promise<DoctorCheck | null> {
+  const { memoryHooksLiveness } = await import("./memory/install.js");
+  const name = "memory hooks";
+  const category = "hooks";
+  const live = memoryHooksLiveness();
+  if (!live.everInstalled) return null; // never installed here → nothing to verify
+  if (live.missing.length === 0) {
+    return { name, status: "pass", detail: `${live.present.length} wired`, category };
+  }
+  // Installed once, but a hook has since vanished — capture is silently off.
+  return {
+    name,
+    status: "fail",
+    detail: `installed but missing from settings.json: ${live.missing.join(", ")} — memory capture is silently off. Run: kit memory install`,
+    category,
+  };
+}
+
 async function checkGitHooks(config: kitConfig): Promise<DoctorCheck[]> {
   if (!config.hooks) return [];
 
@@ -208,6 +226,9 @@ export async function runDoctor(config: kitConfig, cwd: string): Promise<DoctorR
 
   const wrapperCheck = await checkKitWrapper();
   if (wrapperCheck) allChecks.push(wrapperCheck);
+
+  const memoryHooksCheck = await checkMemoryHooks();
+  if (memoryHooksCheck) allChecks.push(memoryHooksCheck);
 
   const passed = allChecks.filter((c) => c.status === "pass").length;
   const warnings = allChecks.filter((c) => c.status === "warn").length;

--- a/src/memory/install.test.ts
+++ b/src/memory/install.test.ts
@@ -8,6 +8,7 @@ import {
   uninstallMemoryHooks,
   installStatusline,
   uninstallStatusline,
+  memoryHooksLiveness,
 } from "./install.js";
 
 describe("memory hook installer", () => {
@@ -171,5 +172,54 @@ describe("status-line installer", () => {
     installStatusline();
     assert.equal(uninstallStatusline().removed, true);
     assert.equal(JSON.parse(readFileSync(settingsPath, "utf8")).statusLine, undefined);
+  });
+});
+
+describe("memoryHooksLiveness (R5: silent hook removal is visible)", () => {
+  let tmp: string;
+  let settings: string;
+  let marker: string;
+
+  before(() => {
+    tmp = mkdtempSync(join(tmpdir(), "kit-liveness-"));
+    settings = join(tmp, "settings.json");
+    marker = join(tmp, "marker");
+  });
+  after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  it("everInstalled=false when the marker is absent (never installed → no false alarm)", () => {
+    writeFileSync(settings, "{}");
+    const live = memoryHooksLiveness(settings, join(tmp, "nope"));
+    assert.equal(live.everInstalled, false);
+  });
+
+  it("all present after a real install", () => {
+    // Install into `settings`, marker into `marker`.
+    const prevS = process.env.KIT_CLAUDE_SETTINGS;
+    const prevM = process.env.KIT_MEMORY_HOOK_MARKER;
+    process.env.KIT_CLAUDE_SETTINGS = settings;
+    process.env.KIT_MEMORY_HOOK_MARKER = marker;
+    try {
+      writeFileSync(settings, "{}");
+      installMemoryHooks();
+      const live = memoryHooksLiveness(settings, marker);
+      assert.equal(live.everInstalled, true);
+      assert.deepEqual(live.missing, []);
+      assert.equal(live.present.length, 3);
+    } finally {
+      if (prevS === undefined) delete process.env.KIT_CLAUDE_SETTINGS;
+      else process.env.KIT_CLAUDE_SETTINGS = prevS;
+      if (prevM === undefined) delete process.env.KIT_MEMORY_HOOK_MARKER;
+      else process.env.KIT_MEMORY_HOOK_MARKER = prevM;
+    }
+  });
+
+  it("reports missing hooks when the marker survives but settings were stripped", () => {
+    writeFileSync(marker, "installed\n"); // durable marker present
+    writeFileSync(settings, "{}"); // ...but hooks removed
+    const live = memoryHooksLiveness(settings, marker);
+    assert.equal(live.everInstalled, true);
+    assert.equal(live.missing.length, 3, "all three hooks flagged missing");
+    assert.equal(live.present.length, 0);
   });
 });

--- a/src/memory/install.ts
+++ b/src/memory/install.ts
@@ -5,7 +5,14 @@
  * settings without touching the user's other hooks. Re-running adds nothing.
  * Honors KIT_CLAUDE_SETTINGS for tests.
  */
-import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  copyFileSync,
+  unlinkSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { join, dirname, resolve } from "node:path";
 import { kitWrapperPath } from "../kit-wrapper.js";
@@ -44,6 +51,51 @@ const MEMORY_HOOKS: { event: string; sub: string }[] = [
 
 export function getClaudeSettingsPath(): string {
   return process.env.KIT_CLAUDE_SETTINGS ?? join(homedir(), ".claude", "settings.json");
+}
+
+/**
+ * A durable marker that memory hooks were installed on this machine. It survives
+ * even if the hooks are later stripped from settings.json — that's the whole point:
+ * it lets a liveness check tell "never installed" (silent = fine) apart from
+ * "was installed, now GONE" (the loop silently degraded to capture-nothing).
+ */
+export function memoryInstallMarkerPath(): string {
+  return process.env.KIT_MEMORY_HOOK_MARKER ?? join(homedir(), ".kit", ".memory-hooks-installed");
+}
+
+export interface HookLiveness {
+  /** Memory hooks were installed here at least once (marker present). */
+  everInstalled: boolean;
+  /** Wired events currently present in settings.json. */
+  present: string[];
+  /** Events that SHOULD be wired (were installed) but are missing now. */
+  missing: string[];
+}
+
+/**
+ * R5: is the capture loop still wired? If memory was ever installed (marker) but
+ * a hook has since vanished from settings.json, the loop silently stops recording
+ * — the worst failure mode. This makes that visible. Deterministic, read-only.
+ */
+export function memoryHooksLiveness(
+  settingsPath: string = getClaudeSettingsPath(),
+  markerPath: string = memoryInstallMarkerPath(),
+): HookLiveness {
+  const everInstalled = existsSync(markerPath);
+  let hooks: Record<string, HookGroup[]> = {};
+  try {
+    hooks = (readSettings(settingsPath).hooks ?? {}) as Record<string, HookGroup[]>;
+  } catch {
+    hooks = {}; // unparseable settings → treat all as missing (surfaced as a problem)
+  }
+  const present: string[] = [];
+  const missing: string[] = [];
+  for (const { event, sub } of MEMORY_HOOKS) {
+    const groups = Array.isArray(hooks[event]) ? hooks[event] : [];
+    if (groupsHaveHook(groups, sub)) present.push(event);
+    else missing.push(event);
+  }
+  return { everInstalled, present, missing };
 }
 
 interface HookCmd {
@@ -115,6 +167,15 @@ export function installMemoryHooks(path: string = getClaudeSettingsPath()): {
     added.push(event);
   }
   if (added.length) writeSettings(path, s);
+  // Durable "installed here" marker for the liveness check (idempotent). After
+  // this call the hooks ARE present (added or alreadyPresent), so stamp it.
+  try {
+    const marker = memoryInstallMarkerPath();
+    mkdirSync(dirname(marker), { recursive: true });
+    if (!existsSync(marker)) writeFileSync(marker, new Date().toISOString() + "\n");
+  } catch {
+    /* best-effort: a missing marker only weakens the liveness check, never breaks install */
+  }
   return { added, alreadyPresent, resolved };
 }
 
@@ -180,5 +241,13 @@ export function uninstallMemoryHooks(path: string = getClaudeSettingsPath()): {
     }
   }
   if (removed.length) writeSettings(path, s);
+  // Intentional uninstall clears the marker, so the liveness check won't then
+  // report the (deliberate) absence as silent tampering.
+  try {
+    const marker = memoryInstallMarkerPath();
+    if (existsSync(marker)) unlinkSync(marker);
+  } catch {
+    /* best-effort */
+  }
   return { removed };
 }


### PR DESCRIPTION
## Description

R5 from the self-play security plan. A memory hook stripped from `~/.claude/settings.json` (container reset, a settings edit, tampering) silently stops all capture — the store looks installed but records nothing. This makes it visible.

## Changes
- Durable marker `~/.kit/.memory-hooks-installed` written by `installMemoryHooks`, cleared by `uninstallMemoryHooks` — so "never installed" (fine) is distinguishable from "was installed, now gone" (broken); a deliberate uninstall is never flagged.
- `memoryHooksLiveness()` — deterministic: `everInstalled` + `present`/`missing` hook events.
- `kit doctor`: a **"memory hooks"** check that **fails** when the marker exists but hooks are missing (naming them), passes when all wired, and is skipped when never installed.

## Type of Change
- [x] New feature (observability / integrity)

## Testing
- [x] `install.test.ts`: never-installed → no alarm; all present after install; marker-survives-strip → all 3 flagged missing. **Full suite green: 2030, 0 fail**; prettier clean.

## Breaking Changes
None / N/A.

## Reviewer Notes
Deliberately **not** emitting an audit event from the doctor check — `kit doctor` runs casually and would spam the audit log; the `fail` status is the surfaced signal. Last remaining plan item after this: **R4** (Ed25519-signed shared tier), which will be its own careful PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_