### PR TITLE
security: warn on an active KIT_DEVICE_ID override (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Security — surface a trust-bearing KIT_DEVICE_ID override (#79)
+
+- **`kit check` warns when a KIT_DEVICE_ID override is active on a real store.** The
+  device id is trust-bearing — the device fences in `palList` / `palSyncFindings`
+  auto-close another device's open findings by it, so a spoofed value could silently
+  close them; the protection was doc-only. New `deviceIdOverrideActive()` +
+  `device-id override` check warns (never fails by default; escalates under
+  `--fail-on-warning`) when a well-formed override is set AND a store exists (a fence is
+  actually in effect); skips otherwise. `src/memory/pal.ts`, `src/check-security.ts`.
+
 ### Security — shared-tier signature verification on the recall inject path (R4/#77)
 
 - **Auto-injected team decisions are now signature-verified.** `recentDecisions`

--- a/src/check-security.test.ts
+++ b/src/check-security.test.ts
@@ -10,6 +10,7 @@ import {
   jvmProjectKind,
   findJvmProject,
   checkMemoryHooksLiveness,
+  checkDeviceIdOverride,
   type SecurityCheckResult,
 } from "./check-security.js";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
@@ -46,6 +47,56 @@ describe("gateStatus — scanner-health strict by default", () => {
       gateStatus(r({ status: "warn", didNotRun: true }), { failOnWarning: true }),
       "fail",
     );
+  });
+});
+
+describe("checkDeviceIdOverride (#79 — trust-bearing env override)", () => {
+  const withEnv = async (
+    deviceId: string | undefined,
+    dbPath: string | undefined,
+    fn: (r: SecurityCheckResult) => void,
+  ) => {
+    const prevD = process.env.KIT_DEVICE_ID;
+    const prevDb = process.env.KIT_MEMORY_DB;
+    try {
+      if (deviceId === undefined) delete process.env.KIT_DEVICE_ID;
+      else process.env.KIT_DEVICE_ID = deviceId;
+      if (dbPath === undefined) delete process.env.KIT_MEMORY_DB;
+      else process.env.KIT_MEMORY_DB = dbPath;
+      fn(await checkDeviceIdOverride());
+    } finally {
+      if (prevD === undefined) delete process.env.KIT_DEVICE_ID;
+      else process.env.KIT_DEVICE_ID = prevD;
+      if (prevDb === undefined) delete process.env.KIT_MEMORY_DB;
+      else process.env.KIT_MEMORY_DB = prevDb;
+    }
+  };
+
+  it("skips when no override is set", async () => {
+    await withEnv(undefined, undefined, (r) => assert.equal(r.status, "skip"));
+  });
+
+  it("skips when set but no store exists (no device fence in effect)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-devid-"));
+    try {
+      await withEnv("laptop-1", join(dir, "nope.db"), (r) => assert.equal(r.status, "skip"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("WARNs when a valid override is active on a real store", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-devid-"));
+    try {
+      const dbPath = join(dir, "memory.db");
+      writeFileSync(dbPath, ""); // existsSync is all the check needs
+      await withEnv("laptop-1", dbPath, (r) => {
+        assert.equal(r.status, "warn");
+        assert.match(r.detail, /KIT_DEVICE_ID/);
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -91,6 +91,41 @@ export function gateStatus(
 }
 
 /**
+ * A KIT_DEVICE_ID override is trust-bearing: the device fences in `palList` /
+ * `palSyncFindings` auto-close another device's open findings by this id, so a
+ * spoofed value could silently close them. deviceId() only validates the format —
+ * this surfaces the posture. WARNs (never fails by default) when the override is
+ * active AND a real store exists (a device fence is actually in effect); skips
+ * otherwise. Escalates under `--fail-on-warning`.
+ */
+export async function checkDeviceIdOverride(): Promise<SecurityCheckResult> {
+  const name = "device-id override";
+  const category = "secrets" as const;
+  const { deviceIdOverrideActive } = await import("./memory/pal.js");
+  if (!deviceIdOverrideActive()) {
+    return { category, name, status: "skip", detail: "no KIT_DEVICE_ID override" };
+  }
+  const { existsSync } = await import("node:fs");
+  const { getMemoryDbPath } = await import("./memory/db.js");
+  if (!existsSync(getMemoryDbPath())) {
+    return {
+      category,
+      name,
+      status: "skip",
+      detail: "KIT_DEVICE_ID set but no store — no device fence in effect",
+    };
+  }
+  return {
+    category,
+    name,
+    status: "warn",
+    severity: "low",
+    detail:
+      "KIT_DEVICE_ID override is active — device-fenced auto-close of PAL/security findings trusts this value; unset it unless this device intentionally uses a fixed id",
+  };
+}
+
+/**
  * R5 — the self-playing loop (memory capture + statusline) depends on hooks in
  * ~/.claude/settings.json. If they were installed here (durable marker present) but
  * have since VANISHED from settings.json, capture is silently OFF — the store looks
@@ -1799,6 +1834,7 @@ export async function checkSecurity(): Promise<SecurityCheckResult[]> {
   // Self-playing loop liveness: fail if capture hooks were installed but have since
   // vanished from settings.json (capture silently off — a false green).
   results.push(await checkMemoryHooksLiveness());
+  results.push(await checkDeviceIdOverride());
 
   // Inbound integration: fold any third-party findings a partner tool emitted to
   // `.kit-scan-results.jsonl` into the verdict. No file → no-op. Can only escalate

--- a/src/memory/pal.test.ts
+++ b/src/memory/pal.test.ts
@@ -15,6 +15,7 @@ import {
   palAutoVerify,
   palPrune,
   deviceId,
+  deviceIdOverrideActive,
   importLegacyLedger,
   palSyncFindings,
   findingPalId,
@@ -464,5 +465,27 @@ describe("PAL — device coupling (don't nag about ephemeral-session items)", ()
   it("deviceId is stable within a process and overridable", () => {
     assert.equal(deviceId(), deviceId());
     withDevice("pinned", () => assert.equal(deviceId(), "pinned"));
+  });
+});
+
+describe("deviceIdOverrideActive (KIT_DEVICE_ID trust posture)", () => {
+  const withEnv = (val: string | undefined, fn: () => void) => {
+    const prev = process.env.KIT_DEVICE_ID;
+    if (val === undefined) delete process.env.KIT_DEVICE_ID;
+    else process.env.KIT_DEVICE_ID = val;
+    try {
+      fn();
+    } finally {
+      if (prev === undefined) delete process.env.KIT_DEVICE_ID;
+      else process.env.KIT_DEVICE_ID = prev;
+    }
+  };
+
+  it("is false when unset, true for a well-formed override, false for a malformed one", () => {
+    withEnv(undefined, () => assert.equal(deviceIdOverrideActive(), false));
+    withEnv("laptop-2", () => assert.equal(deviceIdOverrideActive(), true));
+    withEnv("   ", () => assert.equal(deviceIdOverrideActive(), false));
+    // malformed (spaces/punctuation) is ignored by deviceId() → not "active"
+    withEnv("bad id!", () => assert.equal(deviceIdOverrideActive(), false));
   });
 });

--- a/src/memory/pal.ts
+++ b/src/memory/pal.ts
@@ -62,6 +62,18 @@ function hostnameDeviceId(): string {
  *     peer on a shared store can also guess from `sha256(hostname+user)`.
  *  3. Hostname-derived hash, only if the id file can't be read or written.
  */
+/**
+ * True when a KIT_DEVICE_ID override is set AND well-formed — i.e. actually TRUSTED
+ * by deviceId() (a malformed override is ignored, so it is not "active"). This id is
+ * trust-bearing: the device fences in palList/palSyncFindings auto-close another
+ * device's open findings by it, so a spoofed value could silently close them. Callers
+ * (kit check) surface a warning when it is active on a real store.
+ */
+export function deviceIdOverrideActive(): boolean {
+  const override = (process.env.KIT_DEVICE_ID ?? "").trim();
+  return override !== "" && DEVICE_ID_RE.test(override);
+}
+
 export function deviceId(): string {
   const override = (process.env.KIT_DEVICE_ID ?? "").trim();
   if (override && DEVICE_ID_RE.test(override)) return override;


### PR DESCRIPTION
## Description

The last actionable code item from `holistic-review-4.0.md`. The device id is trust-bearing — the device fences in `palList` / `palSyncFindings` auto-close another device's open findings by it, so a spoofed `KIT_DEVICE_ID` could silently close them. `deviceId()` only validates the format; the protection was otherwise doc-only.

## Changes

- `deviceIdOverrideActive()` (`src/memory/pal.ts`) — true only when `KIT_DEVICE_ID` is set AND well-formed (a malformed override is ignored by `deviceId()`, so it isn't "active").
- `device-id override` check (`src/check-security.ts`) — WARNs (never fails by default; escalates under `--fail-on-warning`) when the override is active AND a store exists (a device fence is actually in effect); skips otherwise.

## Type of Change

- [x] Security hardening

## Testing

- [x] `npm test` — 2373 pass, 0 fail
- New tests: `deviceIdOverrideActive` (unset / valid / blank / malformed); `checkDeviceIdOverride` (skip-no-override / skip-no-store / warn).

## Verified already-fixed (no change)

- **#45/#47** — `isNewer` already strips prerelease/build before the numeric compare, is exported, and has direct prerelease/build tests. No change needed.

## Breaking Changes

`kit check` gains a low-severity `device-id override` warning when `KIT_DEVICE_ID` is set on a machine with a memory store. Informational; only escalates under `--fail-on-warning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_