### PR TITLE
chore(release): 4.2.0 — security hardening sweep + external findings ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [4.2.0] - 2026-07-06
+
 ### Security — surface a trust-bearing KIT_DEVICE_ID override (#79)
 
 - **`kit check` warns when a KIT_DEVICE_ID override is active on a real store.** The

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "4.0.0",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "4.0.0",
+      "version": "4.2.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
## kit 4.2.0

Cuts `[Unreleased]` to `[4.2.0] - 2026-07-06` + bumps package.json 4.1.0 → 4.2.0.
(4.1.0 was cut in the CHANGELOG on Jul 4 but never tagged/published — everything ships here.)

**In this release** (PRs #232–#246 + sweeps): red-team critical fixes, shared-tier signature
verification on recall inject (R4/#77), memory-hooks liveness gate (R5/#71), poisoned-store
gate (R3), KIT_DEVICE_ID override warn (#79), Swedish personnummer PII parity, MCP kit_run
tokenization, external findings ingestion + scanner severity aliases, self-healing scanner
preflight, supply-chain/secrets/control-plane hardening (B1–B5), exec-broker resource gates
(opt-in, non-breaking), RBAC identity providers (Entra ID, Google Cloud Identity).

No breaking changes → minor bump.

After merge: signed tag `v4.2.0` on the merge commit → publish.yml → npm with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)