### PR TITLE
feat(agents): multi-agent coverage expansion — 5.0.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,48 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.0.0-alpha.1] - 2026-07-04
+
+First step on the road to 5.0: broaden kit's four-surface agent model
+(rules / memory / install-gate / lifecycle hooks) across the coding-agent
+ecosystem, shipping only where the transcript path, format, and block
+contract are verified — and naming the rest as honest limitations rather
+than faking coverage.
+
 ### Added
 
+- **Six more agents onboarded (research-driven).** kit now indexes memory and/or
+  enforces installs for a much wider agent set. Every surface below was verified
+  against the agent's own format before shipping; unverifiable surfaces are
+  documented as limitations, not stubbed.
+  - **AWS Kiro CLI — memory.** New parser for `kiro-cli/data.sqlite3` (same
+    storage design as Amazon Q; reads `conversations_v2`, falling back to
+    `conversations`), tagged `harness=kiro`. Read-only, incremental, fail-safe.
+    Kiro is the 10th indexed harness. (Its install-gate + rules shipped earlier.)
+  - **Factory Droid — memory + install-gate.** Indexes its Claude-Code-compatible
+    JSONL transcripts under `~/.factory/projects/**/*.jsonl` (`harness=droid`),
+    and wires a PreToolUse gate to `.factory/hooks.json`. The one adaptation vs
+    the Claude gate is matcher `"Execute"`; `kit gate-bash` is unchanged.
+  - **Aider — memory + rules.** Parses its project-local markdown chat log
+    (`$GIT_ROOT/.aider.chat.history.md`, honoring `AIDER_CHAT_HISTORY_FILE`),
+    `harness=aider`. A **bespoke** rules installer writes `CONVENTIONS.md` AND
+    wires `read: CONVENTIONS.md` into `.aider.conf.yml` (Aider auto-reads no
+    rules file, so the block alone would be a no-op). No install-gate: Aider has
+    no pre-tool hook surface.
+  - **Google Antigravity — memory + install-gate.** New JSONL parser for
+    `~/.gemini/{antigravity-cli,antigravity-ide,antigravity}/brain/*/.system_generated/logs/transcript_full.jsonl`
+    (a real gap the `~/.gemini/tmp` Gemini parser never covered), `harness=antigravity`.
+    Install-gate to the workspace `.agents/hooks.json` (PreToolUse, matcher
+    `run_command`).
+  - **Augment — install-gate.** Wires a PreToolUse gate to `.augment/settings.json`
+    (matcher `"launch-process"`). Rules already routed via `.augment-guidelines`.
+  - **Kilo Code — rules marker.** `.kilocode` / `.kilo` / `kilo.jsonc` now route
+    the kit block into `AGENTS.md`. (Memory + gate deferred — contradicted across
+    Kilo product generations; no false-green.)
+- **`extractCommandFromHookPayload` now spans two more wire shapes.** It reads
+  Antigravity's `toolCall.args.CommandLine` and Sourcegraph Amp's
+  `arguments.command` in addition to the existing shapes — a pure,
+  backward-compatible extension so those agents' gates need no `--format` adapter.
 - **AWS Kiro install-gate.** `kit agent-config --install-gate` now wires the
   fail-closed PreToolUse gate for Kiro CLI: it adds a `hooks.preToolUse` entry
   (matcher `execute_bash`) to each `.kiro/agents/*.json` agent config. Kiro is

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -82,10 +82,12 @@ transcripts from every supported coding agent on the machine, each tagged with a
 (`~/.codex/sessions`), **Gemini CLI** (`~/.gemini/tmp`), **Continue.dev**
 (`~/.continue/sessions`), **Cursor** (`state.vscdb`), **Amazon Q Developer CLI**
 (`amazon-q/data.sqlite3`), **AWS Kiro CLI** (`kiro-cli/data.sqlite3` — same
-schema as Amazon Q, `conversations_v2` with a `conversations` fallback), **Cline**
-(VS Code `saoudrizwan.claude-dev/tasks`), and **OpenCode**
-(`~/.local/share/opencode` — SQLite `opencode.db` or the legacy `storage/` tree).
-Absent agents are skipped silently. Adding one
+schema as Amazon Q, `conversations_v2` with a `conversations` fallback),
+**Factory Droid** (`~/.factory/projects/**/*.jsonl` — Claude-Code-compatible JSONL),
+**Aider** (project-local `$GIT_ROOT/.aider.chat.history.md` markdown, honoring
+`AIDER_CHAT_HISTORY_FILE`), **Cline** (VS Code `saoudrizwan.claude-dev/tasks`), and
+**OpenCode** (`~/.local/share/opencode` — SQLite `opencode.db` or the legacy
+`storage/` tree). Absent agents are skipped silently. Adding one
 is a single parser in `indexAllHarnesses()`. Each parser is built against the
 agent's own serialization format (verified from its source), never guessed. The
 Cursor + Amazon Q + Kiro parsers read app-internal SQLite defensively — if the

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -81,14 +81,16 @@ transcripts from every supported coding agent on the machine, each tagged with a
 `harness` so recall spans them: **Claude Code** (`~/.claude`), **Codex**
 (`~/.codex/sessions`), **Gemini CLI** (`~/.gemini/tmp`), **Continue.dev**
 (`~/.continue/sessions`), **Cursor** (`state.vscdb`), **Amazon Q Developer CLI**
-(`amazon-q/data.sqlite3`), **Cline** (VS Code `saoudrizwan.claude-dev/tasks`), and
-**OpenCode** (`~/.local/share/opencode` — SQLite `opencode.db` or the legacy
-`storage/` tree). Absent agents are skipped silently. Adding one
+(`amazon-q/data.sqlite3`), **AWS Kiro CLI** (`kiro-cli/data.sqlite3` — same
+schema as Amazon Q, `conversations_v2` with a `conversations` fallback), **Cline**
+(VS Code `saoudrizwan.claude-dev/tasks`), and **OpenCode**
+(`~/.local/share/opencode` — SQLite `opencode.db` or the legacy `storage/` tree).
+Absent agents are skipped silently. Adding one
 is a single parser in `indexAllHarnesses()`. Each parser is built against the
 agent's own serialization format (verified from its source), never guessed. The
