### PR TITLE
fix(honesty): kit team stubs fail loudly + machine-enforce the zero-LLM invariant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   (a destructive op, or a permission only approval can override) — run those via the
   kit CLI. A blocked tool returns a `{ ok: false, governance: "denied", error }` result.
 
+### Changed
+
+- **The zero-LLM invariant is now machine-enforced.** kit is deterministic and never
+  calls a model — it emits prompts for a bring-your-own LLM. That rule lived in ~35
+  code comments but nothing failed the build if an LLM SDK crept in. An eslint
+  `no-restricted-imports` rule now bans the known model SDKs (`openai`, `@anthropic-ai/*`,
+  `@google/generative-ai`, `cohere-ai`, `@mistralai/*`, `langchain`, the Vercel `ai`
+  SDK, …) in `src/`, so the most important invariant is enforced like the command
+  contract, not left to review. (`@modelcontextprotocol` — a protocol, not a model
+  client — is intentionally allowed.)
+
 ### Fixed
 
+- **`kit team invite` / `kit team member remove` no longer print fake success.** Both
+  were stubs that printed "Invitation sent" / "Member removed" and exited 0 with no
+  backend behind them — a literal false-green, the exact thing kit's thesis condemns.
+  They now fail honestly (non-zero, "not implemented — no team backend configured"),
+  matching how `kit team create` already behaved.
 - **`kit check` (CLI) and `kit_check` (MCP) can no longer disagree on green.** The
   two surfaces computed the overall ok/green verdict in two different places with
   two different rules — the MCP path used a naive `every(authenticated)`, reduced

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -92,6 +92,47 @@ export default tseslint.config(
     rules: { "no-useless-escape": "off" },
   },
   {
+    // Zero-LLM invariant, MACHINE-ENFORCED. kit is deterministic and never calls a
+    // model — it EMITS prompts for a bring-your-own LLM. That rule was documented in
+    // ~35 comments but nothing failed the build if an LLM SDK crept in. This bans the
+    // known SDKs in src/ so the most important invariant is enforced like the command
+    // contract (public-surface.test.ts), not left to code review. @modelcontextprotocol
+    // (MCP transport) is intentionally NOT banned — it is a protocol, not a model client.
+    files: ["src/**/*.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "openai",
+                "openai/*",
+                "@anthropic-ai/sdk",
+                "@anthropic-ai/*",
+                "@google/generative-ai",
+                "@google/genai",
+                "@google-cloud/vertexai",
+                "cohere-ai",
+                "@mistralai/*",
+                "groq-sdk",
+                "ollama",
+                "replicate",
+                "langchain",
+                "langchain/*",
+                "@langchain/*",
+                "llamaindex",
+                "ai", // Vercel AI SDK
+              ],
+              message:
+                "kit is ZERO-LLM: no LLM SDK may be imported in src/. kit emits prompts for a bring-your-own model; it never calls one. This invariant is enforced, not advisory.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     // Test files: keep correctness rules but exempt the size/complexity metrics —
     // a describe() block is one big "function" + long fixtures are normal there.
     files: ["**/*.test.ts"],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5554,9 +5554,15 @@ async function cmdTeam(): Promise<boolean> {
           return false;
         }
 
-        console.log(`${c.yellow}Invitation sent to ${email} as ${role}${c.reset}`);
-        console.log(`${c.dim}Check your email for the invitation link${c.reset}`);
-        return true;
+        // No backend exists — do NOT print "Invitation sent" for a no-op (that is a
+        // literal false-green, the exact thing kit's thesis condemns). Fail honestly.
+        console.error(
+          `${c.red}Error: kit team invite is not implemented — no team backend is configured${c.reset}`,
+        );
+        console.error(
+          `${c.dim}would invite ${email} as ${role}; team management requires backend service integration${c.reset}`,
+        );
+        return false;
       }
 
       case "members": {
@@ -5582,8 +5588,14 @@ async function cmdTeam(): Promise<boolean> {
           return false;
         }
 
-        console.log(`${c.yellow}Member ${email} removed from team${c.reset}`);
-        return true;
+        // No backend — never claim a removal that did not happen. Fail honestly.
+        console.error(
+          `${c.red}Error: kit team member remove is not implemented — no team backend is configured${c.reset}`,
+        );
+        console.error(
+          `${c.dim}would remove ${email}; team management requires backend service integration${c.reset}`,
+        );
+        return false;
       }
 
       case "audit": {


### PR DESCRIPTION
## Description

Two "green = honest" gaps from the 4.0 holistic review (the cheap, thesis-critical sweep).

## Type of Change
- [x] Bug fix
- [x] Changed (enforced invariant)

## Changes Made
- **`kit team invite` / `kit team member remove` no longer print fake success.** Both were stubs that printed *"Invitation sent"* / *"Member removed"* and returned `true` with **no backend** — a literal false-green. They now fail honestly (non-zero + *"not implemented — no team backend configured"*), matching how `kit team create` already behaved.
- **The zero-LLM invariant is now machine-enforced.** It lived only in ~35 code comments; nothing failed the build if an LLM SDK crept in. A new eslint `no-restricted-imports` rule bans the known model SDKs (`openai`, `@anthropic-ai/*`, `@google/generative-ai`, `cohere-ai`, `@mistralai/*`, `langchain`, the Vercel `ai` SDK, …) in `src/`. `@modelcontextprotocol` (a protocol, not a model client) is intentionally allowed.

## Testing
- [x] `npm test` — **2056 pass, 0 fail**; `tsc` clean; prettier clean.
- [x] `eslint src` — **0 errors** (no LLM SDK is imported anywhere), so CI stays green.
- [x] Verified the ban **fires**: a probe `import OpenAI from "openai"` produces the rule error; verified `kit team invite` / `member remove` now exit non-zero.

## Breaking Changes
`kit team invite` / `kit team member remove` now exit non-zero instead of falsely reporting success. That's the fix — no real behavior was lost (there was never a backend).

## Reviewer Notes
Third and final PR in the review-fix series (after the unified verdict #211, R2 recall-sanitize #212, and MCP governance floor #213). The website version pass (site still markets 3.x while `package.json` is 4.0.0) is the remaining review item — handled separately in the `sandstream.github.io` repo since it's a different codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_