### PR TITLE
chore(release): settle on stable 4.1.0 (drop the alpha preview line)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-## [5.0.0-alpha.1] - 2026-07-04
+## [4.1.0] - 2026-07-04
 
-**First alpha of the 5.0 line.** This opens the road to 5.0 along two axes:
-broader agent coverage and the first **v1 foundations of the three north-star
-pillars**. Everything here is additive today, but it is published as a
-**prerelease** (npm dist-tag `next`, never `latest`) because the 5.0 line will
-land _breaking_ capabilities before its stable cut — hardware-key migration,
-enforcement-on-by-default, a required control plane. Install the preview with
-`npm i sandstream-kit@next`; `npm i sandstream-kit` stays on the stable 4.x.
-Built via a multi-agent workflow (design → implement → adversarial verify), then
-hardened on the verify findings.
+A wholly **additive**, backward-compatible release along two axes — broader agent
+coverage and the first **v1 foundations of the 5.0 north-star pillars**. Semver
+note: nothing here breaks an existing contract (all-new modules, no default
+flipped), so this is a MINOR, not a major. The pillar work lands behind the
+interfaces the north-star design calls for, but the _breaking_ capabilities that
+will justify **5.0.0** — hardware-key migration, enforcement-on-by-default, a
+required control plane — deliberately do NOT ship here; `5.0.0` is reserved for
+when the first of those lands. Built via a multi-agent workflow (design →
+implement → adversarial verify), then hardened on the verify findings.
 
 ### Added — 5.0 pillar foundations
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.0.0-alpha.1",
+  "version": "4.1.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
## Description

Settle on the simple, stable scheme: **this is `4.1.0`**, not a `5.0.0-alpha` prerelease. An additive, backward-compatible MINOR (agent coverage + v1 pillar foundations). `5.0.0` stays reserved for the first breaking pillar capability.

Nothing was published to npm at any point, so this is a clean settle.

## Type of Change

- [x] Documentation update (versioning + CHANGELOG)

## Changes Made

- `package.json`: `5.0.0-alpha.1` → `4.1.0`.
- `CHANGELOG.md`: reframe the entry back to `[4.1.0]` (stable MINOR).
- Kept: the `publish.yml` dist-tag safety from the prior change (prerelease → `next`, stable → `latest`). It's harmless for a stable release (resolves to `latest`) and prevents a future prerelease from clobbering `latest`.

## Testing

- [x] `npm run build` clean; `npm test` — **2193 pass, 0 fail**; version-sensitive `cli.test` green.

## Breaking Changes

None / N/A — version string + CHANGELOG only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_