### PR TITLE
feat(standards): kit standards P2 — per-language specific gate (TS/JS · Python · Go · Rust)

### DIFF
--- a/src/check-standards-specific.test.ts
+++ b/src/check-standards-specific.test.ts
@@ -1,0 +1,235 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseEslintJson,
+  parseTscOutput,
+  parseRuffJson,
+  parseMypyOutput,
+  parseGoVet,
+  parseGofmtList,
+  parseClippyShort,
+  parseCargoFmtCheck,
+  checkStandardsSpecific,
+  scanSpecific,
+  collectSpecificKeys,
+  specificKey,
+  SPECIFIC_LANGUAGES,
+  type SpecificScanResult,
+} from "./check-standards-specific.js";
+import type { ExecResult } from "./utils/execFileNoThrow.js";
+
+const ok = (stdout: string, exitCode = 0): ExecResult => ({
+  stdout,
+  stderr: "",
+  exitCode,
+  ok: exitCode === 0,
+});
+const err = (stderr: string, exitCode = 1): ExecResult => ({
+  stdout: "",
+  stderr,
+  exitCode,
+  ok: false,
+});
+
+describe("specific parsers — eslint", () => {
+  it("flattens filePath + messages into findings", () => {
+    const json = JSON.stringify([
+      {
+        filePath: "/repo/src/a.ts",
+        messages: [
+          { line: 3, ruleId: "no-unused-vars", message: "x is unused", severity: 2 },
+          { line: 9, ruleId: "eqeqeq", message: "use ===", severity: 1 },
+        ],
+      },
+      { filePath: "/repo/src/b.ts", messages: [] },
+    ]);
+    const f = parseEslintJson(ok(json));
+    assert.equal(f.length, 2);
+    assert.deepEqual(f[0], {
+      file: "/repo/src/a.ts",
+      line: 3,
+      rule: "no-unused-vars",
+      message: "x is unused",
+    });
+  });
+  it("tolerates non-JSON", () => {
+    assert.deepEqual(parseEslintJson(ok("boom")), []);
+  });
+});
+
+describe("specific parsers — tsc", () => {
+  it("parses `file(line,col): error TSxxxx: msg` (stdout or stderr)", () => {
+    const out = [
+      "src/x.ts(12,5): error TS2322: Type 'string' is not assignable to type 'number'.",
+      "src/y.ts(1,1): error TS1005: ';' expected.",
+      "Found 2 errors.",
+    ].join("\n");
+    const f = parseTscOutput(ok(out, 2));
+    assert.equal(f.length, 2);
+    assert.deepEqual(f[0], {
+      file: "src/x.ts",
+      line: 12,
+      rule: "TS2322",
+      message: "Type 'string' is not assignable to type 'number'.",
+    });
+  });
+});
+
+describe("specific parsers — ruff", () => {
+  it("maps filename/location.row/code", () => {
+    const json = JSON.stringify([
+      {
+        filename: "app/m.py",
+        location: { row: 4 },
+        code: "F401",
+        message: "os imported but unused",
+      },
+    ]);
+    const f = parseRuffJson(ok(json, 1));
+    assert.deepEqual(f, [
+      { file: "app/m.py", line: 4, rule: "F401", message: "os imported but unused" },
+    ]);
+  });
+});
+
+describe("specific parsers — mypy", () => {
+  it("parses `file:line: error: msg [code]`", () => {
+    const out = [
+      'm.py:10: error: Incompatible return value type (got "int", expected "str")  [return-value]',
+      "m.py:12: error: Name 'x' is not defined",
+      "Found 2 errors in 1 file",
+    ].join("\n");
+    const f = parseMypyOutput(ok(out, 1));
+    assert.equal(f.length, 2);
+    assert.equal(f[0].file, "m.py");
+    assert.equal(f[0].line, 10);
+    assert.equal(f[0].rule, "return-value");
+    assert.equal(f[1].rule, undefined);
+  });
+});
+
+describe("specific parsers — go vet + gofmt", () => {
+  it("go vet parses `file:line:col: msg` from stderr", () => {
+    const f = parseGoVet(err("main.go:7:2: unreachable code\nx.go:3:5: printf: wrong arg"));
+    assert.equal(f.length, 2);
+    assert.deepEqual(f[0], { file: "main.go", line: 7, message: "unreachable code" });
+  });
+  it("gofmt -l lists unformatted files", () => {
+    const f = parseGofmtList(ok("main.go\ninternal/x.go\n"));
+    assert.deepEqual(
+      f.map((x) => x.file),
+      ["main.go", "internal/x.go"],
+    );
+    assert.equal(f[0].rule, "gofmt");
+  });
+});
+
+describe("specific parsers — clippy + rustfmt", () => {
+  it("clippy short: `file:line:col: warning|error: msg`", () => {
+    const out = [
+      "src/main.rs:10:5: warning: unused variable: `y`",
+      "src/lib.rs:3:1: error: mismatched types",
+    ].join("\n");
+    const f = parseClippyShort(err(out));
+    assert.equal(f.length, 2);
+    assert.deepEqual(f[0], { file: "src/main.rs", line: 10, message: "unused variable: `y`" });
+  });
+  it("cargo fmt --check: `Diff in <file> at line N` (deduped per file)", () => {
+    const out = [
+      "Diff in src/main.rs at line 5:",
+      "-foo",
+      "+foo;",
+      "Diff in src/main.rs at line 22:",
+      "Diff in src/lib.rs at line 1:",
+    ].join("\n");
+    const f = parseCargoFmtCheck(ok(out, 1));
+    assert.deepEqual(
+      f.map((x) => x.file),
+      ["src/main.rs", "src/lib.rs"],
+    );
+    assert.equal(f[0].rule, "rustfmt");
+  });
+});
+
+describe("specificKey", () => {
+  it("prefers rule, falls back to line, then bare file", () => {
+    assert.equal(
+      specificKey("go", "vet", { file: "a.go", line: 5, rule: "printf" }),
+      "go/vet:a.go#printf",
+    );
+    assert.equal(specificKey("go", "vet", { file: "a.go", line: 5 }), "go/vet:a.go:5");
+    assert.equal(specificKey("go", "gofmt", { file: "a.go" }), "go/gofmt:a.go");
+  });
+});
+
+describe("checkStandardsSpecific — gating", () => {
+  const scan: SpecificScanResult = {
+    language: "go",
+    runs: [
+      {
+        spec: { id: "vet", label: "go vet" },
+        findings: [{ file: `${process.cwd()}/main.go`, line: 7, message: "unreachable" }],
+        didNotRun: false,
+      },
+      {
+        spec: { id: "gofmt", label: "gofmt -l" },
+        findings: [],
+        didNotRun: false,
+      },
+    ],
+  };
+
+  it("passes a clean linter, warns net-new by default", async () => {
+    const r = await checkStandardsSpecific({ language: "go", scan });
+    const vet = r.find((x) => x.name.includes("go vet"));
+    const fmt = r.find((x) => x.name.includes("gofmt"));
+    assert.equal(fmt?.status, "pass");
+    assert.equal(vet?.status, "warn");
+    assert.match(vet?.files?.[0] ?? "", /main\.go:7/);
+  });
+
+  it("fails net-new under --enforce", async () => {
+    const r = await checkStandardsSpecific({ language: "go", scan, enforce: true });
+    assert.equal(r.find((x) => x.name.includes("go vet"))?.status, "fail");
+  });
+
+  it("baseline-frozen finding downgrades to a low warn (never fails)", async () => {
+    const r = await checkStandardsSpecific({
+      language: "go",
+      scan,
+      enforce: true,
+      baseline: [specificKey("go", "vet", { file: "main.go", line: 7 })],
+    });
+    const vet = r.find((x) => x.name.includes("go vet"));
+    assert.equal(vet?.status, "warn");
+    assert.equal(vet?.severity, "low");
+  });
+
+  it("a missing linter is a setup gap: warn default, fail under enforce", async () => {
+    const gap: SpecificScanResult = {
+      language: "rust",
+      runs: [{ spec: { id: "clippy", label: "cargo clippy" }, findings: [], didNotRun: true }],
+    };
+    assert.equal((await checkStandardsSpecific({ language: "rust", scan: gap }))[0].status, "warn");
+    assert.equal(
+      (await checkStandardsSpecific({ language: "rust", scan: gap, enforce: true }))[0].status,
+      "fail",
+    );
+  });
+});
+
+describe("scanSpecific + collectSpecificKeys", () => {
+  it("an unsupported language yields no runs", async () => {
+    const s = await scanSpecific(process.cwd(), "haskell");
+    assert.deepEqual(s.runs, []);
+    assert.deepEqual(await collectSpecificKeys(process.cwd(), "haskell"), []);
+  });
+  it("disabled linters are skipped via the toggle map", async () => {
+    // eslint/tsc absent in this env → didNotRun; disabling both leaves no runs at all.
+    const s = await scanSpecific(process.cwd(), "typescript", { eslint: false, tsc: false });
+    assert.deepEqual(s.runs, []);
+  });
+  it("exposes the four P2 languages", () => {
+    assert.deepEqual([...SPECIFIC_LANGUAGES].sort(), ["go", "python", "rust", "typescript"]);
+  });
+});

