### PR TITLE
feat(memory): quarantine-state hint in injection scan + acknowledgements section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,12 @@ fail-closed throughout.
   deterministic, high-precision `isBoilerplate` filter (structural tags + a leading slash
   command + a few verbatim harness phrases — never generic words) drops them before ranking.
   `src/memory/learn.ts`.
+- **`kit memory scan --injection` surfaces quarantine state (found by dogfooding).** The scan
+  reads every row regardless of quarantine, so re-running it after `--quarantine` showed the
+  same high-confidence list and read as "still exposed" even though those rows are excluded
+  from recall. Plain injection scans with high-confidence findings now print how many messages
+  are already quarantined and point at `--quarantine`. Deliberately NOT a path/content allowlist:
+  a suppression channel on an injection scanner would be a bypass. `src/commands/memory.ts`.
 
 ### Security — red-team critical fixes
 

--- a/README.md
+++ b/README.md
@@ -914,3 +914,30 @@ See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 - [mise-en-place](https://mise.jdx.dev): tool version management
 - [1Password CLI](https://developer.1password.com/docs/cli/): secret management
 - Node.js CLI (primarily TypeScript; JavaScript tooling/scripts, plus a Python triage checker)
+
+## Acknowledgements
+
+kit is its own codebase, but several projects shaped how we approached specific
+problems. We studied them and borrowed ideas and design patterns — the
+implementations here are kit's own (deterministic, zero-LLM). Thanks to:
+
+- **[cloudctx](https://github.com/chadptk1238/cloudctx)** (MIT) — the memory
+  store's SQLite schema and two-hook capture design.
+- **[headroom](https://github.com/chopratejas/headroom)** — the idea behind
+  `kit memory learn`: mine transcripts for recurring instructions and *suggest*
+  memory rules (kit does it deterministically, bring-your-own-LLM, no model call).
+- **[guild](https://github.com/mathomhaus/guild)** (Apache-2.0) — atomic PAL
+  ("blocked-on-you") claiming: claim/release with auto-release of abandoned
+  claims, so parallel agents don't collide on the same item.
+- **[veto](https://github.com/PlawIO/veto)** (Apache-2.0) — expressing
+  allow/deny/approval decisions declaratively and proving guarantees with a
+  checked-in baseline enforced in CI; echoed in kit's gated, fail-closed checks.
+- **[aigis](https://github.com/killertcell428/aigis)** (Apache-2.0) — the
+  tamper-evident audit trail and a reproducible findings shape, and the idea of
+  filtering memory writes against prompt injection.
+
+We also learned from peers in the zero-LLM agent-safety and dev-tooling space —
+including [sentrux](https://github.com/sentrux/sentrux),
+[rtk](https://github.com/rtk-ai/rtk), and
+[depgraph-cli](https://github.com/synthesiseng/depgraph-cli) — even where kit
+hasn't (yet) drawn code or patterns from them.

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -1190,6 +1190,24 @@ async function memContext(): Promise<boolean> {
   return true;
 }
 
+/**
+ * Mitigation context for a plain `--injection` scan with high-confidence findings.
+ * The scan reads EVERY row regardless of quarantine state, so on a store that already
+ * ran --quarantine the same high list reappears and reads as "still exposed" — but
+ * quarantined rows are excluded from recall and cannot be re-injected. We surface that
+ * state and point at the fix rather than SUPPRESSING findings: an allowlist on an
+ * injection scanner would be a bypass (an attacker's "just discussing…" is the payload).
+ */
+function printInjectionMitigation(totalQuarantined: number): void {
+  const already =
+    totalQuarantined > 0
+      ? `${c.dim}${totalQuarantined} message(s) already quarantined (excluded from recall). ${c.reset}`
+      : "";
+  console.log(
+    `${already}${c.dim}Run ${c.reset}kit memory scan --injection --quarantine${c.dim} to exclude high-confidence rows from recall.${c.reset}`,
+  );
+}
+
 async function memScan(): Promise<boolean> {
   const jsonMode = hasFlag(process.argv, "--json");
   // --injection scans for prompt-injection patterns (the store is replayed into
@@ -1238,6 +1256,9 @@ async function memScan(): Promise<boolean> {
     }
   } else {
     console.log(`${c.green}✓${c.reset} no high-confidence ${noun}s`);
+  }
+  if (injectionMode && !doQuarantine && high.length) {
+    printInjectionMitigation(totalQuarantined);
   }
   if (heuristic.length) {
     const showAll = hasFlag(process.argv, "--all");


### PR DESCRIPTION
## Description

Two independent, low-risk changes:

1. **`kit memory scan --injection` surfaces quarantine state.** Dogfooding follow-up.
2. **Add an Acknowledgements section to the README** crediting the prior art kit drew from (previously only cloudctx was credited, inline).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Related Issues

Follow-up to the dogfooding sweep (#238, #239). No tracked issue.

## Changes Made

**Injection scan (`src/commands/memory.ts`)**
- The scan reads every row regardless of quarantine state, so re-running it after `--quarantine` showed the same high-confidence list and read as "still exposed" even though those rows are excluded from recall. Plain `--injection` scans with high-confidence findings now print how many messages are already quarantined and point at `--quarantine`.
- Deliberately **not** a path/content allowlist — a suppression channel on an injection scanner would be a bypass (an attacker's "I'm just discussing this…" is the payload). This adds mitigation *context*; it does not hide findings.
- Extracted the note into `printInjectionMitigation` to keep `memScan` under the complexity budget.

**Acknowledgements (`README.md`)**
- New `## Acknowledgements` section crediting the projects kit borrowed ideas/patterns from, sourced from the `kit-research` evaluation notes and **verified against shipped code**: cloudctx (memory schema + two-hook capture), headroom (the `memory learn` idea), guild (atomic PAL claiming), veto (declarative allow/deny/approval + checked-in baseline), aigis (tamper-evident audit + reproducible findings shape).
- depgraph-cli's publish-age/version-velocity signals are mentioned as ecosystem peers but not credited as borrowed, since those signals aren't in the code yet.

## Testing

### Test Coverage
- [x] All tests pass (`npm test`) — 2333 pass, 0 fail
- Pure scan logic is unchanged (already covered by `scan.test.ts` / `injection.test.ts`); the new output is presentational.

### Manual Testing
1. `kit memory scan --injection` on the real store → high-confidence list now ends with "N message(s) already quarantined (excluded from recall). Run kit memory scan --injection --quarantine …".
2. README renders with the new section.

## Breaking Changes

None / N/A

## Performance Impact

- [x] No performance impact

## Reviewer Notes

The acknowledgements use the exact project identifiers recorded in the research notes; if any upstream URL has since moved, it's a one-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_