### PR TITLE
fix(mcp): route mutating MCP tools through the governance/audit floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Security — MCP surface
+
+- **The mutating MCP tools now pass through the governance/audit floor.** `kit_run`,
+  `kit_secrets`, `kit_install`, and `kit_fix` previously ran with only a read-only-mode
+  guard — bypassing the revocation / budget / permission / expired-secret checks and
+  the tamper-evident audit log that the CLI applies to the same operations. They now
+  route through a new **MCP-safe** governed executor (`runGoverned`) that runs the same
+  deterministic pre-flight checks and emits the same audit events, but NEVER prompts:
+  it writes nothing to stdout (which on the MCP stdio transport IS the JSON-RPC
+  channel) and **fail-closed-denies** anything that would need interactive approval
+  (a destructive op, or a permission only approval can override) — run those via the
+  kit CLI. A blocked tool returns a `{ ok: false, governance: "denied", error }` result.
+
 ### Fixed
 
 - **`kit check` (CLI) and `kit_check` (MCP) can no longer disagree on green.** The

--- a/src/governance-middleware.test.ts
+++ b/src/governance-middleware.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { withGovernance, checkGovernance } from "./governance-middleware.js";
+import { withGovernance, checkGovernance, runGoverned } from "./governance-middleware.js";
 import { clearBudgetState, getBudgetStatus, recordUsage } from "./budget.js";
 import type { kitConfig, GovernanceConfig } from "./config.js";
 
@@ -303,5 +303,110 @@ describe("withGovernance", () => {
       },
     );
     assert.equal(executed, true);
