### PR TITLE
fix(triage): refresh installed skill on upgrade + record B1–B5 in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ fail-closed throughout.
   the `agent_writes` authz lookup is `Object.hasOwn`-guarded against prototype keys;
   `.env.local` is created `0o600` atomically. `src/id-generator.ts`, `src/policy.ts`,
   `src/provision.ts`.
+- **Triage skill refresh on upgrade (found by dogfooding).** The bundled triage script
+  was only copied to `~/.claude/skills/triage` when ABSENT, so a kit upgrade that improved
+  `triage.py` (e.g. the B2 version resolver, new secret patterns) never reached existing
+  installs — the CLI silently kept running the old script (a pinned `pkg@1.2.3` was even
+  false-blocked because the stale copy fetched the literal `pkg@1.2.3` name → 404). The
+  installed copy is now version-stamped and refreshed when it was written by an older kit.
+  `src/triage.ts`.
 
 ### Security — red-team critical fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Security — supply-chain gate, secrets/audit & control-plane hardening (backlog B1–B5)
+
+A deep MEDIUM/LOW security sweep, each area hardened through repeated adversarial
+re-attacks against the compiled build until it converged. Deterministic and
+fail-closed throughout.
+
+- **Install-gate parser (B1).** Closed ~20 fetch-and-execute bypass classes in the
+  `gate-bash` hook: intra-word quoting, path/backslash/env-prefix binaries, process
+  substitution + here-strings, missing verbs (`npm install-test`/`it`/`update`/`ci`,
+  `yarn global add`, `uv run --with`, `corepack` incl. `corepack pnpm@9` dispatch,
+  create/init initiators), shell `-c` (flag clusters `-lc`, ANSI-C `$'…'`,
+  escaped-quote nesting), `${IFS}`/`${IFS<op>}` word-splitting, `npm exec -c/--call`
+  and runner→package-manager chaining, bare-reinstall + registry-redirect fail-close,
+  and `$VAR`/`xargs` indirection. Also fixed three hot-path algorithmic-complexity
+  DoS issues (regex ReDoS, `SEGMENT_SPLIT` O(N²), queue-driver O(N²)) — all now
+  linear with timing regression tests. `src/install-gate.ts`.
+- **Triage version semantics (B2).** The gate stripped the version, so `npm i evil@1.2.3`
+  was triaged as `latest` — a clean latest could vouch for a yanked/malicious pinned
+  version. The pinned version/tag is now carried onto the triage ref and the triage
+  script **resolves the spec to the exact version the manager installs** (semver /
+  PEP 440: exact pins, dist-tags, ranges like `@2`/`@^1`/`<2`/`~=1.2`); npm alias specs
+  (`name@npm:other`) fail closed. Documented that a PASS is an existence/health/version
+  gate, not a malware verdict (that is opt-in GuardDog). `src/install-gate.ts`,
+  `skills/triage/scripts/triage.py`.
+- **Secrets & redaction (B3).** New detectors — raw PEM private keys, Azure `AccountKey=`,
+  SendGrid, Slack `xapp-`, npm tokens, token-in-URL-userinfo (all ReDoS-bounded). The
+  audit sink now redacts `error`/`metadata`/`operation`/`environment` **by value** before
+  writing (covers the chain, remote push, and pending queue), the hash chain still
+  verifies, and reassembly is prototype-pollution-safe. `env-inspect` no longer leaks a
+  fixed prefix; the plaintext scanner now opens `.npmrc`/`id_rsa`/`*.pem`/`*.key`.
+- **Control-plane (B4).** A monotonic, signed `policy.revision` ratchet rejects a replayed
+  older policy over the untrusted transport (the floor is trusted only from a verifying
+  on-disk policy). gzip-bomb guard bounds decompression on `kit memory pull`; the remote
+  bundle fetch is now timeout- and size-capped. `src/control-plane/distribute.ts`,
+  `src/policy-doc.ts`, `src/memory/backup.ts`.
+- **Cross-cutting (B5).** IDs use `crypto.randomUUID()` (unguessable approval handles);
+  the `agent_writes` authz lookup is `Object.hasOwn`-guarded against prototype keys;
+  `.env.local` is created `0o600` atomically. `src/id-generator.ts`, `src/policy.ts`,
+  `src/provision.ts`.
+
 ### Security — red-team critical fixes
 
 A code-in-hand adversarial red-team of kit found three CONFIRMED critical

