### PR TITLE
feat(agent-config): wider rules-file coverage — Gemini, Augment, Kiro, Droid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   Amazon Q: wires every existing agent file, and SKIPS honestly (no false-green)
   when none exist rather than writing a partial agent config. Kiro is now the 8th
   install-gated agent.
+- **Wider agent coverage for the rules/context file.** `kit agent-config` now writes
+  and detects three more agents: **Gemini CLI** (`GEMINI.md` — kit already
+  indexed + install-gated Gemini but never wrote its rules file, only status-checked
+  it), and **Augment** (`.augment-guidelines`). AGENTS.md detection also now
+  recognizes **AWS Kiro** (`.kiro/`) and **Factory Droid** (`.factory/`), which read
+  the root `AGENTS.md` (the Linux-Foundation cross-tool standard) — so a Kiro- or
+  Droid-only project gets its kit block wired. Deeper coverage (memory indexing)
+  for these agents is tracked in kit-research `agent-coverage.md`.
 
 ### Fixed
 

--- a/src/agent-config.test.ts
+++ b/src/agent-config.test.ts
@@ -153,6 +153,41 @@ describe("detectAgentTargets", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("detects Gemini CLI via a .gemini/ dir (→ GEMINI.md)", () => {
+    const dir = tmpRepo();
+    try {
+      mkdirSync(join(dir, ".gemini"));
+      const files = detectAgentTargets(dir).map((t) => t.file);
+      assert.deepEqual(files, ["GEMINI.md"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects Augment via a .augment/ dir (→ .augment-guidelines)", () => {
+    const dir = tmpRepo();
+    try {
+      mkdirSync(join(dir, ".augment"));
+      const files = detectAgentTargets(dir).map((t) => t.file);
+      assert.deepEqual(files, [".augment-guidelines"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("wires AGENTS.md for a Kiro (.kiro/) or Droid (.factory/) project", () => {
+    for (const marker of [".kiro", ".factory"]) {
+      const dir = tmpRepo();
+      try {
+        mkdirSync(join(dir, marker));
+        const files = detectAgentTargets(dir).map((t) => t.file);
+        assert.deepEqual(files, ["AGENTS.md"], `${marker} → AGENTS.md`);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
 });
 
 describe("writeAgentConfig", () => {

--- a/src/agent-config.ts
+++ b/src/agent-config.ts
@@ -49,6 +49,11 @@ export const AGENT_TARGETS: AgentTarget[] = [
   { agent: "Cursor", file: ".cursorrules" },
   { agent: "Cline", file: ".clinerules" },
   { agent: "Copilot", file: ".github/copilot-instructions.md" },
+  // Gemini CLI reads GEMINI.md — kit already indexes/gates Gemini but never wrote
+  // its rules file (only status-checked it), so this closes that gap.
+  { agent: "Gemini CLI", file: "GEMINI.md" },
+  // Augment reads a root .augment-guidelines file (applies to all Agent/Chat sessions).
+  { agent: "Augment", file: ".augment-guidelines" },
 ];
 
 /**
@@ -67,14 +72,23 @@ export function detectAgentTargets(cwd: string = process.cwd()): AgentTarget[] {
         // AGENTS.md is the shared cross-tool rules file: Codex AND OpenCode both
         // read it, so an OpenCode-only project (opencode.json / .opencode, no
         // .codex) should still wire its block into AGENTS.md.
+        // AGENTS.md is the Linux-Foundation cross-tool standard: Codex, OpenCode,
+        // Factory Droid (.factory) and AWS Kiro (.kiro, reads root AGENTS.md) all
+        // consume it, so any of their marker dirs should wire the block into AGENTS.md.
         return (
           existsSync(resolve(cwd, ".codex")) ||
           existsSync(resolve(cwd, ".opencode")) ||
           existsSync(resolve(cwd, "opencode.json")) ||
-          existsSync(resolve(cwd, "opencode.jsonc"))
+          existsSync(resolve(cwd, "opencode.jsonc")) ||
+          existsSync(resolve(cwd, ".kiro")) ||
+          existsSync(resolve(cwd, ".factory"))
         );
       case "Cursor":
         return existsSync(resolve(cwd, ".cursor"));
+      case "Gemini CLI":
+        return existsSync(resolve(cwd, ".gemini"));
+      case "Augment":
+        return existsSync(resolve(cwd, ".augment"));
       case "Copilot":
         // GitHub Copilot (VS Code / Visual Studio) reads
         // `.github/copilot-instructions.md`. The file check above covers an


### PR DESCRIPTION
## Description

Part of an agent-coverage sweep (full research in kit-research `agent-coverage.md`). kit's coverage is asymmetric — only **Claude Code** has all four integration surfaces (memory index + install-gate + hooks/statusline + rules file); the rules/context file was written for just 5 agents. This widens the **rules dimension** to the agents a coverage review + CodexBar's agent list surfaced as missing.

## Type of Change
- [x] New feature (wider agent coverage)

## Changes Made
- **`AGENT_TARGETS`**: `+ Gemini CLI → GEMINI.md` (kit already **indexed + install-gated** Gemini but never *wrote* its rules file — `cli.ts` only status-checked `GEMINI.md`, a real gap); `+ Augment → .augment-guidelines`.
- **`detectAgentTargets`**: the `AGENTS.md` case (the Linux-Foundation cross-tool standard) now also triggers on `.kiro/` (**AWS Kiro**) and `.factory/` (**Factory Droid**) — both read the root `AGENTS.md` — so a Kiro- or Droid-only project wires its kit block. New `.gemini/` and `.augment/` markers for the two new targets.
- Tests for each new detection path.

## Testing
- [x] `npm test` — **2073 pass, 0 fail**; `tsc` + prettier clean. Empty-repo default (`CLAUDE.md` + `AGENTS.md`) is unchanged, so existing behavior holds.

## Breaking Changes
None — additive targets + detection markers.

## Reviewer Notes
**Scope is deliberately the rules/context dimension only.** The deeper surfaces are not blind-implemented here because they need per-agent specifics I want verified first: memory indexing needs a local transcript parser per format (Droid has a local session DB → feasible; Amp/Augment/Antigravity store threads server-side → not locally indexable), and the install-gate needs each agent's PreToolUse hook contract (Kiro's `.kiro/hooks/preToolUse` is the cleanest next target — it has `preToolUse`/`userPromptSubmit`/`stop` parity with Claude Code). The full matrix + per-agent onboarding plan + sequencing is in the kit-research doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_