### PR TITLE
feat(exec-broker): wire the broker into the MCP mutating-tool path (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **exec-broker wired into the MCP mutating-tool path (opt-in)** via `runBrokered`
+  (`src/exec-broker/`) and `runGovernedBrokered` (`src/governance-middleware.ts`).
+  The Pelare-3 resource gates (egress / fs-write / env) now compose ON TOP of the
+  governance floor at the four MCP mutating tools. It is **opt-in and
+  non-breaking**: with no `.kit-exec-broker.json` (nor `KIT_EXEC_BROKER_POLICY`)
+  present, `runBrokered` is a transparent passthrough, so behavior is identical
+  until a user drops a policy in. A present-but-malformed policy fails **closed**
+  (deny) — a broken gate never silently disables enforcement.
 - **RBAC identity providers for Microsoft Entra ID and Google Cloud Identity**
   (`src/rbac/providers-cloud.ts`), siblings of the GitHub backend. Both compile
   role bindings at ENROLLMENT time behind an injectable membership source (real

--- a/src/exec-broker/broker.test.ts
+++ b/src/exec-broker/broker.test.ts
@@ -1,9 +1,17 @@
-import { describe, it, beforeEach, afterEach } from "node:test";
+import { describe, it, beforeEach, afterEach, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, readFileSync, existsSync, symlinkSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  symlinkSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { brokerExec, type BrokerContext } from "./broker.js";
+import { brokerExec, runBrokered, type BrokerContext } from "./broker.js";
 import type { BrokerPolicy } from "./policy.js";
 
 const POLICY: BrokerPolicy = {
@@ -220,6 +228,62 @@ describe("brokerExec symlink hardening (impure realpath check)", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe("runBrokered opt-in (policy file present/absent)", () => {
+  const prev = process.env.KIT_EXEC_BROKER_POLICY;
+  after(() => {
+    if (prev === undefined) delete process.env.KIT_EXEC_BROKER_POLICY;
+    else process.env.KIT_EXEC_BROKER_POLICY = prev;
+  });
+
+  it("NOT configured (no policy file) → runs unmediated, no default-deny", async () => {
+    delete process.env.KIT_EXEC_BROKER_POLICY; // sandbox cwd has no .kit-exec-broker.json
+    let ran = false;
+    const out = await runBrokered(
+      CTX({ egressTargets: ["https://anything.example"] }),
+      async () => {
+        ran = true;
+        return "ok";
+      },
+    );
+    assert.equal(out.ok, true, "passthrough when broker is not opted into");
+    assert.equal(out.result, "ok");
+    assert.equal(ran, true);
+  });
+
+  it("configured with a valid policy → enforces (denies out-of-allowlist egress)", async () => {
+    const pol = join(sandbox, "broker.json");
+    writeFileSync(
+      pol,
+      JSON.stringify({
+        egress: { allow: ["api.example.com"] },
+        fs: { root: sandbox },
+        env: { declared: [] },
+      }),
+    );
+    process.env.KIT_EXEC_BROKER_POLICY = pol;
+    let ran = false;
+    const out = await runBrokered(CTX({ egressTargets: ["https://evil.com"] }), async () => {
+      ran = true;
+      return 1;
+    });
+    assert.equal(out.ok, false);
+    assert.equal(ran, false, "gate denied before running");
+  });
+
+  it("configured but MALFORMED policy → fail-closed deny (never silently off)", async () => {
+    const pol = join(sandbox, "broker-bad.json");
+    writeFileSync(pol, "{ not valid json");
+    process.env.KIT_EXEC_BROKER_POLICY = pol;
+    let ran = false;
+    const out = await runBrokered(CTX(), async () => {
+      ran = true;
+      return 1;
+    });
+    assert.equal(out.ok, false, "a broken policy fails closed, not open");
+    assert.equal(ran, false);
   });
 });
 

--- a/src/exec-broker/broker.ts
+++ b/src/exec-broker/broker.ts
@@ -28,7 +28,7 @@ import { dirname, resolve, sep } from "node:path";
 import type { OperationContext } from "../governance-middleware.js";
 import { appendAuditEventDirect } from "../audit.js";
 import { checkEgress, checkFsWrite, scopeEnv } from "./decisions.js";
-import type { BrokerPolicy } from "./policy.js";
+import { brokerPolicyPath, loadBrokerPolicy, type BrokerPolicy } from "./policy.js";
 
 /** Environment label stamped on broker audit entries. */
 const BROKER_ENV = "exec-broker";
@@ -144,6 +144,34 @@ function collectDenials(context: BrokerContext, policy: BrokerPolicy): string[] 
   }
 
   return denials;
+}
+
+/**
+ * OPT-IN entry point. The broker only mediates when a policy FILE is present:
+ *   - No `.kit-exec-broker.json` (nor `KIT_EXEC_BROKER_POLICY`) → run UNMEDIATED,
+ *     exactly like before the broker existed (this is the opt-in switch — a fresh
+ *     install is never silently gated).
+ *   - File present but malformed → `loadBrokerPolicy` returns null → `brokerExec`
+ *     default-DENIES. A broken gate fails closed; it never silently disables
+ *     enforcement (no false-green).
+ *   - File present + valid → full `brokerExec` mediation.
+ * This is the drop-in every call site adopts to become broker-aware without
+ * changing behavior for users who haven't opted in.
+ */
+export async function runBrokered<T>(
+  context: BrokerContext,
+  run: (scopedEnv: Record<string, string>) => Promise<T>,
+  opts: { policyOverride?: string } = {},
+): Promise<BrokerOutcome<T>> {
+  if (!existsSync(brokerPolicyPath(opts.policyOverride))) {
+    // Not configured → unmediated passthrough (full env, no scoping).
+    try {
+      return { ok: true, result: await run(scopeEnv(Object.keys(process.env), process.env)) };
+    } catch (err) {
+      return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+    }
+  }
+  return brokerExec(context, loadBrokerPolicy(opts.policyOverride), run);
 }
 
 /**

--- a/src/exec-broker/index.ts
+++ b/src/exec-broker/index.ts
@@ -11,4 +11,4 @@ export {
   type BrokerPolicy,
 } from "./policy.js";
 
-export { brokerExec, type BrokerContext, type BrokerOutcome } from "./broker.js";
+export { brokerExec, runBrokered, type BrokerContext, type BrokerOutcome } from "./broker.js";

--- a/src/governance-middleware.ts
+++ b/src/governance-middleware.ts
@@ -298,6 +298,35 @@ export async function runGoverned<T>(
 }
 
 /**
+ * {@link runGoverned} with the Pelare 3 exec-broker composed ON TOP. The broker
+ * gates an operation's declared RESOURCE effects (egress / fs-write / env)
+ * BEFORE governance (identity / budget / permission) runs; the two are separate
+ * concerns that stack.
+ *
+ * OPT-IN and non-breaking: `runBrokered` is a passthrough unless a broker policy
+ * file (`.kit-exec-broker.json` / `KIT_EXEC_BROKER_POLICY`) is present, so a call
+ * site swapping `runGoverned` → `runGovernedBrokered` behaves IDENTICALLY until a
+ * user opts in by dropping a policy in. A present-but-malformed policy fails
+ * closed (deny). Returns the same {@link GovernedOutcome} shape callers already
+ * render.
+ */
+export async function runGovernedBrokered<T>(
+  config: kitConfig,
+  context: OperationContext,
+  operation: () => Promise<T>,
+): Promise<GovernedOutcome<T>> {
+  const { runBrokered } = await import("./exec-broker/index.js");
+  const outcome = await runBrokered(context, async () => {
+    const gov = await runGoverned(config, context, operation);
+    // Signal a governance denial (or op error) as a throw so the broker layer
+    // surfaces it as a not-ok outcome with the same reason.
+    if (!gov.ok) throw new Error(gov.reason ?? "denied");
+    return gov.result as T;
+  });
+  return outcome.ok ? { ok: true, result: outcome.result } : { ok: false, reason: outcome.reason };
+}
+
+/**
  * Perform pre-flight checks without executing the operation
  */
 export async function checkGovernance(

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -33,7 +33,7 @@ import { executeCommand } from "./run.js";
 import { gatherProjectContext } from "./context.js";
 import { isReadOnlyMode } from "./read-only-mode.js";
 import { escapeWorkflowCmd } from "./utils/ci-escape.js";
-import { runGoverned } from "./governance-middleware.js";
+import { runGovernedBrokered } from "./governance-middleware.js";
 import type { kitConfig } from "./config.js";
 
 const KIT_FILE = ".kit.toml";
@@ -243,7 +243,7 @@ function register_kit_install(server: McpServer): void {
           };
         }
 
-        const gov = await runGoverned(
+        const gov = await runGovernedBrokered(
           config,
           {
             operation: "tools.install",
@@ -337,7 +337,7 @@ function register_kit_secrets(server: McpServer): void {
           };
         }
 
-        const gov = await runGoverned(
+        const gov = await runGovernedBrokered(
           config,
           { operation: "secrets.generate", operationType: "write", metadata: {} },
           () => generateSecrets(config.secrets!, join(cwd ?? process.cwd(), ".env.local")),
@@ -383,7 +383,7 @@ function register_kit_fix(server: McpServer): void {
       try {
         const config = await loadConfig(configPath(cwd));
 
-        const gov = await runGoverned(
+        const gov = await runGovernedBrokered(
           config,
           { operation: "fix", operationType: "write", metadata: {} },
           async () => {
@@ -802,7 +802,7 @@ function register_kit_run(server: McpServer): void {
         // budget, permission, expired-secret block) and be audited — not just gated
         // by read-only mode.
         const config = await loadConfigForGovernance(cwd);
-        const gov = await runGoverned(
+        const gov = await runGovernedBrokered(
           config,
           { operation: "run", operationType: "write", metadata: { command } },
           () =>


### PR DESCRIPTION
## Description

First real call-path wiring for **Pelare 3** — the exec-broker (shipped as an unwired module in the prior alpha) now composes on top of the governance floor at kit's MCP mutating tools. **Opt-in and non-breaking**: dormant until a user drops a broker policy in.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `src/exec-broker/broker.ts`: new `runBrokered(context, run, {policyOverride?})` — the opt-in entry point. No policy file (`.kit-exec-broker.json` / `KIT_EXEC_BROKER_POLICY`) → runs **unmediated** (passthrough). Policy present + valid → full `brokerExec` mediation. Policy present but **malformed** → `loadBrokerPolicy` returns null → `brokerExec` default-**denies** (fail-closed; a broken gate never silently disables enforcement). Exported from the barrel.
- `src/governance-middleware.ts`: new `runGovernedBrokered` — composes `runBrokered` over `runGoverned` (resource gates on top of identity/budget/permission), returning the same `GovernedOutcome` shape.
- `src/mcp-server.ts`: swap the four `runGoverned` mutating-tool sites → `runGovernedBrokered`.

## Why this is safe to merge now

- **Default = identical behavior.** No policy file → `runBrokered` is a passthrough, so every existing MCP tool call behaves exactly as before. The broker only engages when a user opts in.
- **Fail-closed on breakage**, never fail-open.
- Broker stays **off the RBAC decision path** and makes no LLM/network calls.

## Testing

- [x] Added `runBrokered` opt-in tests: not-configured → unmediated; valid policy → enforces (denies out-of-allowlist egress); malformed policy → fail-closed deny.
- [x] `npm test` — **2203 pass, 0 fail**; MCP tool-surface guard test still green; `eslint` 0 errors (only the pre-existing `withGovernance` complexity warning); `prettier` clean.

## Breaking Changes

None / N/A.

## Reviewer Notes

Scope: this wires the broker into the **MCP** path. The MCP tools don't yet *declare* egress/fs effects, so with a policy present the active enforcement is env-scoping + audit + (once tools declare effects) egress/fs gating — the declared-effects trust boundary is documented in `broker.ts`. Threading effect declarations into each tool is the natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_