### PR TITLE
fix(memory): audit kit memory uninstall (R5 loop-liveness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   never released it — so it dropped out of every default (open) surface indefinitely,
   silently blocking the human waiting on it. `reapStaleClaims()` (run inside
   `palList`) releases any claim older than 24h back to `open` so it resurfaces.
+- **Tearing down the memory hooks is now audited.** `kit memory uninstall` removes
+  the self-playing capture loop but wrote settings with no audit trail. It now emits
+  a `memory.hooks.uninstall` audit event (best-effort, fail-open) so a teardown isn't
+  invisible where audit is enabled — a no-op when audit is off (the default), so no
+  surprise files appear.
 
 ### Security — memory sync
 

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -3,7 +3,7 @@
 import { c } from "../utils/colors.js";
 import { hasFlag, flagValue } from "../utils/flags.js";
 import { existsSync } from "node:fs";
-import { basename } from "node:path";
+import { basename, join } from "node:path";
 import {
   openMemoryDb,
   getStats,
@@ -949,8 +949,31 @@ async function memUninstall(): Promise<boolean> {
   } else {
     console.log(`${c.dim}no kit memory hooks were installed${c.reset}`);
   }
-  if (uninstallStatusline().removed) {
+  const slRemoved = uninstallStatusline().removed;
+  if (slRemoved) {
     console.log(`${c.green}✓${c.reset} removed kit status line`);
+  }
+  // Removing the hooks tears down the self-playing capture loop — a security-relevant
+  // event. Audit it (best-effort, fail-open) so a teardown isn't invisible when audit
+  // is enabled. A no-op when audit is off (the default), so no surprise files appear.
+  if (removed.length || slRemoved) {
+    try {
+      const { logAuditEvent } = await import("../audit.js");
+      const { mergeGovernanceConfigAsync } = await import("../governance.js");
+      const { loadConfig } = await import("../config.js");
+      const cfg = await loadConfig(join(process.cwd(), ".kit.toml")).catch(
+        () => ({}) as Awaited<ReturnType<typeof loadConfig>>,
+      );
+      const gov = await mergeGovernanceConfigAsync(cfg.governance);
+      await logAuditEvent(gov, {
+        operation: "memory.hooks.uninstall",
+        environment: gov.environment,
+        success: true,
+        metadata: { removedHooks: removed, statusline: slRemoved },
+      });
+    } catch {
+      // audit is best-effort here — never let it block or fail an uninstall
+    }
   }
   return true;
 }


### PR DESCRIPTION
## Description

The last item of the R5 cluster from the 4.0 holistic review. Removing the memory hooks tears down the self-playing capture loop, but `kit memory uninstall` wrote `~/.claude/settings.json` with **no audit trail** — a security-relevant teardown was invisible.

## Type of Change
- [x] Bug fix (observability)

## Changes Made
- **`memUninstall` (`commands/memory.ts`)** now emits a `memory.hooks.uninstall` audit event after removing hooks/statusline: loads config best-effort, merges governance, `logAuditEvent` with the removed hook names + statusline flag.
- **Best-effort + fail-open**: wrapped so audit can never block or fail an uninstall. A **no-op when audit is disabled** (the default), so no surprise `.kit-audit.jsonl` appears.

## Testing
- [x] `npm test` — **2064 pass, 0 fail**; `tsc` + prettier clean; eslint 0 errors.
- [x] Verified end-to-end: with `[governance.audit] enabled = true` and a settings file holding a kit hook, `kit memory uninstall` writes the `memory.hooks.uninstall` event to `.kit-audit.jsonl` (the hash-chained append is the existing, separately-tested audit machinery). With audit off, no file is written.

## Breaking Changes
None — additive, opt-in (only writes when audit is already enabled).

## Reviewer Notes
Completes the R5 cluster (with #216: `session-end.log` surfacing + stale-claim reaper). After this the only outstanding review items are the two **site** UX pieces — a full light theme and reframing the comparison table — which I'm doing in `sandstream.github.io`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_