### PR TITLE
fix(memory): surface a failed capture + reap stale PAL claims (R5 liveness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed — self-playing loop liveness (R5)
+
+- **A silently failed background capture is now surfaced on the next SessionStart.**
+  The detached SessionEnd / mid-session index workers run with stdio ignored, so
+  their only failure channel is `~/.kit/session-end.log` — whose docstring promised
+  it was "surfaced on the next SessionStart", but nothing ever read it, so a failed
+  capture stayed invisible (the store looked captured, recorded nothing). `kit`'s
+  SessionStart recovery now reads and CONSUMES that log (each event surfaces exactly
+  once) and warns that recent turns may be unsearchable.
+- **PAL auto-releases a stale claim so a crashed agent can't hide a blocked item.**
+  `kit memory pal claim` flips an item open→claimed, but a crashed/abandoned claimer
+  never released it — so it dropped out of every default (open) surface indefinitely,
+  silently blocking the human waiting on it. `reapStaleClaims()` (run inside
+  `palList`) releases any claim older than 24h back to `open` so it resurfaces.
+
 ### Security — memory sync
 
 - **The incoming-store injection gate (R7) no longer fails open on a crafted schema.**

--- a/src/memory/hook.test.ts
+++ b/src/memory/hook.test.ts
@@ -11,6 +11,8 @@ import {
   dueForHarnessSweep,
   dueForMidSessionIndex,
   startDetachedSessionEnd,
+  consumeSessionEndLog,
+  logSessionEndEvent,
 } from "./hook.js";
 import { getCurrentProjectRoot } from "./project.js";
 import { shareEntry } from "./shared.js";
@@ -114,6 +116,44 @@ describe("memory hook — SessionStart recovery", () => {
     const text = sessionStartRecovery();
     assert.match(text, /flagged: possible prompt-injection/, "the poisoned line is badged");
     assert.ok(!text.includes(ZWSP), "hidden zero-width char stripped from the injected text");
+  });
+});
+
+describe("memory hook — detached-worker log surfacing (R5)", () => {
+  let tmp: string;
+  const prevDir = process.env.KIT_MEMORY_DIR;
+  const prevDb = process.env.KIT_MEMORY_DB;
+
+  before(() => {
+    tmp = mkdtempSync(join(tmpdir(), "kit-worklog-"));
+    process.env.KIT_MEMORY_DIR = tmp;
+    process.env.KIT_MEMORY_DB = join(tmp, "memory.db");
+  });
+  after(() => {
+    if (prevDir === undefined) delete process.env.KIT_MEMORY_DIR;
+    else process.env.KIT_MEMORY_DIR = prevDir;
+    if (prevDb === undefined) delete process.env.KIT_MEMORY_DB;
+    else process.env.KIT_MEMORY_DB = prevDb;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("consumeSessionEndLog reads then clears the log (surfaced exactly once)", () => {
+    logSessionEndEvent("session-end index FAILED: disk full");
+    const first = consumeSessionEndLog();
+    assert.ok(
+      first.some((l) => l.includes("index FAILED")),
+      "the logged failure is read back",
+    );
+    assert.deepEqual(consumeSessionEndLog(), [], "second read is empty — the log was consumed");
+  });
+
+  it("sessionStartRecovery surfaces a worker failure, then clears it", () => {
+    logSessionEndEvent("mid-session index spawn failed: ENOENT");
+    const text = sessionStartRecovery();
+    assert.match(text, /background capture reported problems/);
+    assert.match(text, /ENOENT/);
+    // Consumed: a second start no longer repeats the same warning.
+    assert.doesNotMatch(sessionStartRecovery(), /background capture reported problems/);
   });
 });
 

--- a/src/memory/hook.ts
+++ b/src/memory/hook.ts
@@ -9,7 +9,7 @@
  * block a prompt or break a session. Deterministic, zero model calls.
  */
 import { basename, join, resolve } from "node:path";
-import { existsSync, statSync, writeFileSync, appendFileSync, rmSync } from "node:fs";
+import { existsSync, statSync, writeFileSync, appendFileSync, rmSync, readFileSync } from "node:fs";
 import { spawn } from "node:child_process";
 import { openMemoryDb, getStats, recentMessages, getMemoryDir, ensureMemoryDir } from "./db.js";
 import { indexClaudeTranscripts, indexAllHarnesses } from "./parser.js";
@@ -125,6 +125,34 @@ export function recentDecisions(root: string, limit: number): SharedEntry[] {
 }
 
 /**
+ * Read and CONSUME the detached-worker log (`~/.kit/session-end.log`). The
+ * SessionEnd / mid-session workers run detached with stdio ignored, so their ONLY
+ * failure channel is this file (see {@link logSessionEndEvent}) — but nothing read
+ * it, so `logSessionEndEvent`'s promise to surface a failure "on the next
+ * SessionStart" went unkept and a failed capture stayed invisible (the store looked
+ * captured but recorded nothing). This reads the last few lines and DELETES the file
+ * so each event surfaces exactly once. Fail-open: [] on any error.
+ */
+export function consumeSessionEndLog(max = 5): string[] {
+  try {
+    const path = join(getMemoryDir(), "session-end.log");
+    if (!existsSync(path)) return [];
+    const lines = readFileSync(path, "utf8")
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+    try {
+      rmSync(path, { force: true });
+    } catch {
+      /* best-effort: worst case the same lines surface again next start */
+    }
+    return lines.slice(-max);
+  } catch {
+    return [];
+  }
+}
+
+/**
  * SessionStart recovery — re-inject "where you left off" for THIS project after a
  * resume/compact, so the agent regains continuity instead of starting blank. Pulls
  * the most recent messages + open action items from the store. FAIL-OPEN and
@@ -142,11 +170,27 @@ export function sessionStartRecovery(opts: { limit?: number } = {}): string {
     // Fail-open (readShared swallows a missing/broken file → []).
     const decisions = recentDecisions(root, 3);
     const stale = staleKitNotice();
-    if (recent.length === 0 && openItems.length === 0 && decisions.length === 0 && !stale)
+    // Surface (once) any failure the detached capture worker logged — a silently
+    // failed capture is the worst failure mode (looks captured, recorded nothing).
+    const workerLog = consumeSessionEndLog();
+    if (
+      recent.length === 0 &&
+      openItems.length === 0 &&
+      decisions.length === 0 &&
+      !stale &&
+      workerLog.length === 0
+    )
       return "";
 
     const lines: string[] = [];
     if (stale) lines.push(stale);
+    if (workerLog.length) {
+      // kit's own diagnostic (not stored/untrusted data) — outside the DATA boundary.
+      lines.push(
+        "⚠ kit background capture reported problems since your last session (recent turns may be unsearchable — run `kit memory index`):",
+      );
+      for (const l of workerLog) lines.push(`  · ${safeCell(l)}`);
+    }
     if (recent.length > 0 || openItems.length > 0 || decisions.length > 0) {
       // Explicit data/instruction boundary: everything indented below is STORED,
       // possibly-untrusted content (transcripts can echo web pages the agent read),

--- a/src/memory/pal.test.ts
+++ b/src/memory/pal.test.ts
@@ -11,6 +11,7 @@ import {
   palSnooze,
   palClaim,
   palRelease,
+  reapStaleClaims,
   palAutoVerify,
   palPrune,
   deviceId,
@@ -85,6 +86,39 @@ describe("PAL — pending actions", () => {
     const open = palList(db);
     assert.equal(open.length, 1);
     assert.equal(open[0]?.claimed_by, null); // claim cleared
+    db.close();
+  });
+
+  it("reaps a stale claim (crashed claimer) back to open; a fresh claim is spared", () => {
+    const db = fresh();
+    const id = palAdd(db, { title: "finish the migration" });
+    palClaim(db, id, "agent-a");
+    assert.deepEqual(reapStaleClaims(db), [], "a just-made claim is NOT reaped");
+    assert.equal(palList(db, { status: "claimed" }).length, 1);
+    // Backdate the claim past the TTL → abandoned.
+    db.prepare("UPDATE pending_actions SET claimed_at=datetime('now','-30 hours') WHERE id=?").run(
+      id,
+    );
+    assert.deepEqual(reapStaleClaims(db), [id]);
+    const claimed = db
+      .prepare("SELECT status, claimed_by FROM pending_actions WHERE id=?")
+      .get(id) as { status: string; claimed_by: string | null };
+    assert.equal(claimed.status, "open");
+    assert.equal(claimed.claimed_by, null);
+    db.close();
+  });
+
+  it("palList auto-reaps a stale claim so a crashed agent can't hide a blocked item", () => {
+    const db = fresh();
+    const id = palAdd(db, { title: "unblock me" });
+    palClaim(db, id, "agent-a");
+    assert.equal(palList(db).length, 0, "fresh claim stays hidden");
+    db.prepare("UPDATE pending_actions SET claimed_at=datetime('now','-48 hours') WHERE id=?").run(
+      id,
+    );
+    const open = palList(db); // reap runs inside palList
+    assert.equal(open.length, 1, "the abandoned item resurfaces as open");
+    assert.equal(open[0]?.id, id);
     db.close();
   });
 

--- a/src/memory/pal.ts
+++ b/src/memory/pal.ts
@@ -166,8 +166,36 @@ export interface PalListOptions {
   allDevices?: boolean;
 }
 
+/** A claim older than this with no release is treated as abandoned (the claimer
+ *  crashed / the ephemeral session died) and auto-released back to 'open'. */
+const STALE_CLAIM_TTL_HOURS = 24;
+
+/**
+ * Auto-release claims whose claimer went silent. `palClaim` flips open→claimed and
+ * stamps `claimed_at`, but a crashed or abandoned agent never calls `palRelease` —
+ * so the item drops out of every default (open) surface indefinitely, silently
+ * blocking the human who is actually waiting on it. This releases any `claimed` row
+ * older than `ttlHours` back to `open` so it resurfaces for another agent.
+ * Idempotent; returns the released ids. Deterministic (SQLite clock).
+ */
+export function reapStaleClaims(db: DatabaseSync, ttlHours = STALE_CLAIM_TTL_HOURS): string[] {
+  const cutoff = `-${Math.max(1, Math.floor(ttlHours))} hours`;
+  const stale = "status='claimed' AND claimed_at IS NOT NULL AND claimed_at <= datetime('now', ?)";
+  const rows = db.prepare(`SELECT id FROM pending_actions WHERE ${stale}`).all(cutoff) as {
+    id: string;
+  }[];
+  if (!rows.length) return [];
+  db.prepare(
+    `UPDATE pending_actions SET status='open', claimed_by=NULL, claimed_at=NULL WHERE ${stale}`,
+  ).run(cutoff);
+  return rows.map((r) => r.id);
+}
+
 export function palList(db: DatabaseSync, opts: PalListOptions = {}): PendingAction[] {
   const status = opts.status ?? "open";
+  // Before listing the open work, resurface anything a crashed claimer abandoned —
+  // otherwise a stale claim hides a blocked-on-you item from every default surface.
+  if (status === "open") reapStaleClaims(db);
   const where: string[] = ["status = ?"];
   const params: unknown[] = [status];
   if (opts.scope !== undefined) {


### PR DESCRIPTION
## Description

Two ways the self-playing loop could degrade **silently**, from the 4.0 holistic review (R5 cluster).

## Type of Change
- [x] Bug fix (observability / correctness)

## Changes Made
- **`session-end.log` had writers but no readers.** The detached SessionEnd / mid-session index workers run with stdio ignored, so `logSessionEndEvent` (`~/.kit/session-end.log`) is their only failure channel — and its docstring *promised* it was "surfaced on the next SessionStart", but nothing read it, so a failed capture was invisible (the store looked captured, recorded nothing). New `consumeSessionEndLog()` reads **and deletes** the log (each event surfaces exactly once); `sessionStartRecovery` now warns that recent turns may be unsearchable and to run `kit memory index`.
- **A crashed PAL claimer stranded a blocked-on-you item.** `palClaim` flips open→claimed, but an abandoned claim was never released, so the item left every default (open) surface indefinitely — silently blocking the human waiting on it. New `reapStaleClaims()` (run inside `palList`) releases any claim older than 24h back to `open` so it resurfaces for another agent.

## Testing
- [x] Added tests; `npm test` — **2064 pass, 0 fail**; `tsc` + prettier clean.
- Log: surfaced-once + cleared (direct and via `sessionStartRecovery`, whose repeat call no longer shows it).
- Reaper: a stale claim is released while a fresh claim is spared; `palList` auto-reaps so a crashed agent can't hide a blocked item.

## Breaking Changes
None — additive observability + a self-healing default (24h claim TTL).

## Reviewer Notes
The third R5-cluster item — an audit event on `kit memory uninstall` — is left out: `uninstallMemoryHooks` lives in the install path with no governance config in scope, so wiring `logAuditEvent` there is a larger change better done on its own. Remaining review items after this: a quarantine column so recall *skips* flagged rows (vs only badging, PR #212), and the two site UX nits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_