+  });
+});
+
+describe("runGoverned (MCP-safe, never prompts)", () => {
+  let tempDir: string;
+  let originalCwd: string;
+
+  before(async () => {
+    originalCwd = process.cwd();
+    tempDir = await mkdtemp(join(tmpdir(), "kit-govmcp-"));
+    process.chdir(tempDir);
+  });
+  after(async () => {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+  afterEach(async () => {
+    await clearBudgetState();
+  });
+
+  it("runs and returns the result when governance is disabled", async () => {
+    const r = await runGoverned(disabledConfig, { operation: "run", operationType: "write" }, () =>
+      Promise.resolve("did-it"),
+    );
+    assert.deepEqual(r, { ok: true, result: "did-it" });
+  });
+
+  it("runs and returns the result when governance allows the op", async () => {
+    const r = await runGoverned(makeConfig(), { operation: "run", operationType: "write" }, () =>
+      Promise.resolve(42),
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.result, 42);
+  });
+
+  it("denies (does NOT run) when the environment forbids writes — fail-closed, no throw", async () => {
+    const config = makeConfig({
+      environment: "staging",
+      access: { staging: { read: true, write: false, delete: false } },
+    });
+    let executed = false;
+    const r = await runGoverned(config, { operation: "run", operationType: "write" }, async () => {
+      executed = true;
+      return "nope";
+    });
+    assert.equal(r.ok, false);
+    assert.equal(executed, false, "the op must not run when denied");
+    assert.match(r.reason ?? "", /Write operations not allowed/);
+  });
+
+  it("denies a DESTRUCTIVE op even when the CLI would auto-approve it (no approval over MCP)", async () => {
+    // withGovernance auto-approves this exact config; runGoverned must still refuse,
+    // because approval cannot be requested over the MCP stdio channel.
+    const config = makeConfig({
+      approval: { destructive_operations: [], production_writes: false },
+    });
+    let executed = false;
+    const r = await runGoverned(
+      config,
+      { operation: "cleanup", operationType: "delete", destructive: true },
+      async () => {
+        executed = true;
+      },
+    );
+    assert.equal(r.ok, false);
+    assert.equal(executed, false);
+    assert.match(r.reason ?? "", /interactive approval/);
+  });
+
+  it("denies when the token budget is exceeded", async () => {
+    const config = makeConfig({ agent: { max_tokens_per_day: 50, max_operations_per_hour: 100 } });
+    await recordUsage(config.governance!, 40);
+    const r = await runGoverned(
+      config,
+      { operation: "run", operationType: "write", estimatedTokens: 20 },
+      () => Promise.resolve("x"),
+    );
+    assert.equal(r.ok, false);
+    assert.match(r.reason ?? "", /budget/i);
+  });
+
+  it("captures a thrown op as ok:false (never throws) and records no usage", async () => {
+    const config = makeConfig({ agent: { max_tokens_per_day: 1000, max_operations_per_hour: 10 } });
+    const r = await runGoverned(
+      config,
+      { operation: "run", operationType: "write", estimatedTokens: 100 },
+      async () => {
+        throw new Error("boom");
+      },
+    );
+    assert.equal(r.ok, false);
+    assert.match(r.reason ?? "", /boom/);
+    const status = await getBudgetStatus(config.governance);
+    assert.equal(status.tokens_used, 0);
+  });
+
+  it("records usage after a successful governed op", async () => {
+    const config = makeConfig({ agent: { max_tokens_per_day: 1000, max_operations_per_hour: 10 } });
+    await runGoverned(
+      config,
+      { operation: "run", operationType: "write", estimatedTokens: 100 },
+      () => Promise.resolve("ok"),
+    );
+    const status = await getBudgetStatus(config.governance);
+    assert.equal(status.tokens_used, 100);
   });
 });

--- a/src/governance-middleware.ts
+++ b/src/governance-middleware.ts
@@ -182,6 +182,121 @@ export async function withGovernance<T>(
   return result;
 }
 
+export interface GovernedOutcome<T> {
+  /** True → the op ran; result is set. False → denied or the op threw; reason is set. */
+  ok: boolean;
+  result?: T;
+  reason?: string;
+}
+
+/**
+ * MCP-safe governed execution — the shared "floor" the MCP mutating tools were
+ * bypassing (they only checked `isReadOnlyMode`). Unlike {@link withGovernance},
+ * which can PROMPT for approval on stdin and print to stdout — both fatal on the
+ * MCP stdio channel, where stdout IS the JSON-RPC transport — this NEVER prompts
+ * and writes NOTHING to stdout. It runs the deterministic pre-flight checks
+ * (revocation → budget → permission → secret-expiration), FAIL-CLOSED-denies
+ * anything that would require interactive approval (a destructive op, or a
+ * permission that only `requiresApproval` can override — approval can't be
+ * requested over the protocol channel), emits the same audit events, then executes
+ * and audits success/failure. Returns an outcome the caller renders itself.
+ */
+export async function runGoverned<T>(
+  config: kitConfig,
+  context: OperationContext,
+  operation: () => Promise<T>,
+): Promise<GovernedOutcome<T>> {
+  const startTime = Date.now();
+  const governanceConfig = await mergeGovernanceConfigAsync(config.governance);
+
+  // Governance disabled → run, no audit (nothing is being governed).
+  if (!governanceConfig.enabled) {
+    try {
+      return { ok: true, result: await operation() };
+    } catch (err) {
+      return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  const auditDeny = (error: string, extra?: Record<string, unknown>) =>
+    logAuditEvent(governanceConfig, {
+      operation: context.operation,
+      environment: governanceConfig.environment,
+      success: false,
+      error,
+      metadata: extra ? { ...context.metadata, ...extra } : context.metadata,
+    });
+
+  // 1. Revocation
+  if (await checkRevocationStatus(config.governance)) {
+    await auditDeny("Access revoked");
+    return { ok: false, reason: "Access revoked" };
+  }
+
+  // 2. Budget
+  const budgetCheck = await checkBudgetLimits(config.governance, context.estimatedTokens || 0);
+  if (!budgetCheck.allowed) {
+    const reason = budgetCheck.reason || "Budget limit exceeded";
+    await auditDeny(reason);
+    return { ok: false, reason };
+  }
+
+  // 3. Permission — fail CLOSED for anything approval-gated (can't prompt over MCP).
+  const permissionCheck = checkOperationAllowed(governanceConfig, context.operationType);
+  if (!permissionCheck.allowed) {
+    const reason = permissionCheck.requiresApproval
+      ? `${permissionCheck.reason || "Operation requires approval"} — approval cannot be requested over the MCP channel; run this via the kit CLI to approve`
+      : permissionCheck.reason || "Operation not allowed";
+    await auditDeny(reason);
+    return { ok: false, reason };
+  }
+
+  // 4. Destructive ops need approval → not available non-interactively over MCP.
+  if (context.destructive) {
+    const reason =
+      "Destructive operation requires interactive approval — run it via the kit CLI, not MCP";
+    await auditDeny(reason);
+    return { ok: false, reason };
+  }
+
+  // 5. Secret expiration blocks the op.
+  if (governanceConfig.secrets.check_expiration && config.secrets?.keys) {
+    const secretKeys = Object.keys(config.secrets.keys);
+    const expirations = await checkSecretExpiration(config.governance, secretKeys, config.secrets);
+    if (hasExpiredSecrets(expirations)) {
+      await auditDeny("Expired secrets detected", {
+        expired_secrets: expirations.filter((e) => e.expired).map((e) => e.key),
+      });
+      return { ok: false, reason: "Operation blocked: expired secrets detected" };
+    }
+  }
+
+  // Execute + audit success/failure.
+  try {
+    const result = await operation();
+    await recordUsage(config.governance, context.estimatedTokens || 0);
+    await logAuditEvent(governanceConfig, {
+      operation: context.operation,
+      environment: governanceConfig.environment,
+      success: true,
+      duration_ms: Date.now() - startTime,
+      metadata: context.metadata,
+    });
+    return { ok: true, result };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    await logAuditEvent(governanceConfig, {
+      operation: context.operation,
+      environment: governanceConfig.environment,
+      success: false,
+      duration_ms: Date.now() - startTime,
+      error,
+      metadata: context.metadata,
+    });
+    return { ok: false, reason: error };
+  }
+}
+
 /**
  * Perform pre-flight checks without executing the operation
  */

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -33,6 +33,8 @@ import { executeCommand } from "./run.js";
 import { gatherProjectContext } from "./context.js";
 import { isReadOnlyMode } from "./read-only-mode.js";
 import { escapeWorkflowCmd } from "./utils/ci-escape.js";
+import { runGoverned } from "./governance-middleware.js";
+import type { kitConfig } from "./config.js";
 
 const KIT_FILE = ".kit.toml";
 
@@ -79,6 +81,33 @@ function readOnlyRefusal(tool: string): {
     ],
     isError: true,
   };
+}
+
+/** Refusal result for a mutating tool blocked by the governance floor (revocation,
+ *  budget, permission/approval, expired secrets). Mirrors the CLI's fail-closed deny. */
+function governanceRefusal(reason: string): {
+  content: { type: "text"; text: string }[];
+  isError: true;
+} {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({ ok: false, governance: "denied", error: reason }, null, 2),
+      },
+    ],
+    isError: true,
+  };
+}
+
+/** Load config for governance; a missing/invalid .kit.toml yields an empty config
+ *  (governance disabled by default) so a governed tool still runs where it always did. */
+async function loadConfigForGovernance(cwd?: string): Promise<kitConfig> {
+  try {
+    return await loadConfig(configPath(cwd));
+  } catch {
+    return {} as kitConfig;
+  }
 }
 
 export function createMcpServer(): McpServer {
@@ -214,7 +243,17 @@ function register_kit_install(server: McpServer): void {
           };
         }
 
