### PR TITLE
feat(check): a missing scanner is installed and, if it still can't run, fails strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Security — self-healing scanner preflight: install a missing scanner instead of only failing (found by dogfooding)
+
+- **`kit check` / `kit ci` now auto-provision a declared-but-missing scanner before
+  scanning.** A missing scanner shouldn't just fail the gate — in an ephemeral
+  environment it should be installed so the scan actually runs. `autoInstallScanners`
+  installs any security scanner that is DECLARED in `.kit.toml [tools]` but not yet
+  present (`semgrep`, `socket`, `trufflehog`, `trivy`, `osv-scanner`), then the scan
+  runs against it. It is the runtime complement to `kit install` at env-setup (which
+  provisions the same tools); this backstops the case where setup did not run. Only
+  kit's known scanner refs are touched, and only when already declared, so it can
+  never pull in a tool the project didn't opt into. Triage-gated and read-only-aware
+  (via `installTools`), best-effort (a failed install leaves the check to fail closed),
+  skipped when air-gapped, and opt-out via `--no-auto-install` / `KIT_CHECK_NO_AUTOINSTALL`.
+  `src/install.ts`, `src/cli.ts`.
+
 ### Security — scanner-health strict: a missing scanner no longer passes as a warning (found by dogfooding)
 
 - **`didNotRun` was missing on tool-absent scanner branches.** `check-security`'s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Security — scanner-health strict: a missing scanner no longer passes as a warning (found by dogfooding)
+
+- **`didNotRun` was missing on tool-absent scanner branches.** `check-security`'s
+  contract is that a check which could not RUN because its tool is absent is
+  `didNotRun` and FAILS the strict gate (`kit ci`) — "green means every check
+  actually ran". Five branches violated it, returning a plain `warn`: `pip-audit`
+  (with a `requirements.txt` present), `guarddog` (opted in, manifest present),
+  `trivy` container / IaC / Maven scans (Dockerfile / Compose / Terraform / pom
+  present), and the `license check` (neither `license-checker` nor `npx`
+  available). A repo with Dockerfiles but no trivy therefore passed strict CI as a
+  mere warning — a scanner-health false-green. All five now set `didNotRun`, so an
+  unscanned-because-uninstalled scanner fails strict (still downgradable with
+  `--lenient` / `KIT_CI_LENIENT`). Local `kit check` output is unchanged; opt-in and
+  not-applicable cases remain honest skips. `src/check-security.ts`.
+
 ### Security — supply-chain gate, secrets/audit & control-plane hardening (backlog B1–B5)
 
 A deep MEDIUM/LOW security sweep, each area hardened through repeated adversarial

--- a/src/check-security.test.ts
+++ b/src/check-security.test.ts
@@ -207,6 +207,23 @@ describe("checkSecurity", () => {
     }
   });
 
+  it("marks every tool-absent warn as didNotRun (scanner-health contract)", () => {
+    // The module's contract: a check that could not RUN because its tool is absent
+    // is `didNotRun` (fails the strict gate) — not a mere warning that slips through
+    // as green. Environment-independent: where the tool IS installed the check turns
+    // to pass (filtered out here); where it is absent it must carry didNotRun.
+    const toolAbsentWarns = cached.filter(
+      (r) => r.status === "warn" && /not installed|npx also unavailable/i.test(r.detail),
+    );
+    for (const r of toolAbsentWarns) {
+      assert.strictEqual(
+        r.didNotRun,
+        true,
+        `"${r.name}" (${r.detail}) is a tool-absent warn but is not marked didNotRun — it would pass the strict gate as a mere warning`,
+      );
+    }
+  });
+
   it("includes npm audit check", () => {
     assert.ok(
       cached.find((r) => r.name === "npm audit"),

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -190,6 +190,10 @@ async function checkPipAudit(): Promise<SecurityCheckResult> {
       status: "warn",
       detail: "pip-audit not installed (run: pip install pip-audit)",
       severity: "medium",
+      // requirements.txt is present (we returned above otherwise) → a Python
+      // project's CVEs are UNSCANNED because the tool is absent: a scanner-health
+      // failure under strict, not an honest skip.
+      didNotRun: true,
     };
   }
 
@@ -801,6 +805,9 @@ async function checkGuardDog(): Promise<SecurityCheckResult> {
       detail: "guarddog not installed — malware heuristics unavailable",
       severity: "medium",
       suggestion: "mise use pipx:guarddog",
+      // guarddog is opted in (env/config) AND a manifest is present, but the tool
+      // is absent → the opted-in malware scan did NOT run (mirrors semgrep below).
+      didNotRun: true,
     };
   }
 
@@ -839,6 +846,9 @@ async function checkTrivy(): Promise<SecurityCheckResult> {
       detail: "trivy not installed -container CVEs undetected",
       severity: "medium",
       suggestion: "mise use aqua:aquasecurity/trivy  (or: brew install trivy)",
+      // A Dockerfile is present but trivy is absent → container CVEs UNSCANNED: a
+      // scanner-health failure under strict, not an honest skip.
+      didNotRun: true,
     };
   }
 
