### PR TITLE
feat(memory): Ed25519-sign the shared tier + kit memory verify (R4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Security — memory as attack surface (the store is replayed into the prompt)
 
+- **The shared memory tier is now Ed25519-signed on write and verifiable on read.**
+  Entries in `.kit/shared/memory.jsonl` are committed and re-injected into every
+  colleague's session as trusted "team decisions", so their integrity + provenance
+  matter. `kit memory share` now signs each entry with the machine identity (adds a
+  `kid` + `sig` over the canonical content) when one exists — no identity ⇒ unsigned
+  (backward-compatible), and sharing never auto-creates a key. New `kit memory verify`
+  reports each entry as `trusted` / `bad-sig` / `untrusted-signer` / `unsigned`.
+  Trust mirrors the policy discipline: with a committed `.kit-policy.signers` anchor
+  only those org keys are trusted (`--strict` exits non-zero on an un-anchored
+  signer); with no anchor it verifies against this machine's own keys, so tampering
+  (`bad-sig`) is always caught. Asymmetric, offline, zero-LLM.
 - **The update-check version string can no longer carry a prompt-injection payload.**
   `latest` comes from the npm registry (or its on-disk cache) and is interpolated
   verbatim into the Claude Code hooks (`staleKitNotice`), yet `isNewer()` compared

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -49,6 +49,7 @@ import {
   effectiveStatus,
   formatAge,
   getSharedPath,
+  verifySharedTier,
   type SharedKind,
   type SharedStatus,
   type SharedEntry,
@@ -114,6 +115,7 @@ export async function cmdMemory(): Promise<boolean> {
     install: memInstall,
     uninstall: memUninstall,
     share: memShare,
+    verify: memVerify,
     areas: memAreas,
     area: memArea,
     context: memContext,
@@ -366,6 +368,9 @@ async function memHelp(): Promise<boolean> {
   console.log("  kit memory backup <file>    Encrypted backup (set KIT_MEMORY_PASSPHRASE)");
   console.log("  kit memory restore <file>   Restore an encrypted backup (new machine)");
   console.log("  kit memory share …          Promote a curated entry to shared (team) memory");
+  console.log(
+    "  kit memory verify           Verify Ed25519 signatures on the shared tier (--strict fails on an un-anchored signer)",
+  );
   console.log("  kit memory areas            List shared responsibility areas");
   console.log("  kit memory area <name>      Show shared entries for one area");
   console.log(
@@ -986,6 +991,60 @@ async function memShare(): Promise<boolean> {
     return false;
   }
   return true;
+}
+
+async function memVerify(): Promise<boolean> {
+  const jsonMode = hasFlag(process.argv, "--json");
+  const strict = hasFlag(process.argv, "--strict");
+  const root = getCurrentProjectRoot();
+  const v = verifySharedTier(root);
+  if (jsonMode) {
+    console.log(
+      JSON.stringify({
+        anchored: v.anchored,
+        total: v.total,
+        counts: v.counts,
+        results: v.results.map((r) => ({ id: r.entry.id, area: r.entry.area, verdict: r.verdict })),
+      }),
+    );
+    // Same exit rule as the human path (see below).
+    return !(v.counts["bad-sig"] > 0 || (strict && v.anchored && v.counts["untrusted-signer"] > 0));
+  }
+  if (v.total === 0) {
+    console.log(`${c.dim}no shared entries to verify (${getSharedPath(root)} is empty)${c.reset}`);
+    return true;
+  }
+  const anchorNote = v.anchored
+    ? `${c.dim}trust anchor: .kit-policy.signers (only org keys trusted)${c.reset}`
+    : `${c.dim}no .kit-policy.signers anchor — verifying against this machine's identity keys${c.reset}`;
+  console.log(
+    `${c.bold}${v.total}${c.reset} shared entr${v.total === 1 ? "y" : "ies"} · ${c.green}${v.counts.trusted} trusted${c.reset} · ${c.red}${v.counts["bad-sig"]} bad-sig${c.reset} · ${c.yellow}${v.counts["untrusted-signer"]} untrusted${c.reset} · ${c.dim}${v.counts.unsigned} unsigned${c.reset}`,
+  );
+  console.log(`  ${anchorNote}`);
+  // List anything that isn't cleanly trusted, so a tampered/untrusted entry is named.
+  for (const r of v.results) {
+    if (r.verdict === "trusted") continue;
+    const color =
+      r.verdict === "bad-sig" ? c.red : r.verdict === "untrusted-signer" ? c.yellow : c.dim;
+    const who = r.entry.kid ? ` ${c.dim}(${r.entry.kid})${c.reset}` : "";
+    console.log(
+      `  ${color}[${r.verdict}]${c.reset} ${c.bold}${r.entry.id}${c.reset} ${r.entry.title}${who}`,
+    );
+  }
+  // Exit non-zero on tamper always; on an un-anchored signer only under --strict when
+  // an anchor is present (mirrors the policy gate's "fail-closed once anchored").
+  const failed =
+    v.counts["bad-sig"] > 0 || (strict && v.anchored && v.counts["untrusted-signer"] > 0);
+  if (v.counts["bad-sig"] > 0) {
+    console.error(
+      `${c.red}✗ ${v.counts["bad-sig"]} entr${v.counts["bad-sig"] === 1 ? "y" : "ies"} failed signature verification — the shared store may have been tampered with${c.reset}`,
+    );
+  } else if (failed) {
+    console.error(
+      `${c.red}✗ ${v.counts["untrusted-signer"]} entr${v.counts["untrusted-signer"] === 1 ? "y" : "ies"} signed by a key not in .kit-policy.signers (--strict)${c.reset}`,
+    );
+  }
+  return !failed;
 }
 
 async function memAreas(): Promise<boolean> {

--- a/src/memory/shared.test.ts
+++ b/src/memory/shared.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from "node:test";
+import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -12,7 +12,13 @@ import {
   effectiveStatus,
   activeShared,
   formatAge,
+  sharedEntryCanonical,
+  verifySharedEntry,
+  verifySharedTier,
+  getSharedPath,
 } from "./shared.js";
+import { loadOrCreateIdentity, tryLoadIdentity } from "../identity.js";
+import { addPolicySigner } from "../policy-trust.js";
 
 const ALLOWED = new Set([
   "id",
@@ -27,6 +33,8 @@ const ALLOWED = new Set([
   "status",
   "supersedes",
   "reverses",
+  "kid",
+  "sig",
 ]);
 
 describe("shared project memory (Track D)", () => {
@@ -161,5 +169,113 @@ describe("shared memory — decision lifecycle (gap #2)", () => {
     assert.equal(formatAge("2026-03-01T00:00:00Z", now), "4mo ago"); // 120d / 30
     assert.equal(formatAge("2024-01-01T00:00:00Z", now), "2y ago");
     assert.equal(formatAge("not-a-date", now), "");
+  });
+});
+
+describe("shared memory — Ed25519 signing (R4)", () => {
+  let idDir: string;
+  const prevIdDir = process.env.KIT_IDENTITY_DIR;
+
+  before(() => {
+    // Hermetic identity: sign/verify read KIT_IDENTITY_DIR, so point it at a temp
+    // dir and mint a fresh keypair there — never touch the machine's real ~/.kit.
+    idDir = mkdtempSync(join(tmpdir(), "kit-id-"));
+    process.env.KIT_IDENTITY_DIR = idDir;
+    loadOrCreateIdentity();
+  });
+  after(() => {
+    if (prevIdDir === undefined) delete process.env.KIT_IDENTITY_DIR;
+    else process.env.KIT_IDENTITY_DIR = prevIdDir;
+    rmSync(idDir, { recursive: true, force: true });
+  });
+
+  it("signs on write and verifies as trusted against the local identity (no anchor)", () => {
+    const r = mkdtempSync(join(tmpdir(), "kit-sig-"));
+    const e = shareEntry(
+      r,
+      { area: "auth", kind: "decision", title: "use Ed25519", body: "x" },
+      "t",
+    );
+    assert.ok(e.kid && e.kid.startsWith("kid_"), "entry carries a signer kid");
+    assert.ok(e.sig && e.sig.length > 0, "entry carries a signature");
+    const v = verifySharedTier(r);
+    assert.equal(v.anchored, false);
+    assert.equal(v.counts.trusted, 1);
+    assert.equal(v.counts["bad-sig"], 0);
+    rmSync(r, { recursive: true, force: true });
+  });
+
+  it("detects tampering — an edited body no longer verifies (bad-sig)", () => {
+    const r = mkdtempSync(join(tmpdir(), "kit-tamper-"));
+    shareEntry(r, { area: "auth", kind: "decision", title: "keep RSA", body: "orig" }, "t");
+    // Rewrite the body on disk WITHOUT re-signing — the classic tamper.
+    const path = getSharedPath(r);
+    const entry = JSON.parse(readFileSync(path, "utf8"));
+    entry.body = "attacker-edited";
+    writeFileSync(path, JSON.stringify(entry) + "\n");
+    const v = verifySharedTier(r);
+    assert.equal(v.counts["bad-sig"], 1);
+    assert.equal(v.counts.trusted, 0);
+    // A signed entry with an empty trust store → untrusted-signer, not bad-sig.
+    assert.equal(verifySharedEntry(readShared(r)[0], new Map()), "untrusted-signer");
+    rmSync(r, { recursive: true, force: true });
+  });
+
+  it("canonical excludes kid/sig and is stable regardless of field order", () => {
+    const r = mkdtempSync(join(tmpdir(), "kit-canon-"));
+    const e = shareEntry(r, { area: "x", kind: "note", title: "t", body: "b" }, "ts");
+    const canon = sharedEntryCanonical(e);
+    assert.ok(!canon.includes(e.sig!), "signature is not part of the signed bytes");
+    assert.ok(!canon.includes('"kid"'), "kid is not part of the signed bytes");
+    // Same content in a reshuffled object → identical canonical bytes.
+    const reshuffled = {
+      sig: e.sig,
+      ts: e.ts,
+      body: e.body,
+      id: e.id,
+      kid: e.kid,
+      area: e.area,
+      kind: e.kind,
+      title: e.title,
+      refs: e.refs,
+      author: e.author,
+      source_ref: e.source_ref,
+    };
+    assert.equal(sharedEntryCanonical(reshuffled as typeof e), canon);
+    rmSync(r, { recursive: true, force: true });
+  });
+
+  it("with a .kit-policy.signers anchor, an un-anchored signer is untrusted (fail-closed)", () => {
+    const r = mkdtempSync(join(tmpdir(), "kit-anchor-"));
+    shareEntry(r, { area: "auth", kind: "decision", title: "signed by me", body: "x" }, "t");
+    // Anchor trusts some OTHER org key, not this machine's identity.
+    const otherDir = mkdtempSync(join(tmpdir(), "kit-other-"));
+    const prev = process.env.KIT_IDENTITY_DIR;
+    process.env.KIT_IDENTITY_DIR = otherDir;
+    const other = loadOrCreateIdentity().identity;
+    process.env.KIT_IDENTITY_DIR = prev;
+    addPolicySigner(r, other.publicKey, "org");
+    const v = verifySharedTier(r);
+    assert.equal(v.anchored, true);
+    assert.equal(v.counts["untrusted-signer"], 1);
+    assert.equal(v.counts.trusted, 0);
+    rmSync(r, { recursive: true, force: true });
+    rmSync(otherDir, { recursive: true, force: true });
+  });
+
+  it("leaves entries unsigned when no identity exists (backward-compatible)", () => {
+    const r = mkdtempSync(join(tmpdir(), "kit-noid-"));
+    const emptyId = mkdtempSync(join(tmpdir(), "kit-emptyid-"));
+    const prev = process.env.KIT_IDENTITY_DIR;
+    process.env.KIT_IDENTITY_DIR = emptyId; // no key here
+    assert.equal(tryLoadIdentity(), null);
+    const e = shareEntry(r, { area: "x", kind: "note", title: "t", body: "b" }, "ts");
+    process.env.KIT_IDENTITY_DIR = prev;
+    assert.equal(e.kid, undefined);
+    assert.equal(e.sig, undefined);
+    const v = verifySharedTier(r);
+    assert.equal(v.counts.unsigned, 1);
+    rmSync(r, { recursive: true, force: true });
+    rmSync(emptyId, { recursive: true, force: true });
   });
 });

--- a/src/memory/shared.ts
+++ b/src/memory/shared.ts
@@ -19,6 +19,13 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, appendFileSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { findSecrets } from "../utils/redactSecrets.js";
+import {
+  tryLoadIdentity,
+  signWithIdentity,
+  verifySignature,
+  localPublicKeys,
+} from "../identity.js";
+import { policySignersMap, hasPolicyAnchor } from "../policy-trust.js";
 
 export type SharedKind = "decision" | "convention" | "how-built" | "status" | "security" | "note";
 
@@ -45,6 +52,10 @@ export interface SharedEntry {
   supersedes?: string;
   /** Id of the entry this one reverses (tried + undone — re-introducing it should warn). */
   reverses?: string;
+  /** Ed25519 signer id (kid) — set when the entry was signed on write. */
+  kid?: string;
+  /** Base64 Ed25519 signature over the canonical content (excludes kid/sig itself). */
+  sig?: string;
 }
 
 export interface ShareInput {
@@ -91,6 +102,83 @@ function gitHead(root: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Canonical bytes that a signature covers — every semantic field EXCEPT `kid`/`sig`
+ * (the signature can't cover itself). Reconstructed in a FIXED key order so it is
+ * independent of on-disk field order and of how the object was parsed: read →
+ * re-canonicalize → verify is byte-stable. Optional fields are included only when
+ * present, matching how `shareEntry` writes them (so an unsigned legacy entry, if
+ * later signed, canonicalizes identically). Pure.
+ */
+export function sharedEntryCanonical(entry: SharedEntry): string {
+  const canon: Record<string, unknown> = {
+    id: entry.id,
+    area: entry.area,
+    kind: entry.kind,
+    title: entry.title,
+    body: entry.body,
+    refs: entry.refs,
+    author: entry.author,
+    ts: entry.ts,
+  };
+  if (entry.source_ref !== undefined) canon.source_ref = entry.source_ref;
+  if (entry.status !== undefined) canon.status = entry.status;
+  if (entry.supersedes !== undefined) canon.supersedes = entry.supersedes;
+  if (entry.reverses !== undefined) canon.reverses = entry.reverses;
+  return JSON.stringify(canon);
+}
+
+/**
+ * Verdict for one shared entry against a kid → public-key trust store:
+ *  - `trusted`          signer is in the store AND the signature verifies;
+ *  - `bad-sig`          signer is known but the signature does NOT verify (tamper);
+ *  - `untrusted-signer` entry is signed but the signer is not in the trust store;
+ *  - `unsigned`         no signature at all (legacy / signed by no-identity machine).
+ */
+export type SharedVerdict = "trusted" | "bad-sig" | "untrusted-signer" | "unsigned";
+
+/** Classify one entry against a kid → PEM trust store. Pure, never throws. */
+export function verifySharedEntry(entry: SharedEntry, signers: Map<string, string>): SharedVerdict {
+  if (!entry.kid || !entry.sig) return "unsigned";
+  const pem = signers.get(entry.kid);
+  if (!pem) return "untrusted-signer";
+  const ok = verifySignature(sharedEntryCanonical(entry), Buffer.from(entry.sig, "base64"), pem);
+  return ok ? "trusted" : "bad-sig";
+}
+
+export interface SharedTierVerification {
+  /** True when a committed `.kit-policy.signers` anchor is present ⇒ fail-closed. */
+  anchored: boolean;
+  total: number;
+  results: { entry: SharedEntry; verdict: SharedVerdict }[];
+  counts: Record<SharedVerdict, number>;
+}
+
+/**
+ * Verify every entry in the shared tier. Trust store mirrors the policy discipline:
+ * when a committed `.kit-policy.signers` anchor is present, ONLY those org keys are
+ * trusted (an un-anchored signer → `untrusted-signer`, fail-closed under --strict);
+ * with no anchor, the machine's own identity keys resolve, giving self-integrity
+ * (tamper → `bad-sig`) without ceremony. `identityDir` is injectable for tests.
+ */
+export function verifySharedTier(root: string, identityDir?: string): SharedTierVerification {
+  const anchored = hasPolicyAnchor(root);
+  const signers = anchored ? policySignersMap(root) : localPublicKeys(identityDir);
+  const entries = readShared(root);
+  const counts: Record<SharedVerdict, number> = {
+    trusted: 0,
+    "bad-sig": 0,
+    "untrusted-signer": 0,
+    unsigned: 0,
+  };
+  const results = entries.map((entry) => {
+    const verdict = verifySharedEntry(entry, signers);
+    counts[verdict]++;
+    return { entry, verdict };
+  });
+  return { anchored, total: entries.length, results, counts };
 }
 
 export function readShared(root: string): SharedEntry[] {
@@ -144,6 +232,19 @@ export function shareEntry(root: string, input: ShareInput, now: string): Shared
   if (input.status && input.status !== "active") entry.status = input.status;
   if (input.supersedes) entry.supersedes = input.supersedes;
   if (input.reverses) entry.reverses = input.reverses;
+  // Sign on write when a machine identity exists (attributable provenance a
+  // reviewer/colleague can verify offline with just the public key). No identity ⇒
+  // unsigned entry (backward-compatible) — we never AUTO-CREATE a key as a
+  // side-effect of sharing a note. Best-effort: a sign failure leaves it unsigned.
+  const id = tryLoadIdentity();
+  if (id) {
+    try {
+      entry.kid = id.id;
+      entry.sig = signWithIdentity(sharedEntryCanonical(entry)).toString("base64");
+    } catch {
+      delete entry.kid; // no readable private key → leave the entry unsigned
+    }
+  }
   const path = getSharedPath(root);
   mkdirSync(dirname(path), { recursive: true });
   appendFileSync(path, JSON.stringify(entry) + "\n");


### PR DESCRIPTION
## Description

R4 from the self-play security plan — the **last** plan item. The curated shared tier (`.kit/shared/memory.jsonl`) is committed and re-injected into every colleague's session as trusted "team decisions", so its integrity and provenance matter. This signs each entry with the machine's Ed25519 identity on write and makes the tier verifiable on read.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Related Issues
- Related to the self-play security plan (kit-research: `self-playing-security-plan.md`, R4)

## Changes Made
- **`shared.ts`**: `SharedEntry` gains optional `kid`/`sig`. `sharedEntryCanonical()` is the stable, **field-order-independent** byte string a signature covers (excludes `kid`/`sig` themselves). `shareEntry()` signs with the machine identity **when one exists** (`tryLoadIdentity` — never auto-creates a key as a side-effect of sharing a note); no identity ⇒ unsigned, fully backward-compatible.
- **Verification**: `verifySharedEntry()` / `verifySharedTier()` classify each entry as `trusted` | `bad-sig` | `untrusted-signer` | `unsigned`. Trust **mirrors the policy gate**: with a committed `.kit-policy.signers` anchor only those org keys are trusted (fail-closed); with no anchor, this machine's own identity keys resolve, so tampering (`bad-sig`) is always caught.
- **`kit memory verify [--strict] [--json]`**: exits non-zero on `bad-sig` always, and on an un-anchored signer under `--strict` when an anchor is present (the "fail-closed once anchored" discipline). Names any non-trusted entry.
- Help text + CHANGELOG.

## Testing

### Test Coverage
- [x] Added new tests
- [x] Updated existing tests (allow-list now includes `kid`/`sig`)
- [x] All tests pass (`npm test`) — **2033 pass, 0 fail**; prettier clean; `tsc` build clean.

New `shared.test.ts` cases (hermetic — a temp `KIT_IDENTITY_DIR`, never the real `~/.kit`): sign→`trusted`, on-disk tamper→`bad-sig`, canonical excludes `kid`/`sig` and is order-independent, anchored repo + un-anchored signer→`untrusted-signer`, no-identity→`unsigned`.

## Breaking Changes

None / N/A — `kid`/`sig` are additive optional fields; unsigned (legacy) entries verify as `unsigned`, never an error.

## Reviewer Notes

Reuses existing crypto — `signWithIdentity`/`verifySignature`/`localPublicKeys` (`identity.ts`) and `policySignersMap`/`hasPolicyAnchor` (`policy-trust.ts`) — so no new signing primitives. Same-UID threat boundary as the rest of the identity layer (documented in `identity.ts`): the payoff here is asymmetric, offline, third-party-verifiable attribution for a store that travels with the repo. Deterministic, zero-LLM, local-first. Completes R1–R7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_