### PR TITLE
chore(release): re-version to 4.1.0 (additive; reserve 5.0.0 for breaking pillar work)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-## [5.0.0-alpha.2] - 2026-07-04
+## [4.1.0] - 2026-07-04
 
-Road to 5.0, step two: land **v1 of the three north-star pillars** behind the
-interfaces the design calls for — real, tested, fail-closed modules with honest
-degradation where a capability can't be exercised yet. These are foundations
-(new modules, not yet wired into every call path); wiring + hardware/control-plane
-backends follow in beta/rc. Built via a multi-agent workflow (design → implement
-→ adversarial verify), then hardened on the verify findings.
+A wholly **additive**, backward-compatible release along two axes — broader agent
+coverage and the first **v1 foundations of the 5.0 north-star pillars**. Semver
+note: nothing here breaks an existing contract (all-new modules, no default
+flipped), so this is a MINOR, not a major. The pillar work lands behind the
+interfaces the north-star design calls for, but the _breaking_ capabilities that
+will justify **5.0.0** — hardware-key migration, enforcement-on-by-default, a
+required control plane — deliberately do NOT ship here. `5.0.0` is reserved for
+when the first of those lands. Built via a multi-agent workflow (design →
+implement → adversarial verify), then hardened on the verify findings.
 
-### Added
+### Added — 5.0 pillar foundations
 
 - **Pelare 1 — hardware-rooted identity behind a `KeyStore` port** (`src/keystore/`).
   A `KeyStore` interface (`available`/`publicKeyPem`/`sign`/`create`/`rotate`) with a
@@ -43,15 +46,12 @@ backends follow in beta/rc. Built via a multi-agent workflow (design → impleme
   and Google documented as future backends of the same interface); a non-OK GitHub
   response fails closed (throws) rather than reporting spurious empty membership.
 
-## [5.0.0-alpha.1] - 2026-07-04
+### Added — wider agent coverage
 
-First step on the road to 5.0: broaden kit's four-surface agent model
-(rules / memory / install-gate / lifecycle hooks) across the coding-agent
-ecosystem, shipping only where the transcript path, format, and block
-contract are verified — and naming the rest as honest limitations rather
-than faking coverage.
-
-### Added
+Broaden kit's four-surface agent model (rules / memory / install-gate / lifecycle
+hooks) across the coding-agent ecosystem, shipping only where the transcript path,
+format, and block contract are verified — and naming the rest as honest
+limitations rather than faking coverage.
 
 - **Six more agents onboarded (research-driven).** kit now indexes memory and/or
   enforces installs for a much wider agent set. Every surface below was verified

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.0.0-alpha.2",
+  "version": "4.1.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
## Description

Answers the open "is this 5.0 or 4.1?" question with the honest semver call: **it's 4.1.0.** Everything merged since 4.0.0 — the six-agent coverage expansion and the v1 foundations of the three north-star pillars (KeyStore, exec-broker, RBAC) — is **additive and backward-compatible**: all-new modules, no default flipped, nothing existing changed. By strict semver that's a MINOR.

`5.0.0` is reserved for the first **breaking** pillar capability (hardware-key migration, enforcement-on-by-default, a required control plane) — none of which ship yet. Calling v1 *foundations* a major would over-promise, which is exactly the false-green kit refuses elsewhere.

Nothing was published to npm (the `5.0.0-alpha.*` tags were created locally and never pushed), so this is a clean correction.

## Type of Change

- [x] Documentation update (versioning + CHANGELOG)

## Changes Made

- `package.json`: `5.0.0-alpha.2` → `4.1.0`.
- `CHANGELOG.md`: consolidate the two `5.0.0-alpha.*` pre-release sections into a single `[4.1.0]` with two subsections — "5.0 pillar foundations" and "wider agent coverage" — plus a semver note explaining why this is a MINOR and what `5.0.0` is reserved for.

## Testing

- [x] `npm run build` clean; `npm test` — **2193 pass, 0 fail**; version-sensitive `cli.test` green.

## Breaking Changes

None / N/A.

## Reviewer Notes

Pure version/changelog change — no source touched. If you'd rather run a long `5.0.0-alpha` preview line (publish prereleases only until the pillars are breaking-complete) or split into `4.1.0` (agents) + `4.2.0` (pillars), say so and I'll re-cut — it's a one-commit change either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_