@@ -962,6 +972,9 @@ async function checkTrivyConfig(): Promise<SecurityCheckResult> {
       detail: "trivy not installed -IaC misconfigurations undetected",
       severity: "medium",
       suggestion: "mise use aqua:aquasecurity/trivy  (or: brew install trivy)",
+      // IaC (Dockerfile/Compose/Terraform) is present but trivy is absent → those
+      // misconfigurations are UNSCANNED: a scanner-health failure under strict.
+      didNotRun: true,
     };
   }
 
@@ -1098,6 +1111,9 @@ async function checkMavenAudit(): Promise<SecurityCheckResult> {
       detail: "trivy not installed -maven CVEs undetected",
       severity: "medium",
       suggestion: "mise use aqua:aquasecurity/trivy  (or: brew install trivy)",
+      // A Maven/Gradle project is present but trivy is absent → JVM dependency CVEs
+      // are UNSCANNED: a scanner-health failure under strict, not an honest skip.
+      didNotRun: true,
     };
   }
 
@@ -1323,6 +1339,9 @@ async function checkLicenses(): Promise<SecurityCheckResult> {
       detail: "license-checker not installed (npx also unavailable)",
       severity: "low",
       suggestion: "npm install -g license-checker",
+      // Neither the binary nor the npx fallback is available → the license scan
+      // could not run at all: a scanner-health failure under strict, not a skip.
+      didNotRun: true,
     };
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -325,6 +325,7 @@ async function cmdCheck(): Promise<boolean> {
       const webSearchResult = config.web?.search
         ? await step("web search", () => checkWebSearch(config.web!.search!))
         : null;
+      await autoInstallScanners(config, live); // self-heal missing scanners before scanning
       const securityResults = await step("security scan", () => checkSecurity());
       const lockResults = await step("lock files", () => checkLockFiles(config));
 
@@ -746,6 +747,39 @@ async function cmdInstall(): Promise<boolean> {
       return allOk;
     },
   );