--- a/src/triage.test.ts
+++ b/src/triage.test.ts
@@ -218,4 +218,21 @@ describe("installBundledTriageSkill (self-bootstrapping the gate)", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("stamps a version marker so a stale copy can be detected + refreshed", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kit-triage-"));
+    const target = resolve(dir, ".claude/skills/triage");
+    try {
+      await installBundledTriageSkill(target);
+      // the install writes a .kit-skill-version stamp (drives the upgrade-refresh path in
+      // ensureTriageScript — without it, an improved triage.py never reaches existing installs)
+      const marker = await readFile(resolve(target, ".kit-skill-version"), "utf8");
+      assert.match(marker.trim(), /^\d+\.\d+\.\d+/);
+      // the freshly-installed script carries the current version-resolver logic
+      const py = await readFile(resolve(target, "scripts/triage.py"), "utf8");
+      assert.match(py, /_resolve_npm_spec/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/triage.ts
+++ b/src/triage.ts
@@ -3,7 +3,8 @@
  * Wraps the Python triage script and integrates with kit's check-security system.
  */
 
-import { access, cp, mkdir } from "node:fs/promises";
+import { access, cp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -18,6 +19,21 @@ const TRIAGE_SKILL_DIR = resolve(homedir(), ".claude/skills/triage");
 const TRIAGE_SCRIPT = resolve(TRIAGE_SKILL_DIR, "scripts/triage.py");
 /** The copy kit ships in its own package (published via package.json "files"). */
 const BUNDLED_TRIAGE_SKILL = resolve(__dirname, "..", "skills", "triage");
+/** Stamp of the kit version that produced the installed skill copy. Used to refresh a STALE
+ *  copy after a kit upgrade — otherwise an improved `triage.py` (e.g. a fixed version resolver
+ *  or a new secret pattern) would never reach existing installs, silently running old logic. */
+const SKILL_VERSION_MARKER = resolve(TRIAGE_SKILL_DIR, ".kit-skill-version");
+const KIT_VERSION = (() => {
+  try {
+    return (
+      JSON.parse(readFileSync(resolve(__dirname, "..", "package.json"), "utf-8")) as {
+        version: string;
+      }
+    ).version;
+  } catch {
+    return "unknown";
+  }
+})();
 
 /**
  * Self-bootstrap the gate: copy the triage skill kit ships with into
@@ -32,9 +48,20 @@ export async function installBundledTriageSkill(
     await mkdir(dirname(targetDir), { recursive: true });
     await cp(BUNDLED_TRIAGE_SKILL, targetDir, { recursive: true });
     await access(resolve(targetDir, "scripts/triage.py"));
+    // Stamp the version so a later kit upgrade knows to refresh this copy.
+    await writeFile(resolve(targetDir, ".kit-skill-version"), KIT_VERSION, "utf-8");
     return true;
   } catch {
     return false;
+  }
+}
+
+/** True when the installed skill was written by the CURRENT kit version. */
+async function installedSkillIsCurrent(): Promise<boolean> {
+  try {
+    return (await readFile(SKILL_VERSION_MARKER, "utf-8")).trim() === KIT_VERSION;
+  } catch {
+    return false; // no marker → an old/hand-copied skill → treat as stale
   }
 }
 
@@ -57,7 +84,9 @@ export interface TriageResult {
 async function ensureTriageScript(): Promise<boolean> {
   try {
     await access(TRIAGE_SCRIPT);
-    return true;
+    // Present — but refresh if it was written by an older kit (stale logic otherwise persists).
+    if (await installedSkillIsCurrent()) return true;
+    return installBundledTriageSkill();
   } catch {
     return installBundledTriageSkill();
   }


### PR DESCRIPTION
## Description

Follow-up to the merged security PR (#237), from dogfooding kit on itself:

1. **fix(triage): refresh the installed triage skill on kit upgrade.** `ensureTriageScript` copied the bundled skill into `~/.claude/skills/triage` only when the script was *absent*, never when *stale* — so a kit upgrade that improves `triage.py` (the B2 version resolver, new secret patterns) never reached existing installs. The CLI kept running the old script; a real pinned install (`npm i express@4.17.1`) was even **false-blocked** because the stale copy fetched the literal `express@4.17.1` name → 404. The installed copy is now version-stamped (`.kit-skill-version`) and refreshed when it predates the running kit. Verified end-to-end through `kit gate-bash`.
2. **docs(changelog):** record the B1–B5 security hardening (and this fix) under `[Unreleased]`.

## Type of Change

- [x] Bug fix (non-breaking)
- [x] Documentation

## Testing

- [x] New regression test (version-marker stamp / refresh). Full suite: **2329 pass**.
- [x] Dogfooded through `kit gate-bash`: clean pkg + real pins/ranges allow; untriaged, bad pins, and the B1 bypass strings (`${IFS}`, `corepack pnpm@9`, `uv run --with`, `bash -lc`) all block.

## Breaking Changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2