-Cursor + Amazon Q parsers read app-internal SQLite defensively — if the shape
-ever differs they index nothing rather than risk wrong data. (GitHub Copilot
-CLI, Antigravity IDE, Zed, and Kiro stay out until their formats are
+Cursor + Amazon Q + Kiro parsers read app-internal SQLite defensively — if the
+shape ever differs they index nothing rather than risk wrong data. (GitHub Copilot
+CLI, Antigravity IDE, and Zed stay out until their formats are
 source-verifiable: see the table in the repo notes.)
 
 ### Pending actions (PAL)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "4.0.0",
+  "version": "5.0.0-alpha.1",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/agent-config.test.ts
+++ b/src/agent-config.test.ts
@@ -14,6 +14,7 @@ import {
   installInstallGateCodex,
   installInstallGateAmazonQ,
   installInstallGateKiro,
+  installInstallGateDroid,
   installInstallGateGemini,
   installInstallGateCursor,
   installInstallGateOpenCode,
@@ -470,6 +471,62 @@ describe("installInstallGateKiro", () => {
     const dir = mkdtempSync(join(tmpdir(), "kit-kirogate2-"));
     try {
       assert.equal((await installInstallGateKiro(dir)).action, "skipped");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("installInstallGateDroid", () => {
+  it("writes a PreToolUse Execute gate to .factory/hooks.json, idempotently", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-droidgate-"));
+    try {
+      mkdirSync(join(dir, ".factory"), { recursive: true });
+      const r1 = await installInstallGateDroid(dir);
+      assert.equal(r1.action, "created");
+      const s = JSON.parse(readFileSync(join(dir, ".factory", "hooks.json"), "utf-8"));
+      const groups = s.hooks.PreToolUse;
+      assert.ok(Array.isArray(groups) && groups.length === 1);
+      // the ONE adaptation vs Claude/Codex: matcher is "Execute", not "Bash"
+      assert.equal(groups[0].matcher, "Execute");
+      assert.ok(groups[0].hooks[0].command.endsWith("gate-bash"));
+
+      const r2 = await installInstallGateDroid(dir);
+      assert.equal(r2.action, "unchanged");
+      const s2 = JSON.parse(readFileSync(join(dir, ".factory", "hooks.json"), "utf-8"));
+      assert.equal(s2.hooks.PreToolUse.length, 1, "no duplicate group on re-run");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("treats a legacy .factory/hooks/hooks.json gate as already-wired", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-droidgate-legacy-"));
+    try {
+      mkdirSync(join(dir, ".factory", "hooks"), { recursive: true });
+      writeFileSync(
+        join(dir, ".factory", "hooks", "hooks.json"),
+        JSON.stringify({
+          hooks: {
+            PreToolUse: [
+              { matcher: "Execute", hooks: [{ type: "command", command: "/x/cli.js gate-bash" }] },
+            ],
+          },
+        }),
+      );
+      const r = await installInstallGateDroid(dir);
+      assert.equal(r.action, "unchanged");
+      // must NOT create a second scope-root file
+      assert.equal(existsSync(join(dir, ".factory", "hooks.json")), false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips when no Factory Droid project is present (no false-green)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-droidgate2-"));
+    try {
+      assert.equal((await installInstallGateDroid(dir)).action, "skipped");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agent-config.test.ts
+++ b/src/agent-config.test.ts
@@ -15,6 +15,7 @@ import {
   installInstallGateAmazonQ,
   installInstallGateKiro,
   installInstallGateDroid,
+  installInstallGateAugment,
   installInstallGateGemini,
   installInstallGateCursor,
   installInstallGateOpenCode,
@@ -527,6 +528,51 @@ describe("installInstallGateDroid", () => {
     const dir = mkdtempSync(join(tmpdir(), "kit-droidgate2-"));
     try {
       assert.equal((await installInstallGateDroid(dir)).action, "skipped");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("installInstallGateAugment", () => {
+  it("writes a PreToolUse launch-process gate to .augment/settings.json, idempotently", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-auggate-"));
+    try {
+      mkdirSync(join(dir, ".augment"), { recursive: true });
+      const r1 = await installInstallGateAugment(dir);
+      assert.equal(r1.action, "created");
+      const s = JSON.parse(readFileSync(join(dir, ".augment", "settings.json"), "utf-8"));
+      const groups = s.hooks.PreToolUse;
+      assert.ok(Array.isArray(groups) && groups.length === 1);
+      // the one adaptation: Augment's shell tool is "launch-process"
+      assert.equal(groups[0].matcher, "launch-process");
+      assert.ok(groups[0].hooks[0].command.endsWith("gate-bash"));
+
+      const r2 = await installInstallGateAugment(dir);
+      assert.equal(r2.action, "unchanged");
+      const s2 = JSON.parse(readFileSync(join(dir, ".augment", "settings.json"), "utf-8"));
+      assert.equal(s2.hooks.PreToolUse.length, 1, "no duplicate group on re-run");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects via a bare .augment-guidelines file too", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-auggate-g-"));
+    try {
+      writeFileSync(join(dir, ".augment-guidelines"), "# guidelines\n");
+      const r = await installInstallGateAugment(dir);
+      assert.equal(r.action, "created");
+      assert.ok(existsSync(join(dir, ".augment", "settings.json")));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips when no Augment project is present (no false-green)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-auggate2-"));
+    try {
+      assert.equal((await installInstallGateAugment(dir)).action, "skipped");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agent-config.test.ts
+++ b/src/agent-config.test.ts
@@ -181,8 +181,8 @@ describe("detectAgentTargets", () => {
     }
   });
 
-  it("wires AGENTS.md for a Kiro (.kiro/) or Droid (.factory/) project", () => {
-    for (const marker of [".kiro", ".factory"]) {
+  it("wires AGENTS.md for Kiro (.kiro/), Droid (.factory/) and Kilo (.kilocode/.kilo) projects", () => {
+    for (const marker of [".kiro", ".factory", ".kilocode", ".kilo"]) {
       const dir = tmpRepo();
       try {
         mkdirSync(join(dir, marker));
@@ -191,6 +191,17 @@ describe("detectAgentTargets", () => {
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }
+    }
+  });
+
+  it("wires AGENTS.md for a Kilo project marked by kilo.jsonc", () => {
+    const dir = tmpRepo();
+    try {
+      writeFileSync(join(dir, "kilo.jsonc"), "{}\n");
+      const files = detectAgentTargets(dir).map((t) => t.file);
+      assert.deepEqual(files, ["AGENTS.md"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/src/agent-config.test.ts
+++ b/src/agent-config.test.ts
@@ -16,6 +16,8 @@ import {
   installInstallGateKiro,
   installInstallGateDroid,
   installInstallGateAugment,
+  installAiderRules,
+  mergeAiderRead,
   installInstallGateGemini,
   installInstallGateCursor,
   installInstallGateOpenCode,
@@ -573,6 +575,81 @@ describe("installInstallGateAugment", () => {
     const dir = mkdtempSync(join(tmpdir(), "kit-auggate2-"));
     try {
       assert.equal((await installInstallGateAugment(dir)).action, "skipped");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("mergeAiderRead (conf.yml read: merge, no YAML dep)", () => {
+  it("no-ops when CONVENTIONS.md is already referenced", () => {
+    const r = mergeAiderRead("read:\n  - CONVENTIONS.md\n");
+    assert.equal(r.changed, false);
+  });
+  it("creates a read block when the key is absent", () => {
+    const r = mergeAiderRead("model: gpt-4\n");
+    assert.equal(r.changed, true);
+    assert.ok(r.next.includes("read:\n  - CONVENTIONS.md"));
+    assert.ok(r.next.includes("model: gpt-4"), "preserves other keys");
+  });
+  it("promotes a scalar read: to a two-item block list", () => {
+    const r = mergeAiderRead("read: OTHER.md\n");
+    assert.equal(r.changed, true);
+    assert.ok(r.next.includes("- OTHER.md"));
+    assert.ok(r.next.includes("- CONVENTIONS.md"));
+  });
+  it("appends to an existing block list, matching indent", () => {
+    const r = mergeAiderRead("read:\n  - OTHER.md\n");
+    assert.equal(r.changed, true);
+    assert.ok(/read:\n {2}- CONVENTIONS\.md\n {2}- OTHER\.md|read:\n {2}- OTHER\.md/.test(r.next));
+    assert.ok(r.next.includes("- CONVENTIONS.md"));
+  });
+  it("refuses to text-edit a flow list (manual instead of corrupting)", () => {
+    const r = mergeAiderRead("read: [a.md, b.md]\n");
+    assert.equal(r.changed, false);
+    assert.equal(r.manual, true);
+  });
+});
+
+describe("installAiderRules (bespoke: CONVENTIONS.md + conf.yml)", () => {
+  it("writes the kit block AND wires read: CONVENTIONS.md, idempotently", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-aider-"));
+    try {
+      writeFileSync(join(dir, ".aider.conf.yml"), "model: gpt-4\n");
+      const r1 = await installAiderRules(dir);
+      assert.notEqual(r1.action, "failed");
+      const conv = readFileSync(join(dir, "CONVENTIONS.md"), "utf-8");
+      assert.ok(conv.includes("kit triage"), "kit block written to CONVENTIONS.md");
+      const conf = readFileSync(join(dir, ".aider.conf.yml"), "utf-8");
+      assert.ok(conf.includes("CONVENTIONS.md"), "read: CONVENTIONS.md wired");
+      assert.ok(conf.includes("model: gpt-4"), "preserves existing conf");
+
+      const r2 = await installAiderRules(dir);
+      assert.equal(r2.action, "unchanged");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects via a bare .aider.chat.history.md and creates both files", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-aider2-"));
+    try {
+      writeFileSync(join(dir, ".aider.chat.history.md"), "# aider chat started at x\n");
+      const r = await installAiderRules(dir);
+      assert.notEqual(r.action, "failed");
+      assert.ok(existsSync(join(dir, "CONVENTIONS.md")));
+      assert.ok(readFileSync(join(dir, ".aider.conf.yml"), "utf-8").includes("CONVENTIONS.md"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips when no Aider project is present (no false-green)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-aider3-"));
+    try {
+      const r = await installAiderRules(dir);
+      assert.equal(r.detail, "no Aider project detected");
+      assert.equal(existsSync(join(dir, "CONVENTIONS.md")), false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agent-config.test.ts
+++ b/src/agent-config.test.ts
@@ -16,6 +16,7 @@ import {
   installInstallGateKiro,
   installInstallGateDroid,
   installInstallGateAugment,
+  installInstallGateAntigravity,
   installAiderRules,
   mergeAiderRead,
   installInstallGateGemini,
@@ -575,6 +576,38 @@ describe("installInstallGateAugment", () => {
     const dir = mkdtempSync(join(tmpdir(), "kit-auggate2-"));
     try {
       assert.equal((await installInstallGateAugment(dir)).action, "skipped");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("installInstallGateAntigravity", () => {
+  it("writes a PreToolUse run_command gate to .agents/hooks.json, idempotently", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-antigrav-"));
+    try {
+      mkdirSync(join(dir, ".agents"), { recursive: true });
+      const r1 = await installInstallGateAntigravity(dir);
+      assert.equal(r1.action, "created");
+      const s = JSON.parse(readFileSync(join(dir, ".agents", "hooks.json"), "utf-8"));
+      const groups = s.hooks.PreToolUse;
+      assert.ok(Array.isArray(groups) && groups.length === 1);
+      assert.equal(groups[0].matcher, "run_command");
+      assert.ok(groups[0].hooks[0].command.endsWith("gate-bash"));
+
+      const r2 = await installInstallGateAntigravity(dir);
+      assert.equal(r2.action, "unchanged");
+      const s2 = JSON.parse(readFileSync(join(dir, ".agents", "hooks.json"), "utf-8"));
+      assert.equal(s2.hooks.PreToolUse.length, 1, "no duplicate group on re-run");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips when no Antigravity (.agents/) project is present (no false-green)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-antigrav2-"));
+    try {
+      assert.equal((await installInstallGateAntigravity(dir)).action, "skipped");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agent-config.ts
+++ b/src/agent-config.ts
@@ -795,6 +795,51 @@ export async function installInstallGateDroid(
   }
 }
 
+/**
+ * Augment (Auggie) install-gate: a `PreToolUse` hook in `.augment/settings.json`
+ * (same nested hooks > Event > matcher > hooks[] shape as Claude Code). The one
+ * adaptation is the shell-tool matcher is `"launch-process"` (Augment's process
+ * tool). Augment passes the command at `tool_input.command` and blocks on exit 2,
+ * so `kit gate-bash` works unchanged. We write the committable project file
+ * (config precedence: system > project `.augment/settings.json` > `.local` > user).
+ * Idempotent; preserves other settings/hooks.
+ */
+export async function installInstallGateAugment(
+  cwd: string = process.cwd(),
+): Promise<HookInstallResult> {
+  const file = ".augment/settings.json";
+  const path = resolve(cwd, file);
+  const { isReadOnlyMode } = await import("./read-only-mode.js");
+  if (isReadOnlyMode()) return { file, action: "skipped", detail: "read-only mode" };
+  if (!existsSync(resolve(cwd, ".augment")) && !existsSync(resolve(cwd, ".augment-guidelines"))) {
+    return { file, action: "skipped", detail: "no Augment project detected" };
+  }
+  let settings: { hooks?: Record<string, SettingsHookGroup[]>; [k: string]: unknown } = {};
+  let existed = false;
+  try {
+    settings = JSON.parse(await readFile(path, "utf-8")) as typeof settings;
+    existed = true;
+  } catch {
+    settings = {};
+  }
+  const hooks = (settings.hooks ??= {});
+  const pre = (hooks.PreToolUse ??= []);
+  if (pre.some((g) => g.hooks?.some((h) => h.command?.endsWith("gate-bash")))) {
+    return { file, action: "unchanged", detail: "install-gate already wired" };
+  }
+  pre.push({
+    matcher: "launch-process",
+    hooks: [{ type: "command", command: kitGateInvocation() }],
+  });
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, JSON.stringify(settings, null, 2) + "\n", "utf-8");
+    return { file, action: existed ? "updated" : "created" };
+  } catch (err) {
+    return { file, action: "failed", detail: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 /** Per-agent install-gate result. */
 export interface GateInstallEntry {
   agent:
@@ -803,6 +848,7 @@ export interface GateInstallEntry {
     | "Amazon Q"
     | "Kiro"
     | "Factory Droid"
+    | "Augment"
     | "Gemini CLI"
     | "Cursor"
     | "OpenCode"
@@ -820,6 +866,7 @@ export async function installAllInstallGates(
     { agent: "Amazon Q", result: await installInstallGateAmazonQ(cwd) },
     { agent: "Kiro", result: await installInstallGateKiro(cwd) },
     { agent: "Factory Droid", result: await installInstallGateDroid(cwd) },
+    { agent: "Augment", result: await installInstallGateAugment(cwd) },
     { agent: "Gemini CLI", result: await installInstallGateGemini(cwd) },
     { agent: "Cursor", result: await installInstallGateCursor(cwd) },
     { agent: "OpenCode", result: await installInstallGateOpenCode(cwd) },

--- a/src/agent-config.ts
+++ b/src/agent-config.ts
@@ -73,15 +73,19 @@ export function detectAgentTargets(cwd: string = process.cwd()): AgentTarget[] {
         // read it, so an OpenCode-only project (opencode.json / .opencode, no
         // .codex) should still wire its block into AGENTS.md.
         // AGENTS.md is the Linux-Foundation cross-tool standard: Codex, OpenCode,
-        // Factory Droid (.factory) and AWS Kiro (.kiro, reads root AGENTS.md) all
-        // consume it, so any of their marker dirs should wire the block into AGENTS.md.
+        // Factory Droid (.factory), AWS Kiro (.kiro) and Kilo Code (.kilocode/.kilo/
+        // kilo.jsonc — reads AGENTS.md primary, CLAUDE.md compat) all consume it,
+        // so any of their marker dirs should wire the block into AGENTS.md.
         return (
           existsSync(resolve(cwd, ".codex")) ||
           existsSync(resolve(cwd, ".opencode")) ||
           existsSync(resolve(cwd, "opencode.json")) ||
           existsSync(resolve(cwd, "opencode.jsonc")) ||
           existsSync(resolve(cwd, ".kiro")) ||
-          existsSync(resolve(cwd, ".factory"))
+          existsSync(resolve(cwd, ".factory")) ||
+          existsSync(resolve(cwd, ".kilocode")) ||
+          existsSync(resolve(cwd, ".kilo")) ||
+          existsSync(resolve(cwd, "kilo.jsonc"))
         );
       case "Cursor":
         return existsSync(resolve(cwd, ".cursor"));

--- a/src/agent-config.ts
+++ b/src/agent-config.ts
@@ -965,6 +965,49 @@ export async function installInstallGateAugment(
   }
 }
 
+/**
+ * Google Antigravity install-gate: a `PreToolUse` hook in the workspace-scoped
+ * `.agents/hooks.json` (preferred over the global ~/.gemini/config/hooks.json to
+ * keep kit's per-project pattern). Distinct from the Gemini CLI gate: event key
+ * `"PreToolUse"` (not `BeforeTool`), matcher `"run_command"`. Antigravity carries
+ * the command at `toolCall.args.CommandLine` — handled by the extended
+ * `extractCommandFromHookPayload` — and blocks on exit 2, so `kit gate-bash`
+ * works unchanged. Idempotent; preserves other hooks. Detected via a repo
+ * `.agents/` dir.
+ */
+export async function installInstallGateAntigravity(
+  cwd: string = process.cwd(),
+): Promise<HookInstallResult> {
+  const file = ".agents/hooks.json";
+  const path = resolve(cwd, file);
+  const { isReadOnlyMode } = await import("./read-only-mode.js");
+  if (isReadOnlyMode()) return { file, action: "skipped", detail: "read-only mode" };
+  if (!existsSync(resolve(cwd, ".agents"))) {
+    return { file, action: "skipped", detail: "no Antigravity (.agents/) project detected" };
+  }
+  let settings: { hooks?: Record<string, SettingsHookGroup[]>; [k: string]: unknown } = {};
+  let existed = false;
+  try {
+    settings = JSON.parse(await readFile(path, "utf-8")) as typeof settings;
+    existed = true;
+  } catch {
+    settings = {};
+  }
+  const hooks = (settings.hooks ??= {});
+  const pre = (hooks.PreToolUse ??= []);
+  if (pre.some((g) => g.hooks?.some((h) => h.command?.endsWith("gate-bash")))) {
+    return { file, action: "unchanged", detail: "install-gate already wired" };
+  }
+  pre.push({ matcher: "run_command", hooks: [{ type: "command", command: kitGateInvocation() }] });
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, JSON.stringify(settings, null, 2) + "\n", "utf-8");
+    return { file, action: existed ? "updated" : "created" };
+  } catch (err) {
+    return { file, action: "failed", detail: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 /** Per-agent install-gate result. */
 export interface GateInstallEntry {
   agent:
@@ -974,6 +1017,7 @@ export interface GateInstallEntry {
     | "Kiro"
     | "Factory Droid"
     | "Augment"
+    | "Antigravity"
     | "Gemini CLI"
     | "Cursor"
     | "OpenCode"
@@ -992,6 +1036,7 @@ export async function installAllInstallGates(
     { agent: "Kiro", result: await installInstallGateKiro(cwd) },
     { agent: "Factory Droid", result: await installInstallGateDroid(cwd) },
     { agent: "Augment", result: await installInstallGateAugment(cwd) },
+    { agent: "Antigravity", result: await installInstallGateAntigravity(cwd) },
     { agent: "Gemini CLI", result: await installInstallGateGemini(cwd) },
     { agent: "Cursor", result: await installInstallGateCursor(cwd) },
     { agent: "OpenCode", result: await installInstallGateOpenCode(cwd) },

--- a/src/agent-config.ts
+++ b/src/agent-config.ts
@@ -735,6 +735,66 @@ exec ${kitGateInvocation()} --format cline
   }
 }
 
+/**
+ * Factory Droid install-gate: a `PreToolUse` hook in `.factory/hooks.json`. Droid
+ * is Claude-Code-compatible and uses the same nested `{hooks:{PreToolUse:[{matcher,
+ * hooks:[{type:"command",command}]}]}}` shape — the ONE adaptation is the shell
+ * matcher is `"Execute"` (not `"Bash"`). Droid passes the command at
+ * `tool_input.command` and blocks on exit 2, so `kit gate-bash` works unchanged.
+ * Idempotent (keyed on a `gate-bash` command); also treats the legacy
+ * `.factory/hooks/hooks.json` as already-wired so we don't double-install.
+ * Preserves any other hooks/settings.
+ */
+export async function installInstallGateDroid(
+  cwd: string = process.cwd(),
+): Promise<HookInstallResult> {
+  const file = ".factory/hooks.json";
+  const path = resolve(cwd, file);
+  const { isReadOnlyMode } = await import("./read-only-mode.js");
+  if (isReadOnlyMode()) return { file, action: "skipped", detail: "read-only mode" };
+  if (!existsSync(resolve(cwd, ".factory"))) {
+    return { file, action: "skipped", detail: "no Factory Droid project detected" };
+  }
+
+  // Legacy location: if a prior hooks file already carries the gate, do nothing.
+  const legacy = resolve(cwd, ".factory/hooks/hooks.json");
+  if (existsSync(legacy)) {
+    try {
+      if ((await readFile(legacy, "utf-8")).includes("gate-bash")) {
+        return {
+          file: ".factory/hooks/hooks.json",
+          action: "unchanged",
+          detail: "install-gate already wired",
+        };
+      }
+    } catch {
+      // unreadable legacy file → fall through and write the scope-root file
+    }
+  }
+
+  let settings: { hooks?: Record<string, SettingsHookGroup[]>; [k: string]: unknown } = {};
+  let existed = false;
+  try {
+    settings = JSON.parse(await readFile(path, "utf-8")) as typeof settings;
+    existed = true;
+  } catch {
+    settings = {};
+  }
+  const hooks = (settings.hooks ??= {});
+  const pre = (hooks.PreToolUse ??= []);
+  if (pre.some((g) => g.hooks?.some((h) => h.command?.endsWith("gate-bash")))) {
+    return { file, action: "unchanged", detail: "install-gate already wired" };
+  }
+  pre.push({ matcher: "Execute", hooks: [{ type: "command", command: kitGateInvocation() }] });
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, JSON.stringify(settings, null, 2) + "\n", "utf-8");
+    return { file, action: existed ? "updated" : "created" };
+  } catch (err) {
+    return { file, action: "failed", detail: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 /** Per-agent install-gate result. */
 export interface GateInstallEntry {
   agent:
@@ -742,6 +802,7 @@ export interface GateInstallEntry {
     | "Codex"
     | "Amazon Q"
     | "Kiro"
+    | "Factory Droid"
     | "Gemini CLI"
     | "Cursor"
     | "OpenCode"
@@ -758,6 +819,7 @@ export async function installAllInstallGates(
     { agent: "Codex", result: await installInstallGateCodex(cwd) },
     { agent: "Amazon Q", result: await installInstallGateAmazonQ(cwd) },
     { agent: "Kiro", result: await installInstallGateKiro(cwd) },
+    { agent: "Factory Droid", result: await installInstallGateDroid(cwd) },
     { agent: "Gemini CLI", result: await installInstallGateGemini(cwd) },
     { agent: "Cursor", result: await installInstallGateCursor(cwd) },
     { agent: "OpenCode", result: await installInstallGateOpenCode(cwd) },

--- a/src/agent-config.ts
+++ b/src/agent-config.ts
@@ -199,6 +199,131 @@ export async function writeAgentConfig(
 }
 
 /**
+ * Merge `CONVENTIONS.md` into an `.aider.conf.yml` `read:` directive without a
+ * YAML dependency. Idempotent (a mention of CONVENTIONS.md is a no-op) and
+ * conservative: handles the common scalar (`read: X`) and block-list forms, but
+ * refuses to text-edit a flow list (`read: [a, b]`) — it returns `manual:true`
+ * so the caller can tell the user to add the entry by hand rather than risk
+ * corrupting their YAML.
+ */
+export function mergeAiderRead(existing: string): {
+  next: string;
+  changed: boolean;
+  manual?: boolean;
+} {
+  if (/CONVENTIONS\.md/.test(existing)) return { next: existing, changed: false };
+  const lines = existing.split("\n");
+  const readIdx = lines.findIndex((l) => /^read\s*:/.test(l));
+  if (readIdx === -1) {
+    const sep = existing.length && !existing.endsWith("\n") ? "\n" : "";
+    return { next: existing + sep + "read:\n  - CONVENTIONS.md\n", changed: true };
+  }
+  const rhs = (lines[readIdx].match(/^read\s*:\s*(.*)$/)?.[1] ?? "").trim();
+  if (rhs === "") {
+    // Block list (or empty) follows — match the existing item indent if any.
+    let indent = "  ";
+    for (let i = readIdx + 1; i < lines.length; i++) {
+      const m = lines[i].match(/^(\s*)-\s+/);
+      if (m) {
+        indent = m[1];
+        break;
+      }
+      if (lines[i].trim() !== "" && !/^\s/.test(lines[i])) break; // next top-level key
+    }
+    lines.splice(readIdx + 1, 0, `${indent}- CONVENTIONS.md`);
+    return { next: lines.join("\n"), changed: true };
+  }
+  if (rhs.startsWith("[")) return { next: existing, changed: false, manual: true };
+  // Scalar value → promote to a two-item block list.
+  const val = rhs.replace(/^["']|["']$/g, "");
+  lines[readIdx] = `read:\n  - ${val}\n  - CONVENTIONS.md`;
+  return { next: lines.join("\n"), changed: true };
+}
+
+/**
+ * Aider rules — a BESPOKE installer (not an `AGENT_TARGETS` row). Aider does NOT
+ * auto-read any rules file, so dropping `CONVENTIONS.md` alone is a no-op. This
+ * does TWO things idempotently: (1) writes the managed kit block into
+ * `CONVENTIONS.md`, and (2) ensures `.aider.conf.yml` carries `read: CONVENTIONS.md`
+ * so aider actually loads it. Detected via `.aider.conf.yml` /
+ * `.aider.chat.history.md` / `.aider.input.history`.
+ */
+export async function installAiderRules(cwd: string = process.cwd()): Promise<AgentConfigResult> {
+  const file = "CONVENTIONS.md";
+  const { isReadOnlyMode, refuseWrite } = await import("./read-only-mode.js");
+  if (isReadOnlyMode()) {
+    const refusal = await refuseWrite("install-aider-rules", {});
+    return { agent: "Aider", file, action: "failed", detail: refusal.reason };
+  }
+  const detected =
+    existsSync(resolve(cwd, ".aider.conf.yml")) ||
+    existsSync(resolve(cwd, ".aider.chat.history.md")) ||
+    existsSync(resolve(cwd, ".aider.input.history"));
+  if (!detected) {
+    return { agent: "Aider", file, action: "unchanged", detail: "no Aider project detected" };
+  }
+
+  // (1) CONVENTIONS.md kit block.
+  const convPath = resolve(cwd, file);
+  let existing = "";
+  try {
+    existing = await readFile(convPath, "utf-8");
+  } catch {
+    existing = "";
+  }
+  const { next, action } = upsertKitBlock(existing);
+  try {
+    if (action !== "unchanged") await writeFile(convPath, next, "utf-8");
+  } catch (err) {
+    return {
+      agent: "Aider",
+      file,
+      action: "failed",
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  // (2) .aider.conf.yml `read: CONVENTIONS.md` — the step that makes it non-no-op.
+  const confPath = resolve(cwd, ".aider.conf.yml");
+  let conf = "";
+  try {
+    conf = await readFile(confPath, "utf-8");
+  } catch {
+    conf = "";
+  }
+  const merged = mergeAiderRead(conf);
+  let confNote = "read: CONVENTIONS.md already set";
+  if (merged.manual) {
+    confNote = "add `- CONVENTIONS.md` under read: in .aider.conf.yml (flow list not auto-merged)";
+  } else if (merged.changed) {
+    try {
+      await writeFile(confPath, merged.next, "utf-8");
+      confNote = "wired read: CONVENTIONS.md in .aider.conf.yml";
+    } catch (err) {
+      return {
+        agent: "Aider",
+        file: ".aider.conf.yml",
+        action: "failed",
+        detail: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  const blockNote =
+    action === "created"
+      ? "wrote kit block to CONVENTIONS.md"
+      : action === "updated"
+        ? "updated kit block in CONVENTIONS.md"
+        : "kit block already current";
+  return {
+    agent: "Aider",
+    file,
+    action: action === "unchanged" && !merged.changed ? "unchanged" : "updated",
+    detail: `${blockNote}; ${confNote}`,
+  };
+}
+
+/**
  * The READ-ONLY kit commands an agent should be allowed to run without a
  * permission prompt. Teaching the agent to "use kit" is useless if every
  * `kit …` hits the permission wall in auto/non-interactive mode and the agent

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1536,7 +1536,7 @@ async function cmdAgentConfig(): Promise<boolean> {
       `  ${c.dim}· "use kit" rules block: Claude Code, Codex, Cursor, Cline, OpenCode${c.reset}\n` +
       `  ${c.dim}· Config/secret audit (kit agent-audit): Claude Code, Codex, Cursor, OpenCode (+ generic .mcp.json)${c.reset}\n` +
       `  ${c.dim}· Permission allowlist + auto-capture hooks: Claude Code${c.reset}\n` +
-      `  ${c.dim}· Blocking install-gate: Claude Code, Codex, Amazon Q, Kiro, Factory Droid, Gemini CLI, Cursor (hooks), OpenCode (plugin), Cline (PreToolUse shim); Continue has no gate surface (#146)${c.reset}\n` +
+      `  ${c.dim}· Blocking install-gate: Claude Code, Codex, Amazon Q, Kiro, Factory Droid, Augment, Gemini CLI, Cursor (hooks), OpenCode (plugin), Cline (PreToolUse shim); Continue has no gate surface (#146)${c.reset}\n` +
       `  ${c.dim}The agent-agnostic enforcement floor is git hooks (${c.reset}${c.bold}kit hooks${c.reset}${c.dim}); the rules block only advises.${c.reset}`,
   );
   return !failed;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,6 +100,7 @@ import {
   detectAgentTargets,
   installKitPermissions,
   installAllInstallGates,
+  installAiderRules,
 } from "./agent-config.js";
 import { applyRecommendedHardening } from "./recommended.js";
 import { checkHooks, isGitRepository } from "./check-hooks.js";
@@ -1485,6 +1486,10 @@ async function cmdAgentConfig(): Promise<boolean> {
   );
 
   const results = await writeAgentConfig();
+  // Aider needs a bespoke installer (CONVENTIONS.md + a `read:` entry in
+  // .aider.conf.yml — it auto-reads no rules file), so it's not an AGENT_TARGETS row.
+  const aider = await installAiderRules();
+  if (aider.detail !== "no Aider project detected") results.push(aider);
   let failed = false;
   for (const r of results) {
     if (r.action === "failed") {
@@ -1532,7 +1537,7 @@ async function cmdAgentConfig(): Promise<boolean> {
   );
   console.log(
     `\n${c.bold}Agent support${c.reset} ${c.dim}(what kit wires up per agent):${c.reset}\n` +
-      `  ${c.dim}· Memory index: Claude Code, Codex, Cursor, Cline, Gemini, Continue, Amazon Q, Kiro, OpenCode${c.reset}\n` +
+      `  ${c.dim}· Memory index: Claude Code, Codex, Cursor, Cline, Gemini, Continue, Amazon Q, Kiro, Factory Droid, Aider, OpenCode${c.reset}\n` +
       `  ${c.dim}· "use kit" rules block: Claude Code, Codex, Cursor, Cline, OpenCode${c.reset}\n` +
       `  ${c.dim}· Config/secret audit (kit agent-audit): Claude Code, Codex, Cursor, OpenCode (+ generic .mcp.json)${c.reset}\n` +
       `  ${c.dim}· Permission allowlist + auto-capture hooks: Claude Code${c.reset}\n` +

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1536,7 +1536,7 @@ async function cmdAgentConfig(): Promise<boolean> {
       `  ${c.dim}· "use kit" rules block: Claude Code, Codex, Cursor, Cline, OpenCode${c.reset}\n` +
       `  ${c.dim}· Config/secret audit (kit agent-audit): Claude Code, Codex, Cursor, OpenCode (+ generic .mcp.json)${c.reset}\n` +
       `  ${c.dim}· Permission allowlist + auto-capture hooks: Claude Code${c.reset}\n` +
-      `  ${c.dim}· Blocking install-gate: Claude Code, Codex, Amazon Q, Gemini CLI, Cursor (hooks), OpenCode (plugin), Cline (PreToolUse shim); Continue has no gate surface (#146)${c.reset}\n` +
+      `  ${c.dim}· Blocking install-gate: Claude Code, Codex, Amazon Q, Kiro, Factory Droid, Gemini CLI, Cursor (hooks), OpenCode (plugin), Cline (PreToolUse shim); Continue has no gate surface (#146)${c.reset}\n` +
       `  ${c.dim}The agent-agnostic enforcement floor is git hooks (${c.reset}${c.bold}kit hooks${c.reset}${c.dim}); the rules block only advises.${c.reset}`,
   );
   return !failed;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1532,7 +1532,7 @@ async function cmdAgentConfig(): Promise<boolean> {
   );
   console.log(
     `\n${c.bold}Agent support${c.reset} ${c.dim}(what kit wires up per agent):${c.reset}\n` +
-      `  ${c.dim}· Memory index: Claude Code, Codex, Cursor, Cline, Gemini, Continue, Amazon Q, OpenCode${c.reset}\n` +
+      `  ${c.dim}· Memory index: Claude Code, Codex, Cursor, Cline, Gemini, Continue, Amazon Q, Kiro, OpenCode${c.reset}\n` +
       `  ${c.dim}· "use kit" rules block: Claude Code, Codex, Cursor, Cline, OpenCode${c.reset}\n` +
       `  ${c.dim}· Config/secret audit (kit agent-audit): Claude Code, Codex, Cursor, OpenCode (+ generic .mcp.json)${c.reset}\n` +
       `  ${c.dim}· Permission allowlist + auto-capture hooks: Claude Code${c.reset}\n` +

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1537,11 +1537,11 @@ async function cmdAgentConfig(): Promise<boolean> {
   );
   console.log(
     `\n${c.bold}Agent support${c.reset} ${c.dim}(what kit wires up per agent):${c.reset}\n` +
-      `  ${c.dim}· Memory index: Claude Code, Codex, Cursor, Cline, Gemini, Continue, Amazon Q, Kiro, Factory Droid, Aider, OpenCode${c.reset}\n` +
+      `  ${c.dim}· Memory index: Claude Code, Codex, Cursor, Cline, Gemini, Continue, Amazon Q, Kiro, Factory Droid, Aider, Antigravity, OpenCode${c.reset}\n` +
       `  ${c.dim}· "use kit" rules block: Claude Code, Codex, Cursor, Cline, OpenCode${c.reset}\n` +
       `  ${c.dim}· Config/secret audit (kit agent-audit): Claude Code, Codex, Cursor, OpenCode (+ generic .mcp.json)${c.reset}\n` +
       `  ${c.dim}· Permission allowlist + auto-capture hooks: Claude Code${c.reset}\n` +
-      `  ${c.dim}· Blocking install-gate: Claude Code, Codex, Amazon Q, Kiro, Factory Droid, Augment, Gemini CLI, Cursor (hooks), OpenCode (plugin), Cline (PreToolUse shim); Continue has no gate surface (#146)${c.reset}\n` +
+      `  ${c.dim}· Blocking install-gate: Claude Code, Codex, Amazon Q, Kiro, Factory Droid, Augment, Antigravity, Gemini CLI, Cursor (hooks), OpenCode (plugin), Cline (PreToolUse shim); Continue has no gate surface (#146)${c.reset}\n` +
       `  ${c.dim}The agent-agnostic enforcement floor is git hooks (${c.reset}${c.bold}kit hooks${c.reset}${c.dim}); the rules block only advises.${c.reset}`,
   );
   return !failed;

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -27,6 +27,20 @@ describe("extractCommandFromHookPayload — per-agent wire shapes", () => {
       "npm install z",
     );
   });
+  it("reads toolCall.args.CommandLine (Antigravity run_command)", () => {
+    assert.equal(
+      extractCommandFromHookPayload({
+        toolCall: { name: "run_command", args: { CommandLine: "npm install evil" } },
+      }),
+      "npm install evil",
+    );
+  });
+  it("reads arguments.command (Amp permissions delegate)", () => {
+    assert.equal(
+      extractCommandFromHookPayload({ tool: "Bash", arguments: { command: "pip install evil" } }),
+      "pip install evil",
+    );
+  });
   it("joins array-form (bin + args)", () => {
     assert.equal(
       extractCommandFromHookPayload({ tool_input: { command: ["npm", "install", "z"] } }),

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -267,10 +267,12 @@ export async function decideBashGate(command: string, deps?: GateDeps): Promise<
 /**
  * Extract the shell command from an agent's PreToolUse-style hook payload,
  * across every wire shape kit's `gate-bash` handler supports:
- *   - Claude Code / Codex / Amazon Q / Gemini → `tool_input.command`
+ *   - Claude Code / Codex / Amazon Q / Gemini / Droid / Augment → `tool_input.command`
  *   - Cursor `beforeShellExecution`            → top-level `command`
  *   - Cline `PreToolUse`                       → `preToolUse.parameters.command`
  *     (verified against @cline/shared `PreToolUseData {toolName, parameters}`)
+ *   - Antigravity `run_command` hook          → `toolCall.args.CommandLine`
+ *   - Sourcegraph Amp permissions delegate    → `arguments.command`
  * Tolerates array-form (`[bin, ...args]`) by joining on spaces. Returns "" when
  * the tool call carries no shell command (→ the gate allows it). Pure.
  */
@@ -279,8 +281,15 @@ export function extractCommandFromHookPayload(payload: unknown): string {
     tool_input?: { command?: unknown };
     command?: unknown;
     preToolUse?: { parameters?: { command?: unknown } };
+    toolCall?: { args?: { CommandLine?: unknown } };
+    arguments?: { command?: unknown };
   };
-  const raw = p.tool_input?.command ?? p.preToolUse?.parameters?.command ?? p.command;
+  const raw =
+    p.tool_input?.command ??
+    p.preToolUse?.parameters?.command ??
+    p.toolCall?.args?.CommandLine ??
+    p.arguments?.command ??
+    p.command;
   if (typeof raw === "string") return raw;
   if (Array.isArray(raw)) return raw.filter((x): x is string => typeof x === "string").join(" ");
   return "";

--- a/src/memory/aider.test.ts
+++ b/src/memory/aider.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openMemoryDb, getStats, searchMessages } from "./db.js";
+import { indexAiderSessions } from "./aider.js";
+
+describe("memory aider parser", () => {
+  let tmp: string;
+  let historyFile: string;
+  const prev = process.env.KIT_AIDER_HISTORY;
+
+  before(() => {
+    tmp = mkdtempSync(join(tmpdir(), "kit-aider-"));
+    historyFile = join(tmp, ".aider.chat.history.md");
+    const md = [
+      "# aider chat started at 2026-05-01 10:00:00",
+      "",
+      "> Added src/app.py to the chat.", // aider output — skipped
+      "",
+      "#### how do I add september retries?", // user turn (one line)
+      "",
+      "Here is the retry approach.", // assistant prose
+      "You wrap the call in a loop.",
+      "",
+      "> Applied edit to src/app.py", // aider output boundary
+      "> Commit abc123", // more aider output
+      "",
+      "#### and a second question", // second user turn
+      "#### spanning two lines", // continuation of same user turn
+      "",
+      "The combined answer.", // assistant
+    ].join("\n");
+    writeFileSync(historyFile, md);
+    process.env.KIT_AIDER_HISTORY = historyFile;
+  });
+
+  after(() => {
+    if (prev === undefined) delete process.env.KIT_AIDER_HISTORY;
+    else process.env.KIT_AIDER_HISTORY = prev;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("parses #### user turns + plain assistant prose, skips > output, tags harness=aider", () => {
+    const db = openMemoryDb(":memory:");
+    const res = indexAiderSessions(db);
+    // 2 user turns + 2 assistant turns = 4; the "> " lines are not indexed.
+    assert.equal(res.messages, 4);
+    assert.equal(getStats(db).messages, 4);
+
+    const session = db
+      .prepare("SELECT harness FROM sessions WHERE session_id = ?")
+      .get(`aider:${historyFile}:0`) as { harness: string } | undefined;
+    assert.equal(session?.harness, "aider");
+
+    assert.equal(searchMessages(db, "september").length, 1);
+    assert.equal(searchMessages(db, "retry approach").length, 1);
+    // aider's own git/shell output must NOT be indexed
+    assert.equal(searchMessages(db, "Commit").length, 0);
+    // two-line user turn merged into one message
+    assert.equal(searchMessages(db, "spanning").length, 1);
+    db.close();
+  });
+
+  it("is incremental + idempotent — re-index skips the unchanged log", () => {
+    const db = openMemoryDb(":memory:");
+    indexAiderSessions(db);
+    const second = indexAiderSessions(db);
+    assert.equal(second.messages, 0);
+    assert.equal(second.filesSkipped, 1);
+    db.close();
+  });
+
+  it("returns empty when no aider log is present (no false-green)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-aider-empty-"));
+    process.env.KIT_AIDER_HISTORY = join(dir, ".aider.chat.history.md");
+    const db = openMemoryDb(":memory:");
+    assert.equal(indexAiderSessions(db).messages, 0);
+    db.close();
+    process.env.KIT_AIDER_HISTORY = historyFile;
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/src/memory/aider.ts
+++ b/src/memory/aider.ts
@@ -1,0 +1,139 @@
+/**
+ * kit memory — Aider transcript parser (multi-harness).
+ *
+ * Aider is the one PROJECT-LOCAL harness: it writes its chat log as markdown to
+ * `$GIT_ROOT/.aider.chat.history.md` (cwd fallback), not a `~/.<agent>` tree. The
+ * format is deterministic:
+ *   - `# aider chat started at <ts>`  → a session delimiter
+ *   - lines prefixed `#### `          → a user turn (one turn = a run of them)
+ *   - plain unprefixed lines          → the assistant response
+ *   - lines prefixed `> `             → aider's own output (commits, shell) — skipped
+ * We index the user/assistant turns, tag harness="aider", and synthesize stable
+ * uuids so re-indexing is idempotent. Content is taken verbatim (no model calls);
+ * a `#### ` line inside an assistant block is the one inherent ambiguity of the
+ * markdown format — it mislabels a role at worst, never fabricates content.
+ *
+ * Resolution order for the log file: KIT_AIDER_HISTORY (test/override) →
+ * AIDER_CHAT_HISTORY_FILE (aider's own env) → <cwd>/.aider.chat.history.md.
+ */
+import { existsSync, statSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { insertMessage, upsertSession, isFileIndexed, markFileIndexed } from "./db.js";
+import type { IndexResult } from "./parser.js";
+
+export function getAiderHistoryFile(cwd: string = process.cwd()): string {
+  return (
+    process.env.KIT_AIDER_HISTORY ??
+    process.env.AIDER_CHAT_HISTORY_FILE ??
+    resolve(cwd, ".aider.chat.history.md")
+  );
+}
+
+type Role = "user" | "assistant";
+
+function indexHistory(db: DatabaseSync, file: string): { messages: number } {
+  let raw: string;
+  try {
+    raw = readFileSync(file, "utf8");
+  } catch {
+    return { messages: 0 };
+  }
+
+  const cwd = dirname(file);
+  let sessionIdx = -1;
+  let sessionId = "";
+  let msgIdx = 0;
+  let role: Role | null = null;
+  let buf: string[] = [];
+  let messages = 0;
+
+  const ensureSession = () => {
+    if (sessionIdx < 0) {
+      // A log with turns but no explicit "started at" header → session 0.
+      sessionIdx = 0;
+      sessionId = `aider:${file}:0`;
+      upsertSession(db, { sessionId, harness: "aider", project: cwd });
+    }
+  };
+
+  const flush = () => {
+    if (role && buf.length) {
+      const content = buf.join("\n").trim();
+      if (content) {
+        ensureSession();
+        const added = insertMessage(db, {
+          uuid: `${sessionId}:${msgIdx}:${role}`,
+          sessionId,
+          type: role,
+          role,
+          content,
+          cwd,
+        });
+        msgIdx++;
+        if (added) messages++;
+      }
+    }
+    buf = [];
+    role = null;
+  };
+
+  for (const line of raw.split("\n")) {
+    if (/^# aider chat started at/.test(line)) {
+      flush();
+      sessionIdx++;
+      sessionId = `aider:${file}:${sessionIdx}`;
+      msgIdx = 0;
+      upsertSession(db, { sessionId, harness: "aider", project: cwd });
+      continue;
+    }
+    if (line.startsWith("#### ") || line === "####") {
+      if (role !== "user") flush();
+      role = "user";
+      buf.push(line.slice(4).replace(/^ /, ""));
+      continue;
+    }
+    if (line.startsWith("> ") || line === ">") {
+      // aider's own output (commit/shell echoes) — a hard boundary, not indexed.
+      flush();
+      continue;
+    }
+    if (line.trim() === "") {
+      // Keep blank lines only inside an active message (paragraph spacing).
+      if (role) buf.push("");
+      continue;
+    }
+    // Any other non-empty line is assistant prose.
+    if (role !== "assistant") flush();
+    role = "assistant";
+    buf.push(line);
+  }
+  flush();
+  return { messages };
+}
+
+/** Index the project's .aider.chat.history.md. Idempotent + incremental + fail-safe. */
+export function indexAiderSessions(db: DatabaseSync, cwd: string = process.cwd()): IndexResult {
+  const result: IndexResult = { files: 0, sessions: 0, messages: 0, toolUses: 0, filesSkipped: 0 };
+  const file = getAiderHistoryFile(cwd);
+  if (!existsSync(file)) return result;
+
+  let st;
+  try {
+    st = statSync(file);
+  } catch {
+    return result;
+  }
+  const mtimeMs = Math.floor(st.mtimeMs);
+  if (isFileIndexed(db, file, mtimeMs, st.size)) {
+    result.filesSkipped++;
+    return result;
+  }
+
+  const counts = indexHistory(db, file);
+  markFileIndexed(db, file, mtimeMs, st.size);
+  result.files++;
+  if (counts.messages > 0) result.sessions++;
+  result.messages += counts.messages;
+  return result;
+}

--- a/src/memory/antigravity.test.ts
+++ b/src/memory/antigravity.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openMemoryDb, getStats, searchMessages } from "./db.js";
+import { indexAntigravitySessions } from "./antigravity.js";
+
+describe("memory antigravity parser", () => {
+  let tmp: string;
+  const prev = process.env.KIT_ANTIGRAVITY_DIR;
+
+  before(() => {
+    tmp = mkdtempSync(join(tmpdir(), "kit-antigravity-"));
+    // ~/.gemini/antigravity-cli/brain/<id>/.system_generated/logs/transcript_full.jsonl
+    const logDir = join(tmp, "antigravity-cli", "brain", "conv-123", ".system_generated", "logs");
+    mkdirSync(logDir, { recursive: true });
+    const lines = [
+      JSON.stringify({ source: "USER_INPUT", content: "december rollout question" }),
+      JSON.stringify({ type: "MODEL", message: { text: "the rollout answer" } }),
+      JSON.stringify({ type: "PLANNER_RESPONSE", content: "planner step" }),
+      JSON.stringify({ source: "TOOL_RESULT", content: "noise, no role → skipped" }),
+    ].join("\n");
+    writeFileSync(join(logDir, "transcript_full.jsonl"), lines);
+    // A second conversation with only the truncated file → fallback path.
+    const logDir2 = join(tmp, "antigravity-ide", "brain", "conv-456", ".system_generated", "logs");
+    mkdirSync(logDir2, { recursive: true });
+    writeFileSync(
+      join(logDir2, "transcript.jsonl"),
+      JSON.stringify({ source: "USER_INPUT", content: "fallback question" }),
+    );
+    process.env.KIT_ANTIGRAVITY_DIR = tmp;
+  });
+
+  after(() => {
+    if (prev === undefined) delete process.env.KIT_ANTIGRAVITY_DIR;
+    else process.env.KIT_ANTIGRAVITY_DIR = prev;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("maps source/type enums to roles, skips non-turns, tags harness=antigravity", () => {
+    const db = openMemoryDb(":memory:");
+    const res = indexAntigravitySessions(db);
+    // conv-123: user + MODEL + PLANNER (3), TOOL_RESULT skipped; conv-456: 1 = 4 total
+    assert.equal(res.messages, 4);
+    assert.equal(getStats(db).messages, 4);
+
+    const session = db
+      .prepare("SELECT harness FROM sessions WHERE session_id = 'antigravity:conv-123'")
+      .get() as { harness: string } | undefined;
+    assert.equal(session?.harness, "antigravity");
+
+    assert.equal(searchMessages(db, "december").length, 1);
+    // nested {message:{text}} extracted
+    assert.equal(searchMessages(db, "rollout answer").length, 1);
+    // truncated-file fallback conversation indexed too
+    assert.equal(searchMessages(db, "fallback").length, 1);
+    db.close();
+  });
+
+  it("is incremental + idempotent — re-index skips unchanged transcripts", () => {
+    const db = openMemoryDb(":memory:");
+    indexAntigravitySessions(db);
+    const second = indexAntigravitySessions(db);
+    assert.equal(second.messages, 0);
+    assert.equal(second.filesSkipped, 2);
+    db.close();
+  });
+
+  it("returns empty when no antigravity dirs exist (no false-green)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-antigravity-empty-"));
+    process.env.KIT_ANTIGRAVITY_DIR = dir;
+    const db = openMemoryDb(":memory:");
+    assert.equal(indexAntigravitySessions(db).messages, 0);
+    db.close();
+    process.env.KIT_ANTIGRAVITY_DIR = tmp;
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/src/memory/antigravity.ts
+++ b/src/memory/antigravity.ts
@@ -1,0 +1,146 @@
+/**
+ * kit memory — Google Antigravity transcript parser (multi-harness).
+ *
+ * Antigravity (Gemini-family IDE/CLI) stores per-conversation JSONL "brain" logs
+ * under ~/.gemini/{antigravity-cli,antigravity-ide,antigravity}/brain/<id>/
+ * .system_generated/logs/transcript_full.jsonl (preferred; falls back to the
+ * truncated transcript.jsonl). The existing gemini.ts reads only ~/.gemini/tmp,
+ * so this is a real, separate gap. One JSON object per line; we map the record's
+ * `source`/`type` to a role (USER_INPUT → user, MODEL/PLANNER_RESPONSE →
+ * assistant), tag harness="antigravity", and flatten content defensively. The
+ * opaque protobuf `.pb` conversation DB is NOT text-indexable and is ignored.
+ * Read-only, idempotent, incremental, fail-safe; no model calls.
+ */
+import { existsSync, statSync, readFileSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { insertMessage, upsertSession, isFileIndexed, markFileIndexed } from "./db.js";
+import type { IndexResult } from "./parser.js";
+
+/** The three Antigravity brain roots under ~/.gemini (CLI, IDE, and 2.0). */
+export function getAntigravityRoots(): string[] {
+  const base = process.env.KIT_ANTIGRAVITY_DIR ?? join(homedir(), ".gemini");
+  return ["antigravity-cli", "antigravity-ide", "antigravity"].map((seg) => join(base, seg));
+}
+
+type Role = "user" | "assistant";
+
+/** Map an Antigravity record's source/type enum to a role, or null to skip. */
+function roleOf(rec: Record<string, unknown>): Role | null {
+  const tag = String(rec.source ?? rec.type ?? rec.role ?? "").toUpperCase();
+  if (tag.includes("USER")) return "user";
+  if (tag.includes("MODEL") || tag.includes("PLANNER") || tag.includes("ASSISTANT")) {
+    return "assistant";
+  }
+  return null;
+}
+
+/** Defensively pull text from a string | {content|text|message|parts} | array. */
+function textOf(node: unknown, depth = 0): string {
+  if (typeof node === "string") return node;
+  if (depth > 4 || node === null || typeof node !== "object") return "";
+  if (Array.isArray(node)) {
+    return node
+      .map((n) => textOf(n, depth + 1))
+      .filter(Boolean)
+      .join("\n");
+  }
+  const obj = node as Record<string, unknown>;
+  for (const field of ["content", "text", "message", "prompt", "parts"]) {
+    const v = obj[field];
+    if (typeof v === "string" && v.trim()) return v;
+    if (v && typeof v === "object") {
+      const nested = textOf(v, depth + 1);
+      if (nested) return nested;
+    }
+  }
+  return "";
+}
+
+/** Yield the preferred transcript file per brain conversation dir. */
+function* walkTranscripts(root: string): Generator<string> {
+  const brain = join(root, "brain");
+  let convs: string[];
+  try {
+    convs = readdirSync(brain, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+  } catch {
+    return;
+  }
+  for (const conv of convs) {
+    const logDir = join(brain, conv, ".system_generated", "logs");
+    const full = join(logDir, "transcript_full.jsonl");
+    const truncated = join(logDir, "transcript.jsonl");
+    if (existsSync(full)) yield full;
+    else if (existsSync(truncated)) yield truncated;
+  }
+}
+
+function indexFile(db: DatabaseSync, filepath: string, sessionId: string): { messages: number } {
+  let raw: string;
+  try {
+    raw = readFileSync(filepath, "utf8");
+  } catch {
+    return { messages: 0 };
+  }
+
+  upsertSession(db, { sessionId, harness: "antigravity" });
+  let messages = 0;
+  let idx = 0;
+  for (const line of raw.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    let rec: Record<string, unknown>;
+    try {
+      rec = JSON.parse(t) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    const role = roleOf(rec);
+    if (!role) continue;
+    const content = textOf(rec).trim();
+    if (!content) continue;
+    const added = insertMessage(db, {
+      uuid: `antigravity:${sessionId}:${idx}:${role}`,
+      sessionId,
+      type: role,
+      role,
+      content,
+    });
+    idx++;
+    if (added) messages++;
+  }
+  return { messages };
+}
+
+/** Walk every ~/.gemini/antigravity-* brain conversation and index its transcript. */
+export function indexAntigravitySessions(db: DatabaseSync): IndexResult {
+  const result: IndexResult = { files: 0, sessions: 0, messages: 0, toolUses: 0, filesSkipped: 0 };
+  for (const root of getAntigravityRoots()) {
+    for (const filepath of walkTranscripts(root)) {
+      let st;
+      try {
+        st = statSync(filepath);
+      } catch {
+        continue;
+      }
+      const mtimeMs = Math.floor(st.mtimeMs);
+      if (isFileIndexed(db, filepath, mtimeMs, st.size)) {
+        result.filesSkipped++;
+        continue;
+      }
+      // Session id = the conversation dir name (…/brain/<id>/.system_generated/…).
+      const parts = filepath.split(/[/\\]/);
+      const brainIdx = parts.lastIndexOf("brain");
+      const conv = brainIdx >= 0 && parts[brainIdx + 1] ? parts[brainIdx + 1] : filepath;
+      const counts = indexFile(db, filepath, `antigravity:${conv}`);
+      markFileIndexed(db, filepath, mtimeMs, st.size);
+      result.files++;
+      if (counts.messages > 0) result.sessions++;
+      result.messages += counts.messages;
+    }
+  }
+  return result;
+}

--- a/src/memory/droid.test.ts
+++ b/src/memory/droid.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openMemoryDb, getStats, searchMessages } from "./db.js";
+import { indexDroidSessions } from "./droid.js";
+
+describe("memory droid parser", () => {
+  let tmp: string;
+  const prev = process.env.KIT_DROID_DIR;
+
+  before(() => {
+    tmp = mkdtempSync(join(tmpdir(), "kit-droid-"));
+    // ~/.factory/projects/<projectHash>/<session-uuid>.jsonl — Claude-shaped lines.
+    const dir = join(tmp, "projects", "a1b2c3");
+    mkdirSync(dir, { recursive: true });
+    const lines = [
+      JSON.stringify({
+        type: "user",
+        uuid: "u1",
+        sessionId: "sess-droid",
+        cwd: "/Users/me/dev/svc",
+        timestamp: "2026-06-01T09:00:00Z",
+        message: { role: "user", content: "november migration question" },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        uuid: "a1",
+        sessionId: "sess-droid",
+        timestamp: "2026-06-01T09:00:05Z",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "the migration answer" },
+            { type: "tool_use", name: "Execute", input: { command: "ls" } },
+          ],
+        },
+      }),
+      // A summary/system line with no user|assistant role → must be skipped.
+      JSON.stringify({ type: "summary", summary: "irrelevant noise" }),
+    ].join("\n");
+    writeFileSync(join(dir, "sess-droid.jsonl"), lines);
+    process.env.KIT_DROID_DIR = tmp;
+  });
+
+  after(() => {
+    if (prev === undefined) delete process.env.KIT_DROID_DIR;
+    else process.env.KIT_DROID_DIR = prev;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("indexes user + assistant turns (Claude-shaped blocks), skips non-turns, tags harness=droid", () => {
+    const db = openMemoryDb(":memory:");
+    const res = indexDroidSessions(db);
+    assert.equal(res.messages, 2); // user + assistant; summary line skipped
+    assert.equal(getStats(db).messages, 2);
+    const session = db
+      .prepare("SELECT harness FROM sessions WHERE session_id = 'sess-droid'")
+      .get() as { harness: string } | undefined;
+    assert.equal(session?.harness, "droid");
+    assert.equal(searchMessages(db, "november").length, 1);
+    // block-array text flattened ("answer" appears only in the assistant text block)
+    assert.equal(searchMessages(db, "answer").length, 1);
+    // project-scoped via the record cwd ("november" is only in the user turn)
+    assert.equal(searchMessages(db, "november", { projectPath: "/Users/me/dev/svc" }).length, 1);
+    db.close();
+  });
+
+  it("is incremental + idempotent — re-index skips the unchanged transcript", () => {
+    const db = openMemoryDb(":memory:");
+    indexDroidSessions(db);
+    const second = indexDroidSessions(db);
+    assert.equal(second.messages, 0);
+    assert.equal(second.filesSkipped, 1);
+    db.close();
+  });
+
+  it("fail-safe on a foreign line shape — indexes nothing rather than wrong text", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-droid-x-"));
+    const pdir = join(dir, "projects", "zz");
+    mkdirSync(pdir, { recursive: true });
+    writeFileSync(
+      join(pdir, "weird.jsonl"),
+      [JSON.stringify({ kind: "telemetry", value: 42 }), "not json at all"].join("\n"),
+    );
+    process.env.KIT_DROID_DIR = dir;
+    const db = openMemoryDb(":memory:");
+    assert.equal(indexDroidSessions(db).messages, 0);
+    db.close();
+    process.env.KIT_DROID_DIR = tmp;
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/src/memory/droid.ts
+++ b/src/memory/droid.ts
@@ -1,0 +1,174 @@
+/**
+ * kit memory — Factory Droid transcript parser (multi-harness).
+ *
+ * Factory's `droid` CLI is Claude-Code-compatible and persists per-session
+ * transcripts as JSONL under ~/.factory/projects/<projectHash>/<session-uuid>.jsonl
+ * — the same line-oriented shape as Claude Code (one JSON record per line, with a
+ * `type`/`message.role` + `message.content` block array). We index the user/
+ * assistant turns, tag harness="droid", and reuse the Claude content flattener.
+ *
+ * Reads are DEFENSIVE: a record's role is taken from `type` | `message.role` |
+ * `role`, and its text from the Claude block-array shape with a plain-string
+ * fallback, so a line that matches no known shape indexes nothing rather than
+ * wrong text. RAW + idempotent + incremental (file_index) + fail-safe; no model
+ * calls. Only ~/.factory/projects/ is globbed — the ~/.factory/sessions/ path is
+ * uncorroborated and deliberately left out.
+ */
+import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, basename } from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { insertMessage, upsertSession, isFileIndexed, markFileIndexed } from "./db.js";
+import { extractText, type IndexResult } from "./parser.js";
+
+export function getDroidProjectsDir(): string {
+  const base = process.env.KIT_DROID_DIR ?? join(homedir(), ".factory");
+  return join(base, "projects");
+}
+
+interface DroidRecord {
+  type?: string;
+  uuid?: string;
+  sessionId?: string;
+  timestamp?: string;
+  cwd?: string;
+  role?: string;
+  content?: unknown;
+  message?: {
+    role?: string;
+    content?: unknown;
+  };
+}
+
+/** Resolve a user/assistant role from the record, or "" if it is neither. */
+function roleOf(rec: DroidRecord): "user" | "assistant" | "" {
+  const raw = rec.type ?? rec.message?.role ?? rec.role ?? "";
+  return raw === "user" || raw === "assistant" ? raw : "";
+}
+
+/** Flatten a record's content: Claude block-array shape, else a plain string. */
+function contentOf(rec: DroidRecord): string {
+  const c = rec.message?.content ?? rec.content;
+  if (typeof c === "string") return c;
+  // extractText handles the Claude {type:"text"|"tool_use"|"tool_result"} blocks.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return extractText(c as any);
+}
+
+function* walkTranscripts(dir: string): Generator<string> {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) yield* walkTranscripts(p);
+    else if (entry.isFile() && entry.name.endsWith(".jsonl")) yield p;
+  }
+}
+
+function indexFile(db: DatabaseSync, filepath: string): { messages: number } {
+  let raw: string;
+  try {
+    raw = readFileSync(filepath, "utf8");
+  } catch {
+    return { messages: 0 };
+  }
+
+  const fallbackSession = basename(filepath, ".jsonl");
+  let sessionId = fallbackSession;
+  let cwd: string | undefined;
+  let messages = 0;
+  let idx = 0;
+  let firstTs: string | undefined;
+  let lastTs: string | undefined;
+  let seededSession = false;
+
+  for (const line of raw.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    let rec: DroidRecord;
+    try {
+      rec = JSON.parse(t) as DroidRecord;
+    } catch {
+      continue;
+    }
+
+    if (!seededSession) {
+      if (typeof rec.sessionId === "string" && rec.sessionId) sessionId = rec.sessionId;
+      if (typeof rec.cwd === "string") cwd = rec.cwd;
+      upsertSession(db, {
+        sessionId,
+        harness: "droid",
+        project: cwd ? basename(cwd) : undefined,
+      });
+      seededSession = true;
+    } else if (!cwd && typeof rec.cwd === "string") {
+      cwd = rec.cwd;
+    }
+
+    const role = roleOf(rec);
+    if (!role) continue;
+    const content = contentOf(rec).trim();
+    if (!content) continue;
+
+    const ts = rec.timestamp;
+    if (ts) {
+      if (!firstTs) firstTs = ts;
+      lastTs = ts;
+    }
+
+    const added = insertMessage(db, {
+      // Prefer the record's own uuid; else a stable per-session index → idempotent.
+      uuid: rec.uuid ?? `droid:${sessionId}:${idx}`,
+      sessionId,
+      type: role,
+      role,
+      content,
+      timestamp: ts,
+      cwd,
+    });
+    idx++;
+    if (added) messages++;
+  }
+
+  if (seededSession) {
+    upsertSession(db, {
+      sessionId,
+      harness: "droid",
+      project: cwd ? basename(cwd) : undefined,
+      firstMessageAt: firstTs,
+      lastMessageAt: lastTs,
+    });
+  }
+  return { messages };
+}
+
+/** Walk ~/.factory/projects and index every transcript. Idempotent + incremental. */
+export function indexDroidSessions(db: DatabaseSync): IndexResult {
+  const dir = getDroidProjectsDir();
+  const result: IndexResult = { files: 0, sessions: 0, messages: 0, toolUses: 0, filesSkipped: 0 };
+  if (!existsSync(dir)) return result;
+
+  for (const filepath of walkTranscripts(dir)) {
+    let st;
+    try {
+      st = statSync(filepath);
+    } catch {
+      continue;
+    }
+    const mtimeMs = Math.floor(st.mtimeMs);
+    if (isFileIndexed(db, filepath, mtimeMs, st.size)) {
+      result.filesSkipped++;
+      continue;
+    }
+    const counts = indexFile(db, filepath);
+    markFileIndexed(db, filepath, mtimeMs, st.size);
+    result.files++;
+    if (counts.messages > 0) result.sessions++;
+    result.messages += counts.messages;
+  }
+  return result;
+}

--- a/src/memory/kiro.test.ts
+++ b/src/memory/kiro.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { openMemoryDb, getStats, searchMessages } from "./db.js";
+import { indexKiroSessions } from "./kiro.js";
+
+describe("memory kiro parser", () => {
+  let tmp: string;
+  let fixture: string;
+  const prev = process.env.KIT_KIRO_DB;
+
+  before(() => {
+    tmp = mkdtempSync(join(tmpdir(), "kit-kiro-"));
+    fixture = join(tmp, "data.sqlite3");
+    const src = new DatabaseSync(fixture);
+    // Newer Kiro builds use `conversations_v2`; keep a legacy `conversations`
+    // table around too to prove the v2 table is PREFERRED, not merged.
+    src.exec("CREATE TABLE conversations (key TEXT PRIMARY KEY, value TEXT)");
+    src.exec("CREATE TABLE conversations_v2 (key TEXT PRIMARY KEY, value TEXT)");
+    src
+      .prepare("INSERT INTO conversations (key, value) VALUES (?, ?)")
+      .run("/legacy/ignored", JSON.stringify({ history: [{ user: { content: "legacy turn" } }] }));
+    const ins = src.prepare("INSERT INTO conversations_v2 (key, value) VALUES (?, ?)");
+    // value = JSON ConversationState. user.content as a string; assistant.content
+    // wrapped in an object to exercise the defensive extractor.
+    ins.run(
+      "/Users/me/dev/api",
+      JSON.stringify({
+        history: [
+          {
+            user: { content: "february deploy question" },
+            assistant: { content: { text: "the deploy answer" } },
+          },
+          {
+            user: { content: "" }, // empty user → skipped, assistant still indexed
+            assistant: { content: "second assistant turn" },
+          },
+        ],
+        transcript: ["> february deploy question", "the deploy answer"],
+      }),
+    );
+    src.close();
+    process.env.KIT_KIRO_DB = fixture;
+  });
+
+  after(() => {
+    if (prev === undefined) delete process.env.KIT_KIRO_DB;
+    else process.env.KIT_KIRO_DB = prev;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("prefers conversations_v2, indexes history turns (defensive extraction), tags harness=kiro", () => {
+    const db = openMemoryDb(":memory:");
+    const res = indexKiroSessions(db);
+    // From conversations_v2 only: turn 1 user+assistant (2) + turn 2 assistant (1) = 3.
+    // The legacy `conversations` "legacy turn" must NOT be indexed.
+    assert.equal(res.messages, 3);
+    assert.equal(getStats(db).messages, 3);
+    assert.equal(searchMessages(db, "legacy").length, 0);
+
+    const session = db
+      .prepare("SELECT harness FROM sessions WHERE session_id = 'kiro:/Users/me/dev/api'")
+      .get() as { harness: string } | undefined;
+    assert.equal(session?.harness, "kiro");
+
+    assert.equal(searchMessages(db, "february").length, 1);
+    // nested {content:{text}} was extracted
+    assert.equal(searchMessages(db, "deploy answer").length, 1);
+    // project-scoped via the conversation key path
+    assert.equal(searchMessages(db, "assistant", { projectPath: "/Users/me/dev/api" }).length, 1);
+    db.close();
+  });
+
+  it("falls back to legacy `conversations` when v2 is absent", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-kiro-legacy-"));
+    const legacyDb = join(dir, "data.sqlite3");
+    const s = new DatabaseSync(legacyDb);
+    s.exec("CREATE TABLE conversations (key TEXT PRIMARY KEY, value TEXT)");
+    s.prepare("INSERT INTO conversations (key, value) VALUES (?, ?)").run(
+      "/Users/me/dev/old",
+      JSON.stringify({ history: [{ user: { content: "old cli turn" } }] }),
+    );
+    s.close();
+    process.env.KIT_KIRO_DB = legacyDb;
+    const db = openMemoryDb(":memory:");
+    assert.equal(indexKiroSessions(db).messages, 1);
+    assert.equal(searchMessages(db, "old cli").length, 1);
+    db.close();
+    process.env.KIT_KIRO_DB = fixture;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("is incremental + idempotent, and fail-safe on a foreign DB shape", () => {
+    const db = openMemoryDb(":memory:");
+    indexKiroSessions(db);
+    const second = indexKiroSessions(db);
+    assert.equal(second.messages, 0);
+    assert.equal(second.filesSkipped, 1);
+    db.close();
+
+    // foreign schema → no crash, nothing indexed
+    const otherDir = mkdtempSync(join(tmpdir(), "kit-kiro-x-"));
+    const otherDb = join(otherDir, "data.sqlite3");
+    const s = new DatabaseSync(otherDb);
+    s.exec("CREATE TABLE other (a TEXT)");
+    s.close();
+    process.env.KIT_KIRO_DB = otherDb;
+    const db2 = openMemoryDb(":memory:");
+    assert.equal(indexKiroSessions(db2).messages, 0);
+    db2.close();
+    process.env.KIT_KIRO_DB = fixture;
+    rmSync(otherDir, { recursive: true, force: true });
+  });
+});

--- a/src/memory/kiro.ts
+++ b/src/memory/kiro.ts
@@ -1,0 +1,177 @@
+/**
+ * kit memory — AWS Kiro CLI transcript parser (multi-harness).
+ *
+ * Kiro's `kiro-cli` chat persists conversations in a SQLite DB with the SAME
+ * layout as the Amazon Q Developer CLI (Kiro is built on the amazon-q-developer-cli
+ * codebase): <data_local_dir>/kiro-cli/data.sqlite3, table
+ * `conversations (key TEXT PRIMARY KEY, value TEXT)` — or `conversations_v2` in
+ * newer builds — where `key` is the working-directory path the chat ran in and
+ * `value` is a JSON-serialized ConversationState:
+ *
+ *   { history: [{ user: UserMessage, assistant: AssistantMessage, ... }],
+ *     transcript: [String] }
+ *
+ * We index the structured `history` user/assistant turns (project-scoped via the
+ * key path), tag harness="kiro", and synthesize stable uuids. Content is
+ * extracted DEFENSIVELY (string | {content|text|prompt} | array) so an
+ * enum/wrapper variant degrades to "no text" rather than wrong text. Read-only,
+ * idempotent, fail-safe, no model calls.
+ */
+import { existsSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { insertMessage, upsertSession, isFileIndexed, markFileIndexed } from "./db.js";
+import type { IndexResult } from "./parser.js";
+
+/** Mirror of Rust `dirs::data_local_dir()` per platform. */
+function dataLocalDir(): string {
+  const home = homedir();
+  switch (process.platform) {
+    case "darwin":
+      return join(home, "Library", "Application Support");
+    case "win32":
+      return process.env.LOCALAPPDATA ?? join(home, "AppData", "Local");
+    default:
+      return process.env.XDG_DATA_HOME ?? join(home, ".local", "share");
+  }
+}
+
+export function getKiroDb(): string {
+  return process.env.KIT_KIRO_DB ?? join(dataLocalDir(), "kiro-cli", "data.sqlite3");
+}
+
+/** Defensively pull message text from a string | {content|text|prompt} | array. */
+function textOf(node: unknown, depth = 0): string {
+  if (typeof node === "string") return node;
+  if (depth > 3 || node === null || typeof node !== "object") return "";
+  if (Array.isArray(node)) {
+    return node
+      .map((n) => textOf(n, depth + 1))
+      .filter(Boolean)
+      .join("\n");
+  }
+  const obj = node as Record<string, unknown>;
+  for (const field of ["content", "text", "prompt"]) {
+    const v = obj[field];
+    if (typeof v === "string" && v.trim()) return v;
+    if (v && typeof v === "object") {
+      const nested = textOf(v, depth + 1);
+      if (nested) return nested;
+    }
+  }
+  return "";
+}
+
+interface HistoryEntry {
+  user?: unknown;
+  assistant?: unknown;
+}
+interface ConversationState {
+  history?: HistoryEntry[];
+}
+
+function indexConversation(db: DatabaseSync, key: string, value: string): { messages: number } {
+  let state: ConversationState;
+  try {
+    state = JSON.parse(value) as ConversationState;
+  } catch {
+    return { messages: 0 };
+  }
+  if (!Array.isArray(state.history)) return { messages: 0 };
+
+  const sessionId = `kiro:${key}`;
+  // `key` is the working-directory path → use it as cwd for project-scoped recall.
+  const cwd = key.startsWith("/") || /^[A-Za-z]:\\/.test(key) ? key : undefined;
+  upsertSession(db, { sessionId, harness: "kiro", project: cwd ? undefined : key });
+
+  let messages = 0;
+  state.history.forEach((entry, idx) => {
+    const userText = textOf(entry?.user).trim();
+    if (userText) {
+      const added = insertMessage(db, {
+        uuid: `kiro:${key}:${idx}:user`,
+        sessionId,
+        type: "user",
+        role: "user",
+        content: userText,
+        cwd,
+      });
+      if (added) messages++;
+    }
+    const assistantText = textOf(entry?.assistant).trim();
+    if (assistantText) {
+      const added = insertMessage(db, {
+        uuid: `kiro:${key}:${idx}:assistant`,
+        sessionId,
+        type: "assistant",
+        role: "assistant",
+        content: assistantText,
+        cwd,
+      });
+      if (added) messages++;
+    }
+  });
+  return { messages };
+}
+
+/** Read the first table that exists, preferring the newer `conversations_v2`. */
+function selectConversations(src: DatabaseSync): { key: string; value: string }[] | null {
+  for (const table of ["conversations_v2", "conversations"]) {
+    try {
+      return src.prepare(`SELECT key, value FROM ${table}`).all() as unknown as {
+        key: string;
+        value: string;
+      }[];
+    } catch {
+      // table absent / differs → try the next candidate
+    }
+  }
+  return null;
+}
+
+/** Read ~/…/kiro-cli/data.sqlite3 and index every conversation. Idempotent + fail-safe. */
+export function indexKiroSessions(db: DatabaseSync): IndexResult {
+  const result: IndexResult = { files: 0, sessions: 0, messages: 0, toolUses: 0, filesSkipped: 0 };
+  const dbPath = getKiroDb();
+  if (!existsSync(dbPath)) return result;
+
+  let st;
+  try {
+    st = statSync(dbPath);
+  } catch {
+    return result;
+  }
+  const mtimeMs = Math.floor(st.mtimeMs);
+  if (isFileIndexed(db, dbPath, mtimeMs, st.size)) {
+    result.filesSkipped++;
+    return result;
+  }
+
+  let src: DatabaseSync;
+  try {
+    src = new DatabaseSync(dbPath, { readOnly: true });
+  } catch {
+    return result; // locked / unreadable → fail-safe
+  }
+
+  try {
+    const rows = selectConversations(src);
+    if (rows === null) {
+      markFileIndexed(db, dbPath, mtimeMs, st.size); // no known table → fail-safe
+      return result;
+    }
+    for (const row of rows) {
+      if (typeof row.value !== "string") continue;
+      const counts = indexConversation(db, row.key, row.value);
+      if (counts.messages > 0) result.sessions++;
+      result.messages += counts.messages;
+    }
+    result.files++;
+  } finally {
+    src.close();
+  }
+
+  markFileIndexed(db, dbPath, mtimeMs, st.size);
+  return result;
+}

--- a/src/memory/parser.ts
+++ b/src/memory/parser.ts
@@ -26,6 +26,7 @@ import { indexCursorSessions } from "./cursor.js";
 import { indexAmazonQSessions } from "./amazonq.js";
 import { indexKiroSessions } from "./kiro.js";
 import { indexDroidSessions } from "./droid.js";
+import { indexAiderSessions } from "./aider.js";
 import { indexClineSessions } from "./cline.js";
 import { indexOpenCodeSessions } from "./opencode.js";
 
@@ -268,6 +269,7 @@ export function indexAllHarnesses(db: DatabaseSync): HarnessResults {
     "amazon-q": indexAmazonQSessions(db),
     kiro: indexKiroSessions(db),
     droid: indexDroidSessions(db),
+    aider: indexAiderSessions(db),
     cline: indexClineSessions(db),
     opencode: indexOpenCodeSessions(db),
   };

--- a/src/memory/parser.ts
+++ b/src/memory/parser.ts
@@ -25,6 +25,7 @@ import { indexContinueSessions } from "./continue.js";
 import { indexCursorSessions } from "./cursor.js";
 import { indexAmazonQSessions } from "./amazonq.js";
 import { indexKiroSessions } from "./kiro.js";
+import { indexDroidSessions } from "./droid.js";
 import { indexClineSessions } from "./cline.js";
 import { indexOpenCodeSessions } from "./opencode.js";
 
@@ -266,6 +267,7 @@ export function indexAllHarnesses(db: DatabaseSync): HarnessResults {
     cursor: indexCursorSessions(db),
     "amazon-q": indexAmazonQSessions(db),
     kiro: indexKiroSessions(db),
+    droid: indexDroidSessions(db),
     cline: indexClineSessions(db),
     opencode: indexOpenCodeSessions(db),
   };

--- a/src/memory/parser.ts
+++ b/src/memory/parser.ts
@@ -24,6 +24,7 @@ import { indexGeminiSessions } from "./gemini.js";
 import { indexContinueSessions } from "./continue.js";
 import { indexCursorSessions } from "./cursor.js";
 import { indexAmazonQSessions } from "./amazonq.js";
+import { indexKiroSessions } from "./kiro.js";
 import { indexClineSessions } from "./cline.js";
 import { indexOpenCodeSessions } from "./opencode.js";
 
@@ -264,6 +265,7 @@ export function indexAllHarnesses(db: DatabaseSync): HarnessResults {
     continue: indexContinueSessions(db),
     cursor: indexCursorSessions(db),
     "amazon-q": indexAmazonQSessions(db),
+    kiro: indexKiroSessions(db),
     cline: indexClineSessions(db),
     opencode: indexOpenCodeSessions(db),
   };

--- a/src/memory/parser.ts
+++ b/src/memory/parser.ts
@@ -27,6 +27,7 @@ import { indexAmazonQSessions } from "./amazonq.js";
 import { indexKiroSessions } from "./kiro.js";
 import { indexDroidSessions } from "./droid.js";
 import { indexAiderSessions } from "./aider.js";
+import { indexAntigravitySessions } from "./antigravity.js";
 import { indexClineSessions } from "./cline.js";
 import { indexOpenCodeSessions } from "./opencode.js";
 
@@ -270,6 +271,7 @@ export function indexAllHarnesses(db: DatabaseSync): HarnessResults {
     kiro: indexKiroSessions(db),
     droid: indexDroidSessions(db),
     aider: indexAiderSessions(db),
+    antigravity: indexAntigravitySessions(db),
     cline: indexClineSessions(db),
     opencode: indexOpenCodeSessions(db),
   };


### PR DESCRIPTION
## Description

Broadens kit's four-surface agent model (rules / memory / install-gate / lifecycle hooks) across the coding-agent ecosystem, driven by a research → adversarial-verify → synthesize workflow. Ships **only** where the transcript path, format, and block contract are verified; unverifiable surfaces are documented as honest limitations rather than stubbed (no false-green). Bumps to `5.0.0-alpha.1`.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Related Issues

- Related to the road-to-5.0 north star (kit-research `agent-coverage.md`, updated to reflect what shipped).

## Changes Made

- **AWS Kiro — memory** (`src/memory/kiro.ts`): `kiro-cli/data.sqlite3`, reads `conversations_v2` → falls back to `conversations`, `harness=kiro`. 10th indexed harness. (Gate + rules shipped earlier in #221/#220.)
- **Factory Droid — memory + install-gate**: indexes Claude-Code-compatible JSONL under `~/.factory/projects/**/*.jsonl` (`harness=droid`, defensive/fail-safe); PreToolUse gate to `.factory/hooks.json` with matcher `"Execute"` (the one adaptation; `kit gate-bash` unchanged).
- **Aider — memory + rules**: project-local markdown parser for `$GIT_ROOT/.aider.chat.history.md` (honors `AIDER_CHAT_HISTORY_FILE`); **bespoke** rules installer writes `CONVENTIONS.md` AND wires `read: CONVENTIONS.md` into `.aider.conf.yml` (conservative text merge, no YAML dep — refuses to edit a flow list). No install-gate (no pre-tool hook surface).
- **Google Antigravity — memory + install-gate**: JSONL parser for `~/.gemini/{antigravity-cli,antigravity-ide,antigravity}/brain/*/.system_generated/logs/transcript_full.jsonl` (a real gap the `~/.gemini/tmp` Gemini parser never covered); gate to workspace `.agents/hooks.json` (matcher `"run_command"`).
- **Augment — install-gate**: `.augment/settings.json`, matcher `"launch-process"`.
- **Kilo Code — rules marker**: `.kilocode`/`.kilo`/`kilo.jsonc` → `AGENTS.md`.
- **Shared plumbing**: `extractCommandFromHookPayload` now also reads `toolCall.args.CommandLine` (Antigravity) and `arguments.command` (Amp delegate) — pure, backward-compatible.
- Registries grown (`indexAllHarnesses`, `GateInstallEntry` + `installAllInstallGates`); `kit agent-config` runs the bespoke Aider installer; CLI "Agent support" summary + `docs/MEMORY.md` + CHANGELOG updated.

## Testing

### Test Coverage
- [x] Added new tests (Kiro, Droid, Aider, Antigravity parsers; Droid/Augment/Antigravity gates; `mergeAiderRead`; `installAiderRules`; new `extractCommandFromHookPayload` wire shapes)
- [x] Updated existing tests
- [x] All tests pass (`npm test`) — 2106 passing

### Manual Testing
1. `npm run build` — clean.
2. `npm test` — 2106 pass, 0 fail.
3. `npm run lint` — 0 errors (pre-existing complexity warnings only); `prettier --check` clean.

## Breaking Changes

None / N/A — additive parsers/installers + a backward-compatible helper extension.

## Deliberately deferred (honest limitation, not shipped)

- **Amp install-gate** — plumbing is in place, but the delegate exit-code contract needs verification on a real install before wiring.
- **Amp memory** — cloud-only, no local transcript.
- **Augment memory** — local but path/schema unverified.
- **Kilo memory + gate** — contradicted across product generations (issue #9476).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've updated documentation as needed
- [x] All new code has test coverage
- [x] All tests pass locally (`npm test`)
- [x] No new warnings or errors introduced
- [x] Commit messages follow conventions
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

## Performance Impact

- [x] No performance impact (parsers are incremental via `file_index`; absent agents are skipped silently)

## Reviewer Notes

Zero-LLM / local-first / fail-closed discipline preserved throughout. Every parser has a `KIT_<AGENT>_DB`/`_DIR`/`_HISTORY` env override for testability + a Windows escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_