+}
+
+/**
+ * Self-healing scanner preflight for `kit check` / `kit ci`. Installs any security
+ * scanner declared in `.kit.toml [tools]` but not yet present, so the scan actually
+ * RUNS in an ephemeral environment instead of reporting the scanner missing (which
+ * fails the strict gate). Complements `kit install` at env-setup — this backstops
+ * the case where setup did not run. Opt out with `--no-auto-install` /
+ * `KIT_CHECK_NO_AUTOINSTALL`; skipped when air-gapped. installTools is triage-gated
+ * and read-only-aware, so this can never run an untriaged binary or write in
+ * --read-only mode. Best-effort: a failed install just leaves the check to fail closed.
+ */
+async function autoInstallScanners(config: kitConfig, live: boolean): Promise<void> {
+  if (!config.tools) return;
+  const { ensureScannersInstalled } = await import("./install.js");
+  const { resolveAirGap } = await import("./airgap/config.js");
+  const disabled =
+    hasFlag(process.argv, "--no-auto-install") ||
+    ["1", "true", "yes"].includes(
+      (process.env.KIT_CHECK_NO_AUTOINSTALL ?? "").trim().toLowerCase(),
+    );
+  const results = await ensureScannersInstalled(config.tools, {
+    disabled,
+    airGapped: resolveAirGap(config.air_gap, process.env).enabled,
+  });
+  const newly = results.filter((r) => r.action === "installed");
+  if (live && newly.length) {
+    console.log(
+      `  ${c.green}✓${c.reset} ${c.dim}auto-installed ${newly
+        .map((r) => r.name)
+        .join(", ")} so its scan can run${c.reset}`,
+    );
+  }
 }
 
 async function ensureSecretsBackend(config: kitConfig): Promise<boolean> {
@@ -3293,6 +3327,7 @@ async function cmdCi(): Promise<boolean> {
       const skillResults = config.skills
         ? await step("skills", () => checkSkills(config.skills!))
         : [];
+      await autoInstallScanners(config, live); // self-heal missing scanners before scanning
       const securityResults = await step("security scan", () => checkSecurity());
       const lockResults = await step("lock files", () => checkLockFiles(config));
       // Signed org policy (.kit-policy.toml) — opt-in (absent ⇒ present:false ⇒ no

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -1,6 +1,11 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { installTools, miseErrorDetail, type InstallDeps } from "./install.js";
+import {
+  installTools,
+  ensureScannersInstalled,
+  miseErrorDetail,
+  type InstallDeps,
+} from "./install.js";
 
 function makeDeps(overrides: Partial<InstallDeps> = {}): InstallDeps {
   return {
@@ -159,6 +164,89 @@ describe("installTools", () => {
     assert.equal(gateCalled, false); // gate skipped entirely
     // post-install verify re-checks; with stub checkTools it stays not-ok → failed, but mise DID run
     assert.notEqual(results[0].action, "blocked");
+  });
+});
+
+describe("ensureScannersInstalled (self-healing check preflight)", () => {
+  it("returns [] when disabled, air-gapped, or no tools (no install attempted)", async () => {
+    let checked = false;
+    const deps = makeDeps({
+      checkTools: async () => {
+        checked = true;
+        return [];
+      },
+    });
+    assert.deepEqual(
+      await ensureScannersInstalled({ semgrep: "latest" }, { disabled: true }, deps),
+      [],
+    );
+    assert.deepEqual(
+      await ensureScannersInstalled({ semgrep: "latest" }, { airGapped: true }, deps),
+      [],
+    );
+    assert.deepEqual(await ensureScannersInstalled(undefined, {}, deps), []);
+    assert.equal(checked, false, "no gating path should have touched checkTools");
+  });
+
+  it("installs ONLY declared scanner refs — never other project tools", async () => {
+    const seen = new Set<string>();
+    const deps = makeDeps({
+      checkTools: async (tools) => {
+        for (const k of Object.keys(tools)) seen.add(k);
+        return Object.keys(tools).map((name) => ({
+          name,
+          required: "latest",
+          installed: null,
+          ok: false,
+        }));
+      },
+      miseInstall: async () => ({ ok: true, detail: "installed" }),
+    });
+    await ensureScannersInstalled(
+      {
+        node: "22", // not a scanner → must be ignored
+        semgrep: "latest", // scanner
+        "aqua:aquasecurity/trivy": "latest", // scanner
+        "some/random-tool": "1", // not a scanner → ignored
+      },
+      {},
+      deps,
+    );
+    assert.deepEqual(
+      [...seen].sort(),
+      ["aqua:aquasecurity/trivy", "semgrep"],
+      "only known scanner refs reach installTools",
+    );
+  });
+
+  it("returns [] when the project declares no scanner tools", async () => {
+    const deps = makeDeps({
+      checkTools: async () => {
+        throw new Error("should not be called — nothing to install");
+      },
+    });
+    assert.deepEqual(await ensureScannersInstalled({ node: "22", python: "3.12" }, {}, deps), []);
+  });
+
+  it("is triage-gated: a blocked scanner is not installed (inherits installTools)", async () => {
+    let miseCalled = false;
+    const deps = makeDeps({
+      checkTools: async () => [
+        { name: "aqua:aquasecurity/trivy", required: "latest", installed: null, ok: false },
+      ],
+      gateInstall: async (tool) => ({ tool, decision: "blocked", reason: "typosquat" }),
+      miseInstall: async () => {
+        miseCalled = true;
+        return { ok: true, detail: "installed" };
+      },
+    });
+    const results = await ensureScannersInstalled(
+      { "aqua:aquasecurity/trivy": "latest" },
+      {},
+      deps,
+    );
+    assert.equal(results[0]?.action, "blocked");
+    assert.equal(miseCalled, false);
   });
 });
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -39,6 +39,56 @@ export function miseErrorDetail(message: string, stderr = ""): string {
   return firstMsg;
 }
 
+/**
+ * The mise refs kit treats as security scanners — the DEFAULT set plus the two
+ * conditionally-provisioned ones (trivy for containers/IaC, osv-scanner for
+ * ecosystems without a dedicated scanner). Only these are auto-installed by the
+ * `kit check` self-healing preflight, and only when the project ALREADY declares
+ * them in `.kit.toml [tools]` — so the preflight can never pull in a tool the
+ * project didn't opt into. Kept in sync with toml-generator's provisioning.
+ */
+const SCANNER_REFS = new Set<string>([
+  "semgrep",
+  "npm:@socketsecurity/cli",
+  "aqua:trufflesecurity/trufflehog",
+  "aqua:aquasecurity/trivy",
+  "aqua:google/osv-scanner",
+]);
+
+export interface EnsureScannersOpts {
+  /** Opt-out (KIT_CHECK_NO_AUTOINSTALL / --no-auto-install) — keep check read-only. */
+  disabled?: boolean;
+  /** Air-gapped posture → don't attempt a (possibly-blocked) network install; the
+   *  enclave pre-provisions tools and the check fails closed if one is missing. */
+  airGapped?: boolean;
+}
+
+/**
+ * Self-healing preflight for `kit check` / `kit ci`: install any security scanner
+ * that is DECLARED in `.kit.toml [tools]` but not yet present, so an ephemeral
+ * environment actually RUNS the scan instead of reporting the scanner missing
+ * (which now fails the strict gate). This is the runtime complement to `kit install`
+ * at env-setup: setup provisions the scanners, and this backstops the case where
+ * setup did not run. Only kit's known scanner refs are touched, only when already
+ * declared, so it can never install a tool the project didn't opt into. Triage-gated
+ * and read-only-aware via installTools; best-effort — a failure just leaves the
+ * scanner missing and the check fails closed honestly. Returns the install results
+ * (empty when skipped or nothing to do).
+ */
+export async function ensureScannersInstalled(
+  tools: ToolConfig | undefined,
+  opts: EnsureScannersOpts = {},
+  deps: InstallDeps = defaultDeps,
+): Promise<InstallResult[]> {
+  if (opts.disabled || opts.airGapped || !tools) return [];
+  const scanners: ToolConfig = {};
+  for (const [ref, version] of Object.entries(tools)) {
+    if (SCANNER_REFS.has(ref)) scanners[ref] = version;
+  }
+  if (Object.keys(scanners).length === 0) return [];
+  return installTools(scanners, deps);
+}
+
 async function miseInstall(
   tool: string,
   version: string,


### PR DESCRIPTION
## Description

Two halves of the same story — what should happen when a security scanner isn't present:

1. **Install it (self-healing preflight).** In an ephemeral environment a missing scanner should be *installed* so the scan actually runs — not merely reported. `kit check` / `kit ci` now auto-provision a declared-but-missing scanner before scanning.
2. **If it still can't run, fail strict (P5).** A scanner that genuinely couldn't run (offline, air-gapped, install failed) now correctly fails the strict gate instead of passing as a warning — closing a scanner-health false-green.

Found by dogfooding.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Follow-up to the dogfooding sweep (#238, #239, #240). No tracked issue.

## Changes Made

**Self-healing preflight (`src/install.ts`, `src/cli.ts`)**
- `ensureScannersInstalled()` installs any security scanner **declared in `.kit.toml [tools]`** but not present — only kit's known refs (`semgrep`, `socket`, `trufflehog`, `trivy`, `osv-scanner`), and only when already declared, so it can never pull in a tool the project didn't opt into.
- Triage-gated and read-only-aware (via `installTools`); best-effort; skipped when air-gapped; opt out with `--no-auto-install` / `KIT_CHECK_NO_AUTOINSTALL`.
- Wired into both `cmdCheck` and `cmdCi` via a shared `autoInstallScanners()` helper. It's the runtime complement to `kit install` at env-setup (which provisions the same tools); this backstops the case where setup didn't run.

**Scanner-health strict (`src/check-security.ts`)**
- Five tool-absent branches (`pip-audit`, `guarddog`, `trivy` container/IaC/Maven, `license check`) now set `didNotRun: true`, matching the module's documented contract and the already-correct `osv`/`semgrep` branches. Under strict `kit ci`, a scanner that couldn't run now fails instead of passing as a warning (downgradable with `--lenient` / `KIT_CI_LENIENT`). Local `kit check` display is unchanged; opt-in / not-applicable cases stay honest skips.

## How the two fit together

`kit install` (setup) → provisions scanners. If setup didn't run, the preflight installs the declared-but-missing ones at check time. If it *still* can't (offline / air-gap / no mise), the scan reports the scanner missing and — under strict — fails closed rather than green.

## Testing

### Test Coverage
- [x] Added new tests (4 for `ensureScannersInstalled`, 1 invariant for the `didNotRun` contract)
- [x] All tests pass (`npm test`) — 2338 pass, 0 fail

### Manual Testing
1. `kit check --category security --no-auto-install` → runs normally, no install (opt-out works).
2. `kit check --category security` (no mise in the env) → preflight fires, install is best-effort (no-op here), scan proceeds and reports trivy missing; no hang, exit 0.
3. Trivy checks report `didNotRun=true` + `gateStatus()=fail` locally (previously a false-green `warn`).

## Breaking Changes

Behavioral: (a) `kit check` / `kit ci` may install a declared-but-missing scanner (opt out with `--no-auto-install` / `KIT_CHECK_NO_AUTOINSTALL`; never runs in `--read-only` or air-gapped mode); (b) strict `kit ci` now fails (instead of warning) when a scanner can't run — the documented scanner-health-strict intent; `--lenient` / `KIT_CI_LENIENT` restores the prior behavior.

## Performance Impact

- [x] No performance impact (preflight is a no-op when scanners are already installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2