### PR TITLE
feat(agent-config): AWS Kiro install-gate (8th gated agent)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **AWS Kiro install-gate.** `kit agent-config --install-gate` now wires the
+  fail-closed PreToolUse gate for Kiro CLI: it adds a `hooks.preToolUse` entry
+  (matcher `execute_bash`) to each `.kiro/agents/*.json` agent config. Kiro is
+  Amazon-Q-lineage — same agent-config hook schema, same `tool_input.command`
+  STDIN, same exit-2-blocks — so `kit gate-bash` works unchanged. Per-agent like
+  Amazon Q: wires every existing agent file, and SKIPS honestly (no false-green)
+  when none exist rather than writing a partial agent config. Kiro is now the 8th
+  install-gated agent.
+
 ### Fixed
 
 - **The update-check version comparator no longer mis-parses a prerelease/patch.**

--- a/src/agent-config.test.ts
+++ b/src/agent-config.test.ts
@@ -13,6 +13,7 @@ import {
   installInstallGate,
   installInstallGateCodex,
   installInstallGateAmazonQ,
+  installInstallGateKiro,
   installInstallGateGemini,
   installInstallGateCursor,
   installInstallGateOpenCode,
@@ -402,6 +403,38 @@ describe("installInstallGateAmazonQ", () => {
     const dir = mkdtempSync(join(tmpdir(), "kit-qgate2-"));
     try {
       assert.equal((await installInstallGateAmazonQ(dir)).action, "skipped");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("installInstallGateKiro", () => {
+  it("adds hooks.preToolUse to existing .kiro/agents JSONs, idempotently", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-kirogate-"));
+    try {
+      mkdirSync(join(dir, ".kiro", "agents"), { recursive: true });
+      writeFileSync(
+        join(dir, ".kiro", "agents", "default.json"),
+        JSON.stringify({ name: "default", tools: ["execute_bash"] }),
+      );
+      const r1 = await installInstallGateKiro(dir);
+      assert.equal(r1.action, "updated");
+      const a = JSON.parse(readFileSync(join(dir, ".kiro", "agents", "default.json"), "utf-8"));
+      assert.equal(a.name, "default", "preserves existing agent fields");
+      assert.equal(a.hooks.preToolUse[0].matcher, "execute_bash");
+      assert.ok(a.hooks.preToolUse[0].command.endsWith("gate-bash"));
+      const r2 = await installInstallGateKiro(dir);
+      assert.equal(r2.action, "unchanged");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips when no Kiro agent config is present (no false-green)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-kirogate2-"));
+    try {
+      assert.equal((await installInstallGateKiro(dir)).action, "skipped");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agent-config.ts
+++ b/src/agent-config.ts
@@ -447,6 +447,74 @@ export async function installInstallGateAmazonQ(
 }
 
 /**
+ * AWS Kiro (CLI) install-gate: add a `hooks.preToolUse` entry (matcher
+ * `execute_bash`) to each Kiro agent config under `.kiro/agents/*.json`. Kiro CLI
+ * is Amazon-Q-lineage — same agent-config hook schema (`hooks.preToolUse` array of
+ * `{matcher, command}`), same `tool_input.command` STDIN, same exit-2-blocks — so
+ * `kit gate-bash` works unchanged. Like Amazon Q, hooks are per-agent, so we wire
+ * every existing agent file and SKIP (honestly, no false-green) when none exist
+ * rather than write a partial/invalid agent config. Idempotent.
+ */
+export async function installInstallGateKiro(
+  cwd: string = process.cwd(),
+): Promise<HookInstallResult> {
+  const dir = ".kiro/agents";
+  const dirPath = resolve(cwd, dir);
+  const { isReadOnlyMode } = await import("./read-only-mode.js");
+  if (isReadOnlyMode()) return { file: dir, action: "skipped", detail: "read-only mode" };
+  let agentFiles: string[] = [];
+  try {
+    agentFiles = readdirSync(dirPath)
+      .filter((f) => f.endsWith(".json"))
+      .map((f) => join(dirPath, f));
+  } catch {
+    agentFiles = [];
+  }
+  if (agentFiles.length === 0) {
+    return {
+      file: dir,
+      action: "skipped",
+      detail: "no Kiro agent config found (create .kiro/agents/*.json first)",
+    };
+  }
+
+  let wired = 0;
+  let already = 0;
+  for (const p of agentFiles) {
+    let agent: {
+      hooks?: Record<string, { matcher?: string; command: string }[]>;
+      [k: string]: unknown;
+    };
+    try {
+      agent = JSON.parse(await readFile(p, "utf-8"));
+    } catch {
+      continue; // skip unparseable agent file
+    }
+    const hooks = (agent.hooks ??= {});
+    const pre = (hooks.preToolUse ??= []);
+    if (pre.some((h) => typeof h?.command === "string" && h.command.endsWith("gate-bash"))) {
+      already++;
+      continue;
+    }
+    pre.push({ matcher: "execute_bash", command: kitGateInvocation() });
+    try {
+      await writeFile(p, JSON.stringify(agent, null, 2) + "\n", "utf-8");
+      wired++;
+    } catch {
+      /* best-effort per file */
+    }
+  }
+  if (wired === 0) {
+    return {
+      file: dir,
+      action: "unchanged",
+      detail: `install-gate already wired (${already} agent[s])`,
+    };
+  }
+  return { file: dir, action: "updated", detail: `wired ${wired} Kiro agent config(s)` };
+}
+
+/**
  * Gemini CLI install-gate: a `BeforeTool` hook in `.gemini/settings.json` (same
  * nested hooks > Event > matcher > hooks[] shape as Claude Code). Gemini passes
  * the command in tool_input.command and blocks on exit 2 — so `kit gate-bash`
@@ -655,7 +723,15 @@ exec ${kitGateInvocation()} --format cline
 
 /** Per-agent install-gate result. */
 export interface GateInstallEntry {
-  agent: "Claude Code" | "Codex" | "Amazon Q" | "Gemini CLI" | "Cursor" | "OpenCode" | "Cline";
+  agent:
+    | "Claude Code"
+    | "Codex"
+    | "Amazon Q"
+    | "Kiro"
+    | "Gemini CLI"
+    | "Cursor"
+    | "OpenCode"
+    | "Cline";
   result: HookInstallResult;
 }
 
@@ -667,6 +743,7 @@ export async function installAllInstallGates(
     { agent: "Claude Code", result: await installInstallGate(cwd) },
     { agent: "Codex", result: await installInstallGateCodex(cwd) },
     { agent: "Amazon Q", result: await installInstallGateAmazonQ(cwd) },
+    { agent: "Kiro", result: await installInstallGateKiro(cwd) },
     { agent: "Gemini CLI", result: await installInstallGateGemini(cwd) },
     { agent: "Cursor", result: await installInstallGateCursor(cwd) },
     { agent: "OpenCode", result: await installInstallGateOpenCode(cwd) },


### PR DESCRIPTION
## Description

Follows the agent-coverage research (kit-research `agent-coverage.md`): **Kiro** was the cleanest next install-gate target because its CLI is Amazon-Q-lineage and shares the exact hook contract kit already implements.

**Verified Kiro format:** hooks live in `.kiro/agents/*.json` (project) / `~/.kiro/agents/*.json` (global) as `hooks.preToolUse: [{ "matcher": "execute_bash", "command": "..." }]`; the command receives `tool_input.command` on STDIN; **exit code 2 blocks** the tool and STDERR is returned to the LLM.

## Type of Change
- [x] New feature (wider agent coverage — install-gate dimension)

## Changes Made
- **`installInstallGateKiro`** — mirrors `installInstallGateAmazonQ` against `.kiro/agents/*.json`: wires a `hooks.preToolUse` `execute_bash` entry running `kit gate-bash` into every existing agent config; **SKIPS honestly when none exist** (no false-green — never writes a partial/invalid agent config). Idempotent (keyed on the `gate-bash` suffix).
- `kit gate-bash` is **unchanged** — it already extracts `tool_input.command` (the shape Kiro / Amazon Q / Claude / Codex / Gemini all use).
- Registered in `installAllInstallGates` + the `GateInstallEntry` union — Kiro is the **8th** install-gated agent.
- Tests: wires + preserves existing agent fields + idempotent; skips when absent.

## Testing
- [x] `npm test` — **2075 pass, 0 fail** locally; `tsc` + prettier clean.

⚠️ **CI note:** the repo's GitHub **Actions** runs stopped scheduling around 11:54 today (looks like an Actions minutes/quota cap after this session's ~20 PRs — Socket, a GitHub App, still reports; Actions-metered jobs don't). So this PR (and #220) may sit without a CI run until Actions resumes. I've verified locally; **please don't merge until the CI gate actually runs green** — merging a security-tool change without its gate would be the false-green kit exists to prevent.

## Breaking Changes
None — additive; existing gates unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_