### PR TITLE
feat(5.0): v1 of the three north-star pillars — KeyStore, exec-broker, RBAC (5.0.0-alpha.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.0.0-alpha.2] - 2026-07-04
+
+Road to 5.0, step two: land **v1 of the three north-star pillars** behind the
+interfaces the design calls for — real, tested, fail-closed modules with honest
+degradation where a capability can't be exercised yet. These are foundations
+(new modules, not yet wired into every call path); wiring + hardware/control-plane
+backends follow in beta/rc. Built via a multi-agent workflow (design → implement
+→ adversarial verify), then hardened on the verify findings.
+
+### Added
+
+- **Pelare 1 — hardware-rooted identity behind a `KeyStore` port** (`src/keystore/`).
+  A `KeyStore` interface (`available`/`publicKeyPem`/`sign`/`create`/`rotate`) with a
+  `file` backend that WRAPS the existing 0600-file identity (pure delegation — the
+  deterministic offline `verifySignature` is untouched), plus honest `secure-enclave`
+  (darwin) and `tpm` (linux/win) extension-point stubs that report
+  `available()={ok:false, reason}` and fail-closed on use (never a false green).
+  `resolveKeyStore()` picks the best available backend, else falls back to file and
+  ALWAYS surfaces the degradation; a forced-but-unavailable `KIT_KEYSTORE` refuses to
+  silently downgrade.
+- **Pelare 3 — gate → runtime exec-broker** (`src/exec-broker/`). Pure, fail-closed
+  decision gates — `checkEgress` (hostname allowlist, subdomain-aware, default-deny),
+  `checkFsWrite` (resolve traversal, writes only within project root), `scopeEnv`
+  (least-privilege env) — and `brokerExec`, which enforces an operation's DECLARED
+  effects BEFORE running, default-denies with no policy, scopes env to the REQUESTED
+  keys, adds an impure realpath symlink-escape check, and writes a fail-closed
+  pre-exec audit entry. Composes on top of `runGoverned` (resources vs identity/budget).
+- **Pelare 2 — RBAC bound to an IdP at enrollment, enforced offline** (`src/rbac/`).
+  Role-bindings (`subject kid → role → permissions`) ride inside the org-signed
+  `.kit-policy`, so authority is verified OFFLINE against `.kit-policy.signers` — there
+  is ZERO network at decision time. `can()`/`effectivePermissions()` are pure and
+  fail-closed (unsigned/unknown-subject/malformed → deny; prototype-safe role lookup;
+  local revocation as a secondary deny). `IdentityProvider` + a GitHub backend map
+  team membership → roles at ENROLLMENT time behind an injectable fetch (Azure/Entra
+  and Google documented as future backends of the same interface); a non-OK GitHub
+  response fails closed (throws) rather than reporting spurious empty membership.
+
 ## [5.0.0-alpha.1] - 2026-07-04
 
 First step on the road to 5.0: broaden kit's four-surface agent model

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.0.0-alpha.1",
+  "version": "5.0.0-alpha.2",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/exec-broker/broker.test.ts
+++ b/src/exec-broker/broker.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, existsSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { brokerExec, type BrokerContext } from "./broker.js";
+import type { BrokerPolicy } from "./policy.js";
+
+const POLICY: BrokerPolicy = {
+  egress: { allow: ["api.example.com"] },
+  fs: { root: "/repo" },
+  env: { declared: ["TOKEN", "REGION"] },
+};
+
+const CTX = (over: Partial<BrokerContext> = {}): BrokerContext => ({
+  operation: "test.op",
+  operationType: "write",
+  ...over,
+});
+
+let cwd: string;
+let sandbox: string;
+let identityDir: string;
+
+function auditLines(): Record<string, unknown>[] {
+  const p = join(sandbox, ".kit-audit.jsonl");
+  if (!existsSync(p)) return [];
+  return readFileSync(p, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+beforeEach(() => {
+  cwd = process.cwd();
+  sandbox = mkdtempSync(join(tmpdir(), "kit-broker-"));
+  // Isolate identity so audit signing never touches a real ~/.kit.
+  identityDir = mkdtempSync(join(tmpdir(), "kit-broker-id-"));
+  process.env.KIT_IDENTITY_DIR = identityDir;
+  process.chdir(sandbox);
+});
+
+afterEach(() => {
+  process.chdir(cwd);
+  delete process.env.KIT_IDENTITY_DIR;
+  rmSync(sandbox, { recursive: true, force: true });
+  rmSync(identityDir, { recursive: true, force: true });
+});
+
+describe("brokerExec default-deny", () => {
+  it("denies when policy is null and NEVER runs the op", async () => {
+    let ran = false;
+    const out = await brokerExec(CTX(), null, async () => {
+      ran = true;
+      return 1;
+    });
+    assert.equal(out.ok, false);
+    assert.match(out.reason ?? "", /no policy \(default-deny\)/);
+    assert.equal(ran, false);
+    const lines = auditLines();
+    assert.equal(lines.length, 1);
+    assert.equal(lines[0].success, false);
+  });
+
+  it("denies when policy is undefined", async () => {
+    const out = await brokerExec(CTX(), undefined, async () => 1);
+    assert.equal(out.ok, false);
+  });
+});
+
+describe("brokerExec per-gate denial", () => {
+  it("denies an out-of-allowlist egress target and does not run", async () => {
+    let ran = false;
+    const out = await brokerExec(CTX({ egressTargets: ["https://evil.com"] }), POLICY, async () => {
+      ran = true;
+      return 1;
+    });
+    assert.equal(out.ok, false);
+    assert.equal(ran, false);
+    assert.equal(out.denials?.length, 1);
+    assert.equal(auditLines().at(-1)?.success, false);
+  });
+
+  it("denies an fs-write escaping root", async () => {
+    const out = await brokerExec(CTX({ fsWrites: ["/repo/../etc/passwd"] }), POLICY, async () => 1);
+    assert.equal(out.ok, false);
+    assert.equal(out.denials?.length, 1);
+  });
+
+  it("denies an undeclared env key", async () => {
+    const out = await brokerExec(
+      CTX({ envRequested: ["SECRET_UNDECLARED"] }),
+      POLICY,
+      async () => 1,
+    );
+    assert.equal(out.ok, false);
+    assert.equal(out.denials?.length, 1);
+  });
+
+  it("collects multiple denials across gates", async () => {
+    const out = await brokerExec(
+      CTX({
+        egressTargets: ["https://evil.com"],
+        fsWrites: ["../outside"],
+        envRequested: ["NOPE"],
+      }),
+      POLICY,
+      async () => 1,
+    );
+    assert.equal(out.ok, false);
+    assert.equal(out.denials?.length, 3);
+  });
+});
+
+describe("brokerExec fail-closed audit", () => {
+  it("refuses to run when the pre-exec 'authorized' audit append fails", async () => {
+    // Force appendAuditEventDirect to return false by making the audit path a
+    // DIRECTORY, so appendFile fails with EISDIR even as root (permission-
+    // independent).
+    mkdirSync(join(sandbox, ".kit-audit.jsonl"));
+    let ran = false;
+    const out = await brokerExec(CTX(), POLICY, async () => {
+      ran = true;
+      return 1;
+    });
+    assert.equal(out.ok, false);
+    assert.match(out.reason ?? "", /audit-log unavailable.*fail-closed/);
+    assert.equal(ran, false);
+  });
+});
+
+describe("brokerExec happy path", () => {
+  it("runs with exactly the REQUESTED (least-privilege) env subset and returns ok", async () => {
+    process.env.TOKEN = "t";
+    process.env.REGION = "eu";
+    process.env.OTHER_SECRET = "leak";
+    try {
+      let seen: Record<string, string> | undefined;
+      const out = await brokerExec(
+        CTX({ egressTargets: ["https://api.example.com/x"], envRequested: ["TOKEN"] }),
+        POLICY,
+        async (env) => {
+          seen = env;
+          return "done";
+        },
+      );
+      assert.equal(out.ok, true);
+      assert.equal(out.result, "done");
+      // Least privilege: only the REQUESTED key (TOKEN) is handed to run(), even
+      // though REGION is also declared — declaring a key permits it, requesting it
+      // provisions it.
+      assert.deepEqual(out.scopedEnv, { TOKEN: "t" });
+      assert.deepEqual(seen, { TOKEN: "t" });
+      assert.equal(seen && "REGION" in seen, false);
+      assert.equal(seen && "OTHER_SECRET" in seen, false);
+      // authorized (pre-exec) + success (post-exec) entries.
+      const lines = auditLines();
+      assert.equal(lines.length, 2);
+      assert.equal((lines[0].metadata as Record<string, unknown>)?.phase, "authorized");
+      assert.equal(lines[1].success, true);
+    } finally {
+      delete process.env.TOKEN;
+      delete process.env.REGION;
+      delete process.env.OTHER_SECRET;
+    }
+  });
+
+  it("audits failure and returns reason when run() throws", async () => {
+    const out = await brokerExec(CTX(), POLICY, async () => {
+      throw new Error("boom");
+    });
+    assert.equal(out.ok, false);
+    assert.equal(out.reason, "boom");
+    assert.equal(auditLines().at(-1)?.success, false);
+  });
+
+  it("composes with a runGoverned-shaped inner run (round-trips result)", async () => {
+    type Governed<T> = { ok: boolean; result?: T; reason?: string };
+    const fakeRunGoverned = async (): Promise<Governed<number>> => ({ ok: true, result: 42 });
+    const out = await brokerExec(CTX(), POLICY, () =>
+      fakeRunGoverned().then((o) =>
+        o.ok ? (o.result as number) : Promise.reject(new Error(o.reason)),
+      ),
+    );
+    assert.equal(out.ok, true);
+    assert.equal(out.result, 42);
+  });
+});
+
+describe("brokerExec symlink hardening (impure realpath check)", () => {
+  it("denies a write through a symlink inside root that escapes root", async () => {
+    const root = mkdtempSync(join(tmpdir(), "kit-broker-root-"));
+    const outside = mkdtempSync(join(tmpdir(), "kit-broker-out-"));
+    try {
+      symlinkSync(outside, join(root, "escape")); // root/escape -> outside
+      const policy: BrokerPolicy = { ...POLICY, fs: { root } };
+      let ran = false;
+      const out = await brokerExec(CTX({ fsWrites: ["escape/evil.txt"] }), policy, async () => {
+        ran = true;
+        return 1;
+      });
+      // Pure string check would ALLOW (escape/ is lexically under root); the
+      // realpath check catches that root/escape actually resolves outside root.
+      assert.equal(out.ok, false);
+      assert.equal(ran, false);
+      assert.match(out.denials?.join(" ") ?? "", /escapes root|realpath/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("allows a write to a not-yet-existing path genuinely under root", async () => {
+    const root = mkdtempSync(join(tmpdir(), "kit-broker-root2-"));
+    try {
+      const policy: BrokerPolicy = { ...POLICY, fs: { root } };
+      const out = await brokerExec(CTX({ fsWrites: ["sub/new.txt"] }), policy, async () => "ok");
+      assert.equal(out.ok, true);
+      assert.equal(out.result, "ok");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("brokerExec is offline", () => {
+  it("succeeds even if global fetch is stubbed to throw (zero egress)", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (() => {
+      throw new Error("network access attempted");
+    }) as typeof fetch;
+    try {
+      const out = await brokerExec(CTX(), POLICY, async () => "ok");
+      assert.equal(out.ok, true);
+      assert.equal(out.result, "ok");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/src/exec-broker/broker.ts
+++ b/src/exec-broker/broker.ts
@@ -1,0 +1,194 @@
+// Pelare 3 — exec-broker: the enforcement wrapper.
+//
+// brokerExec moves governance from advisory-at-chokepoint to ENFORCED-AT-EXEC:
+// it runs the three pure decision gates on an operation's DECLARED effects
+// BEFORE invoking run(), default-denies when policy is absent, and audits every
+// allow/deny to the existing hash-chained trail via appendAuditEventDirect.
+//
+// COMPOSITION: the broker gates *resources* (egress / fs / env); runGoverned
+// gates *identity/budget/permission/secret-expiration*. It composes ON TOP of
+// runGoverned — the caller wires `run` to it — and never rewrites it:
+//
+//   brokerExec(ctx, policy, () =>
+//     runGoverned(config, ctx, realOp).then((o) =>
+//       o.ok ? o.result : Promise.reject(new Error(o.reason))));
+//
+// When both audit, one operation yields two audit ops (exec-broker.* and the
+// governance op) — intended, separate concerns.
+//
+// TRUST BOUNDARY (no false-green): context.egressTargets / fsWrites /
+// envRequested must be populated HONESTLY by the tool adapter. The broker only
+// gates DECLARED effects; an undeclared effect is not "allowed", it is simply
+// un-mediated — so the adapter is the enforcement surface that must be reviewed.
+//
+// Zero LLM, zero network. Deterministic + offline.
+
+import { existsSync, realpathSync } from "node:fs";
+import { dirname, resolve, sep } from "node:path";
+import type { OperationContext } from "../governance-middleware.js";
+import { appendAuditEventDirect } from "../audit.js";
+import { checkEgress, checkFsWrite, scopeEnv } from "./decisions.js";
+import type { BrokerPolicy } from "./policy.js";
+
+/** Environment label stamped on broker audit entries. */
+const BROKER_ENV = "exec-broker";
+
+export interface BrokerContext extends OperationContext {
+  /** Network hosts/URLs this operation intends to reach. */
+  egressTargets?: string[];
+  /** Filesystem paths this operation intends to write. */
+  fsWrites?: string[];
+  /** Environment variable names this operation needs. */
+  envRequested?: string[];
+}
+
+export interface BrokerOutcome<T> {
+  /** True → all gates passed and run() executed; result is set. */
+  ok: boolean;
+  result?: T;
+  reason?: string;
+  /** Populated on a gate denial: one line per denied effect. */
+  denials?: string[];
+  /** The declared env subset handed to run() (present on the allow path). */
+  scopedEnv?: Record<string, string>;
+}
+
+/**
+ * Enforce the resource gates, then run. See module doc for the composition and
+ * trust-boundary contracts.
+ */
+export async function brokerExec<T>(
+  context: BrokerContext,
+  policy: BrokerPolicy | null | undefined,
+  run: (scopedEnv: Record<string, string>) => Promise<T>,
+): Promise<BrokerOutcome<T>> {
+  // Default-deny when policy is absent. run() is NEVER invoked.
+  if (!policy) {
+    const reason = "exec-broker: no policy (default-deny)";
+    await audit(context, false, reason);
+    return { ok: false, reason };
+  }
+
+  // Collect denials across all three gates before deciding.
+  const denials = collectDenials(context, policy);
+
+  // Least privilege: hand run() ONLY the keys it actually requested (all of which
+  // are, by the check above, declared) — not the whole declared set. A caller that
+  // requests nothing gets nothing.
+  const scopedEnv = scopeEnv(context.envRequested ?? [], process.env);
+
+  if (denials.length > 0) {
+    const reason = `exec-broker: denied (${denials.length} violation${
+      denials.length === 1 ? "" : "s"
+    })`;
+    await audit(context, false, reason, { denials });
+    return { ok: false, reason, denials };
+  }
+
+  // Fail-closed auditability (mirrors withGovernance's destructive gate):
+  // persist a pre-exec "authorized" entry and REFUSE to run if it can't be
+  // written. The post-exec success log alone is fail-open.
+  const authorized = await appendAuditEventDirect({
+    operation: context.operation,
+    environment: BROKER_ENV,
+    success: true,
+    metadata: { ...context.metadata, phase: "authorized" },
+  });
+  if (!authorized) {
+    return {
+      ok: false,
+      reason: "exec-broker: audit-log unavailable; refusing to execute (fail-closed)",
+    };
+  }
+
+  // All gates passed → execute with the scoped env, then audit success/failure.
+  try {
+    const result = await run(scopedEnv);
+    await audit(context, true, undefined);
+    return { ok: true, result, scopedEnv };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    await audit(context, false, reason);
+    return { ok: false, reason };
+  }
+}
+
+/**
+ * Run all three resource gates over an operation's DECLARED effects and return one
+ * denial line per violation (empty array = all gates passed). Extracted from
+ * brokerExec so the enforcement wrapper stays simple. fs-write is checked twice:
+ * the pure string/traversal gate, then the impure realpath symlink gate.
+ */
+function collectDenials(context: BrokerContext, policy: BrokerPolicy): string[] {
+  const denials: string[] = [];
+
+  for (const target of context.egressTargets ?? []) {
+    const d = checkEgress(target, { allow: policy.egress.allow });
+    if (!d.ok) denials.push(d.reason ?? `egress denied: ${target}`);
+  }
+
+  for (const path of context.fsWrites ?? []) {
+    const d = checkFsWrite(path, policy.fs.root);
+    if (!d.ok) {
+      denials.push(d.reason ?? `fs-write denied: ${path}`);
+      continue;
+    }
+    const sl = checkFsWriteRealpath(path, policy.fs.root);
+    if (!sl.ok) denials.push(sl.reason ?? `fs-write symlink-escape denied: ${path}`);
+  }
+
+  for (const key of context.envRequested ?? []) {
+    if (!policy.env.declared.includes(key)) {
+      denials.push(`env: requested key ${key} not declared in policy`);
+    }
+  }
+
+  return denials;
+}
+
+/**
+ * Symlink-aware fs-write check (impure companion to the pure decisions.checkFsWrite).
+ * Realpath the nearest EXISTING ancestor of the resolved target and confirm it is
+ * the real root or strictly under it — catching a symlink inside the root that
+ * points outside. The not-yet-existing tail of the path cannot contain symlinks
+ * (nothing is there to be one). Any fs/realpath error → fail-closed deny.
+ */
+function checkFsWriteRealpath(path: string, projectRoot: string): { ok: boolean; reason?: string } {
+  try {
+    const root = realpathSync(resolve(projectRoot));
+    let cur = resolve(root, path);
+    while (!existsSync(cur)) {
+      const parent = dirname(cur);
+      if (parent === cur) break; // reached the filesystem root
+      cur = parent;
+    }
+    const real = realpathSync(cur);
+    if (real === root || real.startsWith(root + sep)) return { ok: true };
+    return { ok: false, reason: `fs-write: real path ${real} escapes root ${root}` };
+  } catch {
+    return { ok: false, reason: "fs-write: realpath check failed (fail-closed)" };
+  }
+}
+
+/**
+ * Best-effort audit of a broker decision. A DENY still returns deny even if this
+ * append fails (we never fail-open to allow) — but surface the logging failure to
+ * stderr, as audit.ts does, so the denial is not silently unlogged.
+ */
+async function audit(
+  context: BrokerContext,
+  success: boolean,
+  error: string | undefined,
+  extra?: Record<string, unknown>,
+): Promise<void> {
+  const logged = await appendAuditEventDirect({
+    operation: context.operation,
+    environment: BROKER_ENV,
+    success,
+    error,
+    metadata: extra ? { ...context.metadata, ...extra } : context.metadata,
+  });
+  if (!logged) {
+    console.error(`[kit] exec-broker: audit append failed for ${context.operation}`);
+  }
+}

--- a/src/exec-broker/decisions.test.ts
+++ b/src/exec-broker/decisions.test.ts
@@ -1,0 +1,122 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolve, sep } from "node:path";
+import { checkEgress, checkFsWrite, scopeEnv } from "./decisions.js";
+
+describe("checkEgress", () => {
+  it("permits an exact host from a full URL", () => {
+    assert.equal(checkEgress("https://api.example.com/x", { allow: ["api.example.com"] }).ok, true);
+  });
+
+  it("permits a bare host (no scheme)", () => {
+    assert.equal(checkEgress("api.example.com", { allow: ["api.example.com"] }).ok, true);
+  });
+
+  it("permits host with port and userinfo (compares hostname only)", () => {
+    assert.equal(
+      checkEgress("http://user:pw@api.example.com:8080/p", { allow: ["api.example.com"] }).ok,
+      true,
+    );
+  });
+
+  it("denies a host not in the allowlist", () => {
+    assert.equal(checkEgress("https://evil.com", { allow: ["api.example.com"] }).ok, false);
+  });
+
+  it("denies the suffix-spoof host api.example.com.evil.com", () => {
+    assert.equal(
+      checkEgress("http://api.example.com.evil.com", { allow: ["api.example.com"] }).ok,
+      false,
+    );
+  });
+
+  it("empty allowlist denies everything (default-deny)", () => {
+    assert.equal(checkEgress("https://api.example.com", { allow: [] }).ok, false);
+  });
+
+  it("malformed targets are denied, never throw", () => {
+    assert.equal(checkEgress("::::", { allow: ["api.example.com"] }).ok, false);
+    assert.equal(checkEgress("", { allow: ["api.example.com"] }).ok, false);
+  });
+
+  it("host match is case-insensitive", () => {
+    assert.equal(checkEgress("https://API.Example.COM", { allow: ["api.example.com"] }).ok, true);
+    assert.equal(checkEgress("https://api.example.com", { allow: ["API.EXAMPLE.COM"] }).ok, true);
+  });
+
+  it("dot-prefixed entry is a subdomain suffix match", () => {
+    const allow = [".example.com"];
+    assert.equal(checkEgress("https://api.example.com", { allow }).ok, true);
+    assert.equal(checkEgress("https://example.com", { allow }).ok, true);
+    assert.equal(checkEgress("https://api.example.com.evil.com", { allow }).ok, false);
+    assert.equal(checkEgress("https://notexample.com", { allow }).ok, false);
+  });
+
+  it("ignores empty/non-string allow entries", () => {
+    assert.equal(checkEgress("https://api.example.com", { allow: [""] }).ok, false);
+  });
+});
+
+describe("checkFsWrite", () => {
+  const root = resolve("/repo");
+
+  it("permits a file directly under root", () => {
+    assert.equal(checkFsWrite(`${root}${sep}a.txt`, root).ok, true);
+  });
+
+  it("permits root itself", () => {
+    assert.equal(checkFsWrite(root, root).ok, true);
+  });
+
+  it("permits a nested path under root", () => {
+    assert.equal(checkFsWrite(`${root}${sep}a${sep}b${sep}c.txt`, root).ok, true);
+  });
+
+  it("resolves a relative path against root", () => {
+    assert.equal(checkFsWrite("a.txt", root).ok, true);
+  });
+
+  it("denies '..' traversal that escapes root", () => {
+    assert.equal(checkFsWrite(`${root}${sep}..${sep}etc${sep}passwd`, root).ok, false);
+    assert.equal(checkFsWrite("../outside", root).ok, false);
+  });
+
+  it("denies an absolute path outside root", () => {
+    assert.equal(checkFsWrite(resolve("/etc/passwd"), root).ok, false);
+  });
+
+  it("denies the prefix-without-separator escape (/repofoo vs /repo)", () => {
+    assert.equal(checkFsWrite(resolve("/repofoo/x"), root).ok, false);
+  });
+
+  it("never throws on odd input", () => {
+    assert.equal(typeof checkFsWrite("", root).ok, "boolean");
+  });
+});
+
+describe("scopeEnv", () => {
+  it("returns only declared keys that are present", () => {
+    assert.deepEqual(scopeEnv(["A", "B"], { A: "1", C: "3" }), { A: "1" });
+  });
+
+  it("empty declared yields empty object", () => {
+    assert.deepEqual(scopeEnv([], { A: "1" }), {});
+  });
+
+  it("omits undefined-valued declared keys", () => {
+    assert.deepEqual(scopeEnv(["A", "B"], { A: "1", B: undefined }), { A: "1" });
+  });
+
+  it("does NOT mutate the input env object", () => {
+    const full = { A: "1", C: "3" };
+    const before = { ...full };
+    scopeEnv(["A"], full);
+    assert.deepEqual(full, before);
+  });
+
+  it("returns a NEW object, not a reference to input", () => {
+    const full = { A: "1" };
+    const out = scopeEnv(["A"], full);
+    assert.notEqual(out, full);
+  });
+});

--- a/src/exec-broker/decisions.ts
+++ b/src/exec-broker/decisions.ts
@@ -1,0 +1,115 @@
+// Pelare 3 — exec-broker: the three pure, fail-closed decision functions.
+//
+// These gate the CONCRETE effects of an agent's tool-call (network egress,
+// filesystem write, environment exposure) at the moment before `run()` touches a
+// real resource. They are PURE: no I/O, no env reads, no throws, no clock, no
+// randomness — the same inputs always yield the same decision, so they are the
+// security-critical core that is exhaustively unit-testable.
+//
+// Zero LLM, zero network. Uses only node:path (resolve, sep) and node:url (URL).
+//
+// BOUNDARY (documented, mirrors identity.ts documenting its same-UID boundary):
+// checkFsWrite is a pure string/path-resolve check — it cannot follow symlinks.
+// A symlink INSIDE projectRoot that points outside would pass this string check
+// yet write outside. Closing that requires fs.realpathSync at the actual write
+// site (which breaks purity), so it stays out of this function by design.
+
+import { resolve, sep } from "node:path";
+
+export interface BrokerDecision {
+  /** True → the effect is permitted by policy. False → denied (fail-closed). */
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * Extract a normalized (lowercase) hostname from a target string, or null if it
+ * cannot be parsed. Accepts full URLs ("https://host/x", "http://u@host:8080")
+ * and bare hosts ("api.example.com", "host:8080"). Returns null — never throws —
+ * on malformed input ("", "::::"), so the caller fails closed.
+ */
+function parseHost(target: string): string | null {
+  const attempt = (s: string): string | null => {
+    try {
+      const h = new URL(s).hostname;
+      return h.length > 0 ? h.toLowerCase() : null;
+    } catch {
+      return null;
+    }
+  };
+  // Try as-is (full URL with scheme) first, then as a bare host by prepending a
+  // scheme. Parsing via URL and comparing ONLY the normalized .hostname (never
+  // the raw string) neutralizes userinfo ("user@host"), ports, paths, and
+  // IDN/punycode homographs — the sharp edges of allowlist matching.
+  return attempt(target) ?? attempt("https://" + target);
+}
+
+/**
+ * Egress gate. Permit `target` only if its hostname matches the allowlist.
+ * Matching is case-insensitive on the normalized hostname. An allow entry that
+ * starts with "." is a SUFFIX (subdomain) match: ".example.com" permits
+ * "example.com" and "api.example.com" but NOT "api.example.com.evil.com". Every
+ * other entry is an EXACT host match. An empty allowlist denies everything
+ * (default-deny). Malformed targets are denied. Never throws.
+ */
+export function checkEgress(target: string, opts: { allow: string[] }): BrokerDecision {
+  const host = parseHost(target);
+  if (host === null) {
+    return { ok: false, reason: `egress: unparseable target ${JSON.stringify(target)}` };
+  }
+  for (const raw of opts.allow) {
+    if (typeof raw !== "string" || raw.length === 0) continue;
+    const entry = raw.toLowerCase();
+    if (entry.startsWith(".")) {
+      // Suffix/subdomain: host is the bare domain (entry sans leading dot) or a
+      // subdomain of it.
+      const bare = entry.slice(1);
+      if (host === bare || host.endsWith(entry)) return { ok: true };
+    } else if (host === entry) {
+      return { ok: true };
+    }
+  }
+  return { ok: false, reason: `egress: host ${host} not in allowlist` };
+}
+
+/**
+ * Filesystem-write gate. Resolve both sides (collapsing any ".." traversal) and
+ * permit only when the resolved path is `projectRoot` itself or lives strictly
+ * under `projectRoot` + path separator. A relative `path` resolves against
+ * projectRoot first. Rejects absolute escapes ("/etc/passwd"), traversal
+ * ("../x", "root/../../x"), and the prefix-without-separator trick ("/repofoo"
+ * vs root "/repo"). Never throws. See the module-level symlink boundary note.
+ */
+export function checkFsWrite(path: string, projectRoot: string): BrokerDecision {
+  try {
+    const root = resolve(projectRoot);
+    const target = resolve(root, path);
+    if (target === root) return { ok: true };
+    if (target.startsWith(root + sep)) return { ok: true };
+    return { ok: false, reason: `fs-write: ${target} is outside root ${root}` };
+  } catch {
+    return { ok: false, reason: "fs-write: unresolvable path" };
+  }
+}
+
+/**
+ * Environment scoping. Return a NEW object containing only the declared keys
+ * that are actually present (with string values) in `fullEnv`. Undeclared keys
+ * are dropped; declared-but-absent (or undefined-valued) keys are omitted. Never
+ * mutates `fullEnv`.
+ *
+ * CALLER CONTRACT: env is only a real boundary if the caller SPAWNS the child
+ * with env:{...scopedEnv} instead of letting it inherit process.env. Returning a
+ * subset does nothing if the tool reads process.env directly in-process.
+ */
+export function scopeEnv(
+  declaredKeys: string[],
+  fullEnv: Record<string, string | undefined>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const k of declaredKeys) {
+    const v = fullEnv[k];
+    if (typeof v === "string") out[k] = v;
+  }
+  return out;
+}

--- a/src/exec-broker/index.ts
+++ b/src/exec-broker/index.ts
@@ -1,0 +1,14 @@
+// Pelare 3 — exec-broker: public barrel. Callers import from
+// "exec-broker/index.js".
+
+export { checkEgress, checkFsWrite, scopeEnv, type BrokerDecision } from "./decisions.js";
+
+export {
+  loadBrokerPolicy,
+  brokerPolicyPath,
+  BROKER_POLICY_ENV,
+  DEFAULT_BROKER_POLICY_FILE,
+  type BrokerPolicy,
+} from "./policy.js";
+
+export { brokerExec, type BrokerContext, type BrokerOutcome } from "./broker.js";

--- a/src/exec-broker/policy.test.ts
+++ b/src/exec-broker/policy.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { loadBrokerPolicy, brokerPolicyPath, BROKER_POLICY_ENV } from "./policy.js";
+
+const VALID = {
+  egress: { allow: ["api.example.com"] },
+  fs: { root: "/repo" },
+  env: { declared: ["TOKEN"] },
+};
+
+function tmp(): string {
+  return mkdtempSync(join(tmpdir(), "kit-broker-policy-"));
+}
+
+afterEach(() => {
+  delete process.env[BROKER_POLICY_ENV];
+});
+
+describe("brokerPolicyPath", () => {
+  it("prefers the explicit override arg", () => {
+    process.env[BROKER_POLICY_ENV] = "/from/env.json";
+    assert.equal(brokerPolicyPath("/from/arg.json"), resolve("/from/arg.json"));
+  });
+
+  it("falls back to the KIT_EXEC_BROKER_POLICY env var", () => {
+    process.env[BROKER_POLICY_ENV] = "/from/env.json";
+    assert.equal(brokerPolicyPath(), resolve("/from/env.json"));
+  });
+
+  it("defaults to .kit-exec-broker.json under cwd", () => {
+    delete process.env[BROKER_POLICY_ENV];
+    assert.equal(brokerPolicyPath(), resolve(process.cwd(), ".kit-exec-broker.json"));
+  });
+});
+
+describe("loadBrokerPolicy", () => {
+  it("returns null when the file is absent (fail-closed)", () => {
+    const dir = tmp();
+    try {
+      assert.equal(loadBrokerPolicy(join(dir, "nope.json")), null);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads and validates a well-formed policy", () => {
+    const dir = tmp();
+    try {
+      const p = join(dir, "p.json");
+      writeFileSync(p, JSON.stringify(VALID));
+      const loaded = loadBrokerPolicy(p);
+      assert.deepEqual(loaded, VALID);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("honors the env override for the path", () => {
+    const dir = tmp();
+    try {
+      const p = join(dir, "env.json");
+      writeFileSync(p, JSON.stringify(VALID));
+      process.env[BROKER_POLICY_ENV] = p;
+      assert.deepEqual(loadBrokerPolicy(), VALID);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null on malformed JSON (fail-closed)", () => {
+    const dir = tmp();
+    try {
+      const p = join(dir, "bad.json");
+      writeFileSync(p, "{ not json");
+      assert.equal(loadBrokerPolicy(p), null);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null on wrong-typed fields (strict validation)", () => {
+    const dir = tmp();
+    try {
+      const cases = [
+        { egress: { allow: "nope" }, fs: { root: "/r" }, env: { declared: [] } },
+        { egress: { allow: [] }, fs: { root: "" }, env: { declared: [] } },
+        { egress: { allow: [] }, fs: { root: "/r" }, env: { declared: [1] } },
+        { egress: { allow: [1] }, fs: { root: "/r" }, env: { declared: [] } },
+        { fs: { root: "/r" }, env: { declared: [] } }, // missing egress
+        { egress: { allow: [] }, env: { declared: [] } }, // missing fs
+        { egress: { allow: [] }, fs: { root: "/r" } }, // missing env
+        [],
+        "string",
+        42,
+      ];
+      cases.forEach((c, i) => {
+        const p = join(dir, `c${i}.json`);
+        writeFileSync(p, JSON.stringify(c));
+        assert.equal(loadBrokerPolicy(p), null, `case ${i} should be null`);
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts empty allow/declared arrays (valid, just deny-all egress)", () => {
+    const dir = tmp();
+    try {
+      const p = join(dir, "empty.json");
+      const pol = { egress: { allow: [] }, fs: { root: "/repo" }, env: { declared: [] } };
+      writeFileSync(p, JSON.stringify(pol));
+      assert.deepEqual(loadBrokerPolicy(p), pol);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/exec-broker/policy.ts
+++ b/src/exec-broker/policy.ts
@@ -1,0 +1,89 @@
+// Pelare 3 — exec-broker: policy shape + fail-closed loader.
+//
+// The BrokerPolicy declares what an operation is ALLOWED to touch: an egress
+// hostname allowlist, a filesystem write root, and the environment keys it may
+// see. It is read from a standalone JSON file resolved via the module's mandated
+// KIT_<X> knob (KIT_EXEC_BROKER_POLICY), else a repo-local default
+// (.kit-exec-broker.json under cwd).
+//
+// FAIL-CLOSED / NO FALSE-GREEN: an absent, unreadable, malformed, or wrong-typed
+// policy loads as `null` — never a permissive default. brokerExec treats null as
+// default-deny, so a missing policy blocks everything rather than silently
+// allowing it. Validation is strict: any deviation → null.
+//
+// Zero LLM, zero network. Synchronous local file read only.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export interface BrokerPolicy {
+  egress: { allow: string[] };
+  fs: { root: string };
+  env: { declared: string[] };
+}
+
+/** The env override knob for this module (mirrors the amazonq/kiro parsers). */
+export const BROKER_POLICY_ENV = "KIT_EXEC_BROKER_POLICY";
+
+/** Default policy filename resolved against cwd when no override is set. */
+export const DEFAULT_BROKER_POLICY_FILE = ".kit-exec-broker.json";
+
+/**
+ * Resolve the broker policy file path. Precedence: explicit `override` arg →
+ * KIT_EXEC_BROKER_POLICY env → repo-local .kit-exec-broker.json under cwd.
+ */
+export function brokerPolicyPath(override?: string): string {
+  const chosen = override ?? process.env[BROKER_POLICY_ENV];
+  if (chosen && chosen.length > 0) return resolve(chosen);
+  return resolve(process.cwd(), DEFAULT_BROKER_POLICY_FILE);
+}
+
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((x) => typeof x === "string");
+}
+
+/**
+ * Strict validation of a parsed JSON value into a BrokerPolicy, or null if it
+ * deviates in any way (fail-closed, no false-green).
+ */
+function validateBrokerPolicy(parsed: unknown): BrokerPolicy | null {
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const p = parsed as Record<string, unknown>;
+
+  const egress = p.egress as Record<string, unknown> | undefined;
+  if (typeof egress !== "object" || egress === null || !isStringArray(egress.allow)) return null;
+
+  const fs = p.fs as Record<string, unknown> | undefined;
+  if (typeof fs !== "object" || fs === null) return null;
+  if (typeof fs.root !== "string" || fs.root.length === 0) return null;
+
+  const env = p.env as Record<string, unknown> | undefined;
+  if (typeof env !== "object" || env === null || !isStringArray(env.declared)) return null;
+
+  return {
+    egress: { allow: [...egress.allow] },
+    fs: { root: fs.root },
+    env: { declared: [...env.declared] },
+  };
+}
+
+/**
+ * Load + parse + validate the broker policy. Returns null on absent, unreadable,
+ * malformed, or wrong-typed input so brokerExec default-denies. Never throws.
+ */
+export function loadBrokerPolicy(override?: string): BrokerPolicy | null {
+  const path = brokerPolicyPath(override);
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return null; // absent / unreadable → fail-closed
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null; // malformed JSON → fail-closed
+  }
+  return validateBrokerPolicy(parsed);
+}

--- a/src/keystore/file-store.test.ts
+++ b/src/keystore/file-store.test.ts
@@ -1,0 +1,73 @@
+/**
+ * FileKeyStore faithfully WRAPS ../identity.js. Proves pure delegation, not a
+ * re-implementation: signatures verify via identity.ts verifySignature, rotation
+ * archives keep resolving via localPublicKeys(), and create() is idempotent.
+ */
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { verifySignature, localPublicKeys } from "../identity.js";
+import { FileKeyStore } from "./file-store.js";
+
+describe("FileKeyStore", () => {
+  let dir: string;
+  const prev = process.env.KIT_IDENTITY_DIR;
+
+  before(() => {
+    dir = mkdtempSync(join(tmpdir(), "kit-keystore-file-"));
+    process.env.KIT_IDENTITY_DIR = dir;
+  });
+  after(() => {
+    if (prev === undefined) delete process.env.KIT_IDENTITY_DIR;
+    else process.env.KIT_IDENTITY_DIR = prev;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("is available and reports kind 'file'", () => {
+    const store = new FileKeyStore();
+    assert.equal(store.kind, "file");
+    assert.equal(store.available().ok, true);
+  });
+
+  it("publicKeyPem() is null before create()", () => {
+    const store = new FileKeyStore();
+    assert.equal(store.publicKeyPem(), null);
+  });
+
+  it("create() creates then is idempotent (delegates to loadOrCreateIdentity)", () => {
+    const store = new FileKeyStore();
+    const first = store.create();
+    assert.equal(first.created, true);
+    assert.match(first.identity.id, /^kid_[0-9a-f]{32}$/);
+    const second = store.create();
+    assert.equal(second.created, false);
+    assert.equal(second.identity.id, first.identity.id);
+    assert.ok(store.publicKeyPem()?.includes("BEGIN PUBLIC KEY"));
+  });
+
+  it("sign() output verifies via identity.ts against publicKeyPem(); tamper fails", () => {
+    const store = new FileKeyStore();
+    store.create();
+    const pem = store.publicKeyPem();
+    assert.ok(pem);
+    const msg = "provenance statement";
+    const sig = store.sign(msg);
+    assert.equal(verifySignature(msg, sig, pem), true);
+    // Asymmetric + fail-closed: a tampered message must not verify.
+    assert.equal(verifySignature("provenance statemenX", sig, pem), false);
+  });
+
+  it("rotate() yields a new id + previousId, and the rotated-away key still resolves", () => {
+    const store = new FileKeyStore();
+    const before = store.create().identity;
+    const rot = store.rotate();
+    assert.notEqual(rot.identity.id, before.id, "rotation must mint a new key");
+    assert.equal(rot.previousId, before.id, "previousId is the archived key");
+    // Delegation intact: localPublicKeys() still knows the rotated-away key.
+    const known = localPublicKeys();
+    assert.ok(known.has(before.id), "archived public key must remain resolvable");
+    assert.ok(known.has(rot.identity.id), "new public key must be resolvable");
+  });
+});

--- a/src/keystore/file-store.ts
+++ b/src/keystore/file-store.ts
@@ -1,0 +1,57 @@
+/**
+ * FileKeyStore — the working default backend for the KeyStore port.
+ *
+ * PURE DELEGATION to ../identity.js: it never re-implements crypto, key
+ * generation, or file permissions — it wraps signWithIdentity /
+ * loadOrCreateIdentity / rotateIdentity / tryLoadIdentity and threads the
+ * existing KIT_IDENTITY_DIR override (via the optional constructor `dir`)
+ * straight through. Rewriting any of that here would fork the trust code; the
+ * whole point of Pelare 1 is that this backend is a thin adapter over the
+ * primitive kit already ships.
+ *
+ * HONEST THREAT BOUNDARY: this backend stores the private key as a 0600 file
+ * under ~/.kit, so a SAME-UID local principal can read it and sign as this
+ * identity — exactly the boundary ../identity.js documents. It is NOT
+ * hardware-rooted; only a real Secure Enclave / TPM backend closes the
+ * same-UID key-theft gap. resolveKeyStore() surfaces this in its degradation
+ * reason so operators are never misled.
+ */
+import type { Identity } from "../identity.js";
+import {
+  signWithIdentity,
+  loadOrCreateIdentity,
+  rotateIdentity,
+  tryLoadIdentity,
+} from "../identity.js";
+import type { KeyStore, KeyStoreAvailability } from "./types.js";
+
+export class FileKeyStore implements KeyStore {
+  readonly kind = "file" as const;
+  /** Optional identity dir; threads through ../identity.js (KIT_IDENTITY_DIR). */
+  private readonly dir?: string;
+
+  constructor(dir?: string) {
+    this.dir = dir;
+  }
+
+  /** The file backend can always operate — the filesystem is the requirement. */
+  available(): KeyStoreAvailability {
+    return { ok: true };
+  }
+
+  publicKeyPem(): string | null {
+    return tryLoadIdentity(this.dir)?.publicKey ?? null;
+  }
+
+  sign(data: Buffer | string): Buffer {
+    return signWithIdentity(data, this.dir);
+  }
+
+  create(now?: string): { identity: Identity; created: boolean } {
+    return loadOrCreateIdentity(this.dir, now);
+  }
+
+  rotate(now?: string): { identity: Identity; previousId: string | null } {
+    return rotateIdentity(this.dir, now);
+  }
+}

--- a/src/keystore/index.ts
+++ b/src/keystore/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Barrel for the KeyStore port (Pelare 1). Callers import from
+ * "./keystore/index.js" — one public path for the whole pillar.
+ */
+export type { KeyStore, KeyStoreKind, KeyStoreAvailability, KeyStoreResolution } from "./types.js";
+export { FileKeyStore } from "./file-store.js";
+export { SecureEnclaveKeyStore } from "./secure-enclave-store.js";
+export { TpmKeyStore } from "./tpm-store.js";
+export { resolveKeyStore } from "./resolve.js";

--- a/src/keystore/resolve.test.ts
+++ b/src/keystore/resolve.test.ts
@@ -1,0 +1,102 @@
+/**
+ * resolveKeyStore() honesty + determinism. Env vars saved/restored per repo
+ * convention; a KIT_IDENTITY_DIR tmpdir backs the end-to-end sign check.
+ */
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { verifySignature } from "../identity.js";
+import { FileKeyStore } from "./file-store.js";
+import { resolveKeyStore } from "./resolve.js";
+
+describe("resolveKeyStore", () => {
+  let dir: string;
+  const prevIdentityDir = process.env.KIT_IDENTITY_DIR;
+  const prevKeystore = process.env.KIT_KEYSTORE;
+
+  before(() => {
+    dir = mkdtempSync(join(tmpdir(), "kit-keystore-resolve-"));
+    process.env.KIT_IDENTITY_DIR = dir;
+  });
+  after(() => {
+    if (prevIdentityDir === undefined) delete process.env.KIT_IDENTITY_DIR;
+    else process.env.KIT_IDENTITY_DIR = prevIdentityDir;
+    if (prevKeystore === undefined) delete process.env.KIT_KEYSTORE;
+    else process.env.KIT_KEYSTORE = prevKeystore;
+    rmSync(dir, { recursive: true, force: true });
+  });
+  beforeEach(() => {
+    delete process.env.KIT_KEYSTORE;
+  });
+
+  it("AUTO falls back to file, degraded with a non-empty reason quoting a skipped hardware backend", () => {
+    const r = resolveKeyStore();
+    assert.equal(r.store.kind, "file");
+    assert.equal(r.degraded, true);
+    assert.equal(typeof r.reason, "string");
+    assert.ok(r.reason && r.reason.length > 0);
+    // reason references a skipped hardware backend requirement.
+    assert.match(r.reason, /Secure Enclave|TPM|hardware/i);
+    // considered[] lists the hardware backends as unavailable.
+    const enclave = r.considered.find((c) => c.kind === "secure-enclave");
+    const tpm = r.considered.find((c) => c.kind === "tpm");
+    assert.ok(enclave && enclave.availability.ok === false);
+    assert.ok(tpm && tpm.availability.ok === false);
+  });
+
+  it("reason is ALWAYS set whenever degraded===true (never a silent downgrade)", () => {
+    const r = resolveKeyStore();
+    if (r.degraded) assert.ok(typeof r.reason === "string" && r.reason.length > 0);
+  });
+
+  it("the AUTO-resolved store signs end-to-end (verifies via identity.ts)", () => {
+    const r = resolveKeyStore();
+    r.store.create();
+    const pem = r.store.publicKeyPem();
+    assert.ok(pem);
+    const sig = r.store.sign("end-to-end");
+    assert.equal(verifySignature("end-to-end", sig, pem), true);
+  });
+
+  it("KIT_KEYSTORE=file forces file, NOT degraded", () => {
+    process.env.KIT_KEYSTORE = "file";
+    const r = resolveKeyStore();
+    assert.equal(r.store.kind, "file");
+    assert.equal(r.degraded, false);
+    assert.equal(r.availability.ok, true);
+  });
+
+  it("KIT_KEYSTORE=tpm forces tpm: unavailable, degraded, refuses downgrade, sign() throws", () => {
+    process.env.KIT_KEYSTORE = "tpm";
+    const r = resolveKeyStore();
+    assert.equal(r.store.kind, "tpm");
+    assert.equal(r.availability.ok, false);
+    assert.equal(r.degraded, true);
+    assert.ok(r.reason && /refus/i.test(r.reason), "reason states refusal to downgrade");
+    assert.throws(() => r.store.sign("x"));
+    // No false green: it is genuinely NOT a file store.
+    assert.ok(!(r.store instanceof FileKeyStore));
+  });
+
+  it("KIT_KEYSTORE=bogus names the bad value and still returns the file default", () => {
+    process.env.KIT_KEYSTORE = "bogus";
+    const r = resolveKeyStore();
+    assert.equal(r.store.kind, "file");
+    assert.ok(r.reason && r.reason.includes("bogus"), "reason names the invalid value");
+    assert.match(r.reason, /file|secure-enclave|tpm/, "reason lists the valid set");
+  });
+
+  it("is deterministic: two calls yield the same kind", () => {
+    const a = resolveKeyStore();
+    const b = resolveKeyStore();
+    assert.equal(a.store.kind, b.store.kind);
+  });
+
+  it("explicit force via opts.force overrides and behaves like the env force", () => {
+    const r = resolveKeyStore({ force: "tpm" });
+    assert.equal(r.store.kind, "tpm");
+    assert.equal(r.degraded, true);
+  });
+});

--- a/src/keystore/resolve.ts
+++ b/src/keystore/resolve.ts
@@ -1,0 +1,131 @@
+/**
+ * resolveKeyStore() — the honest KeyStore selector and the module's KIT_<X>
+ * override (KIT_KEYSTORE), matching the env-override convention of the other
+ * kit parsers.
+ *
+ * AUTO mode (no force): walk the preference order [secure-enclave, tpm, file]
+ * and pick the FIRST backend whose available().ok is true. The hardware stubs
+ * are unavailable today, so it lands on "file" with degraded=true and a reason
+ * that QUOTES the skipped hardware backends' reasons plus the plain statement
+ * that file is same-UID-readable and NOT hardware-rooted.
+ *
+ * FORCE mode (opts.force ?? parse(KIT_KEYSTORE)): select exactly that backend.
+ *   - file          -> degraded=false.
+ *   - hardware OK    -> degraded=false (would only happen once implemented).
+ *   - hardware UNAVAILABLE -> return that (unavailable) store with degraded=true
+ *     and a reason that REFUSES to silently downgrade to file (no false green).
+ *     Its sign() then fails closed at call time.
+ * Unknown KIT_KEYSTORE value -> reason names the bad value + the valid set,
+ * then AUTO-resolves to the safe file default.
+ *
+ * Always populates considered[] (audit trail) and always sets reason when
+ * degraded. No network, no model, deterministic; NEVER throws — fail-closed
+ * happens at sign-time, not here.
+ */
+import type { KeyStore, KeyStoreKind, KeyStoreResolution } from "./types.js";
+import { FileKeyStore } from "./file-store.js";
+import { SecureEnclaveKeyStore } from "./secure-enclave-store.js";
+import { TpmKeyStore } from "./tpm-store.js";
+
+/** Preference order for AUTO mode: strongest (hardware) first, file last. */
+const PREFERENCE: KeyStoreKind[] = ["secure-enclave", "tpm", "file"];
+const VALID_KINDS: KeyStoreKind[] = ["file", "secure-enclave", "tpm"];
+
+function makeStore(kind: KeyStoreKind, dir?: string): KeyStore {
+  switch (kind) {
+    case "file":
+      return new FileKeyStore(dir);
+    case "secure-enclave":
+      return new SecureEnclaveKeyStore();
+    case "tpm":
+      return new TpmKeyStore();
+  }
+}
+
+function parseForce(value: string | undefined): KeyStoreKind | { invalid: string } | undefined {
+  if (value === undefined) return undefined;
+  const v = value.trim();
+  if (v === "") return undefined;
+  if ((VALID_KINDS as string[]).includes(v)) return v as KeyStoreKind;
+  return { invalid: v };
+}
+
+/** AUTO: pick the first available backend by preference, honestly degrading to file. */
+function resolveAuto(dir: string | undefined, preludeReason?: string): KeyStoreResolution {
+  const considered: KeyStoreResolution["considered"] = [];
+  const skippedReasons: string[] = [];
+
+  for (const kind of PREFERENCE) {
+    const store = makeStore(kind, dir);
+    const availability = store.available();
+    considered.push({ kind, availability });
+    if (availability.ok) {
+      const degraded = kind !== PREFERENCE[0] || preludeReason !== undefined;
+      let reason: string | undefined;
+      if (degraded) {
+        const parts: string[] = [];
+        if (preludeReason) parts.push(preludeReason);
+        if (kind === "file") {
+          parts.push(
+            "using the file backend: hardware-rooted backends are unavailable in this environment" +
+              (skippedReasons.length ? ` (${skippedReasons.join("; ")})` : "") +
+              ". The file backend stores the private key as a 0600 file under ~/.kit — it is SAME-UID readable and NOT hardware-rooted; only a real Secure Enclave/TPM backend closes the same-UID key-theft gap.",
+          );
+        }
+        reason = parts.join(" ");
+      }
+      return { store, availability, degraded, reason, considered };
+    }
+    if (availability.reason) skippedReasons.push(availability.reason);
+  }
+
+  // Unreachable in practice: FileKeyStore.available() is always ok. Fail closed.
+  const store = makeStore("file", dir);
+  return {
+    store,
+    availability: store.available(),
+    degraded: true,
+    reason:
+      "no available keystore backend was found; falling back to the file backend" +
+      (preludeReason ? ` (${preludeReason})` : ""),
+    considered,
+  };
+}
+
+export function resolveKeyStore(opts?: { dir?: string; force?: KeyStoreKind }): KeyStoreResolution {
+  const dir = opts?.dir;
+  const forced = opts?.force ?? parseForce(process.env.KIT_KEYSTORE);
+
+  // Unknown KIT_KEYSTORE value: name the bad value + valid set, then AUTO to safe file default.
+  if (forced && typeof forced === "object") {
+    return resolveAuto(
+      dir,
+      `ignoring invalid KIT_KEYSTORE="${forced.invalid}" (valid: ${VALID_KINDS.join(", ")});`,
+    );
+  }
+
+  // No force -> AUTO.
+  if (forced === undefined) return resolveAuto(dir);
+
+  // FORCE mode: select exactly that backend.
+  const store = makeStore(forced, dir);
+  const availability = store.available();
+  const considered: KeyStoreResolution["considered"] = [{ kind: forced, availability }];
+
+  if (availability.ok) {
+    // A forced, available backend is the strongest the operator asked for: not degraded.
+    return { store, availability, degraded: false, considered };
+  }
+
+  // Forced but UNAVAILABLE (a hardware stub today): REFUSE to silently downgrade.
+  return {
+    store,
+    availability,
+    degraded: true,
+    reason:
+      `KIT_KEYSTORE forced the "${forced}" backend, which is unavailable here` +
+      (availability.reason ? ` (${availability.reason})` : "") +
+      ". Refusing to silently downgrade to the file backend (no false green); sign() will fail closed until this backend is available.",
+    considered,
+  };
+}

--- a/src/keystore/secure-enclave-store.ts
+++ b/src/keystore/secure-enclave-store.ts
@@ -1,0 +1,51 @@
+/**
+ * SecureEnclaveKeyStore — the darwin extension-point STUB for the KeyStore port.
+ *
+ * This is where a real, non-exportable Apple Secure Enclave key (via a native
+ * Keychain/SecKey binding) will land. TODAY it is an HONEST stub: in EVERY
+ * environment available() returns { ok:false, reason } — off-darwin the reason
+ * names the platform requirement, on-darwin it states the implementation is not
+ * yet wired. It NEVER reports ok:true here — that would be a false green, which
+ * kit forbids. sign()/create()/rotate() FAIL CLOSED (throw the availability
+ * reason); publicKeyPem() returns null.
+ *
+ * Zero-dep discipline: node builtins only. The real SecKey/Keychain binding is
+ * introduced ONLY alongside a working implementation (behind triage), never as a
+ * speculative dependency — that keeps the offline, zero-dep posture intact.
+ */
+import type { Identity } from "../identity.js";
+import type { KeyStore, KeyStoreAvailability } from "./types.js";
+
+export class SecureEnclaveKeyStore implements KeyStore {
+  readonly kind = "secure-enclave" as const;
+
+  available(): KeyStoreAvailability {
+    if (process.platform !== "darwin") {
+      return {
+        ok: false,
+        reason: `secure-enclave requires macOS (darwin); current platform is ${process.platform}`,
+      };
+    }
+    return {
+      ok: false,
+      reason:
+        "secure-enclave requires a native Keychain/SecKey binding to the Apple Secure Enclave (not yet implemented)",
+    };
+  }
+
+  publicKeyPem(): string | null {
+    return null;
+  }
+
+  sign(_data: Buffer | string): Buffer {
+    throw new Error(this.available().reason);
+  }
+
+  create(_now?: string): { identity: Identity; created: boolean } {
+    throw new Error(this.available().reason);
+  }
+
+  rotate(_now?: string): { identity: Identity; previousId: string | null } {
+    throw new Error(this.available().reason);
+  }
+}

--- a/src/keystore/stubs.test.ts
+++ b/src/keystore/stubs.test.ts
@@ -1,0 +1,39 @@
+/**
+ * The hardware stubs are HONEST on EVERY platform: available().ok===false with a
+ * meaningful reason (no false green regardless of where CI runs), and every
+ * key-touching operation fails closed with that reason.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { SecureEnclaveKeyStore } from "./secure-enclave-store.js";
+import { TpmKeyStore } from "./tpm-store.js";
+
+describe("hardware keystore stubs (honest, fail-closed)", () => {
+  it("SecureEnclaveKeyStore is never available and names macOS/Secure Enclave", () => {
+    const store = new SecureEnclaveKeyStore();
+    assert.equal(store.kind, "secure-enclave");
+    const a = store.available();
+    assert.equal(a.ok, false, "must never fake success");
+    assert.equal(typeof a.reason, "string");
+    assert.ok(a.reason && a.reason.length > 0);
+    assert.match(a.reason, /macOS|darwin|Secure Enclave/i);
+    assert.equal(store.publicKeyPem(), null);
+    assert.throws(() => store.sign("x"), /Enclave|macOS|darwin/i);
+    assert.throws(() => store.create(), /Enclave|macOS|darwin/i);
+    assert.throws(() => store.rotate(), /Enclave|macOS|darwin/i);
+  });
+
+  it("TpmKeyStore is never available and names TPM", () => {
+    const store = new TpmKeyStore();
+    assert.equal(store.kind, "tpm");
+    const a = store.available();
+    assert.equal(a.ok, false, "must never fake success");
+    assert.equal(typeof a.reason, "string");
+    assert.ok(a.reason && a.reason.length > 0);
+    assert.match(a.reason, /TPM/i);
+    assert.equal(store.publicKeyPem(), null);
+    assert.throws(() => store.sign("x"), /TPM/i);
+    assert.throws(() => store.create(), /TPM/i);
+    assert.throws(() => store.rotate(), /TPM/i);
+  });
+});

--- a/src/keystore/tpm-store.ts
+++ b/src/keystore/tpm-store.ts
@@ -1,0 +1,49 @@
+/**
+ * TpmKeyStore — the linux/win extension-point STUB for the KeyStore port.
+ *
+ * Mirror of the Secure Enclave stub, for a TPM 2.0 device (via a PKCS#11 / tpm2
+ * binding). TODAY it is an HONEST stub: in EVERY environment available() returns
+ * { ok:false, reason } — off-platform the reason names the requirement,
+ * on-platform it states the implementation is not yet wired. It NEVER reports
+ * ok:true here (no false green). sign()/create()/rotate() FAIL CLOSED (throw the
+ * availability reason); publicKeyPem() returns null.
+ *
+ * Zero-dep discipline: node builtins only. A real pkcs11/tpm2 binding is added
+ * ONLY alongside a working implementation (behind triage), never speculatively —
+ * preserving kit's offline, zero-dep posture.
+ */
+import type { Identity } from "../identity.js";
+import type { KeyStore, KeyStoreAvailability } from "./types.js";
+
+export class TpmKeyStore implements KeyStore {
+  readonly kind = "tpm" as const;
+
+  available(): KeyStoreAvailability {
+    if (process.platform !== "linux" && process.platform !== "win32") {
+      return {
+        ok: false,
+        reason: `tpm requires Linux or Windows with a TPM 2.0 device; current platform is ${process.platform}`,
+      };
+    }
+    return {
+      ok: false,
+      reason: "tpm requires a TPM 2.0 device and a PKCS#11 / tpm2 binding (not yet implemented)",
+    };
+  }
+
+  publicKeyPem(): string | null {
+    return null;
+  }
+
+  sign(_data: Buffer | string): Buffer {
+    throw new Error(this.available().reason);
+  }
+
+  create(_now?: string): { identity: Identity; created: boolean } {
+    throw new Error(this.available().reason);
+  }
+
+  rotate(_now?: string): { identity: Identity; previousId: string | null } {
+    throw new Error(this.available().reason);
+  }
+}

--- a/src/keystore/types.ts
+++ b/src/keystore/types.ts
@@ -1,0 +1,61 @@
+/**
+ * KeyStore port — Pelare 1: hardware-rooted identity behind an interface.
+ *
+ * This is the abstraction seam that lets kit's Ed25519 private key migrate from
+ * the current 0600 PKCS8 PEM file under ~/.kit to NON-EXPORTABLE hardware
+ * (Apple Secure Enclave / TPM 2.0 / PKCS#11) later, WITHOUT touching the
+ * deterministic offline verifier: `verifySignature` in ../identity.js stays a
+ * pure function over a public PEM and is deliberately NOT part of this port.
+ *
+ * The interface is intentionally SYNCHRONOUS to match ../identity.js and its
+ * many sync callers. Real hardware APIs are async; adopting one is an explicit
+ * future migration (see the "risks" note in the design), not a reason to
+ * async-ify the whole call graph now.
+ *
+ * No I/O and no imports beyond the Identity TYPE — this file is pure contract.
+ */
+import type { Identity } from "../identity.js";
+
+/** The backends kit knows about. "file" is the working default today. */
+export type KeyStoreKind = "file" | "secure-enclave" | "tpm";
+
+/** Whether a backend can operate in the CURRENT environment. Honest, never faked. */
+export interface KeyStoreAvailability {
+  ok: boolean;
+  /** Present whenever ok===false: the platform/implementation requirement. */
+  reason?: string;
+}
+
+/**
+ * The port contract every backend implements. create()/rotate() return the SAME
+ * `Identity` shape (SPKI PEM public key) that ../identity.js callers already
+ * know, so a hardware backend is drop-in for the record contract.
+ */
+export interface KeyStore {
+  readonly kind: KeyStoreKind;
+  /** Can this backend operate in the CURRENT env? Never throws. */
+  available(): KeyStoreAvailability;
+  /** SPKI PEM of the public key, or null if none exists yet. Never throws. */
+  publicKeyPem(): string | null;
+  /** Ed25519 signature over data. Throws (fail-closed) if unavailable or no key. */
+  sign(data: Buffer | string): Buffer;
+  /** Create the identity/key if absent; idempotent. */
+  create(now?: string): { identity: Identity; created: boolean };
+  /** Rotate: archive old, generate new. */
+  rotate(now?: string): { identity: Identity; previousId: string | null };
+}
+
+/**
+ * The result of resolveKeyStore(): the chosen store PLUS the full honesty trail.
+ * `degraded` is true whenever the chosen backend is not the strongest possible
+ * (fell back to file, or a forced hardware backend is unavailable); `reason` is
+ * ALWAYS set when degraded (no silent downgrade). `considered` is the audit
+ * trail of every backend inspected and its availability.
+ */
+export interface KeyStoreResolution {
+  store: KeyStore;
+  availability: KeyStoreAvailability;
+  degraded: boolean;
+  reason?: string;
+  considered: { kind: KeyStoreKind; availability: KeyStoreAvailability }[];
+}

--- a/src/rbac/identity-provider.ts
+++ b/src/rbac/identity-provider.ts
@@ -1,0 +1,199 @@
+/**
+ * kit RBAC identity providers — the ENROLLMENT-ONLY IdP layer for Pelare 2.
+ *
+ * An IdP (GitHub today; Azure/Entra and Google are documented future backends of
+ * the SAME interface) is consulted ONLY at enrollment time to compile role
+ * bindings. It is NEVER imported by the enforcement path (`resolve.ts`) — the
+ * decision engine is fully offline. The one and only network in this whole pillar
+ * lives here, behind an INJECTABLE membership source, so the compilation logic is
+ * unit-testable with zero egress.
+ *
+ * Flow:
+ *   1. `createGithubProvider({ source, org })` wraps a `GithubMembershipSource`
+ *      (team membership) into an `IdentityProvider` that yields group slugs.
+ *   2. `compileRoleBindings({ provider, roleMap, subjects })` maps each subject's
+ *      groups -> kit roles (via `roleMap`) -> signed-policy `RoleBinding[]` you
+ *      paste into the `[rbac]` table before `kit policy sign`.
+ *   3. `createGithubApiSource({ token, org, fetchImpl?, baseUrl? })` is the REAL
+ *      GitHub Teams wiring that satisfies `GithubMembershipSource` — the injection
+ *      point tests replace with an in-memory fake. `KIT_RBAC_GITHUB_API` overrides
+ *      the base URL (e.g. GitHub Enterprise).
+ *
+ * FUTURE BACKENDS (same `IdentityProvider` / membership-source shape):
+ *   - Azure / Entra ID: Microsoft Graph `GET /me/memberOf` (group objectIds/names).
+ *   - Google: Cloud Identity Groups `groups.memberships.searchTransitiveGroups`.
+ * Each becomes a `create<X>Source(...)` returning the membership interface; the
+ * compile + enforcement code is unchanged.
+ *
+ * Enrollment egress note: `createGithubApiSource` MUST be gated by kit's egress
+ * policy and MUST NOT be reachable from the decision path (enforced by the
+ * no-restricted-imports boundary + the architecture-guard test).
+ */
+import { identityId } from "../identity.js";
+import type { RoleBinding } from "./policy-schema.js";
+
+/**
+ * A pluggable identity provider. `resolveMembership` returns the group slugs a
+ * subject belongs to (already namespaced by org where relevant).
+ */
+export interface IdentityProvider {
+  /** Provider kind, e.g. "github". */
+  kind: string;
+  /** Resolve the group slugs a subject belongs to. Enrollment-time only. */
+  resolveMembership(subject: string): Promise<string[]>;
+}
+
+/**
+ * The injectable GitHub membership source. Real wiring (`createGithubApiSource`)
+ * talks to the GitHub Teams API; tests inject an in-memory implementation so no
+ * network is touched.
+ */
+export interface GithubMembershipSource {
+  /** Team slugs the subject (GitHub login) is an active member of. */
+  listTeams(subject: string): Promise<string[]>;
+}
+
+/**
+ * Wrap a `GithubMembershipSource` into an `IdentityProvider`. When `org` is set,
+ * group slugs are namespaced as `org/team` (so `roleMap` keys are unambiguous
+ * across orgs); otherwise the bare team slug is used.
+ */
+export function createGithubProvider(opts: {
+  source: GithubMembershipSource;
+  org?: string;
+}): IdentityProvider {
+  return {
+    kind: "github",
+    async resolveMembership(subject: string): Promise<string[]> {
+      const teams = await opts.source.listTeams(subject);
+      return teams.map((t) => (opts.org ? `${opts.org}/${t}` : t));
+    },
+  };
+}
+
+/** A subject to enroll: the IdP identity plus its kit identity id (and optional key). */
+export interface EnrollmentSubject {
+  /** The IdP subject (e.g. GitHub login) passed to the provider. */
+  subject: string;
+  /** The subject's kit identity id (kid_...) to bind. */
+  kid: string;
+  /** Optional SPKI PEM; when present it MUST derive to `kid` (checked, else throws). */
+  pubkey?: string;
+  /** Optional human label carried into the binding. */
+  label?: string;
+}
+
+export interface EnrollmentInput {
+  provider: IdentityProvider;
+  /** group slug -> kit role name. Subjects in unmapped groups produce no binding. */
+  roleMap: Record<string, string>;
+  subjects: EnrollmentSubject[];
+}
+
+export interface EnrollmentResult {
+  /** Compiled bindings to paste into the `[rbac]` table before signing. */
+  bindings: RoleBinding[];
+  /** Subjects that matched no mapped group (no binding emitted) — surfaced, not silently dropped. */
+  unmapped: EnrollmentSubject[];
+}
+
+/**
+ * Compile role bindings for a set of subjects by resolving each subject's IdP
+ * groups and mapping them through `roleMap`. Deterministic given the injected
+ * provider. A subject in multiple mapped groups yields multiple bindings (one per
+ * distinct role) — permissions UNION at decision time. A subject in no mapped
+ * group is reported in `unmapped`. If a subject supplies a `pubkey` that does not
+ * derive to its `kid`, enrollment FAILS LOUD (throws) — a mismatch must never be
+ * written into a signed policy.
+ */
+export async function compileRoleBindings(input: EnrollmentInput): Promise<EnrollmentResult> {
+  const bindings: RoleBinding[] = [];
+  const unmapped: EnrollmentSubject[] = [];
+
+  for (const subject of input.subjects) {
+    if (subject.pubkey !== undefined) {
+      let derived: string;
+      try {
+        derived = identityId(subject.pubkey);
+      } catch {
+        throw new Error(`pubkey for subject "${subject.subject}" is not a valid public key`);
+      }
+      if (derived !== subject.kid) {
+        throw new Error(
+          `pubkey for subject "${subject.subject}" derives to ${derived}, not its kid ${subject.kid}`,
+        );
+      }
+    }
+
+    const groups = await input.provider.resolveMembership(subject.subject);
+    const roles = [...new Set(groups.map((g) => input.roleMap[g]).filter((r): r is string => !!r))];
+
+    if (roles.length === 0) {
+      unmapped.push(subject);
+      continue;
+    }
+
+    for (const role of roles) {
+      const binding: RoleBinding = { kid: subject.kid, role };
+      if (subject.pubkey !== undefined) binding.pubkey = subject.pubkey;
+      if (subject.label !== undefined) binding.label = subject.label;
+      bindings.push(binding);
+    }
+  }
+
+  return { bindings, unmapped };
+}
+
+/**
+ * The REAL GitHub Teams membership source. This is the only network in the pillar
+ * and runs at enrollment only. Lists the org's teams, then checks the subject's
+ * active membership in each, returning the team slugs they belong to. Fail-closed:
+ * a non-OK response throws rather than reporting spurious (empty) membership.
+ *
+ * `baseUrl` order: `KIT_RBAC_GITHUB_API` env override, then `opts.baseUrl`, then
+ * the public GitHub API. `fetchImpl` is injectable so tests drive it with a fake.
+ */
+export function createGithubApiSource(opts: {
+  token: string;
+  org: string;
+  fetchImpl?: typeof fetch;
+  baseUrl?: string;
+}): GithubMembershipSource {
+  const baseUrl = (
+    process.env.KIT_RBAC_GITHUB_API ??
+    opts.baseUrl ??
+    "https://api.github.com"
+  ).replace(/\/+$/, "");
+  const doFetch = opts.fetchImpl ?? fetch;
+  const headers = {
+    Authorization: `Bearer ${opts.token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  return {
+    async listTeams(subject: string): Promise<string[]> {
+      const teamsRes = await doFetch(`${baseUrl}/orgs/${opts.org}/teams`, { headers });
+      if (!teamsRes.ok) {
+        throw new Error(`GitHub teams list failed for org ${opts.org}: HTTP ${teamsRes.status}`);
+      }
+      const teams = (await teamsRes.json()) as Array<{ slug: string }>;
+      const member: string[] = [];
+      for (const team of teams) {
+        const mRes = await doFetch(
+          `${baseUrl}/orgs/${opts.org}/teams/${team.slug}/memberships/${subject}`,
+          { headers },
+        );
+        if (mRes.status === 404) continue; // not a member — expected, not an error
+        if (!mRes.ok) {
+          throw new Error(
+            `GitHub membership check failed for ${subject} in ${team.slug}: HTTP ${mRes.status}`,
+          );
+        }
+        const body = (await mRes.json()) as { state?: string };
+        if (body.state === "active") member.push(team.slug);
+      }
+      return member;
+    },
+  };
+}

--- a/src/rbac/policy-schema.ts
+++ b/src/rbac/policy-schema.ts
@@ -1,0 +1,188 @@
+/**
+ * kit RBAC schema — Pelare 2 (role-based access control bound to an IdP at
+ * ENROLLMENT time, enforced fully OFFLINE from the org-signed `.kit-policy.toml`).
+ *
+ * This module is the PURE, zero-dependency schema shared by the enforcement path
+ * (`resolve.ts`) and the enrollment path (`identity-provider.ts`). Keeping it
+ * separate does two things:
+ *   1. avoids a circular dependency (resolve.ts ⇄ identity-provider.ts), and
+ *   2. keeps the decision engine free of any provider / network code — the
+ *      enforcement path never transitively imports the GitHub/Azure/Google wiring.
+ *
+ * Role-bindings live INSIDE the policy document (`[rbac]` table): subject kid ->
+ * role -> permissions[]. Because bindings ride inside `.kit-policy.toml`, they are
+ * already covered by the SINGLE org signature (`canonicalPolicyBytes` signs the
+ * whole doc) and verified offline against `.kit-policy.signers`. There is no
+ * separate RBAC signature and no network at decision time.
+ *
+ * No I/O, no model calls, deterministic. Fail-CLOSED: a malformed `[rbac]` table
+ * yields `extractRbac(...) === null`, which the resolver treats as "no bindings"
+ * (total deny) rather than guessing an interpretation.
+ */
+
+/** A single subject -> role assignment, compiled at enrollment and signed in-policy. */
+export interface RoleBinding {
+  /** The subject identity id (kid_...) this binding authorizes. */
+  kid: string;
+  /** The role name; must exist in `RbacPolicy.roles`. */
+  role: string;
+  /**
+   * Optional SPKI PEM of the subject's public key. When present, the resolver
+   * checks that `identityId(pubkey) === kid` and IGNORES the binding otherwise —
+   * so a pubkey/kid mismatch can never grant access (fail-closed integrity).
+   */
+  pubkey?: string;
+  /** Optional human label (e.g. GitHub login) for diagnostics. */
+  label?: string;
+}
+
+/** The `[rbac]` table, normalized. `roles` maps a role name to its permission grants. */
+export interface RbacPolicy {
+  /** role -> permission grants. A grant is exact (`deploy:prod`), a `domain:*` prefix, or `*`. */
+  roles: Record<string, string[]>;
+  /** Subject -> role assignments. A kid may appear more than once (permissions UNION). */
+  bindings: RoleBinding[];
+  /** Optional role granted to a subject that has NO binding of its own. */
+  defaultRole?: string;
+}
+
+export interface RbacValidation {
+  ok: boolean;
+  errors: string[];
+}
+
+const FORBIDDEN_KEYS = ["__proto__", "constructor", "prototype"];
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function checkForbiddenKeys(obj: Record<string, unknown>, where: string, errors: string[]): void {
+  for (const k of FORBIDDEN_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(obj, k))
+      errors.push(`forbidden key \`${k}\` in ${where}`);
+  }
+}
+
+/**
+ * Validate the `[rbac]` table carried on a parsed policy document. Pure.
+ *
+ * `doc` is the WHOLE parsed policy doc; this reads `doc.rbac`. A doc with no
+ * `[rbac]` table is valid (RBAC is optional) and yields `{ ok: true, errors: [] }`.
+ * A present-but-malformed `[rbac]` table produces structured errors.
+ */
+export function validateRbac(doc: unknown): RbacValidation {
+  const errors: string[] = [];
+  if (!isPlainObject(doc)) {
+    return { ok: false, errors: ["policy is not a table"] };
+  }
+  const rbac = doc.rbac;
+  if (rbac === undefined) return { ok: true, errors: [] };
+  if (!isPlainObject(rbac)) {
+    return { ok: false, errors: ["`rbac` must be a table"] };
+  }
+  checkForbiddenKeys(rbac, "`rbac`", errors);
+
+  // roles: Record<string, string[]>
+  if (rbac.roles === undefined) {
+    errors.push("`rbac.roles` is required");
+  } else if (!isPlainObject(rbac.roles)) {
+    errors.push("`rbac.roles` must be a table");
+  } else {
+    checkForbiddenKeys(rbac.roles, "`rbac.roles`", errors);
+    for (const [role, perms] of Object.entries(rbac.roles)) {
+      if (!Array.isArray(perms) || perms.some((p) => typeof p !== "string")) {
+        errors.push(`\`rbac.roles.${role}\` must be an array of permission strings`);
+      }
+    }
+  }
+
+  // bindings: RoleBinding[]
+  if (rbac.bindings === undefined) {
+    errors.push("`rbac.bindings` is required (may be an empty array)");
+  } else if (!Array.isArray(rbac.bindings)) {
+    errors.push("`rbac.bindings` must be an array of tables");
+  } else {
+    rbac.bindings.forEach((b, i) => {
+      if (!isPlainObject(b)) {
+        errors.push(`\`rbac.bindings[${i}]\` must be a table`);
+        return;
+      }
+      checkForbiddenKeys(b, `\`rbac.bindings[${i}]\``, errors);
+      if (typeof b.kid !== "string" || b.kid.length === 0) {
+        errors.push(`\`rbac.bindings[${i}].kid\` must be a non-empty string`);
+      }
+      if (typeof b.role !== "string" || b.role.length === 0) {
+        errors.push(`\`rbac.bindings[${i}].role\` must be a non-empty string`);
+      }
+      if (b.pubkey !== undefined && typeof b.pubkey !== "string") {
+        errors.push(`\`rbac.bindings[${i}].pubkey\` must be a string`);
+      }
+      if (b.label !== undefined && typeof b.label !== "string") {
+        errors.push(`\`rbac.bindings[${i}].label\` must be a string`);
+      }
+    });
+  }
+
+  // default_role: optional string
+  if (rbac.default_role !== undefined && typeof rbac.default_role !== "string") {
+    errors.push("`rbac.default_role` must be a string");
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+/**
+ * Pull and normalize the `[rbac]` table out of a parsed policy document.
+ *
+ * Returns a normalized `RbacPolicy` or `null` when there is no `[rbac]` table OR
+ * when it is malformed (fail-CLOSED: a broken table must never be interpreted as
+ * a permissive grant — the resolver treats `null` as "no bindings", total deny).
+ */
+export function extractRbac(doc: unknown): RbacPolicy | null {
+  if (!validateRbac(doc).ok) return null;
+  if (!isPlainObject(doc)) return null;
+  const rbac = doc.rbac;
+  if (!isPlainObject(rbac)) return null;
+
+  const roles: Record<string, string[]> = {};
+  const rawRoles = rbac.roles;
+  if (isPlainObject(rawRoles)) {
+    for (const [role, perms] of Object.entries(rawRoles)) {
+      if (FORBIDDEN_KEYS.includes(role)) continue;
+      roles[role] = (perms as string[]).map((p) => String(p));
+    }
+  }
+
+  const bindings: RoleBinding[] = [];
+  const rawBindings = rbac.bindings;
+  if (Array.isArray(rawBindings)) {
+    for (const b of rawBindings) {
+      if (!isPlainObject(b)) continue;
+      const binding: RoleBinding = { kid: String(b.kid), role: String(b.role) };
+      if (typeof b.pubkey === "string") binding.pubkey = b.pubkey;
+      if (typeof b.label === "string") binding.label = b.label;
+      bindings.push(binding);
+    }
+  }
+
+  const out: RbacPolicy = { roles, bindings };
+  if (typeof rbac.default_role === "string") out.defaultRole = rbac.default_role;
+  return out;
+}
+
+/**
+ * Does a permission grant match a requested permission? Pure, deterministic.
+ *   - `*`            matches anything
+ *   - `domain:*`     matches any `domain:...` (prefix match, e.g. `secrets:*`)
+ *   - exact          matches only itself
+ */
+export function permissionMatches(grant: string, requested: string): boolean {
+  if (grant === "*") return true;
+  if (grant === requested) return true;
+  if (grant.endsWith(":*")) {
+    const prefix = grant.slice(0, -1); // keep the trailing colon, drop the star
+    return requested.startsWith(prefix);
+  }
+  return false;
+}

--- a/src/rbac/rbac.test.ts
+++ b/src/rbac/rbac.test.ts
@@ -1,0 +1,523 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generateKeyPairSync } from "node:crypto";
+import { extractRbac, validateRbac, permissionMatches, type RbacPolicy } from "./policy-schema.js";
+import {
+  can,
+  effectivePermissions,
+  loadVerifiedPolicy,
+  rbacPolicyRoot,
+  type VerifiedPolicy,
+} from "./resolve.js";
+import {
+  createGithubProvider,
+  createGithubApiSource,
+  compileRoleBindings,
+  type GithubMembershipSource,
+} from "./identity-provider.js";
+import {
+  loadOrCreateIdentity,
+  signWithIdentity,
+  recordRevocation,
+  identityId,
+} from "../identity.js";
+import {
+  loadPolicy,
+  canonicalPolicyBytes,
+  policyFingerprint,
+  getPolicyPath,
+  getPolicySigPath,
+  type PolicyVerifyStatus,
+} from "../policy-doc.js";
+
+// A doc as smol-toml would parse `.kit-policy.toml` (the [rbac] table is a plain object).
+function docWith(rbac: unknown): Record<string, unknown> {
+  return { version: 1, require_triage: true, rbac };
+}
+
+// Build a VerifiedPolicy directly for pure-function tests, defaulting to a valid verdict.
+function vp(doc: Record<string, unknown>, status: PolicyVerifyStatus = "valid"): VerifiedPolicy {
+  return {
+    root: "/x",
+    doc: doc as never,
+    rbac: extractRbac(doc),
+    verify: { status, detail: "test" },
+  };
+}
+
+const ROLES = {
+  admin: ["*"],
+  deployer: ["deploy:*", "secrets:read"],
+  viewer: ["read:*"],
+};
+
+describe("rbac/policy-schema — validate + extract", () => {
+  it("accepts a well-formed [rbac] table and normalizes it", () => {
+    const doc = docWith({
+      default_role: "viewer",
+      roles: ROLES,
+      bindings: [{ kid: "kid_a", role: "admin", label: "peter" }],
+    });
+    assert.deepEqual(validateRbac(doc), { ok: true, errors: [] });
+    const rbac = extractRbac(doc) as RbacPolicy;
+    assert.equal(rbac.defaultRole, "viewer");
+    assert.deepEqual(rbac.roles.deployer, ["deploy:*", "secrets:read"]);
+    assert.deepEqual(rbac.bindings[0], { kid: "kid_a", role: "admin", label: "peter" });
+  });
+
+  it("treats a doc with NO [rbac] table as valid but yields null (=> deny)", () => {
+    assert.deepEqual(validateRbac({ version: 1 }), { ok: true, errors: [] });
+    assert.equal(extractRbac({ version: 1 }), null);
+  });
+
+  it("fail-closed on malformed [rbac]: extract returns null, validate reports errors", () => {
+    const badRoles = docWith({ roles: { admin: "not-an-array" }, bindings: [] });
+    assert.equal(validateRbac(badRoles).ok, false);
+    assert.equal(extractRbac(badRoles), null);
+
+    const badBinding = docWith({ roles: ROLES, bindings: [{ role: "admin" }] }); // missing kid
+    assert.match(validateRbac(badBinding).errors.join(), /kid.*non-empty string/);
+    assert.equal(extractRbac(badBinding), null);
+
+    const missingRoles = docWith({ bindings: [] });
+    assert.match(validateRbac(missingRoles).errors.join(), /rbac\.roles.*required/);
+    assert.equal(extractRbac(missingRoles), null);
+  });
+
+  it("rejects prototype-polluting keys in the rbac table", () => {
+    const doc = docWith(JSON.parse('{"roles":{},"bindings":[],"__proto__":{"x":1}}'));
+    assert.match(validateRbac(doc).errors.join(), /forbidden key/);
+    assert.equal(extractRbac(doc), null);
+  });
+
+  it("permissionMatches: exact, domain prefix, and star", () => {
+    assert.equal(permissionMatches("*", "anything:goes"), true);
+    assert.equal(permissionMatches("secrets:*", "secrets:read"), true);
+    assert.equal(permissionMatches("secrets:*", "deploy:prod"), false);
+    assert.equal(permissionMatches("deploy:prod", "deploy:prod"), true);
+    assert.equal(permissionMatches("deploy:prod", "deploy:staging"), false);
+  });
+});
+
+describe("rbac/resolve — can() permission matching (offline, pure)", () => {
+  const doc = docWith({
+    roles: ROLES,
+    bindings: [
+      { kid: "kid_admin", role: "admin" },
+      { kid: "kid_deployer", role: "deployer" },
+    ],
+  });
+
+  it("grants a `*` role anything", () => {
+    assert.equal(can("kid_admin", "deploy:prod", vp(doc)), true);
+    assert.equal(can("kid_admin", "whatever:x", vp(doc)), true);
+  });
+
+  it("honors domain:* prefix but not across domains", () => {
+    assert.equal(can("kid_deployer", "deploy:prod", vp(doc)), true);
+    assert.equal(can("kid_deployer", "secrets:read", vp(doc)), true); // exact grant
+    assert.equal(can("kid_deployer", "secrets:write", vp(doc)), false);
+    assert.equal(can("kid_deployer", "read:anything", vp(doc)), false);
+  });
+
+  it("effectivePermissions unions grants for the subject's role(s)", () => {
+    assert.deepEqual(effectivePermissions("kid_deployer", vp(doc)).sort(), [
+      "deploy:*",
+      "secrets:read",
+    ]);
+  });
+
+  it("denies a subject whose role is absent from the roles table", () => {
+    const d = docWith({ roles: ROLES, bindings: [{ kid: "kid_x", role: "ghost" }] });
+    assert.equal(can("kid_x", "read:x", vp(d)), false);
+    assert.deepEqual(effectivePermissions("kid_x", vp(d)), []);
+  });
+
+  it("unions permissions across MULTIPLE bindings for one kid", () => {
+    const d = docWith({
+      roles: ROLES,
+      bindings: [
+        { kid: "kid_multi", role: "deployer" },
+        { kid: "kid_multi", role: "viewer" },
+      ],
+    });
+    assert.equal(can("kid_multi", "deploy:prod", vp(d)), true);
+    assert.equal(can("kid_multi", "read:logs", vp(d)), true);
+  });
+});
+
+describe("rbac/resolve — fail-closed matrix (no false green)", () => {
+  const doc = docWith({ roles: ROLES, bindings: [{ kid: "kid_admin", role: "admin" }] });
+
+  it("allows ONLY when verify.status === valid", () => {
+    assert.equal(can("kid_admin", "deploy:prod", vp(doc, "valid")), true);
+    for (const status of [
+      "unsigned",
+      "unverifiable",
+      "invalid",
+      "revoked",
+    ] as PolicyVerifyStatus[]) {
+      assert.equal(
+        can("kid_admin", "deploy:prod", vp(doc, status)),
+        false,
+        `status ${status} must deny`,
+      );
+      assert.deepEqual(effectivePermissions("kid_admin", vp(doc, status)), []);
+    }
+  });
+
+  it("denies on a null policy", () => {
+    assert.equal(can("kid_admin", "deploy:prod", null), false);
+    assert.deepEqual(effectivePermissions("kid_admin", null), []);
+  });
+
+  it("denies an unknown subject with no defaultRole", () => {
+    assert.equal(can("kid_nobody", "read:x", vp(doc)), false);
+    assert.deepEqual(effectivePermissions("kid_nobody", vp(doc)), []);
+  });
+
+  it("grants an unknown subject the defaultRole's perms when set", () => {
+    const d = docWith({ default_role: "viewer", roles: ROLES, bindings: [] });
+    assert.equal(can("kid_nobody", "read:logs", vp(d)), true);
+    assert.equal(can("kid_nobody", "deploy:prod", vp(d)), false);
+  });
+
+  it("denies when the [rbac] table is absent (rbac === null)", () => {
+    const bare = vp({ version: 1 });
+    assert.equal(bare.rbac, null);
+    assert.equal(can("kid_admin", "read:x", bare), false);
+  });
+
+  it("ignores a binding whose pubkey does not derive to its kid", () => {
+    const { publicKey } = generateKeyPairSync("ed25519");
+    const realPem = publicKey.export({ type: "spki", format: "pem" }) as string;
+    const realKid = identityId(realPem);
+
+    // pubkey present but kid is WRONG => binding ignored => deny
+    const mismatched = docWith({
+      roles: ROLES,
+      bindings: [{ kid: "kid_claimed_but_wrong", role: "admin", pubkey: realPem }],
+    });
+    assert.equal(can("kid_claimed_but_wrong", "deploy:prod", vp(mismatched)), false);
+
+    // pubkey present AND kid derives correctly => honored => allow
+    const consistent = docWith({
+      roles: ROLES,
+      bindings: [{ kid: realKid, role: "admin", pubkey: realPem }],
+    });
+    assert.equal(can(realKid, "deploy:prod", vp(consistent)), true);
+  });
+});
+
+describe("rbac/resolve — rbacPolicyRoot override", () => {
+  const prev = process.env.KIT_RBAC_POLICY;
+  after(() => {
+    if (prev === undefined) delete process.env.KIT_RBAC_POLICY;
+    else process.env.KIT_RBAC_POLICY = prev;
+  });
+
+  it("KIT_RBAC_POLICY ?? override ?? cwd", () => {
+    delete process.env.KIT_RBAC_POLICY;
+    assert.equal(rbacPolicyRoot("/explicit"), "/explicit");
+    assert.equal(rbacPolicyRoot(), process.cwd());
+    process.env.KIT_RBAC_POLICY = "/env/root";
+    assert.equal(rbacPolicyRoot("/explicit"), "/env/root"); // env wins
+  });
+});
+
+describe("rbac/resolve — end-to-end signed policy + revocation + tamper", () => {
+  let idDir: string;
+  let subjectKid: string;
+  const prev = process.env.KIT_IDENTITY_DIR;
+
+  before(() => {
+    idDir = mkdtempSync(join(tmpdir(), "kit-rbac-id-"));
+    process.env.KIT_IDENTITY_DIR = idDir;
+    loadOrCreateIdentity(); // the org/local signer, resolvable via localPublicKeys()
+    const { publicKey } = generateKeyPairSync("ed25519");
+    subjectKid = identityId(publicKey.export({ type: "spki", format: "pem" }) as string);
+  });
+  after(() => {
+    if (prev === undefined) delete process.env.KIT_IDENTITY_DIR;
+    else process.env.KIT_IDENTITY_DIR = prev;
+    rmSync(idDir, { recursive: true, force: true });
+  });
+
+  function repo(): string {
+    return mkdtempSync(join(tmpdir(), "kit-rbac-repo-"));
+  }
+  function writePolicyToml(root: string, bindKid: string): void {
+    const toml = [
+      "version = 1",
+      "require_triage = true",
+      "",
+      "[rbac]",
+      'default_role = "viewer"',
+      "",
+      "[rbac.roles]",
+      'admin = ["*"]',
+      'viewer = ["read:*"]',
+      "",
+      "[[rbac.bindings]]",
+      `kid = "${bindKid}"`,
+      'role = "admin"',
+      "",
+    ].join("\n");
+    writeFileSync(getPolicyPath(root), toml);
+  }
+  function sign(root: string): void {
+    const doc = loadPolicy(root);
+    const { identity } = loadOrCreateIdentity();
+    const rec = {
+      kid: identity.id,
+      sig: signWithIdentity(canonicalPolicyBytes(doc)).toString("base64"),
+      ts: "t",
+      fingerprint: policyFingerprint(doc),
+    };
+    writeFileSync(getPolicySigPath(root), JSON.stringify(rec));
+  }
+
+  it("loadVerifiedPolicy resolves valid and can() honors the signed bindings", () => {
+    const root = repo();
+    try {
+      writePolicyToml(root, subjectKid);
+      sign(root);
+      const loaded = loadVerifiedPolicy(root);
+      assert.ok(loaded, "policy should verify valid");
+      assert.equal(loaded!.verify.status, "valid");
+      assert.equal(can(subjectKid, "deploy:prod", loaded), true); // admin => *
+      assert.equal(can("kid_stranger", "deploy:prod", loaded), false); // no binding
+      assert.equal(can("kid_stranger", "read:logs", loaded), true); // defaultRole viewer
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("a one-byte tamper flips verify to invalid => loadVerifiedPolicy null => deny", () => {
+    const root = repo();
+    try {
+      writePolicyToml(root, subjectKid);
+      sign(root);
+      // Mutate the policy AFTER signing — signature no longer matches.
+      const tampered = readFileSync(getPolicyPath(root), "utf8").replace(
+        "require_triage = true",
+        "require_triage = false",
+      );
+      writeFileSync(getPolicyPath(root), tampered);
+      assert.equal(loadVerifiedPolicy(root), null);
+      assert.equal(can(subjectKid, "deploy:prod", loadVerifiedPolicy(root)), false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("a locally-revoked subject kid is denied despite a valid binding", () => {
+    const root = repo();
+    try {
+      // A fresh subject key so revoking it can't bleed into other tests.
+      const { publicKey } = generateKeyPairSync("ed25519");
+      const revKid = identityId(publicKey.export({ type: "spki", format: "pem" }) as string);
+      writePolicyToml(root, revKid);
+      sign(root);
+      const loaded = loadVerifiedPolicy(root);
+      assert.equal(can(revKid, "deploy:prod", loaded), true); // before revocation
+      recordRevocation(revKid, "compromised"); // into KIT_IDENTITY_DIR revocations.jsonl
+      assert.equal(can(revKid, "deploy:prod", loaded), false); // secondary deny
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("rbac/identity-provider — enrollment compiles bindings offline", () => {
+  it("maps teams -> roles, unions multi-group, reports unmapped, with NO network", async () => {
+    let calls = 0;
+    const source: GithubMembershipSource = {
+      async listTeams(subject: string): Promise<string[]> {
+        calls++;
+        const table: Record<string, string[]> = {
+          alice: ["platform-admins"],
+          bob: ["deployers", "viewers"],
+          carol: ["marketing"], // unmapped
+        };
+        return table[subject] ?? [];
+      },
+    };
+    const provider = createGithubProvider({ source });
+    const roleMap = {
+      "platform-admins": "admin",
+      deployers: "deployer",
+      viewers: "viewer",
+    };
+    const result = await compileRoleBindings({
+      provider,
+      roleMap,
+      subjects: [
+        { subject: "alice", kid: "kid_alice" },
+        { subject: "bob", kid: "kid_bob", label: "Bob" },
+        { subject: "carol", kid: "kid_carol" },
+      ],
+    });
+
+    assert.deepEqual(
+      result.bindings.filter((b) => b.kid === "kid_alice"),
+      [{ kid: "kid_alice", role: "admin" }],
+    );
+    // bob is in two mapped groups => two bindings (union of roles), label carried
+    const bobRoles = result.bindings
+      .filter((b) => b.kid === "kid_bob")
+      .map((b) => b.role)
+      .sort();
+    assert.deepEqual(bobRoles, ["deployer", "viewer"]);
+    assert.equal(result.bindings.find((b) => b.kid === "kid_bob")?.label, "Bob");
+    // carol matched no mapped group => unmapped, no binding
+    assert.equal(
+      result.bindings.some((b) => b.kid === "kid_carol"),
+      false,
+    );
+    assert.deepEqual(
+      result.unmapped.map((s) => s.subject),
+      ["carol"],
+    );
+    // membership was consulted, but the in-memory source touched no network.
+    assert.equal(calls, 3);
+  });
+
+  it("namespaces groups by org and validates pubkey/kid consistency", async () => {
+    const { publicKey } = generateKeyPairSync("ed25519");
+    const pem = publicKey.export({ type: "spki", format: "pem" }) as string;
+    const kid = identityId(pem);
+    const source: GithubMembershipSource = {
+      async listTeams(): Promise<string[]> {
+        return ["sec"];
+      },
+    };
+    const provider = createGithubProvider({ source, org: "acme" });
+    const roleMap = { "acme/sec": "admin" };
+
+    const ok = await compileRoleBindings({
+      provider,
+      roleMap,
+      subjects: [{ subject: "dana", kid, pubkey: pem }],
+    });
+    assert.deepEqual(ok.bindings, [{ kid, role: "admin", pubkey: pem }]);
+
+    // a pubkey that does not derive to its kid must fail LOUD at enrollment
+    await assert.rejects(
+      compileRoleBindings({
+        provider,
+        roleMap,
+        subjects: [{ subject: "dana", kid: "kid_wrong", pubkey: pem }],
+      }),
+      /derives to/,
+    );
+  });
+});
+
+describe("rbac/identity-provider — createGithubApiSource (fake fetch, no real network)", () => {
+  const prev = process.env.KIT_RBAC_GITHUB_API;
+  after(() => {
+    if (prev === undefined) delete process.env.KIT_RBAC_GITHUB_API;
+    else process.env.KIT_RBAC_GITHUB_API = prev;
+  });
+
+  it("hits the KIT_RBAC_GITHUB_API base with the bearer token and parses membership", async () => {
+    process.env.KIT_RBAC_GITHUB_API = "https://ghe.example.com/api/v3";
+    const seen: Array<{ url: string; auth: unknown }> = [];
+    const fakeFetch = (async (url: string, init: { headers: Record<string, string> }) => {
+      seen.push({ url: String(url), auth: init.headers.Authorization });
+      const u = String(url);
+      if (u.endsWith("/orgs/acme/teams")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [{ slug: "deployers" }, { slug: "viewers" }],
+        };
+      }
+      if (u.includes("/teams/deployers/memberships/octocat")) {
+        return { ok: true, status: 200, json: async () => ({ state: "active" }) };
+      }
+      if (u.includes("/teams/viewers/memberships/octocat")) {
+        return { ok: false, status: 404, json: async () => ({}) };
+      }
+      return { ok: false, status: 500, json: async () => ({}) };
+    }) as unknown as typeof fetch;
+
+    const src = createGithubApiSource({
+      token: "test-token",
+      org: "acme",
+      fetchImpl: fakeFetch,
+    });
+    const teams = await src.listTeams("octocat");
+    assert.deepEqual(teams, ["deployers"]); // only the active membership
+    assert.ok(seen[0].url.startsWith("https://ghe.example.com/api/v3/orgs/acme/teams"));
+    assert.equal(seen[0].auth, "Bearer test-token");
+  });
+
+  it("offline enrollment via an in-memory source calls fetch ZERO times", async () => {
+    let fetchCalls = 0;
+    const fakeFetch = (async () => {
+      fetchCalls++;
+      return { ok: false, status: 500, json: async () => ({}) };
+    }) as unknown as typeof fetch;
+    // Build an API source but DO NOT use it; enrollment uses an in-memory source.
+    createGithubApiSource({ token: "x", org: "acme", fetchImpl: fakeFetch });
+    const provider = createGithubProvider({
+      source: {
+        async listTeams() {
+          return ["deployers"];
+        },
+      },
+    });
+    const result = await compileRoleBindings({
+      provider,
+      roleMap: { deployers: "deployer" },
+      subjects: [{ subject: "eve", kid: "kid_eve" }],
+    });
+    assert.deepEqual(result.bindings, [{ kid: "kid_eve", role: "deployer" }]);
+    assert.equal(fetchCalls, 0);
+  });
+
+  it("fail-closed: a non-OK teams-list response THROWS (never spurious empty membership)", async () => {
+    const fakeFetch = (async () => ({
+      ok: false,
+      status: 403,
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+    const src = createGithubApiSource({ token: "t", org: "acme", fetchImpl: fakeFetch });
+    await assert.rejects(() => src.listTeams("octocat"), /teams list failed.*HTTP 403/);
+  });
+
+  it("fail-closed: a non-OK, non-404 membership response THROWS", async () => {
+    const fakeFetch = (async (url: string) => {
+      const u = String(url);
+      if (u.endsWith("/orgs/acme/teams")) {
+        return { ok: true, status: 200, json: async () => [{ slug: "deployers" }] };
+      }
+      // membership check returns 500 → must throw, not silently treat as non-member
+      return { ok: false, status: 500, json: async () => ({}) };
+    }) as unknown as typeof fetch;
+    const src = createGithubApiSource({ token: "t", org: "acme", fetchImpl: fakeFetch });
+    await assert.rejects(() => src.listTeams("octocat"), /membership check failed.*HTTP 500/);
+  });
+});
+
+describe("rbac architecture guard — resolve stays offline", () => {
+  it("resolve.js imports neither identity-provider nor a network primitive", () => {
+    const here = dirname(fileURLToPath(import.meta.url)); // dist/rbac
+    const src = readFileSync(join(here, "resolve.js"), "utf8");
+    assert.ok(
+      !/from\s+["'][^"']*identity-provider/.test(src),
+      "resolve.js must not import identity-provider",
+    );
+    assert.ok(
+      !/from\s+["']node:(http|https|net|dns|tls)/.test(src),
+      "resolve.js must not import a node network module",
+    );
+    assert.ok(!/\bfetch\s*\(/.test(src), "resolve.js must not call fetch");
+  });
+});

--- a/src/rbac/resolve.ts
+++ b/src/rbac/resolve.ts
@@ -1,0 +1,148 @@
+/**
+ * kit RBAC resolver — the OFFLINE, deterministic, fail-CLOSED decision engine
+ * for Pelare 2.
+ *
+ * `can(subjectKid, permission, verifiedPolicy)` and
+ * `effectivePermissions(subjectKid, verifiedPolicy)` are PURE functions over a
+ * `VerifiedPolicy`. There is ZERO network at decision time: authority comes
+ * entirely from the org-signed `.kit-policy.toml`, whose signature is verified
+ * offline against the committed `.kit-policy.signers` trust anchor (or the local
+ * identity / a pinned key) by the existing `verifyPolicy`.
+ *
+ * FAIL-CLOSED, no false green. A decision can only ever be ALLOW when:
+ *   - `verify.status === "valid"` (unsigned / unverifiable / invalid / revoked
+ *     policy => deny). `loadVerifiedPolicy` returns `null` unless the verdict is
+ *     valid, AND `can`/`effectivePermissions` DEFENSIVELY re-check the verdict, so
+ *     a hand-built object carrying a non-valid verdict can never yield an allow.
+ *   - the subject has a matching binding (or the policy sets a `defaultRole`), and
+ *   - the subject kid is NOT locally revoked (`isRevoked` — a SECONDARY deny; see
+ *     the honesty note below).
+ *   - if the binding carries a pubkey, `identityId(pubkey) === kid` (a mismatched
+ *     binding is ignored — it cannot grant).
+ *
+ * HONESTY — subject revocation authority: the authoritative offline revocation of
+ * a subject is the ORG re-signing the policy with the binding removed. `isRevoked`
+ * reads the machine-LOCAL `revocations.jsonl`, NOT an org-distributed CRL, so it
+ * is only a secondary, best-effort deny signal — never implied live org revocation.
+ *
+ * Imports ONLY policy-doc.ts, identity.ts, and the pure policy-schema.ts. It never
+ * imports identity-provider.ts or any network primitive (asserted by a test) so
+ * the enforcement surface stays offline.
+ */
+import { loadPolicy, verifyPolicy } from "../policy-doc.js";
+import type { PolicyDoc, PolicyVerifyResult } from "../policy-doc.js";
+import { identityId, isRevoked } from "../identity.js";
+import { extractRbac, permissionMatches } from "./policy-schema.js";
+import type { RbacPolicy } from "./policy-schema.js";
+
+/** A policy that has been loaded AND cryptographically verified offline. */
+export interface VerifiedPolicy {
+  /** Repo root the policy was loaded from. */
+  root: string;
+  /** The parsed policy document. */
+  doc: PolicyDoc;
+  /** The normalized `[rbac]` table, or null when absent/malformed (=> total deny). */
+  rbac: RbacPolicy | null;
+  /** The verification verdict. Only `status === "valid"` may ever yield an allow. */
+  verify: PolicyVerifyResult;
+}
+
+/**
+ * Resolve the policy root: `KIT_RBAC_POLICY` env override wins, then an explicit
+ * `override`, then the current working directory (the kiro `??` convention).
+ */
+export function rbacPolicyRoot(override?: string): string {
+  return process.env.KIT_RBAC_POLICY ?? override ?? process.cwd();
+}
+
+/**
+ * Load + verify the policy at `root`. Returns a `VerifiedPolicy` ONLY when the
+ * signature verdict is `valid`; returns `null` for every other verdict (unsigned,
+ * unverifiable, invalid, revoked) — total deny on an untrustworthy policy.
+ */
+export function loadVerifiedPolicy(
+  root: string,
+  opts: { key?: string } = {},
+): VerifiedPolicy | null {
+  const verify = verifyPolicy(root, opts);
+  if (verify.status !== "valid") return null;
+  const doc = loadPolicy(root);
+  if (!doc) return null; // defensive: verify said valid, so a doc must exist
+  return { root, doc, rbac: extractRbac(doc), verify };
+}
+
+/** Is a verified-policy object actually usable for an ALLOW? Fail-closed guard. */
+function usable(vp: VerifiedPolicy | null): vp is VerifiedPolicy {
+  // Re-check the verdict here (not just at load) so an object hand-built with a
+  // non-valid verdict — or one whose verdict was mutated after load — can never
+  // produce a green decision.
+  return !!vp && vp.verify.status === "valid" && vp.rbac !== null;
+}
+
+/** Bindings that authorize `subjectKid`, dropping any whose pubkey/kid mismatch. */
+function bindingsFor(subjectKid: string, rbac: RbacPolicy): RbacPolicy["bindings"] {
+  return rbac.bindings.filter((b) => {
+    if (b.kid !== subjectKid) return false;
+    if (b.pubkey !== undefined) {
+      try {
+        if (identityId(b.pubkey) !== b.kid) return false; // integrity: pubkey must derive to kid
+      } catch {
+        return false; // malformed pubkey => ignore the binding (fail-closed)
+      }
+    }
+    return true;
+  });
+}
+
+/**
+ * The set of permission grants a subject effectively holds under a verified
+ * policy. Pure and fail-closed: returns `[]` for a null/non-valid policy, an
+ * absent `[rbac]` table, or an unknown subject with no `defaultRole`. Grants from
+ * multiple bindings/roles are UNIONed (a kid may hold several roles by design).
+ */
+export function effectivePermissions(
+  subjectKid: string,
+  verifiedPolicy: VerifiedPolicy | null,
+): string[] {
+  if (!usable(verifiedPolicy)) return [];
+  const rbac = verifiedPolicy.rbac!;
+  const matched = bindingsFor(subjectKid, rbac);
+
+  let roleNames: string[];
+  if (matched.length > 0) {
+    roleNames = matched.map((b) => b.role);
+  } else if (rbac.defaultRole !== undefined) {
+    roleNames = [rbac.defaultRole];
+  } else {
+    return []; // unknown subject, no default => deny
+  }
+
+  const perms = new Set<string>();
+  for (const role of roleNames) {
+    // `Object.hasOwn` guard: a binding whose role is an inherited Object.prototype
+    // name (e.g. "toString") must resolve to NO grants, not the inherited method
+    // (which would be truthy and non-iterable → a throw). Own-property only.
+    const grants = Object.hasOwn(rbac.roles, role) ? rbac.roles[role] : undefined;
+    if (!grants) continue;
+    for (const g of grants) perms.add(g);
+  }
+  return [...perms];
+}
+
+/**
+ * Can `subjectKid` perform `permission` under `verifiedPolicy`? Pure, deterministic,
+ * fail-CLOSED. Denies on: null/non-valid policy, absent `[rbac]`, unknown subject
+ * (no matching binding and no defaultRole), a role missing from the roles table, a
+ * pubkey/kid-mismatched binding, or a LOCALLY revoked subject kid (secondary deny).
+ */
+export function can(
+  subjectKid: string,
+  permission: string,
+  verifiedPolicy: VerifiedPolicy | null,
+): boolean {
+  if (!usable(verifiedPolicy)) return false;
+  // Secondary, best-effort deny: a locally-recorded revocation of the subject.
+  if (isRevoked(subjectKid)) return false;
+  const perms = effectivePermissions(subjectKid, verifiedPolicy);
+  return perms.some((grant) => permissionMatches(grant, permission));
+}


### PR DESCRIPTION
## Description

Lands **v1 of the three kit 5.0 north-star pillars** — each behind the interface the design calls for, fail-closed, with honest degradation where a capability can't be exercised in this environment. Built via a multi-agent workflow (design → implement → adversarial verify), then hardened on the verify findings. These are foundations (new modules, not yet wired into every call path); hardware/control-plane backends + call-path wiring follow in beta/rc.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- **Pelare 1 — hardware-rooted identity behind a `KeyStore` port** (`src/keystore/`): `KeyStore` interface + `file` backend wrapping the existing 0600-file identity (pure delegation; deterministic offline `verifySignature` untouched) + honest `secure-enclave`/`tpm` extension-point stubs (`available()={ok:false,reason}`, fail-closed — never false-green) + `resolveKeyStore()` with honest fallback/degradation and a `KIT_KEYSTORE` force that refuses to silently downgrade.
- **Pelare 3 — gate → runtime exec-broker** (`src/exec-broker/`): pure fail-closed gates `checkEgress`/`checkFsWrite`/`scopeEnv` + `brokerExec` (default-deny with no policy, least-privilege env scoped to *requested* keys, impure realpath symlink-escape check, fail-closed pre-exec audit) composing on top of `runGoverned`.
- **Pelare 2 — RBAC bound to an IdP at enrollment, enforced offline** (`src/rbac/`): role-bindings inside the org-signed `.kit-policy` verified offline against `.kit-policy.signers` (**zero network at decision time**); pure fail-closed `can()`/`effectivePermissions()` (prototype-safe role lookup, unknown-subject/malformed → deny, local revocation as secondary deny); `IdentityProvider` + GitHub enrollment backend behind an injectable fetch (Azure/Entra + Google documented as future backends), fail-closed on non-OK GitHub responses.
- Bump to `5.0.0-alpha.2`; CHANGELOG documents all three.

## Hardening applied from the workflow's adversarial-verify pass

- exec-broker: env scoped to **requested** keys (least privilege), not all declared; added an impure **realpath symlink-escape** check on top of the pure fs gate.
- rbac: **prototype-safe** role lookup (`Object.hasOwn`) so a binding to an inherited method name (`toString`) resolves to no grants instead of throwing; added the missing **fail-closed** tests for non-OK GitHub teams/membership responses.

## Testing

### Test Coverage
- [x] Added new tests — 87 across the three modules (keystore/exec-broker/rbac)
- [x] All tests pass (`npm test`) — **2193 pass, 0 fail**

### Manual Testing
1. `npm run build` — clean.
2. `npm test` — 2193 pass, 0 fail.
3. `npx eslint src/keystore src/exec-broker src/rbac` — 0 errors, 0 warnings; `prettier --check` clean.

## Breaking Changes

None / N/A — all-new modules + a version bump; nothing existing changed.

## Reviewer Notes

Principles held throughout: **zero LLM in core, local-first/offline, fail-closed, no false-green.** Notably: the RBAC decision path takes **zero network** (IdP is enrollment-only, verified by an architecture-guard test); hardware KeyStore backends honestly report unavailable rather than faking; every module has a `KIT_<X>` env override for testability. Scope note: `brokerExec` is a v1 module not yet wired into the live tool-call path — that wiring is the next step in the Pelare 3 sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_