-        const results = await installTools(config.tools);
+        const gov = await runGoverned(
+          config,
+          {
+            operation: "tools.install",
+            operationType: "write",
+            metadata: { tools: Object.keys(config.tools) },
+          },
+          () => installTools(config.tools!),
+        );
+        if (!gov.ok) return governanceRefusal(gov.reason ?? "denied");
+        const results = gov.result!;
         const ok = results.every((r) => r.action !== "failed");
         return {
           content: [
@@ -298,10 +337,13 @@ function register_kit_secrets(server: McpServer): void {
           };
         }
 
-        const { results, written } = await generateSecrets(
-          config.secrets,
-          join(cwd ?? process.cwd(), ".env.local"),
+        const gov = await runGoverned(
+          config,
+          { operation: "secrets.generate", operationType: "write", metadata: {} },
+          () => generateSecrets(config.secrets!, join(cwd ?? process.cwd(), ".env.local")),
         );
+        if (!gov.ok) return governanceRefusal(gov.reason ?? "denied");
+        const { results, written } = gov.result!;
         const ok = results.every((r) => r.resolved);
         const writtenKeys = results.filter((r) => r.resolved).map((r) => r.name);
         // Never serialize `value` — it carries the resolved plaintext secret.
@@ -340,57 +382,70 @@ function register_kit_fix(server: McpServer): void {
       if (isReadOnlyMode()) return readOnlyRefusal("kit_fix");
       try {
         const config = await loadConfig(configPath(cwd));
-        const actions: Array<{ name: string; action: string; detail: string }> = [];
 
-        // Fix missing tools
-        if (config.tools && Object.keys(config.tools).length > 0) {
-          const toolResults = await checkTools(config.tools);
-          if (toolResults.some((t) => !t.ok)) {
-            const installResults = await installTools(config.tools);
-            for (const r of installResults) {
-              if (r.action !== "already_ok") {
-                actions.push({ name: r.name, action: r.action, detail: r.detail });
+        const gov = await runGoverned(
+          config,
+          { operation: "fix", operationType: "write", metadata: {} },
+          async () => {
+            const actions: Array<{ name: string; action: string; detail: string }> = [];
+
+            // Fix missing tools (inside the governed closure)
+            if (config.tools && Object.keys(config.tools).length > 0) {
+              const toolResults = await checkTools(config.tools);
+              if (toolResults.some((t) => !t.ok)) {
+                const installResults = await installTools(config.tools);
+                for (const r of installResults) {
+                  if (r.action !== "already_ok") {
+                    actions.push({ name: r.name, action: r.action, detail: r.detail });
+                  }
+                }
               }
             }
-          }
-        }
 
-        // Fix missing lock files (lock functions use process.cwd())
-        const skillsLock = await readSkillsLock();
-        const cliLock = await readCliLock();
+            // Fix missing lock files (lock functions use process.cwd())
+            const skillsLock = await readSkillsLock();
+            const cliLock = await readCliLock();
 
-        if (!skillsLock) {
-          const skills: Record<string, string> = {
-            ...config.skills?.required,
-            ...config.skills?.optional,
-          };
-          const meta = await readkitMeta();
-          await updateSkillsLock(skills, meta?.name ? `${meta.name}@${meta.version}` : undefined);
-          actions.push({
-            name: "skills-lock.json",
-            action: "generated",
-            detail: "Created skills-lock.json",
-          });
-        }
-
-        if (!cliLock) {
-          const tools: Record<
-            string,
-            { version: string; source: "mise" | "npm" | "pip" | "manual" }
-          > = {};
-          if (config.tools) {
-            for (const [name, version] of Object.entries(config.tools)) {
-              tools[name] = { version, source: "mise" };
+            if (!skillsLock) {
+              const skills: Record<string, string> = {
+                ...config.skills?.required,
+                ...config.skills?.optional,
+              };
+              const meta = await readkitMeta();
+              await updateSkillsLock(
+                skills,
+                meta?.name ? `${meta.name}@${meta.version}` : undefined,
+              );
+              actions.push({
+                name: "skills-lock.json",
+                action: "generated",
+                detail: "Created skills-lock.json",
+              });
             }
-          }
-          await updateCliLock(tools);
-          actions.push({
-            name: "cli-lock.json",
-            action: "generated",
-            detail: "Created cli-lock.json",
-          });
-        }
 
+            if (!cliLock) {
+              const tools: Record<
+                string,
+                { version: string; source: "mise" | "npm" | "pip" | "manual" }
+              > = {};
+              if (config.tools) {
+                for (const [name, version] of Object.entries(config.tools)) {
+                  tools[name] = { version, source: "mise" };
+                }
+              }
+              await updateCliLock(tools);
+              actions.push({
+                name: "cli-lock.json",
+                action: "generated",
+                detail: "Created cli-lock.json",
+              });
+            }
+
+            return actions;
+          },
+        );
+        if (!gov.ok) return governanceRefusal(gov.reason ?? "denied");
+        const actions = gov.result!;
         const ok = actions.every((a) => a.action !== "failed");
         return {
           content: [
@@ -742,11 +797,23 @@ function register_kit_run(server: McpServer): void {
         const workDir = cwd ?? process.cwd();
         const commandArgs = command.split(/\s+/);
 
-        const result = await executeCommand({
-          commandArgs,
-          cwd: workDir,
-          inheritEnv: true,
-        });
+        // kit_run inherits the secret-loaded env and executes an arbitrary command,
+        // so it must pass the same governance floor as a CLI write (revocation,
+        // budget, permission, expired-secret block) and be audited — not just gated
+        // by read-only mode.
+        const config = await loadConfigForGovernance(cwd);
+        const gov = await runGoverned(
+          config,
+          { operation: "run", operationType: "write", metadata: { command } },
+          () =>
+            executeCommand({
+              commandArgs,
+              cwd: workDir,
+              inheritEnv: true,
+            }),
+        );
+        if (!gov.ok) return governanceRefusal(gov.reason ?? "denied");
+        const result = gov.result!;
 
         const status = result.timedOut
           ? "timed_out"


### PR DESCRIPTION
## Description

Fixes the **second high-severity architecture finding** from the 4.0 holistic review. The mutating MCP tools (`kit_run`, `kit_secrets`, `kit_install`, `kit_fix`) ran with only an `isReadOnlyMode()` guard — **bypassing** the revocation / budget / permission / expired-secret checks and the tamper-evident audit log that the CLI applies to the same operations via `withGovernance`. Identical repo/policy state was enforced on the CLI surface and unenforced on the agent-facing MCP surface.

`withGovernance` can't be reused as-is here: it calls `requestApproval`, which prints to **stdout** and can read **stdin** — both fatal on the MCP stdio transport, where stdout *is* the JSON-RPC channel.

## Type of Change
- [x] Bug fix (security hardening)

## Changes Made
- **`governance-middleware.ts`**: new `runGoverned(config, ctx, op)` — an **MCP-safe** governed executor. Runs the same deterministic pre-flight (revocation → budget → permission → secret-expiration), emits the same audit events, but **never prompts** and writes **nothing to stdout**. **Fail-closed-denies** anything approval-gated (a destructive op, or a permission only approval could override), since approval can't be requested over the protocol channel. Returns `{ ok, result?, reason? }`.
- **`mcp-server.ts`**: `kit_install` / `kit_secrets` / `kit_fix` / `kit_run` wrap their mutation in `runGoverned`; a blocked tool returns `{ ok: false, governance: "denied", error }` (`isError`). `kit_run` (which didn't load config) loads it best-effort for governance.

## Testing
### Test Coverage
- [x] Added new tests
- [x] All tests pass (`npm test`) — **2056 pass, 0 fail**; `tsc` clean; prettier clean.

`runGoverned`: disabled-passthrough; allow+run; permission-deny (**op does not run**, no throw); **destructive-deny even where the CLI would auto-approve** (the MCP-specific behavior); budget-deny; a thrown op captured as `ok:false` with **no usage recorded**; usage recorded on success.

## Breaking Changes
None for correct configs. If a governance policy forbids writes / has revoked access / exceeds budget, the four MCP tools now **refuse** (they used to run) — that's the intended fix. Approval-gated ops must be run via the kit CLI (MCP can't prompt).

## Reviewer Notes
Scope: the four tools the review named. The other mutating tools (`kit_add`, `kit_login`, `kit_init`, `kit_adapter_install`) still rely on read-only mode only — a reasonable follow-up now that `runGoverned` exists (each becomes a small wrap). Left out to keep this PR focused and the blast radius small.

Last in the review-fix series after this: the honesty sweep (`kit team` fake-success, site version pass, eslint `no-restricted-imports`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_