### PR TITLE
chore(release): adopt the 5.0.0-alpha preview line + safe prerelease dist-tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,10 +104,29 @@ jobs:
       - name: Build production artifacts
         run: npm run build:prod
 
+      - name: Resolve npm dist-tag (prerelease → next, stable → latest)
+        # A SemVer prerelease (version contains a hyphen, e.g. 5.0.0-alpha.1) MUST
+        # NOT become npm's `latest` — otherwise a plain `npm i sandstream-kit`
+        # would hand every user an alpha. Publish those under `next` so `latest`
+        # only ever moves on a stable release. Fail-closed: an unreadable/invalid
+        # version aborts the publish rather than guessing `latest`.
+        id: disttag
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          if [ -z "$VERSION" ] || [ "$VERSION" = "undefined" ]; then
+            echo "::error::could not read package.json version"; exit 1
+          fi
+          case "$VERSION" in
+            *-*) TAG="next" ;;   # any prerelease identifier
+            *)   TAG="latest" ;;
+          esac
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Publishing $VERSION under dist-tag '$TAG'"
+
       - name: Show what will be published
         # `npm publish --dry-run` lists the exact files going into the tarball
         # and prints the tarball SHA — gives auditors a verifiable trail.
-        run: npm publish --dry-run
+        run: npm publish --dry-run --tag ${{ steps.disttag.outputs.tag }}
 
       - name: Publish to npm with provenance
         # --provenance generates an SLSA build provenance attestation signed
@@ -115,7 +134,9 @@ jobs:
         #   npm audit signatures
         # or
         #   npm view sandstream-kit --json | jq '.dist'
-        run: npm publish --provenance --access public
+        # --tag routes prereleases to `next` (see the resolve step) so they never
+        # clobber `latest`.
+        run: npm publish --provenance --access public --tag ${{ steps.disttag.outputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-## [4.1.0] - 2026-07-04
+## [5.0.0-alpha.1] - 2026-07-04
 
-A wholly **additive**, backward-compatible release along two axes — broader agent
-coverage and the first **v1 foundations of the 5.0 north-star pillars**. Semver
-note: nothing here breaks an existing contract (all-new modules, no default
-flipped), so this is a MINOR, not a major. The pillar work lands behind the
-interfaces the north-star design calls for, but the _breaking_ capabilities that
-will justify **5.0.0** — hardware-key migration, enforcement-on-by-default, a
-required control plane — deliberately do NOT ship here. `5.0.0` is reserved for
-when the first of those lands. Built via a multi-agent workflow (design →
-implement → adversarial verify), then hardened on the verify findings.
+**First alpha of the 5.0 line.** This opens the road to 5.0 along two axes:
+broader agent coverage and the first **v1 foundations of the three north-star
+pillars**. Everything here is additive today, but it is published as a
+**prerelease** (npm dist-tag `next`, never `latest`) because the 5.0 line will
+land _breaking_ capabilities before its stable cut — hardware-key migration,
+enforcement-on-by-default, a required control plane. Install the preview with
+`npm i sandstream-kit@next`; `npm i sandstream-kit` stays on the stable 4.x.
+Built via a multi-agent workflow (design → implement → adversarial verify), then
+hardened on the verify findings.
 
 ### Added — 5.0 pillar foundations
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "4.1.0",
+  "version": "5.0.0-alpha.1",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
## Description

Switches the versioning strategy to a **5.0 alpha preview line** (per the decision to "go alpha"). The agent-coverage + v1 pillar foundations already on main become **`5.0.0-alpha.1`**, published as a **prerelease** rather than a stable 4.x — advertising the road to 5.0 while nothing stable ships until the pillars are breaking-complete.

Critically, this also fixes a **release footgun**: `publish.yml` ran `npm publish` with no `--tag`, so a prerelease would have become npm's `latest` and handed every `npm i sandstream-kit` user an alpha. Now the dist-tag is resolved from the version (prerelease → `next`, stable → `latest`).

## Type of Change

- [x] Documentation update (versioning + CHANGELOG)
- [x] CI/release fix (publish workflow)

## Changes Made

- `package.json`: `4.1.0` → `5.0.0-alpha.1`.
- `.github/workflows/publish.yml`: new "Resolve npm dist-tag" step — a SemVer prerelease (version contains `-`) publishes under `next`, a stable version under `latest`; both the dry-run and real `npm publish` now pass `--tag`. Fail-closed: an unreadable version aborts the publish rather than defaulting to `latest`.
- `CHANGELOG.md`: reframe the entry as `[5.0.0-alpha.1]` — the first alpha of the 5.0 line, with install guidance (`npm i sandstream-kit@next` for the preview, plain install stays on stable 4.x).

## Result — how consumers get each

- `npm i sandstream-kit` → stable 4.x (`latest`, unaffected).
- `npm i sandstream-kit@next` → `5.0.0-alpha.1` (the preview line).

## Testing

- [x] `python3 -c 'import yaml; yaml.safe_load(...)'` — publish.yml is valid YAML.
- [x] `npm run build` clean; `npm test` — **2193 pass, 0 fail**; version-sensitive `cli.test` green.

## Breaking Changes

None / N/A — version string + CHANGELOG + a publish-workflow hardening. No source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_