### PR TITLE
feat(check): external findings ingestion — connect any scanner to kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Integration — external findings ingestion: connect any scanner to `kit check`
+
+- **`kit check` now folds third-party findings into its verdict.** A partner tool
+  (a `kit-plugin-*`, or any in-house gate) appends one JSON object per line to
+  `.kit-scan-results.jsonl` — `{source, severity, title?, id?, package?}` — and
+  `kit check --category security` ingests it: `critical`/`high` **fail** the gate
+  (like `npm audit`), `medium`/`low` **warn**, grouped per source. This is the inbound
+  integration contract from the research: partners connect _to_ kit's stable surface;
+  kit's core needs no per-partner code (the `kit-plugin-snyk`/`-wiz`/`-sentrux` plugins
+  already write this file — nothing consumed it into the verdict until now).
+  No-false-green: ingestion can only add/escalate findings, never emit a `pass`, and a
+  garbage/hostile file cannot green the gate; unparseable lines are surfaced (never
+  silently dropped). No file → no-op. Deterministic, zero-LLM. New `src/external-findings.ts`;
+  documented in `docs/EXTERNAL_FINDINGS.md`.
+
 ### Security — self-healing scanner preflight: install a missing scanner instead of only failing (found by dogfooding)
 
 - **`kit check` / `kit ci` now auto-provision a declared-but-missing scanner before

