### PR TITLE
Real-world hardening: multi-ecosystem detection, fail-closed config parsing, first-run ergonomics

### DIFF
--- a/src/baseline.test.ts
+++ b/src/baseline.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   loadBaseline,
+  loadBaselineForGate,
   saveBaseline,
   baselineGet,
   baselineSet,
@@ -69,6 +70,77 @@ describe("loadBaseline", () => {
         () => loadBaseline(dir),
         new RegExp(`failed to read ${BASELINE_FILE.replace(".", "\\.")}`),
       );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects version:1 with no categories object (was a latent baselineGet crash)", async () => {
+    const dir = tmp();
+    try {
+      writeFileSync(join(dir, BASELINE_FILE), JSON.stringify({ version: 1 }));
+      await assert.rejects(() => loadBaseline(dir), /missing 'categories' object/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// Regression: a malformed / tampered `.kit-baseline.json` MUST NOT crash the gate.
+// It used to throw an uncaught exception out of `kit check` (empty stdout in --json —
+// a denial-of-verdict). loadBaselineForGate fails CLOSED: ignore the file (empty
+// baseline suppresses nothing → every finding gates) and report the reason.
+describe("loadBaselineForGate (fail-closed, never throws)", () => {
+  const CASES: Array<[string, string]> = [
+    ["no version field", JSON.stringify({ categories: {} })],
+    ["version:1 but no categories", JSON.stringify({ version: 1 })],
+    ["unsupported version", JSON.stringify({ version: 2, categories: {} })],
+    ["not JSON at all", "this is not json {{{"],
+    ["JSON array, not object", "[1,2,3]"],
+    ["literal null", "null"],
+  ];
+  for (const [name, content] of CASES) {
+    it(`ignores ${name} and returns an empty baseline`, async () => {
+      const dir = tmp();
+      try {
+        writeFileSync(join(dir, BASELINE_FILE), content);
+        const { baseline, ignored } = await loadBaselineForGate(dir);
+        assert.equal(baseline.version, 1);
+        assert.deepEqual(baseline.categories, {}, "must suppress nothing");
+        assert.ok(ignored, "must report why the baseline was ignored");
+        // and the empty baseline is safe to query without throwing
+        assert.deepEqual(baselineGet(baseline, "tests", "untested_files"), []);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it("no file → empty baseline, ignored=null (normal case, not an error)", async () => {
+    const dir = tmp();
+    try {
+      const { baseline, ignored } = await loadBaselineForGate(dir);
+      assert.equal(ignored, null);
+      assert.deepEqual(baseline.categories, {});
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("valid baseline → loaded, ignored=null", async () => {
+    const dir = tmp();
+    try {
+      writeFileSync(
+        join(dir, BASELINE_FILE),
+        JSON.stringify({
+          version: 1,
+          generated: "x",
+          categories: { tests: { untested_files: ["src/a.ts"] } },
+        }),
+      );
+      const { baseline, ignored } = await loadBaselineForGate(dir);
+      assert.equal(ignored, null);
+      assert.deepEqual(baselineGet(baseline, "tests", "untested_files"), ["src/a.ts"]);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/baseline.ts
+++ b/src/baseline.ts
@@ -44,14 +44,31 @@ async function pathExists(p: string): Promise<boolean> {
   }
 }
 
+/**
+ * Strict parse of baseline file content. Throws on anything that isn't a
+ * well-formed, version-1 baseline object WITH a `categories` object — a bare
+ * `{"version":1}` used to parse "successfully" and then blow up later in
+ * `baselineGet` with a `Cannot read properties of undefined` TypeError.
+ */
+function parseBaseline(raw: string): Baseline {
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("baseline is not a JSON object");
+  }
+  const o = parsed as Record<string, unknown>;
+  if (o.version !== 1) throw new Error(`unsupported baseline version: ${o.version}`);
+  if (!o.categories || typeof o.categories !== "object" || Array.isArray(o.categories)) {
+    throw new Error("baseline missing 'categories' object");
+  }
+  return parsed as Baseline;
+}
+
 export async function loadBaseline(cwd = process.cwd()): Promise<Baseline> {
   const path = resolve(cwd, BASELINE_FILE);
   if (!(await pathExists(path))) return { ...EMPTY_BASELINE };
   try {
     const raw = await readFile(path, "utf-8");
-    const parsed = JSON.parse(raw);
-    if (parsed.version !== 1) throw new Error(`unsupported baseline version: ${parsed.version}`);
-    return parsed;
+    return parseBaseline(raw);
   } catch (err) {
     throw new Error(
       `failed to read ${BASELINE_FILE}: ${err instanceof Error ? err.message : String(err)}`,
@@ -59,9 +76,37 @@ export async function loadBaseline(cwd = process.cwd()): Promise<Baseline> {
   }
 }
 
+/**
+ * Never-throws loader for the GATE paths (`kit check`, `kit review`, MCP `kit_check`).
+ * A baseline only ever SUPPRESSES findings, so a malformed / unreadable / tampered file
+ * must not crash the gate: we fail CLOSED by ignoring it (an empty baseline suppresses
+ * nothing, so every finding gates) and return `ignored` with the reason so the caller
+ * can surface it as a visible finding instead of a silent swallow. This is the fix for
+ * the crash where a hand-written or corrupted `.kit-baseline.json` (no `version`, no
+ * `categories`, non-JSON, null, array, …) took down `kit check` with an uncaught
+ * exception and — in `--json` mode — emitted zero stdout (a denial-of-verdict any
+ * process able to drop the file could trigger).
+ */
+export async function loadBaselineForGate(
+  cwd = process.cwd(),
+): Promise<{ baseline: Baseline; ignored: string | null }> {
+  const path = resolve(cwd, BASELINE_FILE);
+  if (!(await pathExists(path))) return { baseline: { ...EMPTY_BASELINE }, ignored: null };
+  try {
+    const raw = await readFile(path, "utf-8");
+    return { baseline: parseBaseline(raw), ignored: null };
+  } catch (err) {
+    return {
+      baseline: { ...EMPTY_BASELINE },
+      ignored: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
 /** Lookup baseline entries for one category + key. Returns empty array if absent. */
 export function baselineGet(baseline: Baseline, category: string, key: string): string[] {
-  return baseline.categories[category]?.[key] ?? [];
+  // `?.` on `categories` too: a hand-written baseline may omit it entirely.
+  return baseline.categories?.[category]?.[key] ?? [];
 }
 
 /**

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -844,7 +844,7 @@ async function checkSecretsInCode(): Promise<SecurityCheckResult> {
             category: "secrets",
             name: "secrets scan",
             status: "warn",
-            detail: `${files.size} file(s) with unverified secret-shaped strings (basic scan, trufflehog absent) — review for real credentials`,
+            detail: `${files.size} file(s) with unverified secret-shaped strings (basic scan, trufflehog absent — HEAD/working-tree only, does NOT scan git history) — review for real credentials`,
             severity: "medium",
             files: Array.from(files),
             suggestion:
@@ -861,7 +861,7 @@ async function checkSecretsInCode(): Promise<SecurityCheckResult> {
       name: "secrets scan",
       status: "pass",
       detail:
-        "basic scan: no secret-shaped strings outside tests/fixtures (install trufflehog for verified detection)",
+        "basic scan: no secret-shaped strings outside tests/fixtures — HEAD/working-tree only, NOT git history; install trufflehog for full-history + verified detection",
     };
   }
 }

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -197,7 +197,14 @@ async function checkMemoryInjection(): Promise<SecurityCheckResult> {
   }
   try {
     const { replayableInjectionCount } = await import("./memory/scan.js");
-    const { count, sample } = replayableInjectionCount(db);
+    const { count, sample, scanned } = replayableInjectionCount(db);
+    if (scanned === 0) {
+      // Empty store ≡ absent store — nothing recallable to scan. Reporting `skip`
+      // here (not `pass`) keeps `kit check` deterministic: the first run materializes
+      // an empty memory.db as a side effect, and without this the second run would
+      // flip this check skip→pass on identical input.
+      return { category, name, status: "skip", detail: "memory store empty — nothing to scan" };
+    }
     if (count > 0) {
       return {
         category,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5845,8 +5845,10 @@ async function main(): Promise<void> {
 
     process.exitCode = ok ? 0 : 1;
 
-    // Non-interactive / CI: skip update check
-    if (!nonInteractive) {
+    // Non-interactive / CI: skip update check. Also skip in --json mode: the notice
+    // prints to stdout and would corrupt a machine-readable JSON payload (e.g.
+    // `kit check --json` piped to a parser).
+    if (!nonInteractive && !hasFlag(args, "--json")) {
       checkForUpdate(KIT_VERSION)
         .then((info) => {
           if (info) printUpdateNotice(info);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5854,11 +5854,23 @@ async function main(): Promise<void> {
         .catch(() => {}); // never fail
     }
   } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+    const code = err instanceof Error && "code" in err ? (err as { code?: string }).code : undefined;
+    const jsonMode = hasFlag(args, "--json");
+    if (code === "ENOENT") {
+      // In --json mode emit a valid JSON error so consumers never get empty stdout.
+      if (jsonMode) console.log(JSON.stringify({ ok: false, error: `${KIT_FILE} not found` }));
       console.error(`${c.red}Error: ${KIT_FILE} not found in ${process.cwd()}${c.reset}`);
       console.error(
         `${c.dim}Create a .kit.toml to define your project's tools, services, and secrets.${c.reset}`,
       );
+      process.exitCode = 1;
+    } else if (code === "KIT_INVALID_CONFIG") {
+      // A malformed .kit.toml (bad TOML syntax or failed schema validation) must fail
+      // CLOSED like a missing one — a clean error + exit 1, never an uncaught stack
+      // trace with empty --json stdout (a denial-of-verdict any dropped file could cause).
+      const msg = err instanceof Error ? err.message : String(err);
+      if (jsonMode) console.log(JSON.stringify({ ok: false, error: msg }));
+      console.error(`${c.red}${msg}${c.reset}`);
       process.exitCode = 1;
     } else {
       throw err;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -332,8 +332,19 @@ async function cmdCheck(): Promise<boolean> {
       // Test-coverage enforcement (--enforce-tests CLI flag overrides config).
       // Baseline-aware: pre-existing untested files only warn; net-new fail.
       const { checkTests } = await import("./check-tests.js");
-      const { loadBaseline, baselineGet } = await import("./baseline.js");
-      const baseline = await loadBaseline();
+      const { loadBaselineForGate, baselineGet, BASELINE_FILE } = await import("./baseline.js");
+      const { baseline, ignored: baselineIgnored } = await loadBaselineForGate();
+      if (baselineIgnored) {
+        // Fail-closed + visible: a corrupt/tampered baseline is ignored (nothing
+        // suppressed) and surfaced as a finding, never a crash of the gate.
+        securityResults.push({
+          category: "secrets",
+          name: "baseline integrity",
+          status: "warn",
+          severity: "low",
+          detail: `${BASELINE_FILE} ignored (${baselineIgnored}) — gating on all findings; re-freeze with 'kit baseline freeze'`,
+        });
+      }
       const testResults = await step("test coverage", () =>
         checkTests({
           enforce: enforceTests,
@@ -580,8 +591,13 @@ async function cmdDesign(): Promise<boolean> {
   const enforce = hasFlag(process.argv, "--enforce");
   const jsonMode = hasFlag(process.argv, "--json");
   const { checkDesign } = await import("./check-design.js");
-  const { loadBaseline, baselineGet } = await import("./baseline.js");
-  const baseline = await loadBaseline();
+  const { loadBaselineForGate, baselineGet, BASELINE_FILE } = await import("./baseline.js");
+  const { baseline, ignored: baselineIgnored } = await loadBaselineForGate();
+  if (baselineIgnored) {
+    console.error(
+      `${c.yellow}!${c.reset} ${BASELINE_FILE} ignored (${baselineIgnored}) — gating on all findings`,
+    );
+  }
   const results = await checkDesign({
     enforce,
     baseline: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1811,8 +1811,17 @@ async function generateConfigFile(
     console.log(`${c.dim}Could not detect project type — generating minimal config.${c.reset}\n`);
   } else {
     console.log(
-      `  ${c.green}✓${c.reset} Detected: ${c.bold}${detectedLabel}${c.reset}  ${c.dim}(confidence: ${(stack.confidence * 100).toFixed(0)}%)${c.reset}\n`,
+      `  ${c.green}✓${c.reset} Detected: ${c.bold}${detectedLabel}${c.reset}  ${c.dim}(confidence: ${(stack.confidence * 100).toFixed(0)}%)${c.reset}`,
     );
+    // P4 — turn the confidence signal into a guard. Mis-detections cluster in the low band
+    // (~60%) while unambiguous stacks score 85–90%; when we're below that, say so and show how
+    // to correct it, rather than committing a possibly-wrong language silently.
+    if (stack.confidence < 0.7) {
+      console.log(
+        `  ${c.yellow}!${c.reset} ${c.dim}Low confidence — if this is wrong, set the right language under ${c.reset}${c.bold}[project]${c.reset}${c.dim} in .kit.toml (a polyglot repo can carry several manifests).${c.reset}`,
+      );
+    }
+    console.log();
   }
 
   // ── Plaintext-secrets scan ─────────────────────────────────────────────
@@ -5856,7 +5865,8 @@ async function main(): Promise<void> {
         .catch(() => {}); // never fail
     }
   } catch (err: unknown) {
-    const code = err instanceof Error && "code" in err ? (err as { code?: string }).code : undefined;
+    const code =
+      err instanceof Error && "code" in err ? (err as { code?: string }).code : undefined;
     const jsonMode = hasFlag(args, "--json");
     if (code === "ENOENT") {
       // In --json mode emit a valid JSON error so consumers never get empty stdout.

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -214,6 +214,29 @@ node = "22"
     }
   });
 
+  it("throws a tagged InvalidConfigError on malformed TOML syntax (not a raw TomlError)", async () => {
+    // Regression: a .kit.toml with broken syntax used to throw an uncaught TomlError out
+    // of the parser, crashing `kit check` with empty --json stdout. It must now surface as
+    // kit's own tagged error so the gate can fail closed cleanly.
+    const tmpFile = join(tmpdir(), `.kit-test-${process.pid}-badsyntax.toml`);
+    await writeFile(tmpFile, `this is not = = valid ]] toml`, "utf-8");
+    try {
+      await assert.rejects(
+        () => loadConfig(tmpFile),
+        (err: Error & { code?: string }) => {
+          assert.equal(err.code, "KIT_INVALID_CONFIG", `expected tagged code, got: ${err.code}`);
+          assert.ok(
+            err.message.includes("Invalid .kit.toml"),
+            `expected 'Invalid .kit.toml' in: ${err.message}`,
+          );
+          return true;
+        },
+      );
+    } finally {
+      await unlink(tmpFile);
+    }
+  });
+
   it("throws a friendly error when secret source is an unknown enum value", async () => {
     const tmpFile = join(tmpdir(), `.kit-test-${process.pid}-val2.toml`);
     await writeFile(

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,20 @@ import { readFile } from "node:fs/promises";
 import { parse } from "smol-toml";
 import { z } from "zod";
 
+/**
+ * A `.kit.toml` that exists but is unparseable or fails schema validation. Tagged so the
+ * gate (`kit check`/`review`) can fail CLOSED with a clean message + exit 1 — the same
+ * way a MISSING config is handled — instead of letting a raw TomlError crash the process
+ * with an uncaught stack trace and empty `--json` stdout (a denial-of-verdict).
+ */
+export class InvalidConfigError extends Error {
+  readonly code = "KIT_INVALID_CONFIG";
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidConfigError";
+  }
+}
+
 export interface ToolConfig {
   [name: string]: string;
 }
@@ -753,14 +767,24 @@ export function mergeEnvironmentConfig(base: kitConfig, override: EnvOverride): 
 
 export async function loadConfig(path: string, envName?: string): Promise<kitConfig> {
   const content = await readFile(path, "utf-8");
-  const raw = parse(content) as Record<string, unknown>;
+  let raw: Record<string, unknown>;
+  try {
+    raw = parse(content) as Record<string, unknown>;
+  } catch (err) {
+    // A TOML *syntax* error throws out of the parser before schema validation. Convert
+    // it to kit's own tagged, friendly error so the gate can fail CLOSED with a clean
+    // message instead of letting a raw TomlError crash the process (empty --json stdout).
+    throw new InvalidConfigError(
+      `Invalid .kit.toml: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 
   // Validate — surface friendly errors for wrong types, invalid enum values, etc.
   const result = kitConfigSchema.safeParse(raw);
 
   if (!result.success) {
     const formatted = formatValidationErrors(result.error.issues);
-    throw new Error(`Invalid .kit.toml:\n${formatted}`);
+    throw new InvalidConfigError(`Invalid .kit.toml:\n${formatted}`);
   }
 
   // Warn about unknown top-level sections (likely typos like [tolls] vs [tools])

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -10,7 +10,7 @@ import { checkSecurity } from "./check-security.js";
 import { checkSkills } from "./check-skills.js";
 import { checkLockFiles } from "./check-lock.js";
 import { checkTests } from "./check-tests.js";
-import { loadBaseline, baselineGet } from "./baseline.js";
+import { loadBaselineForGate, baselineGet, BASELINE_FILE } from "./baseline.js";
 import { computeCheckVerdict } from "./check-verdict.js";
 import { installTools } from "./install.js";
 import { loginServices } from "./login.js";
@@ -164,7 +164,18 @@ function register_kit_check(server: McpServer): void {
         const lockResults = await checkLockFiles(config);
         // Include test-coverage in the verdict — the CLI does, and omitting it here
         // was one half of the CLI-vs-MCP divergence. Baseline-aware, same as `kit check`.
-        const baseline = await loadBaseline();
+        const { baseline, ignored: baselineIgnored } = await loadBaselineForGate();
+        if (baselineIgnored) {
+          // Same fail-closed baseline handling as `kit check` — parity so the two
+          // surfaces never disagree on the verdict.
+          securityResults.push({
+            category: "secrets",
+            name: "baseline integrity",
+            status: "warn",
+            severity: "low",
+            detail: `${BASELINE_FILE} ignored (${baselineIgnored}) — gating on all findings; re-freeze with 'kit baseline freeze'`,
+          });
+        }
         const testResults = await checkTests({
           baseline: baselineGet(baseline, "tests", "untested_files"),
         });

--- a/src/memory/scan.test.ts
+++ b/src/memory/scan.test.ts
@@ -141,4 +141,22 @@ describe("replayableInjectionCount (gates kit check on a poisoned store)", () =>
     assert.equal(replayableInjectionCount(db).count, 0);
     db.close();
   });
+
+  it("reports `scanned` so an empty store reads the same as an absent one (determinism)", () => {
+    // Empty store: 0 rows scanned → the check treats this identically to 'no store',
+    // so `kit check` can't flip skip→pass once a run materializes an empty memory.db.
+    const empty = openMemoryDb(":memory:");
+    const r0 = replayableInjectionCount(empty);
+    assert.equal(r0.scanned, 0);
+    assert.equal(r0.count, 0);
+    empty.close();
+    // Non-empty clean store: rows are scanned, still zero injections.
+    const clean = openMemoryDb(":memory:");
+    upsertSession(clean, { sessionId: "s1", harness: "claude-code" });
+    insertMessage(clean, { uuid: "c1", sessionId: "s1", type: "user", content: "clean note" });
+    const r1 = replayableInjectionCount(clean);
+    assert.equal(r1.scanned, 1);
+    assert.equal(r1.count, 0);
+    clean.close();
+  });
 });

--- a/src/memory/scan.ts
+++ b/src/memory/scan.ts
@@ -218,7 +218,11 @@ export function scanDbForInjection(db: DatabaseSync): ScanFinding[] {
  * Throws if the store schema can't be queried — the caller turns that into a
  * fail-closed scanner-health result (never a silent pass).
  */
-export function replayableInjectionCount(db: DatabaseSync): { count: number; sample?: string } {
+export function replayableInjectionCount(db: DatabaseSync): {
+  count: number;
+  sample?: string;
+  scanned: number;
+} {
   const rows = db
     .prepare(
       "SELECT rowid AS rowid, content FROM messages WHERE quarantined = 0 AND content IS NOT NULL AND content != ''",
@@ -232,5 +236,8 @@ export function replayableInjectionCount(db: DatabaseSync): { count: number; sam
       sample ??= `messages#${r.rowid}`;
     }
   }
-  return { count, sample };
+  // `scanned` = recallable (non-quarantined, non-empty) rows actually examined. Lets
+  // callers treat an EMPTY store the same as an ABSENT one, so `kit check` doesn't flip
+  // skip→pass once a run materializes an empty memory.db.
+  return { count, sample, scanned: rows.length };
 }

--- a/src/output.ts
+++ b/src/output.ts
@@ -352,17 +352,39 @@ export function printSummary(
   const ok = toolsOk + servicesOk + secretsOk + securityOk;
   const allGood = ok === total;
 
+  // P5 — separate SETUP GAPS (a tool not installed, a service not logged in, a scanner that
+  // couldn't run) from REAL issues (an actual finding a check produced). On a fresh clone the
+  // gap is almost all setup, so a flat "8 issues" reads as failure when it isn't. Missing
+  // tools/auth/secrets are setup; a security result that FAILED because it couldn't run
+  // (didNotRun) is setup too; everything else non-passing is a real finding.
+  const setupGaps =
+    tools.length -
+    toolsOk +
+    (services.length - servicesOk) +
+    (secrets.length - secretsOk) +
+    (security?.filter((s) => s.status !== "pass" && s.status !== "skip" && s.didNotRun).length ??
+      0);
+  const realIssues =
+    security?.filter((s) => s.status !== "pass" && s.status !== "skip" && !s.didNotRun).length ?? 0;
+
   if (allGood) {
     console.log(`${c.bold}${c.green}All ${total} checks passed ✓${c.reset}`);
   } else {
-    console.log(
-      `${c.bold}${ok}/${total} checks passed${c.reset}` +
-        `  ${c.red}(${total - ok} issues)${c.reset}`,
-    );
+    const parts = [`${c.bold}${ok}/${total} passed${c.reset}`];
+    if (setupGaps > 0)
+      parts.push(`${c.yellow}${setupGaps} setup gap${setupGaps === 1 ? "" : "s"}${c.reset}`);
+    if (realIssues > 0)
+      parts.push(`${c.red}${realIssues} real issue${realIssues === 1 ? "" : "s"}${c.reset}`);
+    console.log(parts.join(`${c.dim}  ·  ${c.reset}`));
     console.log();
-    console.log(
-      `${c.dim}Run ${c.reset}${c.bold}kit install${c.reset}${c.dim} to fix tools, ${c.reset}${c.bold}kit login${c.reset}${c.dim} to fix auth${c.reset}`,
-    );
+    if (setupGaps > 0)
+      console.log(
+        `${c.dim}Setup gaps are expected on a fresh clone — run ${c.reset}${c.bold}kit install${c.reset}${c.dim} / ${c.reset}${c.bold}kit login${c.reset}${c.dim} / ${c.reset}${c.bold}kit secrets${c.reset}${c.dim}.${c.reset}`,
+      );
+    if (realIssues > 0)
+      console.log(
+        `${c.dim}Real issues are genuine findings — run ${c.reset}${c.bold}kit check --category security${c.reset}${c.dim} for detail.${c.reset}`,
+      );
   }
 
   console.log();

--- a/src/stack-detector.test.ts
+++ b/src/stack-detector.test.ts
@@ -567,9 +567,67 @@ describe("detectStack", () => {
     await makeProject(dir, {
       "build.zig": "pub fn build(b: *std.Build) void {}\n",
       "CMakeLists.txt": "project(zig)\n",
+      "src/main.zig": "pub fn main() void {}\n",
     });
     try {
       assert.equal((await detectStack(dir)).language, "zig");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("a JS lib with a secondary composer.json (Packagist mirror) stays JS", async () => {
+    // chart.js regression: composer.json with no PHP framework must NOT win over package.json.
+    const dir = join(tmpdir(), `kit-detect-${process.pid}-chartjs`);
+    await makeProject(dir, {
+      "package.json": JSON.stringify({ name: "chart.js", devDependencies: { rollup: "4.0.0" } }),
+      "composer.json": JSON.stringify({ name: "chartjs/chart.js" }),
+    });
+    try {
+      assert.equal((await detectStack(dir)).language, "typescript");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("a JS tool with a native-addon Cargo.toml stays JS", async () => {
+    // pnpm regression: a secondary Cargo.toml must NOT win over package.json.
+    const dir = join(tmpdir(), `kit-detect-${process.pid}-pnpm`);
+    await makeProject(dir, {
+      "package.json": JSON.stringify({ name: "pnpm" }),
+      "Cargo.toml": '[package]\nname = "pnpm-exe"\n',
+    });
+    try {
+      assert.equal((await detectStack(dir)).language, "typescript");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("a Go tool with a secondary Gemfile (gem wrapper, no package.json) is Go", async () => {
+    // fzf regression: Go primary; the Gemfile must not make it Ruby.
+    const dir = join(tmpdir(), `kit-detect-${process.pid}-fzf`);
+    await makeProject(dir, {
+      "go.mod": "module fzf\ngo 1.22\n",
+      Gemfile: `gem "fzf"\n`,
+    });
+    try {
+      assert.equal((await detectStack(dir)).language, "go");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("build.zig used only as a build tool (no .zig sources) falls through to C", async () => {
+    // neovim regression: build.zig + CMake + .c sources ⇒ C, not Zig.
+    const dir = join(tmpdir(), `kit-detect-${process.pid}-nvim`);
+    await makeProject(dir, {
+      "build.zig": "pub fn build() void {}\n",
+      "CMakeLists.txt": "project(nvim)\n",
+      "src/main.c": "int main(){return 0;}\n",
+    });
+    try {
+      assert.equal((await detectStack(dir)).language, "c");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/stack-detector.test.ts
+++ b/src/stack-detector.test.ts
@@ -417,4 +417,175 @@ describe("detectStack", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  // --- New ecosystems + polyglot masking (compatibility sweep fixes) ---
+
+  it("detects Ruby from a Gemfile (Rails)", async () => {
+    const dir = join(tmpdir(), `kit-detect-${process.pid}-ruby`);
+    await makeProject(dir, { Gemfile: `gem "rails", "~> 7.1"\n` });
+    try {
+      const s = await detectStack(dir);
+      assert.equal(s.language, "ruby");
+      assert.equal(s.framework, "rails");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("polyglot masking: a backend Gemfile wins over an asset package.json", async () => {
+    // rails/discourse ship a package.json for the asset pipeline; the backend is Ruby.
+    const dir = join(tmpdir(), `kit-detect-${process.pid}-polyruby`);
+    await makeProject(dir, {
+      Gemfile: `gem "rails"\n`,
+      "package.json": JSON.stringify({ dependencies: { esbuild: "0.19.0" } }),
+    });
+    try {
+      assert.equal((await detectStack(dir)).language, "ruby");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("polyglot masking: Django (manage.py + pyproject) wins over an asset package.json", async () => {
+    const dir = join(tmpdir(), `kit-detect-${process.pid}-polypy`);
+    await makeProject(dir, {
+      "pyproject.toml": '[project]\ndependencies = ["django"]\n',
+      "package.json": JSON.stringify({ devDependencies: { webpack: "5.0.0" } }),
+    });
+    try {
+      const s = await detectStack(dir);
+      assert.equal(s.language, "python");
+      assert.equal(s.framework, "django");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("a real JS meta-framework still wins over an incidental backend manifest", async () => {
+    // Next.js app that also vendors a go.mod tool — JS remains primary.
+    const dir = join(tmpdir(), `kit-detect-${process.pid}-jswins`);
+    await makeProject(dir, {
+      "package.json": JSON.stringify({ dependencies: { next: "14.0.0" } }),
+      "go.mod": "module tool\ngo 1.22\n",
+    });
+    try {
+      const s = await detectStack(dir);
+      assert.equal(s.language, "typescript");
+      assert.equal(s.framework, "nextjs");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects .NET from global.json even when projects live under src/", async () => {
+    const dir = join(tmpdir(), `kit-detect-${process.pid}-dotnet`);
+    await makeProject(dir, {
+      "global.json": `{ "sdk": { "version": "8.0.100" } }`,
+      "package.json": JSON.stringify({ devDependencies: { typescript: "5.0.0" } }),
+    });
+    try {
+      assert.equal((await detectStack(dir)).language, "csharp");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("JVM: a plain Java Gradle project is Java, not Kotlin", async () => {
+    const dir = join(tmpdir(), `kit-detect-${process.pid}-java`);
+    await makeProject(dir, {
+      "build.gradle": `plugins { id 'java' }\ndependencies { implementation 'org.springframework.boot:spring-boot' }\n`,
+      "src/main/java/App.java": "class App {}\n",
+    });
+    try {
+      const s = await detectStack(dir);
+      assert.equal(s.language, "java");
+      assert.equal(s.framework, "spring");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("JVM: Maven pom.xml is Java", async () => {
+    const dir = join(tmpdir(), `kit-detect-${process.pid}-maven`);
+    await makeProject(dir, { "pom.xml": `<project><groupId>com.google.guava</groupId></project>` });
+    try {
+      assert.equal((await detectStack(dir)).language, "java");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("JVM: a Kotlin Gradle (.kts + kotlin plugin) is Kotlin", async () => {
+    const dir = join(tmpdir(), `kit-detect-${process.pid}-kt`);
+    await makeProject(dir, { "build.gradle.kts": `plugins { kotlin("jvm") version "1.9.0" }\n` });
+    try {
+      assert.equal((await detectStack(dir)).language, "kotlin");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects C from a Makefile + .c sources", async () => {
+    const dir = join(tmpdir(), `kit-detect-${process.pid}-c`);
+    await makeProject(dir, {
+      Makefile: "all:\n\tcc main.c\n",
+      "main.c": "int main(){return 0;}\n",
+    });
+    try {
+      assert.equal((await detectStack(dir)).language, "c");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects C++ from CMakeLists.txt even with sources in non-standard dirs", async () => {
+    const dir = join(tmpdir(), `kit-detect-${process.pid}-cpp`);
+    await makeProject(dir, {
+      "CMakeLists.txt": "project(app)\nadd_executable(app libobs/main.cpp)\n",
+      "libobs/main.cpp": "int main(){}\n",
+    });
+    try {
+      assert.equal((await detectStack(dir)).language, "cpp");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("a bare Makefile with no C/C++ sources is NOT mislabelled C", async () => {
+    const dir = join(tmpdir(), `kit-detect-${process.pid}-bareMake`);
+    await makeProject(dir, { Makefile: "build:\n\tgo build\n", "main.go": "package main\n" });
+    try {
+      // go.mod-less Go dir: no C sources ⇒ C/C++ detector must decline ⇒ unknown, not "c".
+      assert.notEqual((await detectStack(dir)).language, "c");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects exotic ecosystems (Zig via build.zig, even with a CMake bootstrap)", async () => {
+    const dir = join(tmpdir(), `kit-detect-${process.pid}-zig`);
+    await makeProject(dir, {
+      "build.zig": "pub fn build(b: *std.Build) void {}\n",
+      "CMakeLists.txt": "project(zig)\n",
+    });
+    try {
+      assert.equal((await detectStack(dir)).language, "zig");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects Elixir (mix.exs) and Scala (build.sbt)", async () => {
+    const ex = join(tmpdir(), `kit-detect-${process.pid}-ex`);
+    const sc = join(tmpdir(), `kit-detect-${process.pid}-sc`);
+    await makeProject(ex, { "mix.exs": "defmodule App.MixProject do\nend\n" });
+    await makeProject(sc, { "build.sbt": `name := "app"\n` });
+    try {
+      assert.equal((await detectStack(ex)).language, "elixir");
+      assert.equal((await detectStack(sc)).language, "scala");
+    } finally {
+      await rm(ex, { recursive: true, force: true });
+      await rm(sc, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/stack-detector.ts
+++ b/src/stack-detector.ts
@@ -322,55 +322,217 @@ async function detectFromSwift(cwd: string): Promise<DetectedStack | null> {
   };
 }
 
-async function detectFromAndroid(cwd: string): Promise<DetectedStack | null> {
-  const gradle =
-    (await readFile(join(cwd, "build.gradle.kts"), "utf-8").catch(() => null)) ??
-    (await readFile(join(cwd, "build.gradle"), "utf-8").catch(() => null));
-  const hasSettings =
-    (await fileExists(join(cwd, "settings.gradle.kts"))) ||
-    (await fileExists(join(cwd, "settings.gradle")));
-  if (gradle === null && !hasSettings) return null;
+/** Shallow scan for source files with any of the given extensions, in cwd and cwd/src
+ *  (one level each). Deterministic, bounded — never walks the whole tree. Used to tell
+ *  siblings apart (C vs C++, Java vs Kotlin) without a full-repo crawl. */
+async function hasSourceExt(cwd: string, exts: string[]): Promise<boolean> {
+  const want = new Set(exts.map((e) => e.toLowerCase()));
+  for (const dir of [cwd, join(cwd, "src")]) {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      if (!e.isFile()) continue;
+      const dot = e.name.lastIndexOf(".");
+      if (dot >= 0 && want.has(e.name.slice(dot).toLowerCase())) return true;
+    }
+  }
+  return false;
+}
 
-  // Only call it Android when the Android Gradle plugin is applied; otherwise
-  // it's a generic JVM/Gradle project (label the language, not a mobile framework).
-  const framework =
-    gradle && /com\.android\.(application|library)/.test(gradle) ? "android" : undefined;
+async function detectFromRuby(cwd: string): Promise<DetectedStack | null> {
+  const gemfile = await readFile(join(cwd, "Gemfile"), "utf-8").catch(() => null);
+  const hasGemspec = (await readdir(cwd).catch(() => [])).some((f) => f.endsWith(".gemspec"));
+  const hasRakefile = await fileExists(join(cwd, "Rakefile"));
+  if (gemfile === null && !hasGemspec && !hasRakefile) return null;
+
+  const text = gemfile ?? "";
+  let framework: string | undefined;
+  if (/\brails\b/.test(text)) framework = "rails";
+  else if (/\bsinatra\b/.test(text)) framework = "sinatra";
+  else if (/\bjekyll\b/.test(text)) framework = "jekyll";
+
   const services = await detectServices({ fileExists: (p) => fileExists(join(cwd, p)) });
-
   return {
-    language: "kotlin",
+    language: "ruby",
     framework,
     services,
-    tools: {},
-    confidence: framework ? 0.85 : 0.6,
+    tools: { ruby: "latest", bundler: "latest" },
+    confidence: framework ? 0.85 : gemfile ? 0.75 : 0.6,
   };
 }
 
+async function detectFromDotnet(cwd: string): Promise<DetectedStack | null> {
+  const entries = await readdir(cwd).catch(() => []);
+  const srcEntries = await readdir(join(cwd, "src")).catch(() => []);
+  const isProj = (f: string) => f.endsWith(".csproj") || f.endsWith(".sln") || f.endsWith(".slnf");
+  const hasCs = entries.some(isProj) || srcEntries.some(isProj);
+  const hasFs = entries.some((f) => f.endsWith(".fsproj"));
+  // Big .NET repos (aspnetcore) keep their projects deep under src/, but always carry a
+  // root .NET anchor — global.json / Directory.Build.props / NuGet.config.
+  const hasAnchor =
+    (await fileExists(join(cwd, "global.json"))) ||
+    (await fileExists(join(cwd, "Directory.Build.props"))) ||
+    (await fileExists(join(cwd, "NuGet.config"))) ||
+    (await fileExists(join(cwd, "nuget.config")));
+  if (!hasCs && !hasFs && !hasAnchor) return null;
+
+  const services = await detectServices({ fileExists: (p) => fileExists(join(cwd, p)) });
+  return {
+    language: hasFs && !hasCs ? "fsharp" : "csharp",
+    services,
+    tools: { dotnet: "latest" },
+    confidence: 0.8,
+  };
+}
+
+async function detectFromJvm(cwd: string): Promise<DetectedStack | null> {
+  const hasPom = await fileExists(join(cwd, "pom.xml"));
+  const gradleKts = await readFile(join(cwd, "build.gradle.kts"), "utf-8").catch(() => null);
+  const gradle =
+    gradleKts ?? (await readFile(join(cwd, "build.gradle"), "utf-8").catch(() => null));
+  const hasSettings =
+    (await fileExists(join(cwd, "settings.gradle.kts"))) ||
+    (await fileExists(join(cwd, "settings.gradle")));
+  if (!hasPom && gradle === null && !hasSettings) return null;
+
+  const gradleText = gradle ?? "";
+  const androidPlugin = /com\.android\.(application|library)/.test(gradleText);
+  // Language: Android defaults to Kotlin; otherwise pick Kotlin only on a real Kotlin
+  // signal (a .kts build, the Kotlin Gradle plugin, or .kt sources) so a plain Java
+  // Maven/Gradle project (spring-boot, guava, RxJava) is correctly labelled Java —
+  // not Kotlin, the sibling it used to be conflated with.
+  const kotlinSignal =
+    gradleKts !== null ||
+    /kotlin\("jvm"\)|org\.jetbrains\.kotlin|id\s+["']kotlin/.test(gradleText) ||
+    (await fileExists(join(cwd, "src/main/kotlin"))) ||
+    (await hasSourceExt(cwd, [".kt"]));
+  const language = androidPlugin || kotlinSignal ? "kotlin" : "java";
+
+  let framework: string | undefined;
+  if (androidPlugin) framework = "android";
+  else if (/org\.springframework\.boot|spring-boot/.test(gradleText)) framework = "spring";
+
+  const tools: Record<string, string> =
+    language === "kotlin" ? { kotlin: "latest" } : { java: "latest" };
+  const services = await detectServices({ fileExists: (p) => fileExists(join(cwd, p)) });
+  return {
+    language,
+    framework,
+    services,
+    tools,
+    confidence: framework ? 0.85 : 0.7,
+  };
+}
+
+async function detectFromCpp(cwd: string): Promise<DetectedStack | null> {
+  // CMake/Meson are used almost exclusively for C/C++ — a definitive signal on their own,
+  // even when sources live in non-standard dirs (obs-studio's libobs/, curl's lib/).
+  const hasCmakeOrMeson =
+    (await fileExists(join(cwd, "CMakeLists.txt"))) || (await fileExists(join(cwd, "meson.build")));
+  const hasWeakBuild =
+    (await fileExists(join(cwd, "Makefile"))) ||
+    (await fileExists(join(cwd, "configure"))) ||
+    (await fileExists(join(cwd, "configure.ac")));
+  if (!hasCmakeOrMeson && !hasWeakBuild) return null;
+
+  const isCpp = await hasSourceExt(cwd, [".cpp", ".cc", ".cxx", ".hpp", ".hh"]);
+  const isC = await hasSourceExt(cwd, [".c", ".h"]);
+  // A bare Makefile/configure is ambiguous (Go/asm/etc. use them too) — require actual
+  // C/C++ sources. CMake/Meson stands alone; default to C++ when sources aren't at the
+  // top level (CMake projects skew C++).
+  if (!hasCmakeOrMeson && !isCpp && !isC) return null;
+
+  const services = await detectServices({ fileExists: (p) => fileExists(join(cwd, p)) });
+  return {
+    language: isCpp ? "cpp" : isC ? "c" : "cpp",
+    services,
+    tools: {},
+    confidence: 0.7,
+  };
+}
+
+/** Lightweight manifest→language map for ecosystems kit doesn't set up deeply yet, so
+ *  they detect correctly (a right answer + osv-scanner) instead of coming up `unknown`. */
+const EXOTIC: { file: string; language: string }[] = [
+  { file: "mix.exs", language: "elixir" },
+  { file: "build.sbt", language: "scala" },
+  { file: "build.zig", language: "zig" },
+  { file: "v.mod", language: "v" },
+  { file: "shard.yml", language: "crystal" },
+  { file: "dune-project", language: "ocaml" },
+  { file: "stack.yaml", language: "haskell" },
+];
+
+async function detectFromExotic(cwd: string): Promise<DetectedStack | null> {
+  for (const { file, language } of EXOTIC) {
+    if (await fileExists(join(cwd, file))) {
+      const services = await detectServices({ fileExists: (p) => fileExists(join(cwd, p)) });
+      return { language, services, tools: {}, confidence: 0.7 };
+    }
+  }
+  // Julia: Project.toml is also used elsewhere, so require a Julia source signal.
+  if ((await fileExists(join(cwd, "Project.toml"))) && (await hasSourceExt(cwd, [".jl"]))) {
+    const services = await detectServices({ fileExists: (p) => fileExists(join(cwd, p)) });
+    return { language: "julia", services, tools: {}, confidence: 0.7 };
+  }
+  return null;
+}
+
+/** JS app frameworks that mean JavaScript/TypeScript is the PRIMARY app — as opposed
+ *  to a bare `react`/`vue`/`express` dep, which routinely appears as the front-end of a
+ *  Rails/Django/Laravel/.NET backend. When only the latter is present alongside a backend
+ *  manifest, the backend is primary (fixes polyglot masking). */
+const JS_APP_FRAMEWORKS = new Set([
+  "nextjs",
+  "remix",
+  "sveltekit",
+  "astro",
+  "nestjs",
+  "react-native",
+]);
+
 /**
- * Detect the project stack from files in the given directory.
- * Returns null only if no recognizable project files are found.
+ * Detect the project stack. Multi-ecosystem aware: a repo often ships a front-end
+ * `package.json` alongside its real backend (Django/Rails/Laravel/.NET), so a bare
+ * package.json no longer wins by default — a definitive backend manifest takes primary
+ * unless the JS side declares a real app framework. Returns `unknown` only when nothing
+ * recognizable is found.
  */
 export async function detectStack(cwd: string): Promise<DetectedStack> {
-  // Try detection in priority order — first match wins. Node first (RN/Expo apps
-  // carry package.json); native-mobile detectors are reached only when none of
-  // the language manifests above them matched.
-  const result =
-    (await detectFromPackageJson(cwd)) ??
-    (await detectFromPython(cwd)) ??
-    (await detectFromGo(cwd)) ??
-    (await detectFromRust(cwd)) ??
-    (await detectFromPhp(cwd)) ??
-    (await detectFromFlutter(cwd)) ??
-    (await detectFromSwift(cwd)) ??
-    (await detectFromAndroid(cwd));
+  const js = await detectFromPackageJson(cwd);
 
-  if (result) return result;
+  // Backends in priority order (first present wins as primary among backends). Native
+  // mobile (flutter/swift) and JVM come after the server languages.
+  const backends = (
+    await Promise.all([
+      detectFromPython(cwd),
+      detectFromPhp(cwd),
+      detectFromRuby(cwd),
+      detectFromDotnet(cwd),
+      detectFromGo(cwd),
+      detectFromRust(cwd),
+      detectFromJvm(cwd),
+      // Exotic before C/C++: a `build.zig` / `build.sbt` is more specific than the CMake
+      // or Makefile a repo may also carry to bootstrap (ziglang/zig ships both).
+      detectFromExotic(cwd),
+      detectFromCpp(cwd),
+      detectFromFlutter(cwd),
+      detectFromSwift(cwd),
+    ])
+  ).filter((s): s is DetectedStack => s !== null);
 
-  // Unknown project — return minimal fallback
-  return {
-    language: "unknown",
-    services: [],
-    tools: {},
-    confidence: 0.0,
-  };
+  if (js && backends.length > 0) {
+    // JS is primary only when it's a real app (meta-framework); otherwise the
+    // co-present backend manifest is the real story and the package.json is assets.
+    if (js.framework && JS_APP_FRAMEWORKS.has(js.framework)) return js;
+    return backends[0];
+  }
+  if (js) return js;
+  if (backends.length > 0) return backends[0];
+
+  return { language: "unknown", services: [], tools: {}, confidence: 0.0 };
 }

--- a/src/stack-detector.ts
+++ b/src/stack-detector.ts
@@ -346,8 +346,9 @@ async function hasSourceExt(cwd: string, exts: string[]): Promise<boolean> {
 async function detectFromRuby(cwd: string): Promise<DetectedStack | null> {
   const gemfile = await readFile(join(cwd, "Gemfile"), "utf-8").catch(() => null);
   const hasGemspec = (await readdir(cwd).catch(() => [])).some((f) => f.endsWith(".gemspec"));
-  const hasRakefile = await fileExists(join(cwd, "Rakefile"));
-  if (gemfile === null && !hasGemspec && !hasRakefile) return null;
+  // A bare Rakefile is NOT a Ruby signal — Go/C projects (fzf) ship one for build tasks.
+  // Require a Gemfile or a .gemspec.
+  if (gemfile === null && !hasGemspec) return null;
 
   const text = gemfile ?? "";
   let framework: string | undefined;
@@ -467,12 +468,32 @@ const EXOTIC: { file: string; language: string }[] = [
   { file: "stack.yaml", language: "haskell" },
 ];
 
+/** True if a real Zig SOURCE file exists (a `.zig` that isn't the `build.zig`/`build.zig.zon`
+ *  build script) in cwd or cwd/src — so a C project that merely uses build.zig isn't Zig. */
+async function hasZigSources(cwd: string): Promise<boolean> {
+  for (const dir of [cwd, join(cwd, "src")]) {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      if (e.isFile() && e.name.endsWith(".zig") && e.name !== "build.zig") return true;
+    }
+  }
+  return false;
+}
+
 async function detectFromExotic(cwd: string): Promise<DetectedStack | null> {
   for (const { file, language } of EXOTIC) {
-    if (await fileExists(join(cwd, file))) {
-      const services = await detectServices({ fileExists: (p) => fileExists(join(cwd, p)) });
-      return { language, services, tools: {}, confidence: 0.7 };
-    }
+    if (!(await fileExists(join(cwd, file)))) continue;
+    // `build.zig` is also used as a BUILD tool by C projects (neovim) — only call it Zig
+    // when actual .zig SOURCES exist (a .zig file other than the build script itself), so
+    // neovim falls through to C/C++.
+    if (language === "zig" && !(await hasZigSources(cwd))) continue;
+    const services = await detectServices({ fileExists: (p) => fileExists(join(cwd, p)) });
+    return { language, services, tools: {}, confidence: 0.7 };
   }
   // Julia: Project.toml is also used elsewhere, so require a Julia source signal.
   if ((await fileExists(join(cwd, "Project.toml"))) && (await hasSourceExt(cwd, [".jl"]))) {
@@ -495,41 +516,57 @@ const JS_APP_FRAMEWORKS = new Set([
   "react-native",
 ]);
 
+/** A backend signal strong enough to override a co-present `package.json`. Deliberately
+ *  excludes Go/Rust/C-C++/JVM/exotic/mobile: those appear as secondary manifests inside JS
+ *  projects (native addons, build tools, Packagist mirrors) too often to outrank an app's
+ *  own package.json. PHP counts only with a detected framework (Laravel/Symfony). */
+function isStrongBackend(s: DetectedStack): boolean {
+  if (["python", "ruby", "csharp", "fsharp", "elixir"].includes(s.language)) return true;
+  if (s.language === "php" && s.framework) return true;
+  return false;
+}
+
 /**
  * Detect the project stack. Multi-ecosystem aware: a repo often ships a front-end
  * `package.json` alongside its real backend (Django/Rails/Laravel/.NET), so a bare
- * package.json no longer wins by default — a definitive backend manifest takes primary
- * unless the JS side declares a real app framework. Returns `unknown` only when nothing
+ * package.json no longer wins by default — a STRONG backend signal takes primary unless
+ * the JS side declares a real app framework. Returns `unknown` only when nothing
  * recognizable is found.
  */
 export async function detectStack(cwd: string): Promise<DetectedStack> {
   const js = await detectFromPackageJson(cwd);
 
-  // Backends in priority order (first present wins as primary among backends). Native
-  // mobile (flutter/swift) and JVM come after the server languages.
+  // Backends in priority order — first present wins as primary among backends (matters only
+  // when a repo has NO package.json but several backend manifests). Ruby is LATE so a Go/
+  // Scala repo that ships a secondary Gemfile (fzf's gem wrapper, scala's Jekyll docs) is
+  // not mislabelled Ruby; C/C++ is last of the languages so a build.zig/sbt wins its bootstrap.
   const backends = (
     await Promise.all([
       detectFromPython(cwd),
       detectFromPhp(cwd),
-      detectFromRuby(cwd),
       detectFromDotnet(cwd),
       detectFromGo(cwd),
       detectFromRust(cwd),
       detectFromJvm(cwd),
-      // Exotic before C/C++: a `build.zig` / `build.sbt` is more specific than the CMake
-      // or Makefile a repo may also carry to bootstrap (ziglang/zig ships both).
       detectFromExotic(cwd),
       detectFromCpp(cwd),
+      detectFromRuby(cwd),
       detectFromFlutter(cwd),
       detectFromSwift(cwd),
     ])
   ).filter((s): s is DetectedStack => s !== null);
 
   if (js && backends.length > 0) {
-    // JS is primary only when it's a real app (meta-framework); otherwise the
-    // co-present backend manifest is the real story and the package.json is assets.
+    // JS is primary when it's a real app (meta-framework). Otherwise a co-present backend
+    // wins ONLY if it's a STRONG signal — a real backend app, not a secondary manifest a
+    // JS project routinely carries (a Packagist `composer.json`, a native-addon `Cargo.toml`,
+    // a tooling `go.mod`). Strong = Python/Ruby/.NET/Elixir, or PHP with a framework
+    // (Laravel/Symfony ⇒ artisan). This fixes django/rails/laravel/aspnetcore without
+    // regressing chart.js (composer mirror) or pnpm (Rust addon) → both stay JS.
     if (js.framework && JS_APP_FRAMEWORKS.has(js.framework)) return js;
-    return backends[0];
+    const strong = backends.find(isStrongBackend);
+    if (strong) return strong;
+    return js;
   }
   if (js) return js;
   if (backends.length > 0) return backends[0];

--- a/src/toml-generator.ts
+++ b/src/toml-generator.ts
@@ -197,6 +197,13 @@ function setupSection(stack: DetectedStack): string {
   else if (stack.language === "dart") installCmd = frameworkSetup?.install ?? "dart pub get";
   else if (stack.language === "swift") installCmd = frameworkSetup?.install ?? "swift build";
   else if (stack.language === "kotlin") installCmd = frameworkSetup?.install ?? "./gradlew build";
+  else if (stack.language === "ruby") installCmd = frameworkSetup?.install ?? "bundle install";
+  else if (stack.language === "java")
+    installCmd = frameworkSetup?.install ?? (stack.tools.java ? "./gradlew build" : "mvn install");
+  else if (stack.language === "csharp" || stack.language === "fsharp")
+    installCmd = frameworkSetup?.install ?? "dotnet restore";
+  else if (stack.language === "c" || stack.language === "cpp")
+    installCmd = frameworkSetup?.install ?? "cmake -B build && cmake --build build";
   else installCmd = frameworkSetup?.install ?? "npm install";
 
   // First detected service that declares a migrate command wins. Registry order


### PR DESCRIPTION
## Description

Hardens kit against the real world. Driven by a 100-repo compatibility sweep + an adversarial red-team: found and fixed 3 gate defects, then overhauled stack detection (71 → 95 of 100 correct) and shipped the full first-run ergonomics plan (P1–P6). Full research write-up lives in the `kit-research` companion PR.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Changes Made

**Fail-closed gate fixes (denial-of-verdict / non-determinism — never false-green):**
- `baseline`: a malformed `.kit-baseline.json` (no `version`, bad JSON, `null`, array, missing `categories`) no longer crashes `kit check`. New `loadBaselineForGate()` never throws — ignores the bad file (empty baseline suppresses nothing → stricter) and surfaces a `baseline integrity` warn on CLI + MCP.
- `config`: a malformed `.kit.toml` (bad TOML syntax) threw an uncaught `TomlError` and `main()` re-threw everything but `ENOENT` → empty `--json` stdout. Now a tagged `InvalidConfigError` fails closed with a clean message + valid `{"ok":false,"error":…}` JSON.
- `check`: the `memory injection` check flipped `skip`→`pass` between two identical runs (the first run materializes an empty `memory.db`). Now empty store ≡ absent store — status is a pure function of content.
- `check --json`: suppressed the "update available" notice on stdout (it corrupted the JSON payload).

**Detection overhaul (71 → 95 of 100):**
- Multi-ecosystem selection — a bare `package.json` no longer wins; only a *strong* backend (Python/Ruby/.NET/Elixir, or PHP-with-framework) overrides it. Fixes polyglot masking (django/rails/laravel/aspnetcore were read as TypeScript) without regressing chart.js/pnpm (secondary composer/Cargo manifests stay JS).
- New first-class ecosystems: Ruby, C#/.NET, C/C++, JVM (Maven+Gradle with a real Java-vs-Kotlin split — fixes spring-boot/RxJava/retrofit/elasticsearch/guava), and exotic (Elixir/Scala/Zig/V/Crystal/OCaml/Haskell/Julia).
- `toml-generator`: install commands for the new languages.

**First-run ergonomics (P4/P5/P6):**
- P5: `kit check` summary separates setup gaps (tool not installed / not logged in / scanner didNotRun) from real issues — `18/27 passed · 5 setup gaps · 4 real issues` instead of a flat "9 issues". Verdict/exit unchanged (still fail-closed).
- P6: the grep secret-scan fallback now states it scans HEAD/working-tree only (not git history) and points at trufflehog.
- P4: `kit init` flags a low-confidence (<70%) detection and how to correct it.

## Testing

### Test Coverage
- [x] Added new tests (baseline fail-closed ×6, config `InvalidConfigError`, memory-injection determinism, detection ×18 incl. polyglot masking + regression cases)
- [x] Updated existing tests
- [x] All tests pass (`npm test`) — **2401/2401**

### Manual Testing
1. Ran `kit init` on the real repos: django→python, rails→ruby, laravel→php, aspnetcore→csharp, spring-boot→java, guava→java, sinatra→ruby, redis→c, curl→c, obs-studio→cpp, zig→zig, chart.js/pnpm→typescript.
2. Fuzzed every config file kit parses (134 runs) → 0 crashes after the fixes.
3. Confirmed `kit check --json` parses clean; secret scan detail states the HEAD-only limitation.

## Breaking Changes

None / N/A — verdict semantics and exit codes are unchanged; changes are new detection coverage, fail-closed error handling, and summary legibility.

## Checklist

- [x] All tests pass locally (`npm test`)
- [x] No new warnings or errors introduced (eslint: 0 errors)
- [x] Commit messages follow conventions
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

## Reviewer Notes

Remaining detection misses are all language-*implementation* repos (neovim, apple/swift, JuliaLang, elixir-lang) that are themselves Makefile/C++/Zig-built — atypical, not normal apps; documented in the commit + research report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_