### PR TITLE
feat(check): accept scanner severity aliases — wire shipped plugins to the findings contract

### DIFF
--- a/docs/EXTERNAL_FINDINGS.md
+++ b/docs/EXTERNAL_FINDINGS.md
@@ -16,13 +16,13 @@ Append one JSON object per line to **`.kit-scan-results.jsonl`** in the project 
 {"source":"my-inhouse-gate","severity":"medium","title":"Deprecated TLS config"}
 ```
 
-| Field | Required | Meaning |
-|-------|----------|---------|
-| `source` | **yes** | Non-empty tool name. Findings are grouped and reported per source (`external: <source>`). |
-| `severity` | **yes** | `critical` \| `high` \| `medium` \| `low` (case-insensitive). |
-| `title` | no | Short description (used in the detail line). |
-| `id` | no | Stable finding id (for your own dedupe/tracking). |
-| `package` | no | Affected package, if applicable. |
+| Field      | Required | Meaning                                                                                                                                                                                                                   |
+| ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `source`   | **yes**  | Non-empty tool name. Findings are grouped and reported per source (`external: <source>`).                                                                                                                                 |
+| `severity` | **yes**  | `critical` \| `high` \| `medium` \| `low` (case-insensitive). Common aliases fold in: `moderate` → `medium`; `info` / `informational` → `low`. Unrecognized values are surfaced as a parse warning, not silently dropped. |
+| `title`    | no       | Short description (used in the detail line).                                                                                                                                                                              |
+| `id`       | no       | Stable finding id (for your own dedupe/tracking).                                                                                                                                                                         |
+| `package`  | no       | Affected package, if applicable.                                                                                                                                                                                          |
 
 Extra keys are ignored, so you can carry your own metadata on the same line.
 

--- a/src/external-findings.test.ts
+++ b/src/external-findings.test.ts
@@ -83,6 +83,40 @@ describe("externalFindingResults (no-false-green)", () => {
   });
 });
 
+describe("reference integration: the shipped kit-plugin-* emit shapes ingest cleanly", () => {
+  // These mirror the exact lines kit-plugin-snyk/-wiz/-sentrux append to
+  // .kit-scan-results.jsonl, so the contract stays wired to the real emitters.
+  it("snyk / wiz / sentrux findings all parse (incl. wiz 'informational' → low)", () => {
+    const lines = [
+      // snyk: severity already critical|high|medium|low
+      '{"timestamp":"t","source":"snyk","project":"p","severity":"high","id":"SNYK-1","title":"x","package":"lodash"}',
+      // wiz: emits .toLowerCase() of INFORMATIONAL|LOW|…|CRITICAL — 'informational' must fold to low, not error
+      '{"timestamp":"t","source":"wiz","severity":"informational","id":"W-1","title":"y"}',
+      '{"timestamp":"t","source":"wiz","severity":"critical","id":"W-2"}',
+      // sentrux: normalized to the four tiers + a hardcoded "high"
+      '{"timestamp":"t","source":"sentrux","severity":"medium","title":"z"}',
+    ].join("\n");
+    const { findings, malformed } = parseExternalFindings(lines);
+    assert.equal(malformed, 0, "no shipped-plugin line should be treated as malformed");
+    assert.equal(findings.length, 4);
+    const wizInfo = findings.find((f) => f.source === "wiz" && f.id === "W-1");
+    assert.equal(wizInfo?.severity, "low", "wiz 'informational' folds to low");
+
+    const results = externalFindingResults({ findings, malformed });
+    assert.equal(results.find((r) => r.name === "external: wiz")?.status, "fail"); // has critical
+    assert.equal(results.find((r) => r.name === "external: snyk")?.status, "fail"); // high
+    assert.equal(results.find((r) => r.name === "external: sentrux")?.status, "warn"); // medium
+  });
+
+  it("accepts the common 'moderate' alias (npm/GitHub advisories) → medium", () => {
+    const { findings, malformed } = parseExternalFindings(
+      '{"source":"gh-advisory","severity":"moderate"}',
+    );
+    assert.equal(malformed, 0);
+    assert.equal(findings[0].severity, "medium");
+  });
+});
+
 describe("checkExternalFindings (IO)", () => {
   it("returns [] when no results file is present (no-op)", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kit-ext-"));

--- a/src/external-findings.ts
+++ b/src/external-findings.ts
@@ -44,8 +44,32 @@ export interface ParsedExternalFindings {
   malformed: number;
 }
 
-const SEVERITIES = new Set<ExternalSeverity>(["critical", "high", "medium", "low"]);
 const RANK: Record<ExternalSeverity, number> = { critical: 3, high: 2, medium: 1, low: 0 };
+
+/**
+ * Map a raw severity string to one of kit's four tiers. Liberal in what we accept
+ * (Postel) so a real scanner's native vocabulary ingests cleanly instead of parse-
+ * erroring: an `info`/`informational` tier (e.g. wiz) folds to `low` (warns, never
+ * fails), and `moderate` (npm/GitHub advisories) folds to `medium`. Anything
+ * unrecognized returns null → the caller counts it as malformed (surfaced, not silent).
+ */
+function normalizeSeverity(raw: string): ExternalSeverity | null {
+  switch (raw.trim().toLowerCase()) {
+    case "critical":
+      return "critical";
+    case "high":
+      return "high";
+    case "medium":
+    case "moderate":
+      return "medium";
+    case "low":
+    case "info":
+    case "informational":
+      return "low";
+    default:
+      return null;
+  }
+}
 
 /**
  * Parse `.kit-scan-results.jsonl` content. PURE and fail-safe: never throws; a line
@@ -71,14 +95,14 @@ export function parseExternalFindings(text: string): ParsedExternalFindings {
     }
     const o = obj as Record<string, unknown>;
     const source = typeof o.source === "string" ? o.source.trim() : "";
-    const severity = typeof o.severity === "string" ? o.severity.trim().toLowerCase() : "";
-    if (!source || !SEVERITIES.has(severity as ExternalSeverity)) {
+    const severity = typeof o.severity === "string" ? normalizeSeverity(o.severity) : null;
+    if (!source || !severity) {
       malformed++;
       continue;
     }
     findings.push({
       source,
-      severity: severity as ExternalSeverity,
+      severity,
       title: typeof o.title === "string" ? o.title : undefined,
       id: typeof o.id === "string" ? o.id : undefined,
       package: typeof o.package === "string" ? o.package : undefined,


### PR DESCRIPTION
## Description

Follow-up to #242: makes the three shipped emitters (`kit-plugin-snyk` / `-wiz` / `-sentrux`) fully wired to the `.kit-scan-results.jsonl` contract as a reference integration, by having the contract fold common real-world severity vocabulary.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `parseExternalFindings` now normalizes severity aliases so a scanner's native output ingests cleanly instead of being counted malformed: **`info` / `informational` → `low`**, **`moderate` → `medium`**. Unrecognized values are still surfaced as a parse warning (never silently dropped).
- **Reference integration verified:** snyk and sentrux already emit the four canonical tiers; wiz emits a lowercased `informational` which now folds to `low`. So all three shipped plugins are wired to the contract **with no change to their code**.
- Locked by a reference test mirroring each plugin's exact emitted line shape; `docs/EXTERNAL_FINDINGS.md` documents the accepted aliases.

## Testing

### Test Coverage
- [x] Added new tests (reference round-trip for snyk/wiz/sentrux shapes + the `moderate` alias)
- [x] All tests pass (`npm test`) — 2347 pass, 0 fail

### Manual Testing
1. A line with `severity:"informational"` (wiz) parses to a `low` finding, not a parse error; `moderate` → `medium`.
2. An unrecognized severity still surfaces as an `external findings (parse)` warning.

## Breaking Changes

None — purely widens what the contract accepts.

## Performance Impact

- [x] No performance impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_