### PR TITLE
fix(security): enforce a revocation authority model (close cross-signer revocation HIGH)

### DIFF
--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -144,7 +144,9 @@ async function cmdAuditVerify(): Promise<boolean> {
   // signed by an unknown key are reported but do not fail verify. A FORGED
   // signature (invalid > 0) is a hard failure.
   const { verifyAuditSignatures } = await import("../audit.js");
-  const { localPublicKeys, loadRevocations } = await import("../identity.js");
+  const { localPublicKeys, revokedKids, localRevocationAuthorities } =
+    await import("../identity.js");
+  const { policySignersMap } = await import("../policy-trust.js");
   const trust = localPublicKeys();
   const s = verifyAuditSignatures(content, (kid) => trust.get(kid) ?? null);
   if (s.signed > 0) {
@@ -161,7 +163,15 @@ async function cmdAuditVerify(): Promise<boolean> {
     // Revocation note (kit panic): entries signed by a now-revoked key are still
     // valid HISTORICAL evidence (the signature was good when made), but that key
     // is no longer trusted for NEW signatures. Surface it; don't fail on it.
-    const revoked = new Set(loadRevocations().map((r) => r.kid));
+    // Only AUTHORITATIVE revocations count — a bare existence check would let a
+    // writer-only attacker plant a line and forge a "signed by a REVOKED key /
+    // kit panic" alarm (integrity-signal DoS). Use the same authority model as
+    // policy/rbac: self-revoke, this machine's local root, or an org anchor signer.
+    const orgSigners = policySignersMap(process.cwd());
+    const revoked = revokedKids(
+      new Map([...trust, ...orgSigners]),
+      new Set([...localRevocationAuthorities(), ...orgSigners.keys()]),
+    );
     if (revoked.size > 0) {
       let revokedSigs = 0;
       for (const line of content.split("\n")) {

--- a/src/identity.test.ts
+++ b/src/identity.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, existsSync, statSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { generateKeyPairSync } from "node:crypto";
@@ -15,7 +15,11 @@ import {
   recordRevocation,
   loadRevocations,
   isRevoked,
+  isRevokedWith,
+  isAuthoritativeRevocation,
+  localRevocationAuthorities,
   revocationStatement,
+  type RevocationRecord,
 } from "./identity.js";
 
 describe("identity", () => {
@@ -130,6 +134,81 @@ describe("identity", () => {
     } finally {
       process.env.KIT_IDENTITY_DIR = dir;
       rmSync(own, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT honor a planted, unsigned, or unauthorized revocation (authority model)", () => {
+    const d = mkdtempSync(join(tmpdir(), "kit-revoke-dos-"));
+    try {
+      process.env.KIT_IDENTITY_DIR = d;
+      const me = loadOrCreateIdentity().identity; // e.g. the org policy signer on this box
+      const revPath = join(d, "revocations.jsonl");
+
+      // A writer-only attacker plants a revocation of `me`, claiming some other key
+      // signed it, with a junk signature. The old bare existence-check honored this
+      // (fail-closed DoS on the real signer); the authority model must not.
+      const fromStranger: RevocationRecord = {
+        kid: me.id,
+        by: "kid_" + "0".repeat(32),
+        ts: "2026-01-01T00:00:00Z",
+        reason: "pwn",
+        sig: Buffer.from("junk").toString("base64"),
+      };
+      writeFileSync(revPath, JSON.stringify(fromStranger) + "\n");
+      assert.equal(loadRevocations().length, 1, "the planted record is on disk");
+      assert.equal(isRevoked(me.id), false, "unauthorized revoker must be ignored");
+
+      // Even a forged SELF-revocation (by === kid) fails: the signature can't verify
+      // against me's real public key (the attacker cannot forge Ed25519).
+      writeFileSync(revPath, JSON.stringify({ ...fromStranger, by: me.id }) + "\n");
+      assert.equal(isRevoked(me.id), false, "forged self-revocation with a bad sig is ignored");
+    } finally {
+      process.env.KIT_IDENTITY_DIR = dir;
+      rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  it("isAuthoritativeRevocation: self OR authorized signer with a valid sig only", () => {
+    const d = mkdtempSync(join(tmpdir(), "kit-revoke-auth-"));
+    try {
+      process.env.KIT_IDENTITY_DIR = d;
+      // `admin` signs a revocation of `victim` (a genuinely different key).
+      const victim = loadOrCreateIdentity().identity;
+      const { identity: admin } = rotateIdentity(); // admin is now current; signs the record
+      const rec = recordRevocation(victim.id, "compromised", undefined, "2026-06-01T00:00:00Z");
+      assert.equal(rec.by, admin.id);
+
+      const keys = localPublicKeys(); // { admin, victim(archived) }
+
+      // Authorized: admin is in the authority set → honored.
+      assert.equal(isAuthoritativeRevocation(rec, keys, new Set([admin.id])), true);
+      // Unauthorized: admin NOT an authority and by !== kid → rejected despite a valid sig.
+      assert.equal(isAuthoritativeRevocation(rec, keys, new Set()), false);
+      // Revoker's public key unknown → cannot verify → rejected.
+      assert.equal(isAuthoritativeRevocation(rec, new Map(), new Set([admin.id])), false);
+      // Tampered target (kid) breaks the signature → rejected even though authorized.
+      assert.equal(
+        isAuthoritativeRevocation(
+          { ...rec, kid: "kid_" + "f".repeat(32) },
+          keys,
+          new Set([admin.id]),
+        ),
+        false,
+      );
+
+      // A self-revocation (by === kid) needs no explicit authority, only a valid sig.
+      const selfRec = recordRevocation(admin.id, "retiring", undefined, "2026-06-02T00:00:00Z");
+      assert.equal(selfRec.by, admin.id);
+      assert.equal(selfRec.kid, admin.id);
+      assert.equal(isAuthoritativeRevocation(selfRec, keys, new Set()), true);
+
+      // The default local isRevoked honors admin (the current identity is local root).
+      assert.equal(localRevocationAuthorities().has(admin.id), true);
+      assert.equal(isRevoked(victim.id), true);
+      assert.equal(isRevokedWith(victim.id, keys, new Set([admin.id])), true);
+    } finally {
+      process.env.KIT_IDENTITY_DIR = dir;
+      rmSync(d, { recursive: true, force: true });
     }
   });
 

--- a/src/identity.test.ts
+++ b/src/identity.test.ts
@@ -17,6 +17,7 @@ import {
   isRevoked,
   isRevokedWith,
   isAuthoritativeRevocation,
+  revokedKids,
   localRevocationAuthorities,
   revocationStatement,
   type RevocationRecord,
@@ -231,6 +232,13 @@ describe("identity", () => {
       assert.equal(localRevocationAuthorities().has(admin.id), true);
       assert.equal(isRevoked(victim.id), true);
       assert.equal(isRevokedWith(victim.id, keys, new Set([admin.id])), true);
+
+      // revokedKids (the audit-command helper) lists the target under authority…
+      assert.equal(revokedKids(keys, new Set([admin.id])).has(victim.id), true);
+      // …and lists NOTHING when the revoker is not an authority (authority narrowing:
+      // this is why policy-doc drops local root — an unauthorized cross-signer
+      // revocation must not veto the target).
+      assert.equal(revokedKids(keys, new Set()).has(victim.id), false);
     } finally {
       process.env.KIT_IDENTITY_DIR = dir;
       rmSync(d, { recursive: true, force: true });

--- a/src/identity.test.ts
+++ b/src/identity.test.ts
@@ -137,6 +137,31 @@ describe("identity", () => {
     }
   });
 
+  it("localPublicKeys rejects a spoofed .bak whose id != fingerprint(publicKey)", () => {
+    const d = mkdtempSync(join(tmpdir(), "kit-keypoison-"));
+    try {
+      process.env.KIT_IDENTITY_DIR = d;
+      const me = loadOrCreateIdentity().identity;
+      // Attacker drops a .bak claiming to BE `me` (same kid) but carrying THEIR key,
+      // trying to poison the kid→pubkey map so a forged revocation "by me" verifies.
+      const attacker = generateKeyPairSync("ed25519").publicKey.export({
+        type: "spki",
+        format: "pem",
+      }) as string;
+      writeFileSync(
+        join(d, "identity.json.2099-01-01T00-00-00-000Z.bak"),
+        JSON.stringify({ id: me.id, algo: "ed25519", publicKey: attacker, createdAt: "x" }),
+      );
+      // The map must still bind `me.id` to the REAL key (fingerprint check rejects the
+      // spoof), so the attacker's key can never masquerade as an authority.
+      assert.equal(localPublicKeys().get(me.id), me.publicKey);
+      assert.notEqual(localPublicKeys().get(me.id), attacker);
+    } finally {
+      process.env.KIT_IDENTITY_DIR = dir;
+      rmSync(d, { recursive: true, force: true });
+    }
+  });
+
   it("does NOT honor a planted, unsigned, or unauthorized revocation (authority model)", () => {
     const d = mkdtempSync(join(tmpdir(), "kit-revoke-dos-"));
     try {

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -250,9 +250,94 @@ export function loadRevocations(dir?: string): RevocationRecord[] {
   }
 }
 
-/** True if `kid` has a revocation record. Pure read. */
+/**
+ * Is `rec` an AUTHORITATIVE revocation — one kit should actually honor? A record is
+ * honored only when BOTH hold:
+ *   1. its Ed25519 signature verifies against `by`'s public key (from `trustedKeys`);
+ *   2. `by` has AUTHORITY over `kid`: either `by === kid` (a key revoking itself, incl.
+ *      the rotation case where the successor id equals the record's own), or `by` is in
+ *      `authorities` (a trust-anchor set — org signers and/or this machine's local root).
+ *
+ * This is the fix for cross-signer revocation authority: without it, `isRevoked` was a
+ * bare existence check over `revocations.jsonl`, so ANY line — unsigned, or signed by a
+ * key with no authority over the target — revoked the target. A writer-only attacker
+ * could plant `{kid: <an org signer>}` and make the org's validly-signed policy verify as
+ * "revoked" (a fail-closed DoS on the real trust anchor), or revoke an arbitrary RBAC
+ * subject. Requiring a valid signature by an authorized revoker closes both: the attacker
+ * cannot forge an Ed25519 signature by an authority key. Pure; fail-closed on any doubt.
+ */
+export function isAuthoritativeRevocation(
+  rec: RevocationRecord,
+  trustedKeys: Map<string, string>,
+  authorities: Set<string>,
+): boolean {
+  if (
+    !rec ||
+    typeof rec.kid !== "string" ||
+    typeof rec.by !== "string" ||
+    typeof rec.ts !== "string" ||
+    typeof rec.reason !== "string" ||
+    typeof rec.sig !== "string"
+  ) {
+    return false;
+  }
+  if (rec.by !== rec.kid && !authorities.has(rec.by)) return false; // unauthorized revoker
+  const pub = trustedKeys.get(rec.by);
+  if (!pub) return false; // revoker's public key unknown → can't verify → don't honor
+  return verifySignature(
+    revocationStatement(rec.kid, rec.ts, rec.reason),
+    Buffer.from(rec.sig, "base64"),
+    pub,
+  );
+}
+
+/** kids carrying at least one AUTHORITATIVE revocation under the given trust context. */
+export function revokedKids(
+  trustedKeys: Map<string, string>,
+  authorities: Set<string>,
+  dir?: string,
+): Set<string> {
+  const out = new Set<string>();
+  for (const rec of loadRevocations(dir)) {
+    if (isAuthoritativeRevocation(rec, trustedKeys, authorities)) out.add(rec.kid);
+  }
+  return out;
+}
+
+/**
+ * Authority-aware revocation check against an explicit trust context. Callers that know
+ * the org trust anchor (e.g. policy verification) pass the org signers so org-propagated
+ * revocations are honored; a local-only caller passes just the machine's own keys.
+ */
+export function isRevokedWith(
+  kid: string,
+  trustedKeys: Map<string, string>,
+  authorities: Set<string>,
+  dir?: string,
+): boolean {
+  return loadRevocations(dir).some(
+    (r) => r.kid === kid && isAuthoritativeRevocation(r, trustedKeys, authorities),
+  );
+}
+
+/**
+ * LOCAL revocation authorities for this machine: the current identity is the local trust
+ * root (and is the rotation successor of its own archived keys, which it signs revocations
+ * with). Every key can additionally self-revoke (handled in isAuthoritativeRevocation).
+ */
+export function localRevocationAuthorities(dir?: string): Set<string> {
+  const cur = tryLoadIdentity(dir);
+  return new Set<string>(cur ? [cur.id] : []);
+}
+
+/**
+ * True if `kid` is revoked under this machine's LOCAL trust context (its own current +
+ * archived keys; the current identity as authority). Org-anchor-signed revocations are
+ * honored by callers that pass the org context via `isRevokedWith` (see policy-doc). This
+ * no longer honors unsigned/unauthorized records — it verifies signature + authority.
+ */
 export function isRevoked(kid: string, dir?: string): boolean {
-  return loadRevocations(dir).some((r) => r.kid === kid);
+  return isRevokedWith(kid, localPublicKeys(dir), localRevocationAuthorities(dir), dir);
 }
 
 /**

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -143,9 +143,20 @@ export function localPublicKeys(dir?: string): Map<string, string> {
   const map = new Map<string, string>();
   const base = identityDir(dir);
   const add = (rec: Identity | null) => {
-    if (rec && typeof rec.id === "string" && typeof rec.publicKey === "string") {
-      map.set(rec.id, rec.publicKey);
+    if (!rec || typeof rec.id !== "string" || typeof rec.publicKey !== "string") return;
+    // A kid IS the fingerprint of its public key, so re-derive and require the match.
+    // Without this, a writer-only attacker could drop a crafted identity.json.*.bak
+    // (or overwrite the record) claiming `{id: <a victim/authority kid>, publicKey:
+    // <attacker key>}` — poisoning this kid→pubkey map so a forged revocation "by"
+    // that kid verifies against the attacker's key. Binding kid==fingerprint(pub)
+    // makes the map unspoofable: the attacker can't produce a key whose fingerprint
+    // is someone else's kid.
+    try {
+      if (identityId(rec.publicKey) !== rec.id) return;
+    } catch {
+      return; // unparseable public key → skip
     }
+    map.set(rec.id, rec.publicKey);
   };
   add(tryLoadIdentity(dir));
   try {

--- a/src/policy-doc.ts
+++ b/src/policy-doc.ts
@@ -27,12 +27,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
 import { parse } from "smol-toml";
-import {
-  localPublicKeys,
-  verifySignature,
-  isRevokedWith,
-  localRevocationAuthorities,
-} from "./identity.js";
+import { localPublicKeys, verifySignature, isRevokedWith } from "./identity.js";
 import { policySignersMap, hasPolicyAnchor } from "./policy-trust.js";
 
 export const POLICY_FILE = ".kit-policy.toml";
@@ -269,13 +264,17 @@ export function verifyPolicy(root: string, opts: { key?: string } = {}): PolicyV
       anchored,
     };
   }
-  // Revocation check with the ORG trust context: a revocation is honored only if it is
-  // validly signed by an AUTHORIZED revoker (the signer itself, this machine's local
-  // root, or an org trust-anchor signer). This stops a planted/unauthorized revocation
-  // line from falsely reporting the org's real signer as revoked (a fail-closed DoS).
+  // Revocation check with the ORG trust context: a revocation of the policy signer is
+  // honored only if it is validly signed by an AUTHORIZED revoker — the signer ITSELF
+  // (self-revoke, via by===kid inside isRevokedWith) or an ORG trust-anchor signer.
+  // The local machine root is deliberately NOT an authority here: who may revoke the
+  // org's trust anchor is an ORG decision, not something a single machine's key gets to
+  // veto. (Local root remains the authority for the LOCAL secondary deny in rbac/isRevoked.)
+  // This also stops a planted/unauthorized revocation line from falsely reporting the
+  // org's real signer as revoked (a fail-closed DoS on the trust anchor).
   const orgSigners = policySignersMap(root);
   const trustedKeys = new Map<string, string>([...localPublicKeys(), ...orgSigners]);
-  const authorities = new Set<string>([...localRevocationAuthorities(), ...orgSigners.keys()]);
+  const authorities = new Set<string>(orgSigners.keys());
   if (isRevokedWith(record.kid, trustedKeys, authorities)) {
     return {
       status: "revoked",

--- a/src/policy-doc.ts
+++ b/src/policy-doc.ts
@@ -27,7 +27,12 @@ import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
 import { parse } from "smol-toml";
-import { localPublicKeys, verifySignature, isRevoked } from "./identity.js";
+import {
+  localPublicKeys,
+  verifySignature,
+  isRevokedWith,
+  localRevocationAuthorities,
+} from "./identity.js";
 import { policySignersMap, hasPolicyAnchor } from "./policy-trust.js";
 
 export const POLICY_FILE = ".kit-policy.toml";
@@ -264,7 +269,14 @@ export function verifyPolicy(root: string, opts: { key?: string } = {}): PolicyV
       anchored,
     };
   }
-  if (isRevoked(record.kid)) {
+  // Revocation check with the ORG trust context: a revocation is honored only if it is
+  // validly signed by an AUTHORIZED revoker (the signer itself, this machine's local
+  // root, or an org trust-anchor signer). This stops a planted/unauthorized revocation
+  // line from falsely reporting the org's real signer as revoked (a fail-closed DoS).
+  const orgSigners = policySignersMap(root);
+  const trustedKeys = new Map<string, string>([...localPublicKeys(), ...orgSigners]);
+  const authorities = new Set<string>([...localRevocationAuthorities(), ...orgSigners.keys()]);
+  if (isRevokedWith(record.kid, trustedKeys, authorities)) {
     return {
       status: "revoked",
       detail: `signer ${record.kid} is revoked`,

--- a/src/policy-trust.ts
+++ b/src/policy-trust.ts
@@ -41,12 +41,23 @@ export function loadPolicySigners(root: string): PolicySigner[] {
       signers?: unknown;
     };
     if (!raw || !Array.isArray(raw.signers)) return [];
-    return raw.signers.filter(
-      (s): s is PolicySigner =>
-        !!s &&
-        typeof (s as PolicySigner).id === "string" &&
-        typeof (s as PolicySigner).publicKey === "string",
-    );
+    return raw.signers.filter((s): s is PolicySigner => {
+      if (
+        !s ||
+        typeof (s as PolicySigner).id !== "string" ||
+        typeof (s as PolicySigner).publicKey !== "string"
+      ) {
+        return false;
+      }
+      // A kid IS the fingerprint of its public key — re-derive and require the match, so
+      // a hand-edited anchor can't list a key under someone else's kid (keeps the kid⇒key
+      // invariant honest everywhere it's consumed: policy verify AND revocation authority).
+      try {
+        return identityId((s as PolicySigner).publicKey) === (s as PolicySigner).id;
+      } catch {
+        return false;
+      }
+    });
   } catch {
     return [];
   }

--- a/src/rbac/rbac.test.ts
+++ b/src/rbac/rbac.test.ts
@@ -331,6 +331,38 @@ describe("rbac/resolve — end-to-end signed policy + revocation + tamper", () =
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("a PLANTED (unsigned/unauthorized) revocation does NOT deny a valid subject", () => {
+    const root = repo();
+    const revFile = join(idDir, "revocations.jsonl");
+    try {
+      const { publicKey } = generateKeyPairSync("ed25519");
+      const goodKid = identityId(publicKey.export({ type: "spki", format: "pem" }) as string);
+      writePolicyToml(root, goodKid);
+      sign(root);
+      const loaded = loadVerifiedPolicy(root);
+      assert.equal(can(goodKid, "deploy:prod", loaded), true);
+      // A writer-only attacker plants a revocation of the legit subject, signed by
+      // some key with no authority over it, with a junk signature. Pre-fix this
+      // silently denied a real subject (DoS); the authority model must ignore it.
+      const planted = {
+        kid: goodKid,
+        by: "kid_" + "0".repeat(32),
+        ts: "2026-01-01T00:00:00Z",
+        reason: "pwn",
+        sig: Buffer.from("junk").toString("base64"),
+      };
+      writeFileSync(revFile, JSON.stringify(planted) + "\n");
+      assert.equal(
+        can(goodKid, "deploy:prod", loaded),
+        true,
+        "planted revocation must not deny the subject",
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(revFile, { force: true });
+    }
+  });
 });
 
 describe("rbac/identity-provider — enrollment compiles bindings offline", () => {

--- a/src/rbac/resolve.ts
+++ b/src/rbac/resolve.ts
@@ -31,7 +31,13 @@
  */
 import { loadPolicy, verifyPolicy } from "../policy-doc.js";
 import type { PolicyDoc, PolicyVerifyResult } from "../policy-doc.js";
-import { identityId, isRevoked } from "../identity.js";
+import {
+  identityId,
+  isRevokedWith,
+  localPublicKeys,
+  localRevocationAuthorities,
+} from "../identity.js";
+import { policySignersMap } from "../policy-trust.js";
 import { extractRbac, permissionMatches } from "./policy-schema.js";
 import type { RbacPolicy } from "./policy-schema.js";
 
@@ -141,8 +147,13 @@ export function can(
   verifiedPolicy: VerifiedPolicy | null,
 ): boolean {
   if (!usable(verifiedPolicy)) return false;
-  // Secondary, best-effort deny: a locally-recorded revocation of the subject.
-  if (isRevoked(subjectKid)) return false;
+  // Secondary deny: an AUTHORITATIVE revocation of the subject — self-revoked, or revoked
+  // by this machine's local root or an org trust-anchor signer, with a verifying signature.
+  // (Unauthorized/unsigned records are ignored so a planted line can't deny a real subject.)
+  const orgSigners = policySignersMap(verifiedPolicy!.root);
+  const trustedKeys = new Map<string, string>([...localPublicKeys(), ...orgSigners]);
+  const authorities = new Set<string>([...localRevocationAuthorities(), ...orgSigners.keys()]);
+  if (isRevokedWith(subjectKid, trustedKeys, authorities)) return false;
   const perms = effectivePermissions(subjectKid, verifiedPolicy);
   return perms.some((grant) => permissionMatches(grant, permission));
 }


### PR DESCRIPTION
## Description

Closes the last outstanding red-team **HIGH**: the identity revocation path had no authority model on the local side.

The control-plane path (`verifyRevocationBatch`) already checks that a revoker is an org trust-anchor signer. But the **local** `isRevoked` was a bare existence check over `revocations.jsonl` — any line, unsigned or signed by a key with no authority over the target, revoked the target. A writer-only attacker could:
- plant `{kid: <the org policy signer>}` → the org's validly-signed policy verifies as **"revoked"** → the gate rejects the real policy (fail-closed **DoS on the trust anchor**), or
- plant `{kid: <an RBAC subject>}` → that subject is denied all grants.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

**Authority model** (`src/identity.ts`) — a revocation is honored only when **both**:
1. its Ed25519 signature verifies against the revoker's (`by`) public key, **and**
2. `by` has authority over `kid` — either `by === kid` (self-revocation, incl. the rotation successor signing "I revoke my old key"), or `by` is a trust-anchor signer (org signers, and this machine's local root).

New exports: `isAuthoritativeRevocation`, `isRevokedWith`, `revokedKids`, `localRevocationAuthorities`. `isRevoked` now evaluates the local trust context instead of trusting any line.

**Wired the org trust context into the two honoring call sites** so org-propagated revocations are still honored while planted/unauthorized ones are ignored:
- `policy-doc.ts` `verifyPolicy` — the `"revoked"` verdict
- `rbac/resolve.ts` `can()` — the secondary subject-revocation deny (uses `VerifiedPolicy.root` for the org anchor)

An attacker cannot forge an Ed25519 signature by an authority key, so the DoS is closed; legitimate self / rotation / org revocations still apply.

## Testing

### Test Coverage
- [x] Added new tests
- [x] All tests pass (`npm test`)

New regression tests: the planted-record DoS (unsigned + forged-self), the authority matrix (self / authorized / unauthorized / unknown-key / tampered-sig), and the `can()` path (planted revocation must not deny a valid subject). Full suite green: **2245 tests**.

## Breaking Changes

None / N/A — the only behavioral change is that unsigned/unauthorized local revocation records are no longer honored (they never should have been). Self, rotation, and org-anchor revocations continue to work.

## Checklist

- [x] All tests pass locally (`npm test`)
- [x] No new warnings or errors introduced
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_