### PR TITLE
feat(security): policy-distributed hardware mandate (require_hardware_identity)

### DIFF
--- a/src/audit.ts
+++ b/src/audit.ts
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 import { createHash } from "node:crypto";
 import type { GovernanceConfig } from "./config.js";
 import { identityId, verifySignature } from "./identity.js";
-import { resolveKeyStore, assertHardwareIdentity } from "./keystore/index.js";
+import { resolveKeyStore, assertHardwareIdentity, hardwareRequired } from "./keystore/index.js";
 
 // ── Tamper-evident hash chain ───────────────────────────────────────────────
 // Each appended line carries `prev` (the previous line's hash) and `hash`
@@ -76,7 +76,8 @@ function signLineHash(hash: string): { kid: string; sig: string } | null {
   const pub = res.store.publicKeyPem();
   if (!pub) return null; // no identity → keyless (fine, backward-compatible)
   try {
-    assertHardwareIdentity(res); // mandate + non-hardware → expected keyless, silently
+    // env OR org-policy mandate; non-hardware under a mandate → expected keyless, silently
+    assertHardwareIdentity(res, hardwareRequired(process.cwd()));
   } catch {
     return null;
   }

--- a/src/check-attestation.ts
+++ b/src/check-attestation.ts
@@ -43,7 +43,7 @@ import {
 } from "node:crypto";
 import { anchorDir, tryReadAuditAnchorKey, getAuditAnchorKey } from "./audit-anchor.js";
 import { secureFile } from "./utils/secure-perms.js";
-import { hardwareRequiredByEnv } from "./keystore/mandate.js";
+import { hardwareRequired } from "./keystore/index.js";
 
 export const ATTESTATION_FILE = ".kit-check-attestation.json";
 const ED25519_KEY_FILE = "attestation-ed25519.key";
@@ -198,12 +198,12 @@ export function expectedKeyToFingerprint(expected: string): string | null {
  * fall back to HMAC. Never throws.
  */
 async function loadOrCreateEd25519Key(dir?: string): Promise<KeyObject | null> {
-  // Under a hardware mandate, refuse the same-UID-readable Ed25519 file key entirely —
-  // otherwise the attestation receipt would be the one place kit still emits an Ed25519
-  // signature made with a kit-managed file key while KIT_REQUIRE_HARDWARE_IDENTITY is set.
-  // Returning null makes signAttestation fall through to HMAC (symmetric, out of scope) or
-  // an honest sig_alg:"none". (mandate.js is import-cycle-free.)
-  if (hardwareRequiredByEnv()) return null;
+  // Under a hardware mandate (env OR org-policy require_hardware_identity), refuse the
+  // same-UID-readable Ed25519 file key entirely — otherwise the attestation receipt would
+  // be the one place kit still emits an Ed25519 signature made with a kit-managed file key
+  // while the mandate is in force. Returning null makes signAttestation fall through to
+  // HMAC (symmetric, out of scope) or an honest sig_alg:"none".
+  if (hardwareRequired(process.cwd())) return null;
   const keyPath = ed25519KeyPath(dir);
   try {
     const pem = await readFile(keyPath, "utf-8");

--- a/src/commands/identity.ts
+++ b/src/commands/identity.ts
@@ -2,7 +2,12 @@
 import { c } from "../utils/colors.js";
 import { hasFlag } from "../utils/flags.js";
 import { loadOrCreateIdentity, tryLoadIdentity, rotateIdentity, identityId } from "../identity.js";
-import { activeKeyStoreStatus, hardwareRequiredByEnv } from "../keystore/index.js";
+import {
+  activeKeyStoreStatus,
+  hardwareRequiredByEnv,
+  hardwareRequired,
+  policyRequiresHardware,
+} from "../keystore/index.js";
 
 /** `kit identity keystore` — surface the active signing backend, honestly. */
 function identityKeystore(): boolean {
@@ -16,9 +21,14 @@ function identityKeystore(): boolean {
   console.log(`${c.bold}kit identity keystore${c.reset}`);
   console.log(`  backend        ${c.bold}${st.kind}${c.reset}  (${held})`);
   console.log(`  key id         ${st.kid ?? c.dim + "none" + c.reset}`);
-  console.log(
-    `  hardware req'd  ${hardwareRequiredByEnv() ? "yes (KIT_REQUIRE_HARDWARE_IDENTITY)" : "no"}`,
-  );
+  const byEnv = hardwareRequiredByEnv();
+  const byPolicy = policyRequiresHardware(process.cwd());
+  const reqLabel = byEnv
+    ? "yes (KIT_REQUIRE_HARDWARE_IDENTITY)"
+    : byPolicy
+      ? "yes (.kit-policy require_hardware_identity)"
+      : "no";
+  console.log(`  hardware req'd  ${reqLabel}`);
   if (st.hardwareRooted) {
     console.log(
       `  ${c.dim}note: kit can't attest this command fronts real hardware — that (non-exportable key + touch/PIN) is the operator's responsibility${c.reset}`,
@@ -30,8 +40,8 @@ function identityKeystore(): boolean {
       `  ${c.dim}to move the key out of a kit-managed file: KIT_KEYSTORE=command with KIT_KEYSTORE_SIGN_CMD + KIT_KEYSTORE_PUBKEY (TPM/HSM/enclave/YubiKey)${c.reset}`,
     );
   }
-  // Fail closed in the exit code when hardware is mandated but not in force.
-  if (hardwareRequiredByEnv() && !st.hardwareRooted) {
+  // Fail closed in the exit code when hardware is mandated (env OR policy) but not in force.
+  if ((byEnv || byPolicy) && !st.hardwareRooted) {
     console.error(`${c.red}✗ hardware-rooted identity required but not active${c.reset}`);
     return false;
   }
@@ -44,6 +54,14 @@ export async function cmdIdentity(): Promise<boolean> {
   if (sub === "keystore") return identityKeystore();
 
   if (sub === "init") {
+    // Under a hardware mandate (env OR org policy), refuse to mint a same-UID file key —
+    // a clean message rather than the raw guard throw from loadOrCreateIdentity.
+    if (hardwareRequired(process.cwd())) {
+      console.error(
+        `${c.red}✗ hardware/externally-held identity required${c.reset} ${c.dim}(env or .kit-policy require_hardware_identity)${c.reset} — provision the key in your TPM/HSM/enclave and set KIT_KEYSTORE=command; kit won't create a file key`,
+      );
+      return false;
+    }
     const { identity, created } = loadOrCreateIdentity();
     console.log(
       `${c.green}✓${c.reset} identity ${created ? "created" : "already exists"}: ${c.bold}${identity.id}${c.reset}`,
@@ -83,6 +101,12 @@ export async function cmdIdentity(): Promise<boolean> {
   }
 
   if (sub === "rotate") {
+    if (hardwareRequired(process.cwd())) {
+      console.error(
+        `${c.red}✗ hardware/externally-held identity required${c.reset} ${c.dim}(env or .kit-policy require_hardware_identity)${c.reset} — rotate the key in your TPM/HSM/enclave and update KIT_KEYSTORE_PUBKEY; kit won't mint a file key`,
+      );
+      return false;
+    }
     const { identity, previousId } = rotateIdentity();
     console.log(`${c.green}✓${c.reset} rotated identity → ${c.bold}${identity.id}${c.reset}`);
     if (previousId) {

--- a/src/commands/panic.test.ts
+++ b/src/commands/panic.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cmdPanic } from "./panic.js";
+import { loadOrCreateIdentity, tryLoadIdentity, loadRevocations } from "../identity.js";
+
+// kit panic reaches rotateIdentity() directly, whose guard is env-only. A policy-only
+// mandate must still block it — otherwise panic re-mints exactly the same-UID file key the
+// mandate forbids (verify Finding #2).
+describe("kit panic — hardware mandate", () => {
+  let idDir: string;
+  let cwd: string;
+  const saved = {
+    id: process.env.KIT_IDENTITY_DIR,
+    anchor: process.env.KIT_AUDIT_ANCHOR,
+    argv: process.argv,
+    cwd: process.cwd(),
+  };
+
+  beforeEach(() => {
+    idDir = mkdtempSync(join(tmpdir(), "kit-panic-id-"));
+    cwd = mkdtempSync(join(tmpdir(), "kit-panic-cwd-"));
+    process.env.KIT_IDENTITY_DIR = idDir;
+    process.env.KIT_AUDIT_ANCHOR = "0";
+    delete process.env.KIT_REQUIRE_HARDWARE_IDENTITY;
+  });
+  afterEach(() => {
+    process.env.KIT_IDENTITY_DIR = saved.id;
+    if (saved.anchor === undefined) delete process.env.KIT_AUDIT_ANCHOR;
+    else process.env.KIT_AUDIT_ANCHOR = saved.anchor;
+    process.argv = saved.argv;
+    process.chdir(saved.cwd);
+    rmSync(idDir, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it("refuses to rotate (mint a file key) under a policy-only mandate", async () => {
+    const id0 = loadOrCreateIdentity().identity; // identity exists BEFORE the policy
+    writeFileSync(join(cwd, ".kit-policy.toml"), "version = 1\nrequire_hardware_identity = true\n");
+    process.chdir(cwd); // getCurrentProjectRoot() → cwd (non-git temp) → finds the policy
+    process.argv = ["node", "kit", "panic", "--no-checklist"];
+
+    const ok = await cmdPanic();
+    assert.equal(ok, false, "panic must fail closed under the mandate");
+    // Identity was NOT rotated (no fresh file key minted) and nothing was revoked.
+    assert.equal(tryLoadIdentity()?.id, id0.id, "identity must be unchanged (no rotation)");
+    assert.equal(loadRevocations().length, 0, "no revocation recorded");
+  });
+});

--- a/src/commands/panic.ts
+++ b/src/commands/panic.ts
@@ -18,6 +18,8 @@ import { c } from "../utils/colors.js";
 import { flagValue, hasFlag } from "../utils/flags.js";
 import { tryLoadIdentity, rotateIdentity } from "../identity.js";
 import { keystoreRecordRevocation } from "../keystore/revoke.js";
+import { hardwareRequired } from "../keystore/index.js";
+import { getCurrentProjectRoot } from "../memory/project.js";
 import { appendAuditEventDirect } from "../audit.js";
 
 /** The accounts/controls kit can only orchestrate — never silently "handle". */
@@ -53,6 +55,18 @@ export async function cmdPanic(): Promise<boolean> {
     console.error(
       `${c.red}no identity to rotate${c.reset} — there is nothing to revoke. ` +
         `Run ${c.bold}kit identity init${c.reset} first if you want a signing identity.`,
+    );
+    return false;
+  }
+
+  // Under a hardware mandate (env OR org policy), refuse to rotate INTO a file key — panic
+  // reaches rotateIdentity() directly, whose own guard is env-only, so without this a
+  // policy-only mandate would let panic re-mint exactly the same-UID file key the mandate
+  // forbids. Provision/rotate the hardware key out of band instead.
+  if (hardwareRequired(getCurrentProjectRoot())) {
+    console.error(
+      `${c.red}✗ hardware/externally-held identity required${c.reset} ${c.dim}(env or .kit-policy require_hardware_identity)${c.reset} — ` +
+        `rotate the key in your TPM/HSM/enclave and update KIT_KEYSTORE_PUBKEY; kit won't mint a file key here.`,
     );
     return false;
   }

--- a/src/commands/policy.ts
+++ b/src/commands/policy.ts
@@ -28,7 +28,12 @@ import {
 } from "../policy-doc.js";
 import { evaluatePolicy, formatPolicyEval } from "../policy-check.js";
 import { identityId } from "../identity.js";
-import { resolveKeyStore, assertHardwareIdentity, isHardwareRooted } from "../keystore/index.js";
+import {
+  resolveKeyStore,
+  assertHardwareIdentity,
+  isHardwareRooted,
+  hardwareRequired,
+} from "../keystore/index.js";
 
 export async function cmdPolicy(): Promise<boolean> {
   const sub = process.argv[3] ?? "show";
@@ -131,10 +136,11 @@ function policySign(root: string): boolean {
     );
     return false;
   }
-  // Fail closed if a hardware-rooted identity is mandated (KIT_REQUIRE_HARDWARE_IDENTITY)
-  // but the active backend isn't one — never sign the org's standard with a same-UID key.
+  // Fail closed if a hardware-rooted identity is mandated (env OR this policy's own
+  // require_hardware_identity) but the active backend isn't one — never sign the org's
+  // standard with a same-UID key.
   try {
-    assertHardwareIdentity(res);
+    assertHardwareIdentity(res, hardwareRequired(root));
   } catch (e) {
     console.error(`${c.red}✗ ${(e as Error).message}${c.reset}`);
     return false;

--- a/src/keystore/active.ts
+++ b/src/keystore/active.ts
@@ -22,11 +22,31 @@
  * to fall back off it. Deterministic, offline, never network.
  */
 import { identityId } from "../identity.js";
+import { loadPolicy } from "../policy-doc.js";
 import { resolveKeyStore } from "./resolve.js";
 import { hardwareRequiredByEnv } from "./mandate.js";
 import type { KeyStoreResolution } from "./types.js";
 
 export { hardwareRequiredByEnv } from "./mandate.js";
+
+/** True when the org policy at `root` mandates a hardware identity (`.kit-policy.toml`). */
+export function policyRequiresHardware(root: string): boolean {
+  try {
+    return loadPolicy(root)?.require_hardware_identity === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The EFFECTIVE mandate: the environment mandate OR the org policy mandate. Tightening-only
+ * by construction (an OR) — a `false`/absent policy value can never relax the env mandate,
+ * so a repo-local policy can add the requirement fleet-wide but never disable it. This is
+ * what the enforcement call sites pass as `required`.
+ */
+export function hardwareRequired(root?: string): boolean {
+  return hardwareRequiredByEnv() || (root ? policyRequiresHardware(root) : false);
+}
 
 /**
  * Is the resolved backend genuinely hardware-rooted — i.e. the private key is NOT a

--- a/src/keystore/active.ts
+++ b/src/keystore/active.ts
@@ -47,11 +47,17 @@ function findPolicyDir(start: string): string | null {
 }
 
 /** True when the governing org policy (at `root` or any ancestor) mandates a hardware
- *  identity via `.kit-policy.toml require_hardware_identity`. */
+ *  identity via `.kit-policy.toml require_hardware_identity`. Fail-closed on a present-but-
+ *  non-boolean value (a typo like `= 1` / `= "true"`): the operator clearly intended to set
+ *  the mandate, so we treat it as ON rather than silently OFF (kit policy validate still
+ *  flags it). Only a strict `false`/absent value means "not mandated". */
 export function policyRequiresHardware(root: string): boolean {
   try {
     const dir = findPolicyDir(root);
-    return dir !== null && loadPolicy(dir)?.require_hardware_identity === true;
+    if (dir === null) return false;
+    const v = loadPolicy(dir)?.require_hardware_identity;
+    if (v === undefined || v === false) return false;
+    return true; // true, or present-but-non-boolean → fail-closed ON
   } catch {
     return false;
   }

--- a/src/keystore/active.ts
+++ b/src/keystore/active.ts
@@ -21,18 +21,37 @@
  * bar is the `command` backend keeping the key off the box; the mandate makes kit refuse
  * to fall back off it. Deterministic, offline, never network.
  */
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { identityId } from "../identity.js";
-import { loadPolicy } from "../policy-doc.js";
+import { loadPolicy, POLICY_FILE } from "../policy-doc.js";
 import { resolveKeyStore } from "./resolve.js";
 import { hardwareRequiredByEnv } from "./mandate.js";
 import type { KeyStoreResolution } from "./types.js";
 
 export { hardwareRequiredByEnv } from "./mandate.js";
 
-/** True when the org policy at `root` mandates a hardware identity (`.kit-policy.toml`). */
+/** Nearest ancestor of `start` (inclusive) that holds a `.kit-policy.toml`, or null. Cheap
+ *  fs walk (no git exec) so it's safe on the audit hot path — and it means a mandate at the
+ *  repo root applies even when kit is invoked from a subdirectory (closes the cwd-vs-root
+ *  gap where a policy mandate would otherwise be silently skipped). */
+function findPolicyDir(start: string): string | null {
+  let dir = start;
+  for (let i = 0; i < 64; i++) {
+    if (existsSync(join(dir, POLICY_FILE))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/** True when the governing org policy (at `root` or any ancestor) mandates a hardware
+ *  identity via `.kit-policy.toml require_hardware_identity`. */
 export function policyRequiresHardware(root: string): boolean {
   try {
-    return loadPolicy(root)?.require_hardware_identity === true;
+    const dir = findPolicyDir(root);
+    return dir !== null && loadPolicy(dir)?.require_hardware_identity === true;
   } catch {
     return false;
   }

--- a/src/keystore/index.ts
+++ b/src/keystore/index.ts
@@ -11,8 +11,11 @@ export { resolveKeyStore } from "./resolve.js";
 export {
   isHardwareRooted,
   hardwareRequiredByEnv,
+  policyRequiresHardware,
+  hardwareRequired,
   assertHardwareIdentity,
   keystoreSign,
   activeKeyStoreStatus,
   type KeyStoreStatus,
 } from "./active.js";
+export { keystoreRecordRevocation } from "./revoke.js";

--- a/src/keystore/mandate.test.ts
+++ b/src/keystore/mandate.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -133,6 +133,41 @@ describe("hardware mandate — no file-key signature escapes", () => {
     ) as { operation: string; sig?: string };
     assert.equal(line.operation, "op-pol");
     assert.equal(line.sig, undefined, "policy-mandated entry must not carry a file-key signature");
+  });
+
+  it("policy mandate applies from a SUBDIRECTORY (upward .kit-policy.toml search)", () => {
+    // Policy at the repo root; kit invoked from a nested subdir. The mandate must still be
+    // found (else a subdir invocation would silently skip a fleet policy → file signature).
+    writeFileSync(join(cwd, ".kit-policy.toml"), "version = 1\nrequire_hardware_identity = true\n");
+    const sub = join(cwd, "a", "b", "c");
+    mkdirSync(sub, { recursive: true });
+    assert.equal(policyRequiresHardware(sub), true, "found via ancestor walk");
+    assert.equal(hardwareRequired(sub), true);
+  });
+
+  it("attestation under a POLICY-only mandate also refuses the Ed25519 file key", async () => {
+    loadOrCreateIdentity();
+    writeFileSync(join(cwd, ".kit-policy.toml"), "version = 1\nrequire_hardware_identity = true\n");
+    const origCwd = process.cwd();
+    process.chdir(cwd);
+    try {
+      const att = await signAttestation(
+        {
+          schema: "kit-check-attestation/v1",
+          command: "check",
+          timestamp: "2026-01-01T00:00:00Z",
+          kit_version: "0.0.0",
+          overall_ok: true,
+          results: { passed: 1, failed: 0, warnings: 0, skipped: 0 },
+          scanners_ran: [],
+        },
+        { dir: cwd, preferEd25519: true },
+      );
+      assert.notEqual(att.sig_alg, "ed25519", "policy mandate must block the file Ed25519 path");
+      assert.equal(existsSync(join(cwd, "attestation-ed25519.key")), false);
+    } finally {
+      process.chdir(origCwd);
+    }
   });
 
   it("recordRevocation fails closed under the mandate (no file-key revocation)", () => {

--- a/src/keystore/mandate.test.ts
+++ b/src/keystore/mandate.test.ts
@@ -13,7 +13,8 @@ import {
 } from "../identity.js";
 import { appendAuditEventDirect } from "../audit.js";
 import { keystoreRecordRevocation } from "./revoke.js";
-import { existsSync } from "node:fs";
+import { hardwareRequired, policyRequiresHardware } from "./active.js";
+import { existsSync, writeFileSync } from "node:fs";
 import { signAttestation } from "../check-attestation.js";
 
 // The mandate must be COMPREHENSIVE: with KIT_REQUIRE_HARDWARE_IDENTITY set and only a
@@ -102,6 +103,36 @@ describe("hardware mandate — no file-key signature escapes", () => {
       false,
       "no Ed25519 file key minted under the mandate",
     );
+  });
+
+  it("a .kit-policy require_hardware_identity mandate (no env) forces audit keyless", async () => {
+    loadOrCreateIdentity();
+    // Org policy at the repo root mandates hardware — NO env var set.
+    writeFileSync(join(cwd, ".kit-policy.toml"), "version = 1\nrequire_hardware_identity = true\n");
+    assert.equal(policyRequiresHardware(cwd), true);
+    assert.equal(hardwareRequired(cwd), true, "policy alone triggers the effective mandate");
+    assert.equal(hardwareRequired(idDir), false, "a dir without the policy is unaffected");
+
+    // Audit append runs at `cwd` (where the policy lives) → the entry must be KEYLESS,
+    // never file-signed, even though KIT_REQUIRE_HARDWARE_IDENTITY is unset.
+    const origCwd = process.cwd();
+    process.chdir(cwd);
+    try {
+      assert.equal(
+        await appendAuditEventDirect(
+          { operation: "op-pol", environment: "dev", success: true },
+          { cwd },
+        ),
+        true,
+      );
+    } finally {
+      process.chdir(origCwd);
+    }
+    const line = JSON.parse(
+      readFileSync(join(cwd, ".kit-audit.jsonl"), "utf-8").trim().split("\n").at(-1)!,
+    ) as { operation: string; sig?: string };
+    assert.equal(line.operation, "op-pol");
+    assert.equal(line.sig, undefined, "policy-mandated entry must not carry a file-key signature");
   });
 
   it("recordRevocation fails closed under the mandate (no file-key revocation)", () => {

--- a/src/keystore/mandate.test.ts
+++ b/src/keystore/mandate.test.ts
@@ -135,6 +135,20 @@ describe("hardware mandate — no file-key signature escapes", () => {
     assert.equal(line.sig, undefined, "policy-mandated entry must not carry a file-key signature");
   });
 
+  it("fail-closed on a present-but-non-boolean require_hardware_identity (typo footgun)", () => {
+    // `= 1` / `= "true"` are validation errors, but must NOT silently disable the mandate.
+    writeFileSync(join(cwd, ".kit-policy.toml"), "version = 1\nrequire_hardware_identity = 1\n");
+    assert.equal(policyRequiresHardware(cwd), true, "non-boolean present → mandate ON");
+    // A strict false / absent is the only "not mandated".
+    writeFileSync(
+      join(cwd, ".kit-policy.toml"),
+      "version = 1\nrequire_hardware_identity = false\n",
+    );
+    assert.equal(policyRequiresHardware(cwd), false);
+    writeFileSync(join(cwd, ".kit-policy.toml"), "version = 1\n");
+    assert.equal(policyRequiresHardware(cwd), false);
+  });
+
   it("policy mandate applies from a SUBDIRECTORY (upward .kit-policy.toml search)", () => {
     // Policy at the repo root; kit invoked from a nested subdir. The mandate must still be
     // found (else a subdir invocation would silently skip a fleet policy → file signature).

--- a/src/keystore/revoke.ts
+++ b/src/keystore/revoke.ts
@@ -12,7 +12,7 @@
  * keystore and identity primitives without the import cycle identity.ts must avoid.
  */
 import { resolveKeyStore } from "./resolve.js";
-import { assertHardwareIdentity } from "./active.js";
+import { assertHardwareIdentity, hardwareRequired } from "./active.js";
 import {
   identityId,
   revocationStatement,
@@ -36,7 +36,8 @@ export function keystoreRecordRevocation(
   const res = resolveKeyStore({ dir });
   const pub = res.store.publicKeyPem();
   if (!pub) throw new Error("no current identity to sign the revocation");
-  assertHardwareIdentity(res); // hardware mandate: fail closed rather than file-sign
+  // env OR org-policy mandate: fail closed rather than file-sign the revocation.
+  assertHardwareIdentity(res, hardwareRequired(process.cwd()));
   const by = identityId(pub);
   const sig = res.store.sign(revocationStatement(kid, now, reason)).toString("base64");
   const rec: RevocationRecord = { kid, reason, ts: now, by, sig };

--- a/src/memory/shared.ts
+++ b/src/memory/shared.ts
@@ -20,7 +20,7 @@ import { existsSync, readFileSync, appendFileSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { findSecrets } from "../utils/redactSecrets.js";
 import { identityId, verifySignature, localPublicKeys } from "../identity.js";
-import { resolveKeyStore, assertHardwareIdentity } from "../keystore/index.js";
+import { resolveKeyStore, assertHardwareIdentity, hardwareRequired } from "../keystore/index.js";
 import { policySignersMap, hasPolicyAnchor } from "../policy-trust.js";
 
 export type SharedKind = "decision" | "convention" | "how-built" | "status" | "security" | "note";
@@ -239,7 +239,7 @@ export function shareEntry(root: string, input: ShareInput, now: string): Shared
     const res = resolveKeyStore();
     const pub = res.store.publicKeyPem();
     if (pub) {
-      assertHardwareIdentity(res);
+      assertHardwareIdentity(res, hardwareRequired(root));
       entry.kid = identityId(pub);
       entry.sig = res.store.sign(sharedEntryCanonical(entry)).toString("base64");
     }

--- a/src/policy-doc.test.ts
+++ b/src/policy-doc.test.ts
@@ -22,10 +22,19 @@ describe("policy-doc — validation", () => {
       require_triage: true,
       required_scanners: ["trivy", "trufflehog"],
       prod_writes_need_approval: false,
+      require_hardware_identity: true,
       min_kit_version: "2.2.0",
       thresholds: { code_health: 7.5 },
     });
     assert.equal(r.ok, true, r.errors.join("; "));
+  });
+
+  it("type-checks require_hardware_identity as a boolean", () => {
+    assert.match(
+      validatePolicy({ version: 1, require_hardware_identity: "yes" }).errors.join(),
+      /require_hardware_identity.*boolean/,
+    );
+    assert.equal(validatePolicy({ version: 1, require_hardware_identity: true }).ok, true);
   });
 
   it("flags a missing / non-integer / future version", () => {

--- a/src/policy-doc.ts
+++ b/src/policy-doc.ts
@@ -52,6 +52,13 @@ export interface PolicyDoc {
   prod_writes_need_approval?: boolean;
   /** Minimum kit version this policy expects. */
   min_kit_version?: string;
+  /**
+   * Mandate a hardware/externally-held signing identity fleet-wide: when true, kit refuses
+   * to sign audit/memory/policy/revocation artifacts with the same-UID-readable file key
+   * (same effect as KIT_REQUIRE_HARDWARE_IDENTITY). Tightening-only — it can add the
+   * mandate but a `false`/absent value never RELAXES an environment mandate.
+   */
+  require_hardware_identity?: boolean;
   /** Numeric thresholds (e.g. code_health). */
   thresholds?: PolicyThresholds;
 }
@@ -104,6 +111,7 @@ export function validatePolicy(doc: unknown): PolicyValidation {
   };
   bool("require_triage");
   bool("prod_writes_need_approval");
+  bool("require_hardware_identity");
   if (
     d.required_scanners !== undefined &&
     (!Array.isArray(d.required_scanners) || d.required_scanners.some((s) => typeof s !== "string"))


### PR DESCRIPTION
## Description

Wires the **fleet-wide** hardware mandate that Pillar 1 (#235) documented as not-yet-wired. An org can now set `require_hardware_identity = true` in `.kit-policy.toml` to mandate a hardware/externally-held signing identity across every repo that commits the policy — no per-machine env var required.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- **Schema**: `PolicyDoc.require_hardware_identity` (validated boolean).
- **Effective mandate**: `hardwareRequired(root) = hardwareRequiredByEnv() || policyRequiresHardware(root)`. **Tightening-only** by construction (an OR): a `false`/absent policy value can never relax an environment mandate; a repo-local policy can only *add* the requirement — the fail-closed, safe direction (worst case is a DoS on a box lacking hardware, never a silent downgrade).
- **Enforcement** now honors the effective mandate at every routed site: `kit policy sign`, audit-chain signing, shared-memory signing, keystore-routed revocation, and `kit identity init/rotate` (refuse to mint a file key under a policy mandate too).
- **Surfacing**: `kit identity keystore` shows whether the mandate is from env or policy.
- `signWithIdentity` stays the env-only backstop (identity.ts must remain import-cycle-free); the routed sites enforce the policy mandate before any file signing can occur.

## Testing

### Test Coverage
- [x] Added new tests
- [x] All tests pass (`npm test`)

New regression tests: a policy-only mandate (no env) forces audit entries keyless; tightening-only semantics (`hardwareRequired` on a dir without the policy is false); schema validation of the new field. Full suite green: **2266 tests**.

## Breaking Changes

None / N/A — default behavior is unchanged (no policy field, no env var → signs with the file key exactly as before). The mandate only ever *adds* strictness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_