--- a/docs/EXTERNAL_FINDINGS.md
+++ b/docs/EXTERNAL_FINDINGS.md
@@ -1,0 +1,63 @@
+# External findings — connect any scanner to `kit check`
+
+kit is the inbound integration point: a third-party security tool doesn't need kit
+to know about it. It emits findings in one small, stable shape and `kit check` folds
+them into its verdict. This is how a partner scanner, a `kit-plugin-*`, or your own
+in-house gate connects to kit **without any change to kit's core**.
+
+## The contract
+
+Append one JSON object per line to **`.kit-scan-results.jsonl`** in the project root
+(JSON Lines — one finding per line).
+
+```jsonl
+{"source":"snyk","severity":"high","id":"SNYK-JS-LODASH-1","title":"Prototype pollution","package":"lodash"}
+{"source":"sentrux","severity":"critical","title":"Public S3 bucket in prod module"}
+{"source":"my-inhouse-gate","severity":"medium","title":"Deprecated TLS config"}
+```
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `source` | **yes** | Non-empty tool name. Findings are grouped and reported per source (`external: <source>`). |
+| `severity` | **yes** | `critical` \| `high` \| `medium` \| `low` (case-insensitive). |
+| `title` | no | Short description (used in the detail line). |
+| `id` | no | Stable finding id (for your own dedupe/tracking). |
+| `package` | no | Affected package, if applicable. |
+
+Extra keys are ignored, so you can carry your own metadata on the same line.
+
+## How kit treats it
+
+- **`critical` / `high` → FAIL** the security gate (same policy as `npm audit` high/critical).
+- **`medium` / `low` → WARN** (surfaced, non-blocking by default).
+- Findings are grouped per `source`; the summary reports the counts and the worst severity.
+- **No file → no-op.** Ingestion is invisible until a tool actually emits findings.
+
+## Guarantees (no false green)
+
+- Ingestion can only **add or escalate** findings. It can never remove or downgrade a
+  finding kit produced, and it **never emits a `pass`** — a garbage or hostile file
+  cannot turn the gate green. The only lever a line has is `severity`, and a
+  `critical` severity fails regardless of any other keys.
+- **Unparseable lines are surfaced, never silently dropped** — a bad line becomes a
+  low-severity `external findings (parse)` warning telling you to fix the emitter.
+- Deterministic and zero-LLM, like the rest of `kit check`.
+
+## Freshness is the emitter's job
+
+kit ingests exactly what the file says — it does not second-guess it. If your tool
+blindly **appends** every run, stale (already-fixed) findings will keep failing the
+gate. Emit findings so the file reflects the **current** state: rewrite it per scan,
+or dedupe by your own `id`. (The existing `kit-plugin-snyk` / `-wiz` / `-sentrux`
+append to this same file — manage rotation accordingly.)
+
+## Minimal example
+
+```bash
+# any tool, any language — just write the shape:
+echo '{"source":"my-gate","severity":"high","title":"secret in config"}' >> .kit-scan-results.jsonl
+kit check --category security   # → "external: my-gate  fail  1 finding(s) (1 high)"
+```
+
+That's the whole integration. See also `docs/PLUGIN_DEVELOPMENT.md` for packaging this
+as a distributable `kit-plugin-*`.

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -1692,6 +1692,12 @@ export async function checkSecurity(): Promise<SecurityCheckResult[]> {
   results.push(await checkDiskEncryption());
   results.push(checkMemoryDirSafety());
 
+  // Inbound integration: fold any third-party findings a partner tool emitted to
+  // `.kit-scan-results.jsonl` into the verdict. No file → no-op. Can only escalate
+  // (fail/warn), never green the gate — see external-findings.ts.
+  const { checkExternalFindings } = await import("./external-findings.js");
+  results.push(...(await checkExternalFindings()));
+
   // Attach a rule citation (CWE/OWASP) to each finding whose check is mapped in
   // the local rules catalog. Deterministic lookup, no network. Unmapped checks
   // pass through unchanged.

--- a/src/external-findings.test.ts
+++ b/src/external-findings.test.ts
@@ -1,0 +1,117 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parseExternalFindings,
+  externalFindingResults,
+  checkExternalFindings,
+  EXTERNAL_FINDINGS_FILE,
+} from "./external-findings.js";
+
+describe("parseExternalFindings", () => {
+  it("parses valid finding lines (case-insensitive severity, extra keys ignored)", () => {
+    const text = [
+      '{"source":"snyk","severity":"HIGH","id":"S-1","title":"t","package":"lodash","cvss":9}',
+      '{"source":"sentrux","severity":"medium"}',
+      "", // blank skipped
+    ].join("\n");
+    const { findings, malformed } = parseExternalFindings(text);
+    assert.equal(malformed, 0);
+    assert.equal(findings.length, 2);
+    assert.equal(findings[0].severity, "high");
+    assert.equal(findings[0].source, "snyk");
+    assert.equal(findings[0].package, "lodash");
+  });
+
+  it("counts malformed lines (bad json / non-object / array / missing source / bad severity)", () => {
+    const text = [
+      "not json",
+      '"a string"',
+      "[1,2,3]",
+      '{"severity":"high"}', // no source
+      '{"source":"x","severity":"nope"}', // bad severity
+      '{"source":"  ","severity":"high"}', // blank source
+    ].join("\n");
+    const { findings, malformed } = parseExternalFindings(text);
+    assert.equal(findings.length, 0);
+    assert.equal(malformed, 6);
+  });
+});
+
+describe("externalFindingResults (no-false-green)", () => {
+  it("FAILS a source with high/critical, WARNs medium/low, and never emits pass", () => {
+    const results = externalFindingResults({
+      findings: [
+        { source: "snyk", severity: "high" },
+        { source: "snyk", severity: "low" },
+        { source: "aigis", severity: "medium" },
+      ],
+      malformed: 0,
+    });
+    const snyk = results.find((r) => r.name === "external: snyk");
+    const aigis = results.find((r) => r.name === "external: aigis");
+    assert.equal(snyk?.status, "fail"); // worst = high → fail
+    assert.equal(snyk?.severity, "high");
+    assert.match(snyk?.detail ?? "", /1 high, 1 low/);
+    assert.equal(aigis?.status, "warn"); // only medium → warn
+    assert.ok(!results.some((r) => r.status === "pass"), "ingestion can never produce a pass");
+    // deterministic sort by source
+    assert.deepEqual(
+      results.map((r) => r.name),
+      ["external: aigis", "external: snyk"],
+    );
+  });
+
+  it("a forged status/pass key in the line cannot green the gate (only severity drives it)", () => {
+    // A hostile emitter tries to sneak a pass through. parse ignores unknown keys;
+    // the only lever is `severity`, and a critical severity FAILS regardless.
+    const { findings } = parseExternalFindings(
+      '{"source":"evil","severity":"critical","status":"pass","ok":true}',
+    );
+    const [r] = externalFindingResults({ findings, malformed: 0 });
+    assert.equal(r.status, "fail");
+    assert.equal(r.severity, "critical");
+  });
+
+  it("surfaces malformed lines as a low warn (never silent)", () => {
+    const results = externalFindingResults({ findings: [], malformed: 3 });
+    assert.equal(results.length, 1);
+    assert.equal(results[0].status, "warn");
+    assert.match(results[0].detail, /3 unparseable/);
+  });
+});
+
+describe("checkExternalFindings (IO)", () => {
+  it("returns [] when no results file is present (no-op)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-ext-"));
+    try {
+      assert.deepEqual(await checkExternalFindings(dir), []);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ingests a partner-written results file into per-source results", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-ext-"));
+    try {
+      writeFileSync(
+        join(dir, EXTERNAL_FINDINGS_FILE),
+        ['{"source":"snyk","severity":"critical","id":"S-9","package":"foo"}', "garbage line"].join(
+          "\n",
+        ),
+      );
+      const results = await checkExternalFindings(dir);
+      const snyk = results.find((r) => r.name === "external: snyk");
+      assert.equal(snyk?.status, "fail");
+      assert.equal(snyk?.severity, "critical");
+      assert.ok(
+        results.some((r) => r.name === "external findings (parse)" && r.status === "warn"),
+        "the garbage line is surfaced, not silently dropped",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/external-findings.ts
+++ b/src/external-findings.ts
@@ -1,0 +1,152 @@
+/**
+ * External-findings ingestion — the inbound contract that lets ANY third-party
+ * security tool (a kit-plugin like snyk/wiz/sentrux, or any partner scanner) fold
+ * its results into `kit check`'s verdict without kit knowing that tool.
+ *
+ * Contract: a tool appends one JSON object per line to `.kit-scan-results.jsonl`
+ * in the project root. kit reads it deterministically and turns each `source` into
+ * a SecurityCheckResult. This is how "connect to kit" works — partners emit the
+ * shape; kit ingests it; there is no per-partner code in kit's core.
+ *
+ * Minimal line shape (extra keys ignored):
+ *   {"source":"snyk","severity":"high","id":"SNYK-JS-…","title":"…","package":"lodash"}
+ * `source` (non-empty string) and `severity` (critical|high|medium|low) are required.
+ *
+ * SECURITY / no-false-green: ingestion can only ADD findings (escalate the verdict),
+ * never remove or downgrade a kit finding, and it NEVER emits a `pass` — so a
+ * garbage or hostile file cannot turn the gate green. A high/critical finding FAILS
+ * the gate (like npm audit); medium/low only WARN. Unparseable lines are skipped but
+ * COUNTED and surfaced (no silent drop). Deterministic, zero-LLM.
+ *
+ * Freshness is the EMITTER's responsibility: a tool should rewrite (or dedupe) its
+ * findings per scan, not blindly append forever, or stale findings will keep failing
+ * the gate. kit ingests what the file says — it does not second-guess it.
+ */
+import { resolve } from "node:path";
+import type { SecurityCheckResult } from "./check-security.js";
+
+/** The de-facto sink kit-plugin-snyk/wiz/sentrux already append to. */
+export const EXTERNAL_FINDINGS_FILE = ".kit-scan-results.jsonl";
+
+export type ExternalSeverity = "critical" | "high" | "medium" | "low";
+
+export interface ExternalFinding {
+  source: string;
+  severity: ExternalSeverity;
+  title?: string;
+  id?: string;
+  package?: string;
+}
+
+export interface ParsedExternalFindings {
+  findings: ExternalFinding[];
+  /** Non-empty lines that were not a usable finding object (surfaced, never silent). */
+  malformed: number;
+}
+
+const SEVERITIES = new Set<ExternalSeverity>(["critical", "high", "medium", "low"]);
+const RANK: Record<ExternalSeverity, number> = { critical: 3, high: 2, medium: 1, low: 0 };
+
+/**
+ * Parse `.kit-scan-results.jsonl` content. PURE and fail-safe: never throws; a line
+ * that isn't valid JSON, isn't an object, or lacks a `source`/valid `severity` is
+ * counted as `malformed` — never dropped silently and never turned into a finding.
+ */
+export function parseExternalFindings(text: string): ParsedExternalFindings {
+  const findings: ExternalFinding[] = [];
+  let malformed = 0;
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) continue;
+    let obj: unknown;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      malformed++;
+      continue;
+    }
+    if (!obj || typeof obj !== "object" || Array.isArray(obj)) {
+      malformed++;
+      continue;
+    }
+    const o = obj as Record<string, unknown>;
+    const source = typeof o.source === "string" ? o.source.trim() : "";
+    const severity = typeof o.severity === "string" ? o.severity.trim().toLowerCase() : "";
+    if (!source || !SEVERITIES.has(severity as ExternalSeverity)) {
+      malformed++;
+      continue;
+    }
+    findings.push({
+      source,
+      severity: severity as ExternalSeverity,
+      title: typeof o.title === "string" ? o.title : undefined,
+      id: typeof o.id === "string" ? o.id : undefined,
+      package: typeof o.package === "string" ? o.package : undefined,
+    });
+  }
+  return { findings, malformed };
+}
+
+/**
+ * Turn parsed external findings into per-source SecurityCheckResults. PURE. A source
+ * with any critical/high finding FAILS; only medium/low WARNs. Never emits `pass` —
+ * ingestion can escalate the verdict, never green it. Sources are sorted for a
+ * deterministic order; malformed lines yield one low-severity warn.
+ */
+export function externalFindingResults(parsed: ParsedExternalFindings): SecurityCheckResult[] {
+  const bySource = new Map<string, ExternalFinding[]>();
+  for (const f of parsed.findings) {
+    const arr = bySource.get(f.source) ?? [];
+    arr.push(f);
+    bySource.set(f.source, arr);
+  }
+  const out: SecurityCheckResult[] = [];
+  for (const [source, fs] of [...bySource.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    const counts: Record<ExternalSeverity, number> = { critical: 0, high: 0, medium: 0, low: 0 };
+    let worst: ExternalSeverity = "low";
+    for (const f of fs) {
+      counts[f.severity]++;
+      if (RANK[f.severity] > RANK[worst]) worst = f.severity;
+    }
+    const blocking = counts.critical > 0 || counts.high > 0;
+    const summary = (["critical", "high", "medium", "low"] as ExternalSeverity[])
+      .filter((s) => counts[s] > 0)
+      .map((s) => `${counts[s]} ${s}`)
+      .join(", ");
+    out.push({
+      category: "supply-chain",
+      name: `external: ${source}`,
+      status: blocking ? "fail" : "warn",
+      detail: `${fs.length} finding(s) from ${source} (${summary})`,
+      severity: worst,
+    });
+  }
+  if (parsed.malformed > 0) {
+    out.push({
+      category: "supply-chain",
+      name: "external findings (parse)",
+      status: "warn",
+      detail: `${parsed.malformed} unparseable line(s) in ${EXTERNAL_FINDINGS_FILE} — ignored (fix the emitting tool)`,
+      severity: "low",
+    });
+  }
+  return out;
+}
+
+/**
+ * Read + ingest `.kit-scan-results.jsonl` for `kit check`. No file → [] (no-op, so
+ * this is invisible unless a partner tool has emitted findings). IO wrapper around
+ * the two pure functions above.
+ */
+export async function checkExternalFindings(
+  cwd: string = process.cwd(),
+): Promise<SecurityCheckResult[]> {
+  const { readFile } = await import("node:fs/promises");
+  let text: string;
+  try {
+    text = await readFile(resolve(cwd, EXTERNAL_FINDINGS_FILE), "utf-8");
+  } catch {
+    return []; // no external results → nothing ingested
+  }
+  return externalFindingResults(parseExternalFindings(text));
+}


### PR DESCRIPTION
## Description

Makes kit the **inbound integration point** from the integration-surface research: a third-party security tool (a `kit-plugin-*`, a partner scanner, or an in-house gate) folds its results into `kit check`'s verdict **without any per-partner code in kit's core**. It emits one JSON object per line to `.kit-scan-results.jsonl`; `kit check --category security` ingests it.

This closes a real gap: the existing `kit-plugin-snyk` / `-wiz` / `-sentrux` plugins already **write** `.kit-scan-results.jsonl` "so downstream tools can filter", but **nothing consumed it into the verdict** until now.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Implements the "generalize findings-ingestion" build track from the `kit-research` integration-surface synthesis (kit-research PR #10). No tracked issue.

## Changes Made

- **`src/external-findings.ts`** — the contract + ingestion:
  - `parseExternalFindings(text)` — pure, fail-safe JSONL parser (`{source, severity, title?, id?, package?}`; case-insensitive severity; extra keys ignored).
  - `externalFindingResults(parsed)` — pure aggregation into per-source `SecurityCheckResult`s: `critical`/`high` → **fail**, `medium`/`low` → **warn**, worst-severity + counts; malformed lines → one low warn.
  - `checkExternalFindings(cwd)` — IO reader; no file → `[]` (no-op).
- **`src/check-security.ts`** — wired `checkExternalFindings()` into `checkSecurity()`.
- **`docs/EXTERNAL_FINDINGS.md`** — the published contract so partners know how to connect.

## No false green

- Ingestion can only **add/escalate** findings — it never removes/downgrades a kit finding and **never emits a `pass`**. The only lever a line has is `severity`; a `critical` fails regardless of any other key (a forged `"status":"pass"` is ignored — covered by a test).
- **Unparseable lines are surfaced** as a low warn, never silently dropped.
- Deterministic, zero-LLM. No file present → completely invisible.

## Testing

### Test Coverage
- [x] Added new tests (7: parser, aggregation, no-false-green/forged-pass, malformed surfacing, IO no-op, end-to-end ingest)
- [x] All tests pass (`npm test`) — 2345 pass, 0 fail

### Manual Testing
1. Dropped `{"source":"sentrux","severity":"critical",…}` + `{"source":"snyk","severity":"medium"}` into a temp cwd → `checkSecurity()` produced `external: sentrux` (fail, gate=fail) and `external: snyk` (warn, gate=warn); a garbage line surfaced as an `external findings (parse)` warn.
2. No file → no external results (no-op), existing checks unchanged.

## Breaking Changes

None. Purely additive — invisible unless a tool has written `.kit-scan-results.jsonl`. (A tool that blindly appends stale findings will keep failing the gate; `docs/EXTERNAL_FINDINGS.md` documents that freshness is the emitter's responsibility.)

## Performance Impact

- [x] No performance impact (one file read; skipped entirely when absent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_