--- a/src/check-standards-specific.ts
+++ b/src/check-standards-specific.ts
@@ -1,0 +1,441 @@
+/**
+ * kit standards — P2: the SPECIFIC (per-language) gate.
+ *
+ * Where the general gate (check-standards.ts) measures every stack the same way,
+ * the specific gate delegates to each ecosystem's own canonical linter run in
+ * check/report mode. kit already detects the language (stack-detector) and
+ * provisions these tools; this maps the detected language → its linters, runs
+ * them, and folds their findings into the same StandardsCheckResult verdict.
+ *
+ * P2 covers the four ecosystems kit provisions best:
+ *   typescript (JS folded in) → eslint, tsc --noEmit
+ *   python                    → ruff, mypy
+ *   go                        → go vet, gofmt -l
+ *   rust                      → cargo clippy, cargo fmt --check
+ *
+ * Same principles as P1: deterministic (a linter's exit + parsed findings, never a
+ * model's judgment), baseline-aware (net-new gating on stable file:rule keys), and
+ * warn-by-default / `--enforce` fail-closed. A linter that isn't installed is an
+ * honest SETUP GAP (didNotRun), never a silent pass.
+ *
+ * Each linter is a declarative LinterSpec with a PURE parser (parseEslintJson,
+ * parseTscOutput, …) unit-tested against fixture output — no tool needed.
+ */
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { resolveToolBin } from "./utils/resolveTool.js";
+import { execFileNoThrow, type ExecResult } from "./utils/execFileNoThrow.js";
+import type { StandardsCheckResult } from "./check-standards.js";
+
+/** A normalized finding from any specific linter. `line`/`rule` are best-effort. */
+export interface SpecificFinding {
+  file: string;
+  line?: number;
+  rule?: string;
+  message?: string;
+}
+
+/** Stable baseline key for a specific finding (net-new gating). */
+export const specificKey = (lang: string, tool: string, f: SpecificFinding): string =>
+  `${lang}/${tool}:${f.file}${f.rule ? `#${f.rule}` : f.line ? `:${f.line}` : ""}`;
+
+interface LinterSpec {
+  /** Short id, also the [standards.<lang>] toggle key. */
+  id: string;
+  /** Human label shown in the gate output. */
+  label: string;
+  /** The binary name resolved mise-first then PATH. */
+  bin: string;
+  /** Args to run it in report mode (relative to cwd, passed as an array — no shell). */
+  args: string[];
+  /** Parse stdout/stderr → findings. Pure. */
+  parse: (res: ExecResult) => SpecificFinding[];
+  /** ms budget (compiling linters like clippy/vet need longer). */
+  timeout: number;
+  maxBuffer?: number;
+}
+
+// ── Pure parsers (unit-tested against fixture output) ──────────────────────────
+
+/** eslint `--format json`: `[{ filePath, messages: [{ line, ruleId, message, severity }] }]`. */
+export function parseEslintJson(res: ExecResult): SpecificFinding[] {
+  let data: unknown;
+  try {
+    data = JSON.parse(res.stdout);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(data)) return [];
+  const out: SpecificFinding[] = [];
+  for (const file of data) {
+    const f = (file ?? {}) as Record<string, unknown>;
+    const filePath = typeof f.filePath === "string" ? f.filePath : undefined;
+    const messages = Array.isArray(f.messages) ? f.messages : [];
+    if (!filePath) continue;
+    for (const m of messages) {
+      const msg = (m ?? {}) as Record<string, unknown>;
+      out.push({
+        file: filePath,
+        line: typeof msg.line === "number" ? msg.line : undefined,
+        rule: typeof msg.ruleId === "string" ? msg.ruleId : undefined,
+        message: typeof msg.message === "string" ? msg.message : undefined,
+      });
+    }
+  }
+  return out;
+}
+
+/** tsc `--noEmit --pretty false`: lines `path(line,col): error TSxxxx: message`. */
+export function parseTscOutput(res: ExecResult): SpecificFinding[] {
+  const text = `${res.stdout}\n${res.stderr}`;
+  const out: SpecificFinding[] = [];
+  const re = /^(.+?)\((\d+),\d+\):\s+error\s+(TS\d+):\s*(.*)$/;
+  for (const line of text.split("\n")) {
+    const m = re.exec(line.trim());
+    if (m) out.push({ file: m[1], line: Number(m[2]), rule: m[3], message: m[4] });
+  }
+  return out;
+}
+
+/** ruff `--output-format json`: `[{ filename, location: { row }, code, message }]`. */
+export function parseRuffJson(res: ExecResult): SpecificFinding[] {
+  let data: unknown;
+  try {
+    data = JSON.parse(res.stdout);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(data)) return [];
+  const out: SpecificFinding[] = [];
+  for (const d of data) {
+    const item = (d ?? {}) as Record<string, unknown>;
+    const filename = typeof item.filename === "string" ? item.filename : undefined;
+    if (!filename) continue;
+    const loc = (item.location ?? {}) as Record<string, unknown>;
+    out.push({
+      file: filename,
+      line: typeof loc.row === "number" ? loc.row : undefined,
+      rule: typeof item.code === "string" ? item.code : undefined,
+      message: typeof item.message === "string" ? item.message : undefined,
+    });
+  }
+  return out;
+}
+
+/** mypy default output: `path:line: error: message  [code]`. */
+export function parseMypyOutput(res: ExecResult): SpecificFinding[] {
+  const text = `${res.stdout}\n${res.stderr}`;
+  const out: SpecificFinding[] = [];
+  const re = /^(.+?):(\d+):\s+error:\s+(.*?)(?:\s+\[([a-z-]+)\])?$/;
+  for (const line of text.split("\n")) {
+    const m = re.exec(line.trim());
+    if (m) out.push({ file: m[1], line: Number(m[2]), rule: m[4], message: m[3] });
+  }
+  return out;
+}
+
+/** `go vet ./...` (writes to stderr): `path:line:col: message`. */
+export function parseGoVet(res: ExecResult): SpecificFinding[] {
+  const text = `${res.stdout}\n${res.stderr}`;
+  const out: SpecificFinding[] = [];
+  const re = /^(.+?\.go):(\d+):\d+:\s+(.*)$/;
+  for (const line of text.split("\n")) {
+    const m = re.exec(line.trim());
+    if (m) out.push({ file: m[1], line: Number(m[2]), message: m[3] });
+  }
+  return out;
+}
+
+/** `gofmt -l`: one unformatted file path per line (no line number). */
+export function parseGofmtList(res: ExecResult): SpecificFinding[] {
+  const out: SpecificFinding[] = [];
+  for (const line of res.stdout.split("\n")) {
+    const f = line.trim();
+    if (f && f.endsWith(".go"))
+      out.push({ file: f, rule: "gofmt", message: "not gofmt-formatted" });
+  }
+  return out;
+}
+
+/** `cargo clippy --message-format short`: `path:line:col: warning|error: message`. */
+export function parseClippyShort(res: ExecResult): SpecificFinding[] {
+  const text = `${res.stdout}\n${res.stderr}`;
+  const out: SpecificFinding[] = [];
+  const re = /^(.+?\.rs):(\d+):\d+:\s+(?:warning|error):\s+(.*)$/;
+  for (const line of text.split("\n")) {
+    const m = re.exec(line.trim());
+    if (m) out.push({ file: m[1], line: Number(m[2]), message: m[3] });
+  }
+  return out;
+}
+
+/** `cargo fmt --check` (rustfmt): `Diff in <path> at line N:` per needing-format hunk. */
+export function parseCargoFmtCheck(res: ExecResult): SpecificFinding[] {
+  const text = `${res.stdout}\n${res.stderr}`;
+  const out: SpecificFinding[] = [];
+  const re = /^Diff in (.+?) at line (\d+):/;
+  const seen = new Set<string>();
+  for (const line of text.split("\n")) {
+    const m = re.exec(line.trim());
+    if (m && !seen.has(m[1])) {
+      seen.add(m[1]);
+      out.push({
+        file: m[1],
+        line: Number(m[2]),
+        rule: "rustfmt",
+        message: "not rustfmt-formatted",
+      });
+    }
+  }
+  return out;
+}
+
+// ── The per-language registry ──────────────────────────────────────────────────
+
+const REGISTRY: Record<string, LinterSpec[]> = {
+  typescript: [
+    {
+      id: "eslint",
+      label: "eslint",
+      bin: "eslint",
+      args: [".", "--format", "json"],
+      parse: parseEslintJson,
+      timeout: 120_000,
+      maxBuffer: 64 * 1024 * 1024,
+    },
+    {
+      id: "tsc",
+      label: "tsc --noEmit",
+      bin: "tsc",
+      args: ["--noEmit", "--pretty", "false"],
+      parse: parseTscOutput,
+      timeout: 120_000,
+      maxBuffer: 32 * 1024 * 1024,
+    },
+  ],
+  python: [
+    {
+      id: "ruff",
+      label: "ruff",
+      bin: "ruff",
+      args: ["check", "--output-format", "json", "."],
+      parse: parseRuffJson,
+      timeout: 60_000,
+      maxBuffer: 64 * 1024 * 1024,
+    },
+    {
+      id: "mypy",
+      label: "mypy",
+      bin: "mypy",
+      args: ["."],
+      parse: parseMypyOutput,
+      timeout: 120_000,
+      maxBuffer: 32 * 1024 * 1024,
+    },
+  ],
+  go: [
+    {
+      id: "vet",
+      label: "go vet",
+      bin: "go",
+      args: ["vet", "./..."],
+      parse: parseGoVet,
+      timeout: 120_000,
+      maxBuffer: 32 * 1024 * 1024,
+    },
+    {
+      id: "gofmt",
+      label: "gofmt -l",
+      bin: "gofmt",
+      args: ["-l", "."],
+      parse: parseGofmtList,
+      timeout: 30_000,
+    },
+  ],
+  rust: [
+    {
+      id: "clippy",
+      label: "cargo clippy",
+      bin: "cargo",
+      args: ["clippy", "--message-format", "short", "--quiet"],
+      parse: parseClippyShort,
+      timeout: 300_000,
+      maxBuffer: 64 * 1024 * 1024,
+    },
+    {
+      id: "fmt",
+      label: "cargo fmt --check",
+      bin: "cargo",
+      args: ["fmt", "--check"],
+      parse: parseCargoFmtCheck,
+      timeout: 60_000,
+      maxBuffer: 32 * 1024 * 1024,
+    },
+  ],
+};
+
+/** The languages P2 has specific linters for. */
+export const SPECIFIC_LANGUAGES = Object.keys(REGISTRY);
+
+// ── Runner + result assembly ────────────────────────────────────────────────────
+
+/** Raw run of one linter: its findings, or didNotRun when the binary is absent/errored blind. */
+export interface LinterRun {
+  spec: { id: string; label: string };
+  findings: SpecificFinding[];
+  didNotRun: boolean;
+}
+
+/**
+ * Resolve a linter's binary for THIS project. A node-ecosystem tool (eslint, tsc)
+ * MUST come from the project's own `node_modules/.bin` — a global/mise copy resolves
+ * types and plugins against the wrong tree and floods false positives (e.g. a global
+ * tsc can't see the project's @types, reporting thousands of phantom errors on code
+ * that compiles cleanly locally). Project-local first, then mise, then PATH.
+ */
+async function resolveLinterBin(cwd: string, bin: string): Promise<string | null> {
+  const localCandidates = process.platform === "win32" ? [`${bin}.cmd`, `${bin}.exe`, bin] : [bin];
+  for (const name of localCandidates) {
+    const local = join(cwd, "node_modules", ".bin", name);
+    if (existsSync(local)) return local;
+  }
+  return resolveToolBin(bin);
+}
+
+async function runLinter(cwd: string, spec: LinterSpec): Promise<LinterRun> {
+  const meta = { id: spec.id, label: spec.label };
+  const bin = await resolveLinterBin(cwd, spec.bin);
+  if (!bin) return { spec: meta, findings: [], didNotRun: true };
+  const res = await execFileNoThrow(bin, spec.args, {
+    timeout: spec.timeout,
+    maxBuffer: spec.maxBuffer,
+  });
+  const findings = spec.parse(res);
+  // A linter that found issues exits non-zero — that is NOT didNotRun. Only treat a
+  // non-zero exit with NO parseable findings AND no stdout as a genuine run failure
+  // (e.g. a missing tsconfig / not a cargo project).
+  if (!res.ok && findings.length === 0 && !res.stdout.trim()) {
+    return { spec: meta, findings: [], didNotRun: true };
+  }
+  return { spec: meta, findings, didNotRun: false };
+}
+
+export interface SpecificScanResult {
+  language: string;
+  runs: LinterRun[];
+}
+
+/**
+ * Run every enabled linter for `language`. `enabled` is the per-linter toggle map
+ * from `[standards.<lang>]` (absent ⇒ all on). A language with no P2 support returns
+ * an empty run set (the specific gate simply contributes nothing).
+ */
+export async function scanSpecific(
+  cwd: string,
+  language: string,
+  enabled?: Record<string, boolean>,
+): Promise<SpecificScanResult> {
+  const specs = REGISTRY[language] ?? [];
+  const active = specs.filter((s) => enabled?.[s.id] !== false);
+  const runs = await Promise.all(active.map((s) => runLinter(cwd, s)));
+  return { language, runs };
+}
+
+export interface CheckSpecificOptions {
+  cwd?: string;
+  language: string;
+  enforce?: boolean;
+  /** Per-linter enable/disable from [standards.<lang>]. */
+  enabled?: Record<string, boolean>;
+  /** Baseline finding keys (net-new gating). */
+  baseline?: string[];
+  /** Injected scan (tests / reuse). */
+  scan?: SpecificScanResult;
+}
+
+/** Build the StandardsCheckResult[] for the specific gate of one language. */
+export async function checkStandardsSpecific(
+  opts: CheckSpecificOptions,
+): Promise<StandardsCheckResult[]> {
+  const cwd = opts.cwd ?? process.cwd();
+  const enforce = opts.enforce ?? false;
+  const scan = opts.scan ?? (await scanSpecific(cwd, opts.language, opts.enabled));
+  const seen = new Set(opts.baseline ?? []);
+  const results: StandardsCheckResult[] = [];
+
+  for (const run of scan.runs) {
+    const name = `${opts.language}: ${run.spec.label}`;
+    if (run.didNotRun) {
+      results.push({
+        category: "standards",
+        dimension: "specific",
+        name,
+        status: enforce ? "fail" : "warn",
+        severity: enforce ? "high" : "low",
+        didNotRun: true,
+        detail: `${run.spec.label} not installed — this specific gate did not run (setup gap); --enforce fails CI on setup gaps`,
+      });
+      continue;
+    }
+    const rel = run.findings.map((f) => ({ ...f, file: relPath(cwd, f.file) }));
+    const fresh = rel.filter((f) => !seen.has(specificKey(opts.language, run.spec.id, f)));
+    if (rel.length === 0) {
+      results.push({
+        category: "standards",
+        dimension: "specific",
+        name,
+        status: "pass",
+        detail: "no findings",
+      });
+    } else if (fresh.length === 0) {
+      results.push({
+        category: "standards",
+        dimension: "specific",
+        name,
+        status: "warn",
+        severity: "low",
+        detail: `${rel.length} pre-existing finding(s) (baseline-frozen)`,
+      });
+    } else {
+      results.push({
+        category: "standards",
+        dimension: "specific",
+        name,
+        status: enforce ? "fail" : "warn",
+        severity: enforce ? "high" : "medium",
+        detail: `${fresh.length} new finding(s) (${rel.length} total)`,
+        files: fresh
+          .slice(0, 10)
+          .map(
+            (f) =>
+              `${f.file}${f.line ? `:${f.line}` : ""}${f.rule ? ` [${f.rule}]` : ""}${
+                f.message ? ` ${f.message}` : ""
+              }`,
+          ),
+      });
+    }
+  }
+  return results;
+}
+
+function relPath(cwd: string, p: string): string {
+  const norm = p.startsWith(cwd) ? p.slice(cwd.length).replace(/^[/\\]+/, "") : p;
+  return norm || p;
+}
+
+/** Snapshot current specific findings for `kit baseline freeze` (net-new thereafter). */
+export async function collectSpecificKeys(
+  cwd: string,
+  language: string,
+  enabled?: Record<string, boolean>,
+): Promise<string[]> {
+  const scan = await scanSpecific(cwd, language, enabled);
+  const keys: string[] = [];
+  for (const run of scan.runs) {
+    if (run.didNotRun) continue;
+    for (const f of run.findings) {
+      keys.push(specificKey(language, run.spec.id, { ...f, file: relPath(cwd, f.file) }));
+    }
+  }
+  return keys;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { writeFile, access, mkdir } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { resolve, dirname, join } from "node:path";
 import { loadConfig, type kitConfig, type SecretKeyConfig } from "./config.js";
+import type { StandardsCheckResult } from "./check-standards.js";
 import { createInterface } from "node:readline/promises";
 import { validateSecrets, summarizeValidation } from "./secrets-validate.js";
 import { checkTools } from "./check-tools.js";
@@ -641,7 +642,10 @@ async function cmdDesign(): Promise<boolean> {
 async function cmdStandards(): Promise<boolean> {
   const enforce = hasFlag(process.argv, "--enforce");
   const jsonMode = hasFlag(process.argv, "--json");
+  const category = flagValue(process.argv, "--category"); // general | specific | <lang>
   const { checkStandards } = await import("./check-standards.js");
+  const { checkStandardsSpecific, SPECIFIC_LANGUAGES } =
+    await import("./check-standards-specific.js");
   const { loadBaselineForGate, baselineGet, BASELINE_FILE } = await import("./baseline.js");
   const { baseline, ignored: baselineIgnored } = await loadBaselineForGate();
   if (baselineIgnored) {
@@ -652,32 +656,79 @@ async function cmdStandards(): Promise<boolean> {
   const config = await loadConfig(resolveConfigPath()).catch(
     () => ({}) as Awaited<ReturnType<typeof loadConfig>>,
   );
-  const g = config.standards?.general;
-  const thresholds = {
-    ...(typeof g?.max_complexity === "number" ? { maxComplexity: g.max_complexity } : {}),
-    ...(typeof g?.max_function_lines === "number"
-      ? { maxFunctionLines: g.max_function_lines }
-      : {}),
-    ...(typeof g?.max_file_lines === "number" ? { maxFileLines: g.max_file_lines } : {}),
-    ...(typeof g?.max_duplication_pct === "number"
-      ? { maxDuplicationPct: g.max_duplication_pct }
-      : {}),
-  };
-  const results = await checkStandards({
-    enforce: enforce || config.standards?.enforce === true,
-    thresholds,
-    baseline: {
-      complexity: baselineGet(baseline, "standards", "complexity"),
-      duplication: baselineGet(baseline, "standards", "duplication"),
-      size: baselineGet(baseline, "standards", "size"),
-    },
-  });
+  const effectiveEnforce = enforce || config.standards?.enforce === true;
+
+  // `--category` scoping: default runs general + specific(detected). "general" or
+  // "specific" narrow the dimension; a language name narrows specific to that language.
+  const langCategory = category && SPECIFIC_LANGUAGES.includes(category) ? category : undefined;
+  const runGeneral = !category || category === "general";
+  const runSpecific = !category || category === "specific" || !!langCategory;
+
+  const results: StandardsCheckResult[] = [];
+
+  if (runGeneral) {
+    const g = config.standards?.general;
+    const thresholds = {
+      ...(typeof g?.max_complexity === "number" ? { maxComplexity: g.max_complexity } : {}),
+      ...(typeof g?.max_function_lines === "number"
+        ? { maxFunctionLines: g.max_function_lines }
+        : {}),
+      ...(typeof g?.max_file_lines === "number" ? { maxFileLines: g.max_file_lines } : {}),
+      ...(typeof g?.max_duplication_pct === "number"
+        ? { maxDuplicationPct: g.max_duplication_pct }
+        : {}),
+    };
+    results.push(
+      ...(await checkStandards({
+        enforce: effectiveEnforce,
+        thresholds,
+        baseline: {
+          complexity: baselineGet(baseline, "standards", "complexity"),
+          duplication: baselineGet(baseline, "standards", "duplication"),
+          size: baselineGet(baseline, "standards", "size"),
+        },
+      })),
+    );
+  }
+
+  if (runSpecific) {
+    let language = langCategory;
+    if (!language) {
+      const { detectStack } = await import("./stack-detector.js");
+      language = (await detectStack(process.cwd())).language;
+    }
+    if (SPECIFIC_LANGUAGES.includes(language)) {
+      const langCfg = (config.standards as Record<string, unknown> | undefined)?.[language] as
+        | Record<string, boolean>
+        | undefined;
+      results.push(
+        ...(await checkStandardsSpecific({
+          language,
+          enforce: effectiveEnforce,
+          enabled: langCfg,
+          baseline: baselineGet(baseline, "standards", `specific/${language}`),
+        })),
+      );
+    } else if (category === "specific" || langCategory) {
+      // asked for specific but the detected language has no P2 support — be honest.
+      results.push({
+        category: "standards",
+        dimension: "specific",
+        name: `specific (${language})`,
+        status: "skip",
+        detail: `no per-language standards gate for '${language}' yet (P2 covers ${SPECIFIC_LANGUAGES.join(", ")})`,
+      });
+    }
+  }
+
   const ok = results.every((r) => r.status !== "fail");
   if (jsonMode) {
     console.log(JSON.stringify({ ok, checks: results }, null, 2));
     return ok;
   }
-  console.log(`${c.bold}Standards${c.reset} ${c.dim}(general — deterministic, zero-LLM)${c.reset}`);
+  console.log(
+    `${c.bold}Standards${c.reset} ${c.dim}(general + per-language — deterministic, zero-LLM)${c.reset}`,
+  );
   for (const r of results) {
     const icon =
       r.status === "pass"
@@ -770,9 +821,22 @@ async function cmdBaseline(): Promise<boolean> {
   baselineSet(baseline, "standards", "complexity", standards.complexity);
   baselineSet(baseline, "standards", "duplication", standards.duplication);
   baselineSet(baseline, "standards", "size", standards.size);
+  // P2: freeze the detected language's specific-linter findings too.
+  const { collectSpecificKeys, SPECIFIC_LANGUAGES } = await import("./check-standards-specific.js");
+  const { detectStack } = await import("./stack-detector.js");
+  const detectedLang = (await detectStack(process.cwd())).language;
+  let specificCount = 0;
+  if (SPECIFIC_LANGUAGES.includes(detectedLang)) {
+    const specificKeys = await collectSpecificKeys(process.cwd(), detectedLang);
+    baselineSet(baseline, "standards", `specific/${detectedLang}`, specificKeys);
+    specificCount = specificKeys.length;
+  }
   await saveBaseline(baseline);
   const standardsTotal =
-    standards.complexity.length + standards.duplication.length + standards.size.length;
+    standards.complexity.length +
+    standards.duplication.length +
+    standards.size.length +
+    specificCount;
   console.log(
     `${c.green}✓${c.reset} Wrote ${BASELINE_FILE} — ${untested.length} untested file(s), ${design.a11y.length} a11y, ${design.tokens.length} design-token, ${standardsTotal} standards finding(s) frozen.`,
   );
@@ -5446,7 +5510,7 @@ export const COMMAND_HELP: Record<string, string> = {
     "Signable org policy-as-code in .kit-policy.toml (init/show/validate/sign/verify/check/trust) — identity-signed standard, org-distributable + enforced offline (experimental)",
   design: "Check design quality (a11y, design tokens) against the baseline",
   standards:
-    "Dev-standards gate: general code-quality metrics (complexity/duplication/size) vs the baseline (--enforce fails CI)",
+    "Dev-standards gate: general metrics (complexity/duplication/size) + per-language linters vs the baseline (--category general|specific|<lang>, --enforce fails CI)",
   baseline:
     "Freeze current warnings into .kit-baseline.json so future runs gate only net-new findings",
   memory: "Local conversation memory — index transcripts + show stats",

--- a/src/config.ts
+++ b/src/config.ts
@@ -405,6 +405,12 @@ export interface kitConfig {
       max_file_lines?: number;
       max_duplication_pct?: number;
     };
+    /** P2 per-language linter toggles: `[standards.<lang>]` with `<linter> = false`
+     *  to disable a specific delegate (all on by default for the detected language). */
+    typescript?: Record<string, boolean>;
+    python?: Record<string, boolean>;
+    go?: Record<string, boolean>;
+    rust?: Record<string, boolean>;
   };
 }
 
@@ -683,6 +689,10 @@ export const kitConfigSchema = z
           })
           .passthrough()
           .optional(),
+        typescript: z.record(z.string(), z.boolean()).optional(),
+        python: z.record(z.string(), z.boolean()).optional(),
+        go: z.record(z.string(), z.boolean()).optional(),
+        rust: z.record(z.string(), z.boolean()).optional(),
       })
       .passthrough()
       .optional(),


### PR DESCRIPTION
## Description

Adds the **specific (per-language)** dimension to `kit standards`, building on the P1 general gate (#255). Detects the project language and delegates to each ecosystem's own canonical linters in report mode, folding their findings into the same `StandardsCheckResult` verdict — deterministic, baseline-aware, warn-by-default / `--enforce` fail-closed.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

- Builds on #255 (kit standards P1 — general gate).

## Changes Made

- **`src/check-standards-specific.ts`** — declarative per-linter registry:
  - **typescript** (JS folded in) → eslint (`--format json`), `tsc --noEmit`
  - **python** → ruff (json), mypy
  - **go** → `go vet`, `gofmt -l`
  - **rust** → `cargo clippy` (short), `cargo fmt --check`
- Each linter has a **pure parser** (`parseEslintJson` / `parseTscOutput` / `parseRuffJson` / `parseMypyOutput` / `parseGoVet` / `parseGofmtList` / `parseClippyShort` / `parseCargoFmtCheck`) — unit-tested against fixture output, no tool needed.
- **Project-local resolution first:** node-ecosystem tools resolve `node_modules/.bin` before mise/PATH. A global `tsc` resolves `@types` against the wrong tree and floods thousands of phantom errors on code that compiles cleanly — a false positive is as harmful as a false green, so the delegate must use the project's own toolchain.
- **Net-new gating** on stable `lang/tool:file#rule` keys; `kit baseline freeze` snapshots `standards.specific/<lang>` for the detected language.
- **Config** `[standards.<lang>]` toggle maps (typescript/python/go/rust) to disable individual linters; **`kit standards --category general|specific|<lang>`** scopes the run.
- A linter that isn't installed is an honest **setup gap** (warn locally, fail under `--enforce`) — same fail-closed contract as P1.

## Testing

### Test Coverage
- [x] Added new tests
- [x] All tests pass (`npm test`) — full suite **2463/2463**

- 8 parser fixtures + gating/baseline/enforce/setup-gap/scan-selection matrix (17 new tests).

### Manual Testing
Verified against kit's own repo (`kit standards --category typescript`):
1. `tsc --noEmit` → **pass** (clean) — after the project-local-resolution fix (a global tsc previously reported 3375 phantom errors).
2. `eslint` → surfaces real pre-existing findings (baseline-freezable).
3. `--category general|specific|<lang>` scopes correctly; unsupported language → honest `skip`.

## Breaking Changes

None / N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've updated documentation as needed (plan marked P2-shipped)
- [x] All new code has test coverage
- [x] All tests pass locally (`npm test`)
- [x] No new warnings or errors introduced
- [x] Commit messages follow conventions
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

## Performance Impact

- [x] No performance impact — specific linters run only when their tool is installed and only for the detected language; compiling linters (clippy/go vet) get longer timeouts.

## Migration Guide

N/A — additive and opt-in. Absent `[standards.<lang>]` ⇒ the detected language's canonical linters run by default; disable any with `<linter> = false`.

## Reviewer Notes

- The project-local-first binary resolution is the load-bearing correctness fix — without it the tsc/eslint delegates misfire on any repo whose toolchain differs from the global one.
- Like P1, the specific gate is composed by `kit review` and stays out of `computeCheckVerdict` (so `kit check` / MCP `kit_check` are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_