### PR TITLE
feat(standards): kit standards P3–P5 — plugins · platform + breadth · freeze/score/MCP

### DIFF
--- a/contracts/public-surface.json
+++ b/contracts/public-surface.json
@@ -232,6 +232,7 @@
     "kit_run",
     "kit_secrets",
     "kit_skill_marketplace",
+    "kit_standards",
     "kit_workflow_execute"
   ]
 }

--- a/src/check-standards-platform.test.ts
+++ b/src/check-standards-platform.test.ts
@@ -1,0 +1,97 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parseHadolintJson,
+  findDockerfiles,
+  checkStandardsPlatform,
+  platformKey,
+  type PlatformScan,
+} from "./check-standards-platform.js";
+import type { ExecResult } from "./utils/execFileNoThrow.js";
+
+const ok = (stdout: string, exitCode = 0): ExecResult => ({
+  stdout,
+  stderr: "",
+  exitCode,
+  ok: exitCode === 0,
+});
+
+describe("check-standards-platform — parseHadolintJson", () => {
+  it("maps hadolint json findings", () => {
+    const json = JSON.stringify([
+      {
+        file: "Dockerfile",
+        line: 3,
+        column: 1,
+        level: "warning",
+        code: "DL3008",
+        message: "Pin versions in apt-get",
+      },
+    ]);
+    const f = parseHadolintJson(ok(json, 1));
+    assert.deepEqual(f, [
+      { file: "Dockerfile", line: 3, rule: "DL3008", message: "Pin versions in apt-get" },
+    ]);
+  });
+  it("tolerates non-JSON", () => {
+    assert.deepEqual(parseHadolintJson(ok("boom")), []);
+  });
+});
+
+describe("check-standards-platform — findDockerfiles", () => {
+  it("finds Dockerfile, Dockerfile.prod, app.Dockerfile; skips vendor dirs", () => {
+    const repo = mkdtempSync(join(tmpdir(), "kit-docker-"));
+    try {
+      writeFileSync(join(repo, "Dockerfile"), "FROM alpine\n");
+      writeFileSync(join(repo, "Dockerfile.prod"), "FROM alpine\n");
+      mkdirSync(join(repo, "svc"), { recursive: true });
+      writeFileSync(join(repo, "svc", "app.Dockerfile"), "FROM node\n");
+      mkdirSync(join(repo, "node_modules", "pkg"), { recursive: true });
+      writeFileSync(join(repo, "node_modules", "pkg", "Dockerfile"), "FROM evil\n");
+      const found = findDockerfiles(repo)
+        .map((p) => p.slice(repo.length + 1))
+        .sort();
+      assert.deepEqual(found, ["Dockerfile", "Dockerfile.prod", "svc/app.Dockerfile"]);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("check-standards-platform — gating", () => {
+  it("no Dockerfile → no results (gate doesn't apply)", async () => {
+    const scan: PlatformScan = { dockerfiles: [], findings: [], didNotRun: false };
+    assert.deepEqual(await checkStandardsPlatform({ scan }), []);
+  });
+
+  it("Dockerfile present but hadolint absent → setup gap (warn default, fail enforce)", async () => {
+    const scan: PlatformScan = { dockerfiles: ["Dockerfile"], findings: [], didNotRun: true };
+    assert.equal((await checkStandardsPlatform({ scan }))[0].status, "warn");
+    assert.equal((await checkStandardsPlatform({ scan, enforce: true }))[0].status, "fail");
+    assert.equal((await checkStandardsPlatform({ scan }))[0].didNotRun, true);
+  });
+
+  it("clean Dockerfile → pass; findings → warn/fail; baseline-frozen → low warn", async () => {
+    const clean: PlatformScan = { dockerfiles: ["Dockerfile"], findings: [], didNotRun: false };
+    assert.equal((await checkStandardsPlatform({ scan: clean }))[0].status, "pass");
+
+    const dirty: PlatformScan = {
+      dockerfiles: ["Dockerfile"],
+      findings: [{ file: "Dockerfile", line: 3, rule: "DL3008", message: "pin versions" }],
+      didNotRun: false,
+    };
+    assert.equal((await checkStandardsPlatform({ scan: dirty }))[0].status, "warn");
+    assert.equal((await checkStandardsPlatform({ scan: dirty, enforce: true }))[0].status, "fail");
+
+    const frozen = await checkStandardsPlatform({
+      scan: dirty,
+      enforce: true,
+      baseline: [platformKey("hadolint", { file: "Dockerfile", line: 3, rule: "DL3008" })],
+    });
+    assert.equal(frozen[0].status, "warn");
+    assert.equal(frozen[0].severity, "low");
+  });
+});

--- a/src/check-standards-platform.ts
+++ b/src/check-standards-platform.ts
@@ -1,0 +1,201 @@
+/**
+ * kit standards — P4 platform gate: the deploy surface, not a language.
+ *
+ * P4 ships the CONTAINER gate: if the repo has a Dockerfile, lint it with hadolint
+ * (Dockerfile best-practice + embedded-shell checks). Same contract as every other
+ * standards dimension — deterministic, net-new-gated against the baseline, warn by
+ * default / `--enforce` fail-closed, and an honest setup gap when hadolint is absent.
+ *
+ * Pure parser (parseHadolintJson) is unit-tested against fixture output.
+ */
+import { readdirSync } from "node:fs";
+import { join, relative } from "node:path";
+import { resolveToolBin } from "./utils/resolveTool.js";
+import { execFileNoThrow, type ExecResult } from "./utils/execFileNoThrow.js";
+import type { StandardsCheckResult } from "./check-standards.js";
+
+export interface PlatformFinding {
+  file: string;
+  line?: number;
+  rule?: string;
+  message?: string;
+}
+
+/** Stable baseline key for a platform finding. */
+export const platformKey = (tool: string, f: PlatformFinding): string =>
+  `platform/${tool}:${f.file}${f.rule ? `#${f.rule}` : f.line ? `:${f.line}` : ""}`;
+
+/** hadolint `--format json`: `[{ file, line, column, level, code, message }]`. */
+export function parseHadolintJson(res: ExecResult): PlatformFinding[] {
+  let data: unknown;
+  try {
+    data = JSON.parse(res.stdout);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(data)) return [];
+  const out: PlatformFinding[] = [];
+  for (const d of data) {
+    const item = (d ?? {}) as Record<string, unknown>;
+    const file = typeof item.file === "string" ? item.file : undefined;
+    if (!file) continue;
+    out.push({
+      file,
+      line: typeof item.line === "number" ? item.line : undefined,
+      rule: typeof item.code === "string" ? item.code : undefined,
+      message: typeof item.message === "string" ? item.message : undefined,
+    });
+  }
+  return out;
+}
+
+const DOCKERFILE_RE = /^Dockerfile(\..+)?$|\.Dockerfile$/i;
+const DOCKER_SKIP = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  "out",
+  ".next",
+  ".git",
+  "vendor",
+  "target",
+]);
+
+/** Locate Dockerfiles in the repo (bounded depth ≤4), vendor-excluded. */
+export function findDockerfiles(cwd: string, maxDepth = 4): string[] {
+  const found: string[] = [];
+  const visit = (dir: string, depth: number): void => {
+    if (depth > maxDepth) return;
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (e.isDirectory()) {
+        if (!DOCKER_SKIP.has(e.name)) visit(join(dir, e.name), depth + 1);
+      } else if (DOCKERFILE_RE.test(e.name)) {
+        found.push(join(dir, e.name));
+      }
+    }
+  };
+  visit(cwd, 0);
+  return found;
+}
+
+export interface PlatformScan {
+  dockerfiles: string[];
+  findings: PlatformFinding[];
+  didNotRun: boolean;
+}
+
+/** Run hadolint over the repo's Dockerfiles. */
+export async function scanContainer(cwd: string): Promise<PlatformScan> {
+  const dockerfiles = findDockerfiles(cwd);
+  if (dockerfiles.length === 0) {
+    return { dockerfiles: [], findings: [], didNotRun: false }; // nothing to lint ⇒ clean skip, not a gap
+  }
+  const bin = await resolveToolBin("hadolint");
+  if (!bin) return { dockerfiles, findings: [], didNotRun: true };
+  const res = await execFileNoThrow(bin, ["--format", "json", ...dockerfiles], {
+    timeout: 60_000,
+    maxBuffer: 16 * 1024 * 1024,
+    cwd,
+  });
+  // hadolint exits non-zero when it finds issues; only a run with no parseable JSON is a real failure.
+  const findings = parseHadolintJson(res);
+  if (!res.ok && findings.length === 0 && !res.stdout.trim()) {
+    return { dockerfiles, findings: [], didNotRun: true };
+  }
+  return { dockerfiles, findings, didNotRun: false };
+}
+
+export interface CheckPlatformOptions {
+  cwd?: string;
+  enforce?: boolean;
+  baseline?: string[];
+  scan?: PlatformScan;
+}
+
+/** Build the StandardsCheckResult[] for the platform (container) gate. */
+export async function checkStandardsPlatform(
+  opts: CheckPlatformOptions = {},
+): Promise<StandardsCheckResult[]> {
+  const cwd = opts.cwd ?? process.cwd();
+  const enforce = opts.enforce ?? false;
+  const scan = opts.scan ?? (await scanContainer(cwd));
+
+  // No Dockerfile at all → the container gate simply doesn't apply (no output).
+  if (scan.dockerfiles.length === 0) return [];
+
+  const name = "container: hadolint";
+  if (scan.didNotRun) {
+    return [
+      {
+        category: "standards",
+        dimension: "platform",
+        name,
+        status: enforce ? "fail" : "warn",
+        severity: enforce ? "high" : "low",
+        didNotRun: true,
+        detail: `${scan.dockerfiles.length} Dockerfile(s) found but hadolint is not installed — container gate did not run (setup gap); --enforce fails CI on setup gaps`,
+      },
+    ];
+  }
+  const rel = scan.findings.map((f) => ({ ...f, file: relPath(cwd, f.file) }));
+  const seen = new Set(opts.baseline ?? []);
+  const fresh = rel.filter((f) => !seen.has(platformKey("hadolint", f)));
+  if (rel.length === 0) {
+    return [
+      {
+        category: "standards",
+        dimension: "platform",
+        name,
+        status: "pass",
+        detail: `${scan.dockerfiles.length} Dockerfile(s) — no hadolint findings`,
+      },
+    ];
+  }
+  if (fresh.length === 0) {
+    return [
+      {
+        category: "standards",
+        dimension: "platform",
+        name,
+        status: "warn",
+        severity: "low",
+        detail: `${rel.length} pre-existing Dockerfile finding(s) (baseline-frozen)`,
+      },
+    ];
+  }
+  return [
+    {
+      category: "standards",
+      dimension: "platform",
+      name,
+      status: enforce ? "fail" : "warn",
+      severity: enforce ? "high" : "medium",
+      detail: `${fresh.length} new Dockerfile finding(s) (${rel.length} total)`,
+      files: fresh
+        .slice(0, 10)
+        .map(
+          (f) =>
+            `${f.file}${f.line ? `:${f.line}` : ""}${f.rule ? ` [${f.rule}]` : ""}${
+              f.message ? ` ${f.message}` : ""
+            }`,
+        ),
+    },
+  ];
+}
+
+function relPath(cwd: string, p: string): string {
+  return relative(cwd, p) || p;
+}
+
+/** Snapshot current container findings for `kit baseline freeze`. */
+export async function collectPlatformKeys(cwd: string): Promise<string[]> {
+  const scan = await scanContainer(cwd);
+  if (scan.didNotRun) return [];
+  return scan.findings.map((f) => platformKey("hadolint", { ...f, file: relPath(cwd, f.file) }));
+}

--- a/src/check-standards-specific.test.ts
+++ b/src/check-standards-specific.test.ts
@@ -9,6 +9,12 @@ import {
   parseGofmtList,
   parseClippyShort,
   parseCargoFmtCheck,
+  parseRubocopJson,
+  parsePhpstanJson,
+  parseKtlintJson,
+  parseCheckstyle,
+  parseDotnetFormat,
+  makeLineColParser,
   checkStandardsSpecific,
   scanSpecific,
   collectSpecificKeys,
@@ -229,7 +235,99 @@ describe("scanSpecific + collectSpecificKeys", () => {
     const s = await scanSpecific(process.cwd(), "typescript", { eslint: false, tsc: false });
     assert.deepEqual(s.runs, []);
   });
-  it("exposes the four P2 languages", () => {
-    assert.deepEqual([...SPECIFIC_LANGUAGES].sort(), ["go", "python", "rust", "typescript"]);
+  it("exposes the P2 core + P4 breadth languages", () => {
+    // P2: typescript/python/go/rust · P4: ruby/php/kotlin/java/csharp/cpp/c
+    for (const lang of [
+      "typescript",
+      "python",
+      "go",
+      "rust",
+      "ruby",
+      "php",
+      "kotlin",
+      "java",
+      "csharp",
+      "cpp",
+      "c",
+    ]) {
+      assert.ok(SPECIFIC_LANGUAGES.includes(lang), `${lang} is supported`);
+    }
+  });
+});
+
+describe("specific parsers — P4 languages", () => {
+  it("rubocop json", () => {
+    const json = JSON.stringify({
+      files: [
+        {
+          path: "app/models/user.rb",
+          offenses: [
+            {
+              location: { line: 12 },
+              cop_name: "Style/StringLiterals",
+              message: "prefer single quotes",
+            },
+          ],
+        },
+      ],
+    });
+    const f = parseRubocopJson(ok(json, 1));
+    assert.deepEqual(f, [
+      {
+        file: "app/models/user.rb",
+        line: 12,
+        rule: "Style/StringLiterals",
+        message: "prefer single quotes",
+      },
+    ]);
+  });
+
+  it("phpstan json (files keyed by path)", () => {
+    const json = JSON.stringify({
+      files: { "src/App.php": { messages: [{ line: 5, message: "Undefined variable $x" }] } },
+    });
+    const f = parsePhpstanJson(ok(json, 1));
+    assert.deepEqual(f, [{ file: "src/App.php", line: 5, message: "Undefined variable $x" }]);
+  });
+
+  it("ktlint json", () => {
+    const json = JSON.stringify([
+      {
+        file: "src/Main.kt",
+        errors: [{ line: 3, message: "Unexpected indentation", rule: "indent" }],
+      },
+    ]);
+    const f = parseKtlintJson(ok(json, 1));
+    assert.deepEqual(f, [
+      { file: "src/Main.kt", line: 3, rule: "indent", message: "Unexpected indentation" },
+    ]);
+  });
+
+  it("checkstyle plain output", () => {
+    const out = "[WARN] /repo/src/Main.java:10:5: Missing a Javadoc comment. [JavadocMethod]";
+    const f = parseCheckstyle(ok(out, 1));
+    assert.equal(f.length, 1);
+    assert.equal(f[0].file, "/repo/src/Main.java");
+    assert.equal(f[0].line, 10);
+    assert.equal(f[0].rule, "JavadocMethod");
+  });
+
+  it("dotnet format verify-no-changes", () => {
+    const out =
+      "  /repo/Program.cs(7,1): error WHITESPACE: Fix whitespace formatting. [/repo/App.csproj]";
+    const f = parseDotnetFormat(ok(out, 2));
+    assert.equal(f.length, 1);
+    assert.equal(f[0].file, "/repo/Program.cs");
+    assert.equal(f[0].line, 7);
+    assert.equal(f[0].rule, "WHITESPACE");
+  });
+
+  it("cppcheck via makeLineColParser (ext-filtered)", () => {
+    const parse = makeLineColParser(/\.(c|cc|cpp|cxx|h|hh|hpp)$/);
+    const out = ["src/main.cpp:42: Array index out of bounds", "somenoise: not a finding"].join(
+      "\n",
+    );
+    const f = parse(err(out));
+    assert.deepEqual(f, [{ file: "src/main.cpp", line: 42, message: "Array index out of bounds" }]);
   });
 });

--- a/src/check-standards-specific.ts
+++ b/src/check-standards-specific.ts
@@ -190,6 +190,130 @@ export function parseCargoFmtCheck(res: ExecResult): SpecificFinding[] {
   return out;
 }
 
+/** rubocop `--format json`: `{ files: [{ path, offenses: [{ location: { line }, cop_name, message }] }] }`. */
+export function parseRubocopJson(res: ExecResult): SpecificFinding[] {
+  let data: unknown;
+  try {
+    data = JSON.parse(res.stdout);
+  } catch {
+    return [];
+  }
+  const root = (data ?? {}) as Record<string, unknown>;
+  const files = Array.isArray(root.files) ? root.files : [];
+  const out: SpecificFinding[] = [];
+  for (const f of files) {
+    const file = (f ?? {}) as Record<string, unknown>;
+    const path = typeof file.path === "string" ? file.path : undefined;
+    if (!path) continue;
+    const offenses = Array.isArray(file.offenses) ? file.offenses : [];
+    for (const o of offenses) {
+      const off = (o ?? {}) as Record<string, unknown>;
+      const loc = (off.location ?? {}) as Record<string, unknown>;
+      out.push({
+        file: path,
+        line: typeof loc.line === "number" ? loc.line : undefined,
+        rule: typeof off.cop_name === "string" ? off.cop_name : undefined,
+        message: typeof off.message === "string" ? off.message : undefined,
+      });
+    }
+  }
+  return out;
+}
+
+/** phpstan `analyse --error-format=json`: `{ files: { "<path>": { messages: [{ line, message }] } } }`. */
+export function parsePhpstanJson(res: ExecResult): SpecificFinding[] {
+  let data: unknown;
+  try {
+    data = JSON.parse(res.stdout);
+  } catch {
+    return [];
+  }
+  const root = (data ?? {}) as Record<string, unknown>;
+  const files = (root.files ?? {}) as Record<string, unknown>;
+  const out: SpecificFinding[] = [];
+  for (const [path, v] of Object.entries(files)) {
+    const messages = Array.isArray((v as Record<string, unknown>)?.messages)
+      ? ((v as Record<string, unknown>).messages as unknown[])
+      : [];
+    for (const m of messages) {
+      const msg = (m ?? {}) as Record<string, unknown>;
+      out.push({
+        file: path,
+        line: typeof msg.line === "number" ? msg.line : undefined,
+        message: typeof msg.message === "string" ? msg.message : undefined,
+      });
+    }
+  }
+  return out;
+}
+
+/** ktlint `--reporter=json`: `[{ file, errors: [{ line, message, rule }] }]`. */
+export function parseKtlintJson(res: ExecResult): SpecificFinding[] {
+  let data: unknown;
+  try {
+    data = JSON.parse(res.stdout);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(data)) return [];
+  const out: SpecificFinding[] = [];
+  for (const f of data) {
+    const file = (f ?? {}) as Record<string, unknown>;
+    const path = typeof file.file === "string" ? file.file : undefined;
+    if (!path) continue;
+    const errors = Array.isArray(file.errors) ? file.errors : [];
+    for (const e of errors) {
+      const err = (e ?? {}) as Record<string, unknown>;
+      out.push({
+        file: path,
+        line: typeof err.line === "number" ? err.line : undefined,
+        rule: typeof err.rule === "string" ? err.rule : undefined,
+        message: typeof err.message === "string" ? err.message : undefined,
+      });
+    }
+  }
+  return out;
+}
+
+/** Generic `path:line[:col]: [severity:] message` linter output (cppcheck, clang-tidy).
+ *  `extFilter` restricts to files with that extension so unrelated lines are ignored. */
+export function makeLineColParser(extFilter: RegExp) {
+  return (res: ExecResult): SpecificFinding[] => {
+    const text = `${res.stdout}\n${res.stderr}`;
+    const out: SpecificFinding[] = [];
+    const re = /^(.+?):(\d+):(?:\d+:)?\s+(.*)$/;
+    for (const line of text.split("\n")) {
+      const m = re.exec(line.trim());
+      if (m && extFilter.test(m[1])) out.push({ file: m[1], line: Number(m[2]), message: m[3] });
+    }
+    return out;
+  };
+}
+
+/** checkstyle plain output: `[SEVERITY] /path/File.java:line:col: message [Rule]`. */
+export function parseCheckstyle(res: ExecResult): SpecificFinding[] {
+  const text = `${res.stdout}\n${res.stderr}`;
+  const out: SpecificFinding[] = [];
+  const re = /^\[\w+\]\s+(.+?):(\d+)(?::\d+)?:\s+(.*?)(?:\s+\[(\w+)\])?$/;
+  for (const line of text.split("\n")) {
+    const m = re.exec(line.trim());
+    if (m) out.push({ file: m[1], line: Number(m[2]), rule: m[4], message: m[3] });
+  }
+  return out;
+}
+
+/** `dotnet format --verify-no-changes`: `  path(line,col): error WHITESPACE: msg [proj]`. */
+export function parseDotnetFormat(res: ExecResult): SpecificFinding[] {
+  const text = `${res.stdout}\n${res.stderr}`;
+  const out: SpecificFinding[] = [];
+  const re = /^(.+?)\((\d+),\d+\):\s+(?:error|warning)\s+(\w+):\s+(.*?)(?:\s+\[.*\])?$/;
+  for (const line of text.split("\n")) {
+    const m = re.exec(line.trim());
+    if (m) out.push({ file: m[1], line: Number(m[2]), rule: m[3], message: m[4] });
+  }
+  return out;
+}
+
 // ── The per-language registry ──────────────────────────────────────────────────
 
 const REGISTRY: Record<string, LinterSpec[]> = {
@@ -272,9 +396,88 @@ const REGISTRY: Record<string, LinterSpec[]> = {
       maxBuffer: 32 * 1024 * 1024,
     },
   ],
+  // ── P4: remaining ecosystems (now that detection covers them) ──────────────────
+  ruby: [
+    {
+      id: "rubocop",
+      label: "rubocop",
+      bin: "rubocop",
+      args: ["--format", "json"],
+      parse: parseRubocopJson,
+      timeout: 120_000,
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  ],
+  php: [
+    {
+      id: "phpstan",
+      label: "phpstan",
+      bin: "phpstan",
+      args: ["analyse", "--error-format=json", "--no-progress"],
+      parse: parsePhpstanJson,
+      timeout: 120_000,
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  ],
+  kotlin: [
+    {
+      id: "ktlint",
+      label: "ktlint",
+      bin: "ktlint",
+      args: ["--reporter=json"],
+      parse: parseKtlintJson,
+      timeout: 120_000,
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  ],
+  java: [
+    {
+      id: "checkstyle",
+      label: "checkstyle",
+      bin: "checkstyle",
+      // needs a ruleset (-c) to run; absent one it errors → honest setup gap.
+      args: ["-c", "/google_checks.xml", "src"],
+      parse: parseCheckstyle,
+      timeout: 120_000,
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  ],
+  csharp: [
+    {
+      id: "dotnet-format",
+      label: "dotnet format --verify-no-changes",
+      bin: "dotnet",
+      args: ["format", "--verify-no-changes", "--verbosity", "quiet"],
+      parse: parseDotnetFormat,
+      timeout: 300_000,
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  ],
+  cpp: [
+    {
+      id: "cppcheck",
+      label: "cppcheck",
+      bin: "cppcheck",
+      args: ["--enable=warning,style", "--quiet", "--template={file}:{line}: {message}", "."],
+      parse: makeLineColParser(/\.(c|cc|cpp|cxx|h|hh|hpp)$/),
+      timeout: 180_000,
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  ],
+  c: [
+    {
+      id: "cppcheck",
+      label: "cppcheck",
+      bin: "cppcheck",
+      args: ["--enable=warning,style", "--quiet", "--template={file}:{line}: {message}", "."],
+      parse: makeLineColParser(/\.(c|h)$/),
+      timeout: 180_000,
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  ],
 };
 
-/** The languages P2 has specific linters for. */
+/** The languages the specific gate has linters for (P2 core + P4 breadth). */
 export const SPECIFIC_LANGUAGES = Object.keys(REGISTRY);
 
 // ── Runner + result assembly ────────────────────────────────────────────────────

--- a/src/check-standards.ts
+++ b/src/check-standards.ts
@@ -33,8 +33,9 @@ import { execFileNoThrow } from "./utils/execFileNoThrow.js";
 
 export interface StandardsCheckResult {
   category: "standards";
-  /** general = cross-cutting metric; specific = per-language linter (P2); plugin = user rule (P3). */
-  dimension: "general" | "specific" | "plugin";
+  /** general = cross-cutting metric; specific = per-language linter (P2);
+   *  plugin = user rule (P3); platform = deploy-surface gate e.g. container (P4). */
+  dimension: "general" | "specific" | "plugin" | "platform";
   name: string;
   status: "pass" | "fail" | "warn" | "skip";
   severity?: "high" | "medium" | "low";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import { writeFile, access, mkdir } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { resolve, dirname, join } from "node:path";
 import { loadConfig, type kitConfig, type SecretKeyConfig } from "./config.js";
-import type { StandardsCheckResult } from "./check-standards.js";
+import type { Baseline } from "./baseline.js";
 import { createInterface } from "node:readline/promises";
 import { validateSecrets, summarizeValidation } from "./secrets-validate.js";
 import { checkTools } from "./check-tools.js";
@@ -639,134 +639,98 @@ async function cmdDesign(): Promise<boolean> {
  * warn by default, `--enforce` fails on net-new findings AND on setup gaps (a tool
  * that could not run) — fail-closed for CI, quiet for local first-runs.
  */
+/**
+ * Snapshot every `kit standards` dimension (general + specific + plugins + platform)
+ * into the given baseline object and return the total number of findings frozen.
+ * Shared by `kit baseline freeze` and `kit standards freeze` so the two never drift.
+ */
+async function freezeStandardsBaseline(baseline: Baseline, cwd: string): Promise<number> {
+  const { collectStandardsKeys } = await import("./check-standards.js");
+  const { collectSpecificKeys, SPECIFIC_LANGUAGES } = await import("./check-standards-specific.js");
+  const { collectPluginKeys, DEFAULT_PLUGIN_DIR } = await import("./standards-plugins.js");
+  const { collectMjsPluginKeys } = await import("./standards-plugins-exec.js");
+  const { collectPlatformKeys } = await import("./check-standards-platform.js");
+  const { detectStack } = await import("./stack-detector.js");
+  const { baselineSet } = await import("./baseline.js");
+  const cfg = await loadConfig(resolveConfigPath()).catch(
+    () => ({}) as Awaited<ReturnType<typeof loadConfig>>,
+  );
+
+  const general = await collectStandardsKeys(cwd);
+  baselineSet(baseline, "standards", "complexity", general.complexity);
+  baselineSet(baseline, "standards", "duplication", general.duplication);
+  baselineSet(baseline, "standards", "size", general.size);
+
+  const lang = (await detectStack(cwd)).language;
+  let specificCount = 0;
+  if (SPECIFIC_LANGUAGES.includes(lang)) {
+    const keys = await collectSpecificKeys(cwd, lang);
+    baselineSet(baseline, "standards", `specific/${lang}`, keys);
+    specificCount = keys.length;
+  }
+
+  const dirs =
+    cfg.standards?.plugins?.dirs && cfg.standards.plugins.dirs.length > 0
+      ? cfg.standards.plugins.dirs
+      : [DEFAULT_PLUGIN_DIR];
+  const pluginKeys = [
+    ...collectPluginKeys(cwd, lang, dirs),
+    ...(await collectMjsPluginKeys(cwd, lang, dirs)),
+  ];
+  baselineSet(baseline, "standards", "plugins", pluginKeys);
+
+  const platformKeys = await collectPlatformKeys(cwd);
+  baselineSet(baseline, "standards", "platform", platformKeys);
+
+  return (
+    general.complexity.length +
+    general.duplication.length +
+    general.size.length +
+    specificCount +
+    pluginKeys.length +
+    platformKeys.length
+  );
+}
+
+/** `kit standards freeze` — snapshot ONLY the standards dimensions into the baseline. */
+async function cmdStandardsFreeze(): Promise<boolean> {
+  const { loadBaseline, saveBaseline, BASELINE_FILE } = await import("./baseline.js");
+  const baseline = await loadBaseline();
+  const total = await freezeStandardsBaseline(baseline, process.cwd());
+  await saveBaseline(baseline);
+  console.log(
+    `${c.green}✓${c.reset} Wrote ${BASELINE_FILE} — ${total} standards finding(s) frozen (general + specific + plugins + platform).`,
+  );
+  console.log(`  Future \`kit standards\` runs gate only on NEW findings.`);
+  return true;
+}
+
 async function cmdStandards(): Promise<boolean> {
+  const sub = process.argv[3];
+  if (sub === "freeze") return cmdStandardsFreeze();
   const enforce = hasFlag(process.argv, "--enforce");
   const jsonMode = hasFlag(process.argv, "--json");
-  const category = flagValue(process.argv, "--category"); // general | specific | <lang>
-  const { checkStandards } = await import("./check-standards.js");
-  const { checkStandardsSpecific, SPECIFIC_LANGUAGES } =
-    await import("./check-standards-specific.js");
-  const { loadBaselineForGate, baselineGet, BASELINE_FILE } = await import("./baseline.js");
-  const { baseline, ignored: baselineIgnored } = await loadBaselineForGate();
+  const category = flagValue(process.argv, "--category"); // general | specific | plugins | platform | <lang>
+  const { BASELINE_FILE } = await import("./baseline.js");
+  const { runStandardsGate } = await import("./standards-run.js");
+  // The SAME orchestration the MCP `kit_standards` tool uses — no divergent gate.
+  const {
+    ok,
+    checks: results,
+    summary,
+    baselineIgnored,
+  } = await runStandardsGate({
+    enforce,
+    category,
+  });
   if (baselineIgnored) {
     console.error(
       `${c.yellow}!${c.reset} ${BASELINE_FILE} ignored (${baselineIgnored}) — gating on all findings`,
     );
   }
-  const config = await loadConfig(resolveConfigPath()).catch(
-    () => ({}) as Awaited<ReturnType<typeof loadConfig>>,
-  );
-  const effectiveEnforce = enforce || config.standards?.enforce === true;
-
-  // `--category` scoping: default runs general + specific(detected) + plugins.
-  // "general"/"specific"/"plugins" narrow the dimension; a language name narrows
-  // specific to that language.
-  const langCategory = category && SPECIFIC_LANGUAGES.includes(category) ? category : undefined;
-  const runGeneral = !category || category === "general";
-  const runSpecific = !category || category === "specific" || !!langCategory;
-  const runPlugins = !category || category === "plugins";
-  const runPlatform = !category || category === "platform";
-
-  // Detect the project language once — both the specific gate and the plugin
-  // `applies_to` filter key off it (a language name via --category overrides).
-  let language = langCategory;
-  if ((runSpecific || runPlugins) && !language) {
-    const { detectStack } = await import("./stack-detector.js");
-    language = (await detectStack(process.cwd())).language;
-  }
-
-  const results: StandardsCheckResult[] = [];
-
-  if (runGeneral) {
-    const g = config.standards?.general;
-    const thresholds = {
-      ...(typeof g?.max_complexity === "number" ? { maxComplexity: g.max_complexity } : {}),
-      ...(typeof g?.max_function_lines === "number"
-        ? { maxFunctionLines: g.max_function_lines }
-        : {}),
-      ...(typeof g?.max_file_lines === "number" ? { maxFileLines: g.max_file_lines } : {}),
-      ...(typeof g?.max_duplication_pct === "number"
-        ? { maxDuplicationPct: g.max_duplication_pct }
-        : {}),
-    };
-    results.push(
-      ...(await checkStandards({
-        enforce: effectiveEnforce,
-        thresholds,
-        baseline: {
-          complexity: baselineGet(baseline, "standards", "complexity"),
-          duplication: baselineGet(baseline, "standards", "duplication"),
-          size: baselineGet(baseline, "standards", "size"),
-        },
-      })),
-    );
-  }
-
-  if (runSpecific && language) {
-    if (SPECIFIC_LANGUAGES.includes(language)) {
-      const langCfg = (config.standards as Record<string, unknown> | undefined)?.[language] as
-        | Record<string, boolean>
-        | undefined;
-      results.push(
-        ...(await checkStandardsSpecific({
-          language,
-          enforce: effectiveEnforce,
-          enabled: langCfg,
-          baseline: baselineGet(baseline, "standards", `specific/${language}`),
-        })),
-      );
-    } else if (category === "specific" || langCategory) {
-      // asked for specific but the detected language has no P2 support — be honest.
-      results.push({
-        category: "standards",
-        dimension: "specific",
-        name: `specific (${language})`,
-        status: "skip",
-        detail: `no per-language standards gate for '${language}' yet (P2 covers ${SPECIFIC_LANGUAGES.join(", ")})`,
-      });
-    }
-  }
-
-  if (runPlugins && language) {
-    const { checkStandardsPlugins, DEFAULT_PLUGIN_DIR } = await import("./standards-plugins.js");
-    const { checkStandardsMjsPlugins } = await import("./standards-plugins-exec.js");
-    const pluginCfg = config.standards?.plugins;
-    const dirs =
-      pluginCfg?.dirs && pluginCfg.dirs.length > 0 ? pluginCfg.dirs : [DEFAULT_PLUGIN_DIR];
-    const pluginBaseline = baselineGet(baseline, "standards", "plugins");
-    // Declarative TOML rules (pure regex) + programmatic *.mjs (restricted child,
-    // determinism-verified). Both net-new-gate against the same baseline key.
-    results.push(
-      ...checkStandardsPlugins({
-        language,
-        enforce: effectiveEnforce,
-        dirs,
-        baseline: pluginBaseline,
-      }),
-    );
-    results.push(
-      ...(await checkStandardsMjsPlugins({
-        language,
-        enforce: effectiveEnforce,
-        dirs,
-        baseline: pluginBaseline,
-      })),
-    );
-  }
-
-  if (runPlatform) {
-    const { checkStandardsPlatform } = await import("./check-standards-platform.js");
-    results.push(
-      ...(await checkStandardsPlatform({
-        enforce: effectiveEnforce,
-        baseline: baselineGet(baseline, "standards", "platform"),
-      })),
-    );
-  }
-
-  const ok = results.every((r) => r.status !== "fail");
+  const gaps = results.filter((r) => r.didNotRun);
   if (jsonMode) {
-    console.log(JSON.stringify({ ok, checks: results }, null, 2));
+    console.log(JSON.stringify({ ok, checks: results, summary }, null, 2));
     return ok;
   }
   console.log(
@@ -784,12 +748,17 @@ async function cmdStandards(): Promise<boolean> {
     console.log(`  ${icon} ${r.name}  ${c.dim}${r.detail}${c.reset}`);
     if (r.files) for (const f of r.files) console.log(`      ${c.dim}- ${f}${c.reset}`);
   }
-  // P5-lite: separate SETUP GAPS (a tool not installed) from real findings so a
-  // wall of "did not run" never reads as a quality failure.
-  const gaps = results.filter((r) => r.didNotRun);
+  // Score over gates that ran, then setup gaps and findings called out separately so
+  // neither is mistaken for the other.
+  const scoreColor = summary.failed > 0 ? c.red : summary.findings > 0 ? c.yellow : c.green;
+  console.log(
+    `  ${scoreColor}score ${summary.score}${c.reset} gates passed` +
+      `${summary.findings > 0 ? ` · ${summary.findings} with findings` : ""}` +
+      `${gaps.length > 0 ? ` · ${c.dim}${gaps.length} setup gap(s) (not run)${c.reset}` : ""}`,
+  );
   if (gaps.length > 0 && !enforce) {
     console.log(
-      `  ${c.dim}${gaps.length} setup gap(s) — install the tool(s) to enable these gates; --enforce fails CI on them${c.reset}`,
+      `  ${c.dim}setup gaps are un-provisioned tools, not failures — install them to enable those gates; --enforce fails CI on them${c.reset}`,
     );
   }
   return ok;
@@ -854,53 +823,14 @@ async function cmdBaseline(): Promise<boolean> {
 
   const { findUntestedSources } = await import("./check-tests.js");
   const { collectDesignKeys } = await import("./check-design.js");
-  const { collectStandardsKeys } = await import("./check-standards.js");
   const untested = await findUntestedSources();
   baselineSet(baseline, "tests", "untested_files", untested);
   const design = await collectDesignKeys();
   baselineSet(baseline, "design", "a11y", design.a11y);
   baselineSet(baseline, "design", "tokens", design.tokens);
-  const standards = await collectStandardsKeys();
-  baselineSet(baseline, "standards", "complexity", standards.complexity);
-  baselineSet(baseline, "standards", "duplication", standards.duplication);
-  baselineSet(baseline, "standards", "size", standards.size);
-  // P2: freeze the detected language's specific-linter findings too.
-  const { collectSpecificKeys, SPECIFIC_LANGUAGES } = await import("./check-standards-specific.js");
-  const { detectStack } = await import("./stack-detector.js");
-  const detectedLang = (await detectStack(process.cwd())).language;
-  let specificCount = 0;
-  if (SPECIFIC_LANGUAGES.includes(detectedLang)) {
-    const specificKeys = await collectSpecificKeys(process.cwd(), detectedLang);
-    baselineSet(baseline, "standards", `specific/${detectedLang}`, specificKeys);
-    specificCount = specificKeys.length;
-  }
-  // P3: freeze declarative-plugin matches for the detected language.
-  const { collectPluginKeys, DEFAULT_PLUGIN_DIR } = await import("./standards-plugins.js");
-  const freezeCfg = await loadConfig(resolveConfigPath()).catch(
-    () => ({}) as Awaited<ReturnType<typeof loadConfig>>,
-  );
-  const pluginDirs =
-    freezeCfg.standards?.plugins?.dirs && freezeCfg.standards.plugins.dirs.length > 0
-      ? freezeCfg.standards.plugins.dirs
-      : [DEFAULT_PLUGIN_DIR];
-  const { collectMjsPluginKeys } = await import("./standards-plugins-exec.js");
-  const pluginKeys = [
-    ...collectPluginKeys(process.cwd(), detectedLang, pluginDirs),
-    ...(await collectMjsPluginKeys(process.cwd(), detectedLang, pluginDirs)),
-  ];
-  baselineSet(baseline, "standards", "plugins", pluginKeys);
-  // P4: freeze container (platform) findings.
-  const { collectPlatformKeys } = await import("./check-standards-platform.js");
-  const platformKeys = await collectPlatformKeys(process.cwd());
-  baselineSet(baseline, "standards", "platform", platformKeys);
+  // All standards dimensions (general + specific + plugins + platform) via the shared helper.
+  const standardsTotal = await freezeStandardsBaseline(baseline, process.cwd());
   await saveBaseline(baseline);
-  const standardsTotal =
-    standards.complexity.length +
-    standards.duplication.length +
-    standards.size.length +
-    pluginKeys.length +
-    platformKeys.length +
-    specificCount;
   console.log(
     `${c.green}✓${c.reset} Wrote ${BASELINE_FILE} — ${untested.length} untested file(s), ${design.a11y.length} a11y, ${design.tokens.length} design-token, ${standardsTotal} standards finding(s) frozen.`,
   );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -658,11 +658,21 @@ async function cmdStandards(): Promise<boolean> {
   );
   const effectiveEnforce = enforce || config.standards?.enforce === true;
 
-  // `--category` scoping: default runs general + specific(detected). "general" or
-  // "specific" narrow the dimension; a language name narrows specific to that language.
+  // `--category` scoping: default runs general + specific(detected) + plugins.
+  // "general"/"specific"/"plugins" narrow the dimension; a language name narrows
+  // specific to that language.
   const langCategory = category && SPECIFIC_LANGUAGES.includes(category) ? category : undefined;
   const runGeneral = !category || category === "general";
   const runSpecific = !category || category === "specific" || !!langCategory;
+  const runPlugins = !category || category === "plugins";
+
+  // Detect the project language once — both the specific gate and the plugin
+  // `applies_to` filter key off it (a language name via --category overrides).
+  let language = langCategory;
+  if ((runSpecific || runPlugins) && !language) {
+    const { detectStack } = await import("./stack-detector.js");
+    language = (await detectStack(process.cwd())).language;
+  }
 
   const results: StandardsCheckResult[] = [];
 
@@ -691,12 +701,7 @@ async function cmdStandards(): Promise<boolean> {
     );
   }
 
-  if (runSpecific) {
-    let language = langCategory;
-    if (!language) {
-      const { detectStack } = await import("./stack-detector.js");
-      language = (await detectStack(process.cwd())).language;
-    }
+  if (runSpecific && language) {
     if (SPECIFIC_LANGUAGES.includes(language)) {
       const langCfg = (config.standards as Record<string, unknown> | undefined)?.[language] as
         | Record<string, boolean>
@@ -719,6 +724,33 @@ async function cmdStandards(): Promise<boolean> {
         detail: `no per-language standards gate for '${language}' yet (P2 covers ${SPECIFIC_LANGUAGES.join(", ")})`,
       });
     }
+  }
+
+  if (runPlugins && language) {
+    const { checkStandardsPlugins, DEFAULT_PLUGIN_DIR } = await import("./standards-plugins.js");
+    const { checkStandardsMjsPlugins } = await import("./standards-plugins-exec.js");
+    const pluginCfg = config.standards?.plugins;
+    const dirs =
+      pluginCfg?.dirs && pluginCfg.dirs.length > 0 ? pluginCfg.dirs : [DEFAULT_PLUGIN_DIR];
+    const pluginBaseline = baselineGet(baseline, "standards", "plugins");
+    // Declarative TOML rules (pure regex) + programmatic *.mjs (restricted child,
+    // determinism-verified). Both net-new-gate against the same baseline key.
+    results.push(
+      ...checkStandardsPlugins({
+        language,
+        enforce: effectiveEnforce,
+        dirs,
+        baseline: pluginBaseline,
+      }),
+    );
+    results.push(
+      ...(await checkStandardsMjsPlugins({
+        language,
+        enforce: effectiveEnforce,
+        dirs,
+        baseline: pluginBaseline,
+      })),
+    );
   }
 
   const ok = results.every((r) => r.status !== "fail");
@@ -831,11 +863,27 @@ async function cmdBaseline(): Promise<boolean> {
     baselineSet(baseline, "standards", `specific/${detectedLang}`, specificKeys);
     specificCount = specificKeys.length;
   }
+  // P3: freeze declarative-plugin matches for the detected language.
+  const { collectPluginKeys, DEFAULT_PLUGIN_DIR } = await import("./standards-plugins.js");
+  const freezeCfg = await loadConfig(resolveConfigPath()).catch(
+    () => ({}) as Awaited<ReturnType<typeof loadConfig>>,
+  );
+  const pluginDirs =
+    freezeCfg.standards?.plugins?.dirs && freezeCfg.standards.plugins.dirs.length > 0
+      ? freezeCfg.standards.plugins.dirs
+      : [DEFAULT_PLUGIN_DIR];
+  const { collectMjsPluginKeys } = await import("./standards-plugins-exec.js");
+  const pluginKeys = [
+    ...collectPluginKeys(process.cwd(), detectedLang, pluginDirs),
+    ...(await collectMjsPluginKeys(process.cwd(), detectedLang, pluginDirs)),
+  ];
+  baselineSet(baseline, "standards", "plugins", pluginKeys);
   await saveBaseline(baseline);
   const standardsTotal =
     standards.complexity.length +
     standards.duplication.length +
     standards.size.length +
+    pluginKeys.length +
     specificCount;
   console.log(
     `${c.green}✓${c.reset} Wrote ${BASELINE_FILE} — ${untested.length} untested file(s), ${design.a11y.length} a11y, ${design.tokens.length} design-token, ${standardsTotal} standards finding(s) frozen.`,
@@ -5510,7 +5558,7 @@ export const COMMAND_HELP: Record<string, string> = {
     "Signable org policy-as-code in .kit-policy.toml (init/show/validate/sign/verify/check/trust) — identity-signed standard, org-distributable + enforced offline (experimental)",
   design: "Check design quality (a11y, design tokens) against the baseline",
   standards:
-    "Dev-standards gate: general metrics (complexity/duplication/size) + per-language linters vs the baseline (--category general|specific|<lang>, --enforce fails CI)",
+    "Dev-standards gate: general metrics + per-language linters + user plugins vs the baseline (--category general|specific|plugins|<lang>, --enforce fails CI)",
   baseline:
     "Freeze current warnings into .kit-baseline.json so future runs gate only net-new findings",
   memory: "Local conversation memory — index transcripts + show stats",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -665,6 +665,7 @@ async function cmdStandards(): Promise<boolean> {
   const runGeneral = !category || category === "general";
   const runSpecific = !category || category === "specific" || !!langCategory;
   const runPlugins = !category || category === "plugins";
+  const runPlatform = !category || category === "platform";
 
   // Detect the project language once — both the specific gate and the plugin
   // `applies_to` filter key off it (a language name via --category overrides).
@@ -753,13 +754,23 @@ async function cmdStandards(): Promise<boolean> {
     );
   }
 
+  if (runPlatform) {
+    const { checkStandardsPlatform } = await import("./check-standards-platform.js");
+    results.push(
+      ...(await checkStandardsPlatform({
+        enforce: effectiveEnforce,
+        baseline: baselineGet(baseline, "standards", "platform"),
+      })),
+    );
+  }
+
   const ok = results.every((r) => r.status !== "fail");
   if (jsonMode) {
     console.log(JSON.stringify({ ok, checks: results }, null, 2));
     return ok;
   }
   console.log(
-    `${c.bold}Standards${c.reset} ${c.dim}(general + per-language — deterministic, zero-LLM)${c.reset}`,
+    `${c.bold}Standards${c.reset} ${c.dim}(general + per-language + plugins + platform — deterministic, zero-LLM)${c.reset}`,
   );
   for (const r of results) {
     const icon =
@@ -878,12 +889,17 @@ async function cmdBaseline(): Promise<boolean> {
     ...(await collectMjsPluginKeys(process.cwd(), detectedLang, pluginDirs)),
   ];
   baselineSet(baseline, "standards", "plugins", pluginKeys);
+  // P4: freeze container (platform) findings.
+  const { collectPlatformKeys } = await import("./check-standards-platform.js");
+  const platformKeys = await collectPlatformKeys(process.cwd());
+  baselineSet(baseline, "standards", "platform", platformKeys);
   await saveBaseline(baseline);
   const standardsTotal =
     standards.complexity.length +
     standards.duplication.length +
     standards.size.length +
     pluginKeys.length +
+    platformKeys.length +
     specificCount;
   console.log(
     `${c.green}✓${c.reset} Wrote ${BASELINE_FILE} — ${untested.length} untested file(s), ${design.a11y.length} a11y, ${design.tokens.length} design-token, ${standardsTotal} standards finding(s) frozen.`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -411,6 +411,8 @@ export interface kitConfig {
     python?: Record<string, boolean>;
     go?: Record<string, boolean>;
     rust?: Record<string, boolean>;
+    /** P3 user-defined plugins: local discovery dirs + published org packages. */
+    plugins?: { dirs?: string[]; packages?: string[] };
   };
 }
 
@@ -693,6 +695,13 @@ export const kitConfigSchema = z
         python: z.record(z.string(), z.boolean()).optional(),
         go: z.record(z.string(), z.boolean()).optional(),
         rust: z.record(z.string(), z.boolean()).optional(),
+        plugins: z
+          .object({
+            dirs: z.array(z.string()).optional(),
+            packages: z.array(z.string()).optional(),
+          })
+          .passthrough()
+          .optional(),
       })
       .passthrough()
       .optional(),

--- a/src/mcp-server.test.ts
+++ b/src/mcp-server.test.ts
@@ -65,6 +65,7 @@ describe("MCP server tool registration", () => {
       const { tools } = await client.listTools();
       const names = tools.map((t) => t.name);
       assert.ok(names.includes("kit_check"), "kit_check missing");
+      assert.ok(names.includes("kit_standards"), "kit_standards missing");
       assert.ok(names.includes("kit_install"), "kit_install missing");
       assert.ok(names.includes("kit_login"), "kit_login missing");
       assert.ok(names.includes("kit_secrets"), "kit_secrets missing");
@@ -81,7 +82,7 @@ describe("MCP server tool registration", () => {
       assert.ok(names.includes("kit_agent_governance"), "kit_agent_governance missing");
       assert.ok(names.includes("kit_skill_marketplace"), "kit_skill_marketplace missing");
       assert.ok(names.includes("kit_workflow_execute"), "kit_workflow_execute missing");
-      assert.equal(tools.length, 17);
+      assert.equal(tools.length, 18);
     } finally {
       await cleanup();
     }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -45,6 +45,7 @@ const KIT_FILE = ".kit.toml";
 // this list, so the snapshot can never silently drift.
 export const KIT_MCP_TOOLS: readonly string[] = [
   "kit_check",
+  "kit_standards",
   "kit_install",
   "kit_login",
   "kit_secrets",
@@ -116,6 +117,7 @@ export function createMcpServer(): McpServer {
   // One registrar per tool — keeps this composition flat (was a 774-line
   // function). Each register_* attaches its tool to the server.
   register_kit_check(server);
+  register_kit_standards(server);
   register_kit_install(server);
   register_kit_login(server);
   register_kit_secrets(server);
@@ -220,6 +222,50 @@ function register_kit_check(server: McpServer): void {
                 null,
                 2,
               ),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function register_kit_standards(server: McpServer): void {
+  // kit_standards — run the dev-standards gate (general + per-language + plugins +
+  // platform) and return the SAME { ok, checks, summary } envelope as `kit standards`.
+  // Read-only: no writes, so no governance/read-only gating.
+  server.tool(
+    "kit_standards",
+    "Run kit standards (deterministic dev-standards gate: complexity/duplication/size + per-language linters + user plugins + container) and return structured findings. Read-only.",
+    {
+      cwd: z.string().optional().describe("Working directory (defaults to process.cwd())"),
+      enforce: z
+        .boolean()
+        .optional()
+        .describe("Fail on net-new findings AND setup gaps (CI posture)"),
+      category: z
+        .string()
+        .optional()
+        .describe("Scope: general | specific | plugins | platform | <language>"),
+    },
+    async ({ cwd, enforce, category }) => {
+      try {
+        const { runStandardsGate } = await import("./standards-run.js");
+        const { ok, checks, summary, baselineIgnored } = await runStandardsGate({
+          cwd,
+          enforce,
+          category,
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ ok, checks, summary, baselineIgnored }, null, 2),
             },
           ],
         };

--- a/src/self-audit.ts
+++ b/src/self-audit.ts
@@ -664,6 +664,7 @@ const R7: SelfAuditRule = {
 // test in self-audit.test.ts.
 export const READ_ONLY_SAFE = new Set<string>([
   "kit_check",
+  "kit_standards",
   "kit_env",
   "kit_ci",
   "kit_context",

--- a/src/standards-plugins-exec.test.ts
+++ b/src/standards-plugins-exec.test.ts
@@ -1,0 +1,172 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  checkStandardsMjsPlugins,
+  runMjsPlugins,
+  collectMjsPluginKeys,
+} from "./standards-plugins-exec.js";
+import { DEFAULT_PLUGIN_DIR, pluginKey } from "./standards-plugins.js";
+
+function tmpRepo(): string {
+  return mkdtempSync(join(tmpdir(), "kit-mjs-"));
+}
+function writeMjs(repo: string, name: string, body: string): void {
+  const dir = join(repo, DEFAULT_PLUGIN_DIR);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, name), body);
+}
+
+describe("standards-plugins-exec — programmatic mjs (restricted child)", () => {
+  it("runs a deterministic plugin and surfaces its findings (net-new gated)", async () => {
+    const repo = tmpRepo();
+    try {
+      writeMjs(
+        repo,
+        "p.mjs",
+        `export const id = "my-rule";
+export const title = "My rule";
+export function evaluate(ctx) {
+  return { findings: [{ file: "src/a.ts", line: 5, message: "nope" }] };
+}`,
+      );
+      const r = await checkStandardsMjsPlugins({
+        cwd: repo,
+        language: "typescript",
+        enforce: false,
+        dirs: [DEFAULT_PLUGIN_DIR],
+      });
+      assert.equal(r.length, 1);
+      assert.equal(r[0].name, "plugin: my-rule");
+      assert.equal(r[0].status, "warn");
+      assert.match(r[0].files?.[0] ?? "", /src\/a\.ts:5/);
+
+      // baseline the finding → frozen low warn
+      const frozen = await checkStandardsMjsPlugins({
+        cwd: repo,
+        language: "typescript",
+        dirs: [DEFAULT_PLUGIN_DIR],
+        baseline: [pluginKey("my-rule", "src/a.ts", 5)],
+      });
+      assert.equal(frozen[0].status, "warn");
+      assert.equal(frozen[0].severity, "low");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("severity=fail makes net-new findings fail without --enforce", async () => {
+    const repo = tmpRepo();
+    try {
+      writeMjs(
+        repo,
+        "p.mjs",
+        `export function evaluate() {
+  return { id: "hard", title: "Hard rule", severity: "fail", findings: [{ file: "x.ts", line: 1 }] };
+}`,
+      );
+      const r = await checkStandardsMjsPlugins({
+        cwd: repo,
+        language: "typescript",
+        dirs: [DEFAULT_PLUGIN_DIR],
+      });
+      assert.equal(r[0].status, "fail");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("REJECTS a non-deterministic plugin (two runs differ → integrity warn)", async () => {
+    const repo = tmpRepo();
+    try {
+      writeMjs(
+        repo,
+        "flaky.mjs",
+        `export function evaluate() {
+  const n = Math.floor(Math.random() * 1e9);
+  return { id: "flaky", title: "Flaky", findings: [{ file: "f.ts", line: n }] };
+}`,
+      );
+      const runs = await runMjsPlugins(repo, [DEFAULT_PLUGIN_DIR], "typescript");
+      assert.equal(runs.length, 1);
+      assert.ok(runs[0].integrity, "flaky plugin flagged as integrity failure");
+      assert.match(runs[0].integrity?.detail ?? "", /non-deterministic/);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("runs with a STRIPPED env — the plugin cannot see a secret var", async () => {
+    const repo = tmpRepo();
+    const prev = process.env.KIT_MEMORY_PASSPHRASE;
+    process.env.KIT_MEMORY_PASSPHRASE = "super-secret-value-xyz";
+    try {
+      writeMjs(
+        repo,
+        "leak.mjs",
+        `export function evaluate() {
+  const leaked = process.env.KIT_MEMORY_PASSPHRASE ? "LEAKED" : "clean";
+  return { id: "envcheck", title: "env check", findings: [{ file: leaked + ".ts", line: 1 }] };
+}`,
+      );
+      const r = await checkStandardsMjsPlugins({
+        cwd: repo,
+        language: "typescript",
+        dirs: [DEFAULT_PLUGIN_DIR],
+      });
+      // the child never saw the secret → filename encodes "clean", never "LEAKED"
+      assert.match(r[0].files?.[0] ?? "", /clean\.ts/);
+      assert.doesNotMatch(r[0].files?.[0] ?? "", /LEAKED/);
+    } finally {
+      if (prev === undefined) delete process.env.KIT_MEMORY_PASSPHRASE;
+      else process.env.KIT_MEMORY_PASSPHRASE = prev;
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed on malformed output (schema) and on a missing evaluate export", async () => {
+    const repo = tmpRepo();
+    try {
+      writeMjs(
+        repo,
+        "bad.mjs",
+        `export function evaluate() { return { findings: "not-an-array" }; }`,
+      );
+      writeMjs(repo, "noeval.mjs", `export const notEvaluate = 1;`);
+      const runs = await runMjsPlugins(repo, [DEFAULT_PLUGIN_DIR], "typescript");
+      assert.equal(runs.length, 2);
+      assert.ok(
+        runs.every((run) => run.integrity),
+        "both flagged as integrity failures",
+      );
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("applies_to filters by language; collectMjsPluginKeys snapshots matches", async () => {
+    const repo = tmpRepo();
+    try {
+      writeMjs(
+        repo,
+        "py.mjs",
+        `export function evaluate() {
+  return { id: "py-only", title: "py", appliesTo: ["python"], findings: [{ file: "a.py", line: 3 }] };
+}`,
+      );
+      const filtered = await checkStandardsMjsPlugins({
+        cwd: repo,
+        language: "typescript",
+        dirs: [DEFAULT_PLUGIN_DIR],
+      });
+      assert.equal(filtered.length, 0); // applies_to excludes typescript
+
+      const keys = await collectMjsPluginKeys(repo, "python", [DEFAULT_PLUGIN_DIR]);
+      assert.deepEqual(keys, [pluginKey("py-only", "a.py", 3)]);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/standards-plugins-exec.ts
+++ b/src/standards-plugins-exec.ts
@@ -1,0 +1,303 @@
+/**
+ * kit standards — P3 (programmatic): `*.mjs` plugins in a restricted context.
+ *
+ * A declarative TOML rule can't express everything, so a plugin may instead be an
+ * ES module exporting `evaluate(ctx)` (plus `id` / `title` / `severity` / `appliesTo`
+ * metadata). Because that is arbitrary code, it runs under a deliberately narrow
+ * contract:
+ *
+ *   - RESTRICTED CONTEXT: executed in a fresh `node` child process with a stripped
+ *     env (an ALLOWLIST — PATH/HOME/lang only; NO secret-shaped vars ever), so a
+ *     plugin can't read the operator's credentials. Stricter than the sync
+ *     transport's deny-list, because this is code, not a fixed command.
+ *   - HARD TIMEOUT: a hung/infinite plugin is killed, not the gate.
+ *   - DETERMINISM VERIFY: kit runs the plugin TWICE and rejects it (integrity warn)
+ *     if the two outputs differ — a standards gate must be a pure function of the
+ *     repo. This is the same determinism discipline validated on `kit check`.
+ *   - SCHEMA VALIDATED: the plugin's output is parsed against a fixed schema; a
+ *     malformed result fails closed (ignored + integrity warn), never crashes.
+ *
+ * Honest scope note: env-stripping + child isolation + determinism + schema is the
+ * bar the plan sets ("same env-stripping as the sync transport"). Node cannot block
+ * outbound network from a plain child, so a plugin still runs with roughly the trust
+ * of a dev dependency / npm script — it is code the repo owner placed in the tree.
+ * Treat third-party standards plugins with the same care as any dependency.
+ *
+ * The child harness (HARNESS below) imports the plugin, calls `evaluate(ctx)`, and
+ * prints a single JSON line. kit only ever sees that JSON — the plugin's module
+ * scope never touches kit's process.
+ */
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative, resolve } from "node:path";
+import { z } from "zod";
+import { walkSourceFiles } from "./source-walk.js";
+import { execFileNoThrow } from "./utils/execFileNoThrow.js";
+import { pluginKey } from "./standards-plugins.js";
+import type { StandardsCheckResult } from "./check-standards.js";
+
+/** Env vars the plugin child is allowed to see — everything else (incl. all secrets) is dropped. */
+const ENV_ALLOWLIST = ["PATH", "HOME", "LANG", "LC_ALL", "TMPDIR", "NODE_PATH"];
+
+/** Per-plugin wall-clock budget. */
+const PLUGIN_TIMEOUT_MS = 15_000;
+
+const outputSchema = z
+  .object({
+    id: z.string().regex(/^[a-z0-9][a-z0-9-]*$/),
+    title: z.string().min(1),
+    severity: z.enum(["warn", "fail"]).optional(),
+    appliesTo: z.array(z.string()).optional(),
+    findings: z
+      .array(
+        z.object({
+          file: z.string().min(1),
+          line: z.number().int().positive().optional(),
+          message: z.string().optional(),
+        }),
+      )
+      .max(10_000),
+  })
+  .strict();
+
+export type PluginOutput = z.infer<typeof outputSchema>;
+
+// The child harness. It imports the plugin as an ES module, calls evaluate(ctx),
+// normalizes the result, and prints ONE JSON line prefixed with a sentinel so kit
+// can ignore any incidental stdout the plugin emitted.
+const SENTINEL = "__KIT_STD_PLUGIN__";
+const HARNESS = `
+import { pathToFileURL } from "node:url";
+const [pluginPath, ctxJson] = process.argv.slice(2);
+const ctx = JSON.parse(ctxJson);
+const mod = await import(pathToFileURL(pluginPath).href);
+const evaluate = mod.evaluate ?? mod.default;
+if (typeof evaluate !== "function") {
+  console.error("plugin has no evaluate(ctx) export");
+  process.exit(3);
+}
+const raw = await evaluate(ctx);
+const findings = Array.isArray(raw) ? raw : (raw && raw.findings) || [];
+const out = {
+  id: (raw && raw.id) || mod.id || ctx.defaultId,
+  title: (raw && raw.title) || mod.title || ctx.defaultId,
+  severity: (raw && raw.severity) || mod.severity,
+  appliesTo: (raw && raw.appliesTo) || mod.appliesTo,
+  findings: findings.map((f) => ({ file: String(f.file), line: f.line, message: f.message })),
+};
+process.stdout.write("${SENTINEL}" + JSON.stringify(out) + "\\n");
+`;
+
+/** Extract the sentinel JSON line from possibly-noisy child stdout. */
+function extractOutput(stdout: string): unknown {
+  const line = stdout.split("\n").find((l) => l.startsWith(SENTINEL));
+  if (!line) throw new Error("plugin produced no result line");
+  return JSON.parse(line.slice(SENTINEL.length));
+}
+
+function strippedEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const k of ENV_ALLOWLIST) {
+    if (process.env[k] !== undefined) env[k] = process.env[k];
+  }
+  return env;
+}
+
+/** Run one mjs plugin once in the restricted child; returns validated output. Throws on any failure. */
+async function runOnce(
+  cwd: string,
+  pluginPath: string,
+  language: string,
+  harnessPath: string,
+): Promise<PluginOutput> {
+  const defaultId = pluginBaseName(pluginPath);
+  const ctx = JSON.stringify({ cwd, language, defaultId });
+  const res = await execFileNoThrow(process.execPath, [harnessPath, pluginPath, ctx], {
+    timeout: PLUGIN_TIMEOUT_MS,
+    env: strippedEnv(),
+    cwd,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  if (!res.ok && !res.stdout.includes(SENTINEL)) {
+    throw new Error(res.stderr.trim().split("\n").slice(-1)[0] || `exited ${res.exitCode}`);
+  }
+  const parsed = outputSchema.safeParse(extractOutput(res.stdout));
+  if (!parsed.success) throw new Error(parsed.error.issues[0]?.message ?? "invalid output shape");
+  return parsed.data;
+}
+
+function pluginBaseName(p: string): string {
+  return (
+    p
+      .split(/[/\\]/)
+      .pop()
+      ?.replace(/\.mjs$/, "") ?? "plugin"
+  );
+}
+
+/** Deterministic comparison of two plugin runs (order-insensitive on findings). */
+function sameOutput(a: PluginOutput, b: PluginOutput): boolean {
+  if (a.id !== b.id || a.title !== b.title || a.severity !== b.severity) return false;
+  const norm = (o: PluginOutput) =>
+    o.findings
+      .map((f) => `${f.file}:${f.line ?? ""}:${f.message ?? ""}`)
+      .sort()
+      .join("|");
+  return norm(a) === norm(b);
+}
+
+function integrityWarn(source: string, reason: string): StandardsCheckResult {
+  return {
+    category: "standards",
+    dimension: "plugin",
+    name: `plugin integrity: ${source}`,
+    status: "warn",
+    severity: "low",
+    detail: `ignored programmatic standards plugin — ${reason}`,
+  };
+}
+
+export interface MjsPluginRun {
+  source: string;
+  output?: PluginOutput;
+  integrity?: StandardsCheckResult;
+}
+
+/** Discover + run every `*.mjs` plugin under `dirs`, each TWICE for determinism. */
+export async function runMjsPlugins(
+  cwd: string,
+  dirs: string[],
+  language: string,
+): Promise<MjsPluginRun[]> {
+  const runs: MjsPluginRun[] = [];
+  const tmp = mkdtempSync(join(tmpdir(), "kit-std-plugin-"));
+  const harnessPath = join(tmp, "harness.mjs");
+  try {
+    writeFileSync(harnessPath, HARNESS, { mode: 0o600 });
+    for (const dir of dirs) {
+      const abs = join(cwd, dir);
+      if (!existsSync(abs)) continue;
+      let files: string[];
+      try {
+        files = walkSourceFiles(abs, { exts: [".mjs"], includeTests: true });
+      } catch {
+        continue;
+      }
+      for (const file of files) {
+        const source = relative(cwd, file);
+        try {
+          const first = await runOnce(cwd, resolve(file), language, harnessPath);
+          const second = await runOnce(cwd, resolve(file), language, harnessPath);
+          if (!sameOutput(first, second)) {
+            runs.push({
+              source,
+              integrity: integrityWarn(
+                source,
+                "non-deterministic: two runs produced different output (a gate must be a pure function of the repo)",
+              ),
+            });
+            continue;
+          }
+          runs.push({ source, output: first });
+        } catch (e) {
+          runs.push({ source, integrity: integrityWarn(source, (e as Error).message) });
+        }
+      }
+    }
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+  return runs;
+}
+
+/** Map a validated plugin output → net-new-gated StandardsCheckResult. */
+export function resultFromOutput(
+  out: PluginOutput,
+  enforce: boolean,
+  seen: Set<string>,
+): StandardsCheckResult {
+  // A finding without a line can't be keyed per-line; key it by file (line 0) so it
+  // stays baseline-able alongside line-anchored findings.
+  const allKeys = out.findings.map((f) => pluginKey(out.id, f.file, f.line ?? 0));
+  const fresh = allKeys.filter((k) => !seen.has(k));
+  const name = `plugin: ${out.id}`;
+  const gates = enforce || out.severity === "fail";
+  if (out.findings.length === 0) {
+    return {
+      category: "standards",
+      dimension: "plugin",
+      name,
+      status: "pass",
+      detail: `${out.title} — no matches`,
+    };
+  }
+  if (fresh.length === 0) {
+    return {
+      category: "standards",
+      dimension: "plugin",
+      name,
+      status: "warn",
+      severity: "low",
+      detail: `${out.findings.length} pre-existing match(es) (baseline-frozen)`,
+    };
+  }
+  return {
+    category: "standards",
+    dimension: "plugin",
+    name,
+    status: gates ? "fail" : "warn",
+    severity: gates ? "high" : "medium",
+    detail: `${out.title} — ${fresh.length} new match(es) (${out.findings.length} total)`,
+    files: out.findings
+      .slice(0, 10)
+      .map((f) => `${f.file}${f.line ? `:${f.line}` : ""}${f.message ? ` ${f.message}` : ""}`),
+  };
+}
+
+export interface CheckMjsOptions {
+  cwd?: string;
+  language: string;
+  enforce?: boolean;
+  dirs: string[];
+  baseline?: string[];
+}
+
+/** Evaluate every applicable programmatic plugin → StandardsCheckResult[]. */
+export async function checkStandardsMjsPlugins(
+  opts: CheckMjsOptions,
+): Promise<StandardsCheckResult[]> {
+  const cwd = opts.cwd ?? process.cwd();
+  const enforce = opts.enforce ?? false;
+  const seen = new Set(opts.baseline ?? []);
+  const runs = await runMjsPlugins(cwd, opts.dirs, opts.language);
+  const results: StandardsCheckResult[] = [];
+  for (const run of runs) {
+    if (run.integrity) {
+      results.push(run.integrity);
+      continue;
+    }
+    const out = run.output;
+    if (!out) continue;
+    if (out.appliesTo && out.appliesTo.length > 0 && !out.appliesTo.includes(opts.language))
+      continue;
+    results.push(resultFromOutput(out, enforce, seen));
+  }
+  return results;
+}
+
+/** Snapshot programmatic-plugin matches for `kit baseline freeze`. */
+export async function collectMjsPluginKeys(
+  cwd: string,
+  language: string,
+  dirs: string[],
+): Promise<string[]> {
+  const runs = await runMjsPlugins(cwd, dirs, language);
+  const keys: string[] = [];
+  for (const run of runs) {
+    const out = run.output;
+    if (!out) continue;
+    if (out.appliesTo && out.appliesTo.length > 0 && !out.appliesTo.includes(language)) continue;
+    for (const f of out.findings) keys.push(pluginKey(out.id, f.file, f.line ?? 0));
+  }
+  return keys;
+}

--- a/src/standards-plugins.test.ts
+++ b/src/standards-plugins.test.ts
@@ -1,0 +1,186 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  globToRegExp,
+  loadStandardPlugins,
+  evaluatePluginFindings,
+  checkStandardsPlugins,
+  collectPluginKeys,
+  pluginKey,
+  DEFAULT_PLUGIN_DIR,
+} from "./standards-plugins.js";
+
+function tmpRepo(): string {
+  return mkdtempSync(join(tmpdir(), "kit-splugin-"));
+}
+function writePlugin(repo: string, name: string, toml: string): void {
+  const dir = join(repo, DEFAULT_PLUGIN_DIR);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, name), toml);
+}
+
+describe("standards-plugins — globToRegExp", () => {
+  it("handles **, *, and literal segments", () => {
+    assert.ok(globToRegExp("**/*.test.ts").test("src/deep/a.test.ts"));
+    assert.ok(globToRegExp("scripts/**").test("scripts/x/y.ts"));
+    assert.ok(globToRegExp("*.md").test("README.md"));
+    assert.ok(!globToRegExp("*.md").test("docs/README.md")); // * doesn't cross /
+  });
+});
+
+describe("standards-plugins — loadStandardPlugins (fail-closed)", () => {
+  it("loads a valid plugin", () => {
+    const repo = tmpRepo();
+    try {
+      writePlugin(
+        repo,
+        "no-console.toml",
+        `[standard]
+id = "no-console"
+title = "No console.log"
+applies_to = ["typescript"]
+match = 'console\\.log'
+`,
+      );
+      const { plugins, integrity } = loadStandardPlugins(repo, [DEFAULT_PLUGIN_DIR]);
+      assert.equal(integrity.length, 0);
+      assert.equal(plugins.length, 1);
+      assert.equal(plugins[0].id, "no-console");
+      assert.equal(plugins[0].severity, "warn");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores malformed TOML / schema violations / bad regex with an integrity warn (never throws)", () => {
+    const repo = tmpRepo();
+    try {
+      writePlugin(repo, "broken.toml", "this is not = valid = toml ===");
+      writePlugin(repo, "noid.toml", `[standard]\ntitle = "x"\nmatch = "y"\n`); // missing id
+      writePlugin(
+        repo,
+        "badre.toml",
+        `[standard]\nid = "bad-re"\ntitle = "x"\nmatch = "("\n`, // unbalanced regex
+      );
+      writePlugin(
+        repo,
+        "unknownkey.toml",
+        `[standard]\nid = "unk"\ntitle = "x"\nmatch = "y"\nbogus = true\n`, // strict schema rejects
+      );
+      const { plugins, integrity } = loadStandardPlugins(repo, [DEFAULT_PLUGIN_DIR]);
+      assert.equal(plugins.length, 0);
+      assert.equal(integrity.length, 4);
+      assert.ok(integrity.every((i) => i.status === "warn" && i.dimension === "plugin"));
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects duplicate plugin ids", () => {
+    const repo = tmpRepo();
+    try {
+      writePlugin(repo, "a.toml", `[standard]\nid = "dup"\ntitle = "A"\nmatch = "a"\n`);
+      writePlugin(repo, "b.toml", `[standard]\nid = "dup"\ntitle = "B"\nmatch = "b"\n`);
+      const { plugins, integrity } = loadStandardPlugins(repo, [DEFAULT_PLUGIN_DIR]);
+      assert.equal(plugins.length, 1);
+      assert.ok(integrity.some((i) => /duplicate plugin id/.test(i.detail)));
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("standards-plugins — evaluate + gate", () => {
+  function repoWithSource(): string {
+    const repo = tmpRepo();
+    mkdirSync(join(repo, "src"), { recursive: true });
+    writeFileSync(join(repo, "src", "a.ts"), "const x = 1;\nconsole.log(x);\n");
+    writeFileSync(join(repo, "src", "a.test.ts"), "console.log('in test');\n");
+    return repo;
+  }
+
+  it("matches the regex over source files, honoring exclude globs", () => {
+    const repo = repoWithSource();
+    try {
+      writePlugin(
+        repo,
+        "nc.toml",
+        `[standard]\nid = "nc"\ntitle = "No console"\nmatch = 'console\\.log'\nexclude = ["**/*.test.ts"]\n`,
+      );
+      const { plugins } = loadStandardPlugins(repo, [DEFAULT_PLUGIN_DIR]);
+      const findings = evaluatePluginFindings(repo, plugins[0]);
+      assert.equal(findings.length, 1);
+      assert.equal(findings[0].file, "src/a.ts");
+      assert.equal(findings[0].line, 2);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("applies_to filters out non-matching languages", () => {
+    const repo = repoWithSource();
+    try {
+      writePlugin(
+        repo,
+        "nc.toml",
+        `[standard]\nid = "nc"\ntitle = "No console"\napplies_to = ["python"]\nmatch = 'console\\.log'\n`,
+      );
+      const r = checkStandardsPlugins({ cwd: repo, language: "typescript" });
+      assert.equal(r.length, 0); // skipped: applies_to excludes typescript
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("warns net-new by default, fails when severity=fail, frozen→low warn via baseline", () => {
+    const repo = repoWithSource();
+    try {
+      writePlugin(
+        repo,
+        "nc.toml",
+        `[standard]\nid = "nc"\ntitle = "No console"\nseverity = "fail"\nmatch = 'console\\.log'\nexclude = ["**/*.test.ts"]\n`,
+      );
+      // severity=fail → net-new fails even without --enforce
+      const failing = checkStandardsPlugins({ cwd: repo, language: "typescript" });
+      assert.equal(failing[0].status, "fail");
+
+      // baseline the finding → frozen low warn
+      const frozen = checkStandardsPlugins({
+        cwd: repo,
+        language: "typescript",
+        baseline: [pluginKey("nc", "src/a.ts", 2)],
+      });
+      assert.equal(frozen[0].status, "warn");
+      assert.equal(frozen[0].severity, "low");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("collectPluginKeys snapshots current matches", () => {
+    const repo = repoWithSource();
+    try {
+      writePlugin(
+        repo,
+        "nc.toml",
+        `[standard]\nid = "nc"\ntitle = "No console"\nmatch = 'console\\.log'\nexclude = ["**/*.test.ts"]\n`,
+      );
+      const keys = collectPluginKeys(repo, "typescript");
+      assert.deepEqual(keys, [pluginKey("nc", "src/a.ts", 2)]);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("no plugin dir → no results (opt-in)", () => {
+    const repo = tmpRepo();
+    try {
+      assert.deepEqual(checkStandardsPlugins({ cwd: repo, language: "typescript" }), []);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/standards-plugins.ts
+++ b/src/standards-plugins.ts
@@ -1,0 +1,332 @@
+/**
+ * kit standards — P3: user-defined plugins (the subjective / org-specific rules).
+ *
+ * kit ships NO opinionated standards; a team encodes "our way" as plugins that
+ * follow a fixed, deterministic contract. This module covers the DECLARATIVE case
+ * (the common one): a TOML file describing a ripgrep-style rule.
+ *
+ *   # .kit/standards.d/no-console.toml
+ *   [standard]
+ *   id = "no-console-in-src"
+ *   title = "No console.* in shipped code"
+ *   applies_to = ["typescript"]     # language gate (omit ⇒ all languages)
+ *   severity = "warn"               # warn | fail  (fail = author opts into gating)
+ *   match = 'console\.(log|debug)\('
+ *   exclude = ["scripts/", "test fixtures"]   # glob patterns, matched on the rel path
+ *
+ * Security / determinism (reusing patterns already shipped):
+ *   - Schema-validated at load; a malformed plugin FAILS CLOSED — it is ignored and
+ *     surfaces a `plugin integrity` warning, never crashing the gate (the lesson from
+ *     the .kit-baseline.json crash fix).
+ *   - Deterministic by construction: a regex over the repo's own files is a pure
+ *     function of the repo. Line length is capped to bound pathological regexes.
+ *   - Net-new gating on stable `plugin/<id>:<file>:<line>` keys, same as every other
+ *     standards dimension.
+ *
+ * Programmatic (*.mjs) plugins are handled separately (standards-plugins-exec.ts).
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { parse as parseToml } from "smol-toml";
+import { z } from "zod";
+import { walkSourceFiles } from "./source-walk.js";
+import type { StandardsCheckResult } from "./check-standards.js";
+
+/** Default discovery directory (overridable via [standards.plugins].dirs). */
+export const DEFAULT_PLUGIN_DIR = ".kit/standards.d";
+
+/** Source extensions a declarative plugin scans when it doesn't specify its own. */
+const DEFAULT_PLUGIN_EXTS = [
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+  ".py",
+  ".go",
+  ".rs",
+  ".rb",
+  ".php",
+  ".java",
+  ".kt",
+  ".c",
+  ".h",
+  ".cc",
+  ".cpp",
+  ".cs",
+];
+
+/** Longest line a plugin regex is run against — bounds a pathological (ReDoS) pattern. */
+const MAX_LINE_LEN = 2000;
+
+const pluginSchema = z
+  .object({
+    standard: z
+      .object({
+        id: z
+          .string()
+          .min(1)
+          .regex(/^[a-z0-9][a-z0-9-]*$/, "id must be kebab-case (a-z, 0-9, -)"),
+        title: z.string().min(1),
+        applies_to: z.array(z.string()).optional(),
+        kind: z.enum(["general", "specific"]).optional(),
+        severity: z.enum(["warn", "fail"]).optional(),
+        match: z.string().min(1),
+        exclude: z.array(z.string()).optional(),
+        include_tests: z.boolean().optional(),
+        exts: z.array(z.string()).optional(),
+      })
+      .strict(), // reject unknown keys so a typo'd rule fails loudly, not silently
+  })
+  .strict();
+
+export interface StandardPluginSpec {
+  id: string;
+  title: string;
+  appliesTo?: string[];
+  severity: "warn" | "fail";
+  match: string;
+  exclude: string[];
+  includeTests: boolean;
+  exts: string[];
+  /** Source file the plugin was loaded from (for diagnostics). */
+  source: string;
+}
+
+/** Stable baseline key for a plugin finding. */
+export const pluginKey = (id: string, file: string, line: number): string =>
+  `plugin/${id}:${file}:${line}`;
+
+export interface LoadPluginsResult {
+  plugins: StandardPluginSpec[];
+  /** Fail-closed diagnostics for malformed plugins (already StandardsCheckResults). */
+  integrity: StandardsCheckResult[];
+}
+
+function integrityWarn(source: string, reason: string): StandardsCheckResult {
+  return {
+    category: "standards",
+    dimension: "plugin",
+    name: `plugin integrity: ${source}`,
+    status: "warn",
+    severity: "low",
+    detail: `ignored malformed standards plugin — ${reason}`,
+  };
+}
+
+/**
+ * Load + validate every declarative plugin under `dirs`. Never throws: a malformed
+ * plugin becomes an integrity warning and is skipped. A bad `match` regex is caught
+ * at load (compiled here) so evaluation can't blow up later.
+ */
+export function loadStandardPlugins(cwd: string, dirs: string[]): LoadPluginsResult {
+  const plugins: StandardPluginSpec[] = [];
+  const integrity: StandardsCheckResult[] = [];
+  for (const dir of dirs) {
+    const abs = join(cwd, dir);
+    if (!existsSync(abs)) continue;
+    let files: string[];
+    try {
+      files = walkSourceFiles(abs, { exts: [".toml"], includeTests: true });
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      const rel = relative(cwd, file);
+      let raw: unknown;
+      try {
+        raw = parseToml(readFileSync(file, "utf8"));
+      } catch (e) {
+        integrity.push(integrityWarn(rel, `invalid TOML (${(e as Error).message})`));
+        continue;
+      }
+      const parsed = pluginSchema.safeParse(raw);
+      if (!parsed.success) {
+        integrity.push(integrityWarn(rel, parsed.error.issues[0]?.message ?? "schema mismatch"));
+        continue;
+      }
+      const s = parsed.data.standard;
+      // Compile the regex now so a bad pattern is a load-time integrity warning.
+      try {
+        new RegExp(s.match);
+      } catch (e) {
+        integrity.push(integrityWarn(rel, `invalid match regex (${(e as Error).message})`));
+        continue;
+      }
+      plugins.push({
+        id: s.id,
+        title: s.title,
+        appliesTo: s.applies_to,
+        severity: s.severity ?? "warn",
+        match: s.match,
+        exclude: s.exclude ?? [],
+        includeTests: s.include_tests ?? false,
+        exts: s.exts ?? DEFAULT_PLUGIN_EXTS,
+        source: rel,
+      });
+    }
+  }
+  // Reject duplicate ids (two plugins with the same id → ambiguous baseline keys).
+  const byId = new Map<string, StandardPluginSpec>();
+  for (const p of plugins) {
+    const prior = byId.get(p.id);
+    if (prior) {
+      integrity.push(
+        integrityWarn(
+          p.source,
+          `duplicate plugin id '${p.id}' (already defined in ${prior.source})`,
+        ),
+      );
+      continue;
+    }
+    byId.set(p.id, p);
+  }
+  return { plugins: [...byId.values()], integrity };
+}
+
+/** Minimal glob → RegExp: supports `**`, `*`, `?` and literal path segments. */
+export function globToRegExp(glob: string): RegExp {
+  let re = "";
+  for (let i = 0; i < glob.length; i++) {
+    const ch = glob[i];
+    if (ch === "*") {
+      if (glob[i + 1] === "*") {
+        re += ".*";
+        i++;
+        if (glob[i + 1] === "/") i++; // `**/` matches zero or more dirs
+      } else {
+        re += "[^/]*";
+      }
+    } else if (ch === "?") {
+      re += "[^/]";
+    } else if (".+^${}()|[]\\".includes(ch)) {
+      re += `\\${ch}`;
+    } else {
+      re += ch;
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
+function isExcluded(relFile: string, patterns: RegExp[]): boolean {
+  return patterns.some((re) => re.test(relFile));
+}
+
+export interface PluginFinding {
+  file: string;
+  line: number;
+}
+
+/** Run one plugin's regex over the applicable source files. Pure w.r.t. the repo. */
+export function evaluatePluginFindings(cwd: string, spec: StandardPluginSpec): PluginFinding[] {
+  const re = new RegExp(spec.match);
+  const excludes = spec.exclude.map(globToRegExp);
+  const findings: PluginFinding[] = [];
+  const files = walkSourceFiles(cwd, {
+    exts: spec.exts,
+    includeTests: spec.includeTests,
+    skipDirs: [
+      "node_modules",
+      "dist",
+      "build",
+      "out",
+      ".next",
+      ".git",
+      "coverage",
+      "vendor",
+      "target",
+    ],
+  });
+  for (const file of files) {
+    const rel = relative(cwd, file);
+    if (isExcluded(rel, excludes)) continue;
+    let content: string;
+    try {
+      content = readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    const lines = content.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line.length > MAX_LINE_LEN) continue;
+      if (re.test(line)) findings.push({ file: rel, line: i + 1 });
+    }
+  }
+  return findings;
+}
+
+export interface CheckPluginsOptions {
+  cwd?: string;
+  language: string;
+  enforce?: boolean;
+  dirs?: string[];
+  baseline?: string[];
+}
+
+/**
+ * Evaluate every applicable declarative plugin → StandardsCheckResult[]. A plugin
+ * whose `applies_to` excludes the detected language is skipped. Net-new findings warn
+ * by default; they FAIL when the plugin declares `severity = "fail"` OR under
+ * `--enforce`. Malformed plugins surface as integrity warnings (fail-closed).
+ */
+export function checkStandardsPlugins(opts: CheckPluginsOptions): StandardsCheckResult[] {
+  const cwd = opts.cwd ?? process.cwd();
+  const enforce = opts.enforce ?? false;
+  const dirs = opts.dirs ?? [DEFAULT_PLUGIN_DIR];
+  const seen = new Set(opts.baseline ?? []);
+  const { plugins, integrity } = loadStandardPlugins(cwd, dirs);
+  const results: StandardsCheckResult[] = [...integrity];
+
+  for (const spec of plugins) {
+    if (spec.appliesTo && spec.appliesTo.length > 0 && !spec.appliesTo.includes(opts.language)) {
+      continue;
+    }
+    const findings = evaluatePluginFindings(cwd, spec);
+    const fresh = findings.filter((f) => !seen.has(pluginKey(spec.id, f.file, f.line)));
+    const name = `plugin: ${spec.id}`;
+    const gates = enforce || spec.severity === "fail";
+    if (findings.length === 0) {
+      results.push({
+        category: "standards",
+        dimension: "plugin",
+        name,
+        status: "pass",
+        detail: `${spec.title} — no matches`,
+      });
+    } else if (fresh.length === 0) {
+      results.push({
+        category: "standards",
+        dimension: "plugin",
+        name,
+        status: "warn",
+        severity: "low",
+        detail: `${findings.length} pre-existing match(es) (baseline-frozen)`,
+      });
+    } else {
+      results.push({
+        category: "standards",
+        dimension: "plugin",
+        name,
+        status: gates ? "fail" : "warn",
+        severity: gates ? "high" : "medium",
+        detail: `${spec.title} — ${fresh.length} new match(es) (${findings.length} total)`,
+        files: fresh.slice(0, 10).map((f) => `${f.file}:${f.line}`),
+      });
+    }
+  }
+  return results;
+}
+
+/** Snapshot current plugin matches for `kit baseline freeze` (net-new thereafter). */
+export function collectPluginKeys(cwd: string, language: string, dirs?: string[]): string[] {
+  const { plugins } = loadStandardPlugins(cwd, dirs ?? [DEFAULT_PLUGIN_DIR]);
+  const keys: string[] = [];
+  for (const spec of plugins) {
+    if (spec.appliesTo && spec.appliesTo.length > 0 && !spec.appliesTo.includes(language)) continue;
+    for (const f of evaluatePluginFindings(cwd, spec))
+      keys.push(pluginKey(spec.id, f.file, f.line));
+  }
+  return keys;
+}

--- a/src/standards-run.test.ts
+++ b/src/standards-run.test.ts
@@ -1,0 +1,55 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runStandardsGate } from "./standards-run.js";
+
+// A bare TS project with no linters installed: every gate is a setup gap, so the
+// score is over gates that RAN (0), findings/failed are 0, and ok stays true — the
+// P5 "setup gaps aren't failures" contract.
+describe("standards-run — summary separates setup gaps from findings", () => {
+  it("all-gap repo → ok, zero findings, gaps counted separately", async () => {
+    const repo = mkdtempSync(join(tmpdir(), "kit-srun-"));
+    const prevBaseline = process.env.KIT_BASELINE_FILE;
+    try {
+      writeFileSync(join(repo, "package.json"), JSON.stringify({ name: "x", version: "1.0.0" }));
+      writeFileSync(join(repo, "index.ts"), "export const x = 1;\n");
+      const r = await runStandardsGate({ cwd: repo, category: "general" });
+      // lizard/jscpd/scc absent here → 3 setup gaps, none ran.
+      assert.equal(r.summary.setupGaps >= 1, true);
+      assert.equal(r.summary.findings, 0);
+      assert.equal(r.summary.failed, 0);
+      assert.equal(r.ok, true, "setup gaps do not fail the gate by default");
+    } finally {
+      if (prevBaseline === undefined) delete process.env.KIT_BASELINE_FILE;
+      else process.env.KIT_BASELINE_FILE = prevBaseline;
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("--enforce turns setup gaps into a failing gate", async () => {
+    const repo = mkdtempSync(join(tmpdir(), "kit-srun2-"));
+    try {
+      writeFileSync(join(repo, "index.ts"), "export const x = 1;\n");
+      const r = await runStandardsGate({ cwd: repo, category: "general", enforce: true });
+      assert.equal(r.ok, false, "setup gaps fail closed under --enforce");
+      assert.equal(r.summary.failed >= 1, true);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("an unknown category still returns a well-formed envelope", async () => {
+    const repo = mkdtempSync(join(tmpdir(), "kit-srun3-"));
+    try {
+      const r = await runStandardsGate({ cwd: repo, category: "nonsense" });
+      // no dimension matches "nonsense" → no checks, trivially ok.
+      assert.equal(r.ok, true);
+      assert.equal(r.checks.length, 0);
+      assert.equal(r.summary.score, "0/0");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/standards-run.ts
+++ b/src/standards-run.ts
@@ -1,0 +1,170 @@
+/**
+ * kit standards — the orchestrator shared by the CLI (`kit standards`) and the MCP
+ * surface (`kit_standards`), so the two can never disagree on what the gate does or
+ * what "green" means (the same CLI-vs-MCP parity discipline as `kit check`).
+ *
+ * Runs the requested dimensions — general (P1), specific/per-language (P2),
+ * plugins (P3), platform (P4) — against the fail-closed baseline and config, and
+ * returns a structured envelope { ok, checks, summary }. No printing here.
+ */
+import { resolve } from "node:path";
+import { loadConfig } from "./config.js";
+import { KIT_FILE } from "./cli-shared.js";
+import { loadBaselineForGate, baselineGet } from "./baseline.js";
+import { checkStandards, type StandardsCheckResult } from "./check-standards.js";
+import { checkStandardsSpecific, SPECIFIC_LANGUAGES } from "./check-standards-specific.js";
+import { checkStandardsPlugins, DEFAULT_PLUGIN_DIR } from "./standards-plugins.js";
+import { checkStandardsMjsPlugins } from "./standards-plugins-exec.js";
+import { checkStandardsPlatform } from "./check-standards-platform.js";
+import { detectStack } from "./stack-detector.js";
+
+export interface StandardsSummary {
+  score: string;
+  passed: number;
+  ran: number;
+  findings: number;
+  failed: number;
+  setupGaps: number;
+}
+
+export interface StandardsRunResult {
+  ok: boolean;
+  checks: StandardsCheckResult[];
+  summary: StandardsSummary;
+  baselineIgnored: string | null;
+}
+
+export interface RunStandardsOptions {
+  cwd?: string;
+  enforce?: boolean;
+  /** general | specific | plugins | platform | <language>; undefined ⇒ all. */
+  category?: string;
+}
+
+export async function runStandardsGate(
+  opts: RunStandardsOptions = {},
+): Promise<StandardsRunResult> {
+  const cwd = opts.cwd ?? process.cwd();
+  const { baseline, ignored: baselineIgnored } = await loadBaselineForGate(cwd);
+  const config = await loadConfig(resolve(cwd, KIT_FILE)).catch(
+    () => ({}) as Awaited<ReturnType<typeof loadConfig>>,
+  );
+  const effectiveEnforce = (opts.enforce ?? false) || config.standards?.enforce === true;
+
+  const category = opts.category;
+  const langCategory = category && SPECIFIC_LANGUAGES.includes(category) ? category : undefined;
+  const runGeneral = !category || category === "general";
+  const runSpecific = !category || category === "specific" || !!langCategory;
+  const runPlugins = !category || category === "plugins";
+  const runPlatform = !category || category === "platform";
+
+  let language = langCategory;
+  if ((runSpecific || runPlugins) && !language) {
+    language = (await detectStack(cwd)).language;
+  }
+
+  const checks: StandardsCheckResult[] = [];
+
+  if (runGeneral) {
+    const g = config.standards?.general;
+    const thresholds = {
+      ...(typeof g?.max_complexity === "number" ? { maxComplexity: g.max_complexity } : {}),
+      ...(typeof g?.max_function_lines === "number"
+        ? { maxFunctionLines: g.max_function_lines }
+        : {}),
+      ...(typeof g?.max_file_lines === "number" ? { maxFileLines: g.max_file_lines } : {}),
+      ...(typeof g?.max_duplication_pct === "number"
+        ? { maxDuplicationPct: g.max_duplication_pct }
+        : {}),
+    };
+    checks.push(
+      ...(await checkStandards({
+        cwd,
+        enforce: effectiveEnforce,
+        thresholds,
+        baseline: {
+          complexity: baselineGet(baseline, "standards", "complexity"),
+          duplication: baselineGet(baseline, "standards", "duplication"),
+          size: baselineGet(baseline, "standards", "size"),
+        },
+      })),
+    );
+  }
+
+  if (runSpecific && language) {
+    if (SPECIFIC_LANGUAGES.includes(language)) {
+      const langCfg = (config.standards as Record<string, unknown> | undefined)?.[language] as
+        | Record<string, boolean>
+        | undefined;
+      checks.push(
+        ...(await checkStandardsSpecific({
+          cwd,
+          language,
+          enforce: effectiveEnforce,
+          enabled: langCfg,
+          baseline: baselineGet(baseline, "standards", `specific/${language}`),
+        })),
+      );
+    } else if (category === "specific" || langCategory) {
+      checks.push({
+        category: "standards",
+        dimension: "specific",
+        name: `specific (${language})`,
+        status: "skip",
+        detail: `no per-language standards gate for '${language}' yet (covers ${SPECIFIC_LANGUAGES.join(", ")})`,
+      });
+    }
+  }
+
+  if (runPlugins && language) {
+    const pluginCfg = config.standards?.plugins;
+    const dirs =
+      pluginCfg?.dirs && pluginCfg.dirs.length > 0 ? pluginCfg.dirs : [DEFAULT_PLUGIN_DIR];
+    const pluginBaseline = baselineGet(baseline, "standards", "plugins");
+    checks.push(
+      ...checkStandardsPlugins({
+        cwd,
+        language,
+        enforce: effectiveEnforce,
+        dirs,
+        baseline: pluginBaseline,
+      }),
+    );
+    checks.push(
+      ...(await checkStandardsMjsPlugins({
+        cwd,
+        language,
+        enforce: effectiveEnforce,
+        dirs,
+        baseline: pluginBaseline,
+      })),
+    );
+  }
+
+  if (runPlatform) {
+    checks.push(
+      ...(await checkStandardsPlatform({
+        cwd,
+        enforce: effectiveEnforce,
+        baseline: baselineGet(baseline, "standards", "platform"),
+      })),
+    );
+  }
+
+  const ok = checks.every((r) => r.status !== "fail");
+  const gaps = checks.filter((r) => r.didNotRun);
+  const ran = checks.filter((r) => !r.didNotRun && r.status !== "skip");
+  const passed = ran.filter((r) => r.status === "pass").length;
+  const failed = checks.filter((r) => r.status === "fail").length;
+  const findings = ran.filter((r) => r.status === "warn" || r.status === "fail").length;
+  const summary: StandardsSummary = {
+    score: `${passed}/${ran.length}`,
+    passed,
+    ran: ran.length,
+    findings,
+    failed,
+    setupGaps: gaps.length,
+  };
+
+  return { ok, checks, summary, baselineIgnored };
+}

--- a/src/utils/execFileNoThrow.ts
+++ b/src/utils/execFileNoThrow.ts
@@ -17,12 +17,13 @@ export interface ExecResult {
 export async function execFileNoThrow(
   command: string,
   args: string[],
-  options?: { timeout?: number; env?: NodeJS.ProcessEnv; maxBuffer?: number },
+  options?: { timeout?: number; env?: NodeJS.ProcessEnv; maxBuffer?: number; cwd?: string },
 ): Promise<ExecResult> {
   try {
     const { stdout, stderr } = await execFileAsync(command, args, {
       timeout: options?.timeout ?? 30_000,
       env: options?.env ?? process.env,
+      cwd: options?.cwd,
       // Tool reporters (lizard --csv, scc --by-file) can exceed Node's 1 MB default
       // on a large repo; a truncated stream would corrupt the parse. Let callers raise it.
       maxBuffer: options?.maxBuffer ?? 1024 * 1024,


### PR DESCRIPTION
## Description

Completes the `kit standards` plan (P1/P2 already merged in #255/#256). Adds the plugin system (P3), platform gate + language breadth (P4), and the freeze/score/MCP ergonomics (P5). Every dimension keeps the same contract: deterministic, baseline net-new-gated, warn-by-default / `--enforce` fail-closed, and an honest setup gap when a tool is absent.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

- Builds on #255 (P1 general) and #256 (P2 per-language).

## Changes Made

**P3 — user-defined plugins** (kit ships none; teams encode "our way")
- Declarative `standards-plugins.ts`: TOML rules (id/title/applies_to/severity/match/exclude), strict schema-validated; malformed TOML, bad regex, schema mismatch, and duplicate ids each become an integrity **warn** and are skipped — never crash the gate. Regex run per line (length-capped), net-new-gated.
- Programmatic `standards-plugins-exec.ts`: `*.mjs` exporting `evaluate(ctx)`, run in a fresh **node child with a stripped env** (allowlist — no secret-shaped vars), a hard timeout, **schema-validated output**, and a **determinism double-run** (differing output → rejected). Honest scope note: Node can't block a child's network, so a plugin carries ~dev-dependency trust — env-stripping + isolation + determinism + schema is the bar.

**P4 — breadth + platform**
- Specific delegates: ruby (rubocop), php (phpstan), kotlin (ktlint), java (checkstyle), csharp (dotnet format), c/cpp (cppcheck) — new pure parsers for each.
- New `platform` dimension: `check-standards-platform.ts` lints discovered Dockerfiles with hadolint (bounded, vendor-excluded discovery).

**P5 — ergonomics + MCP parity**
- `kit standards freeze` (standards-only baseline) via a shared `freezeStandardsBaseline()` also used by `kit baseline freeze`.
- Score summary that counts **setup gaps separately from findings** (score over gates that ran) — in both the human line and `--json`.
- Shared `standards-run.ts` orchestrator powering **both** `kit standards` and a new **read-only MCP `kit_standards`** tool, so CLI and MCP can't diverge (same discipline as `kit_check`). R8 read-only allowlisted; fixes a latent baseline-cwd bug found while extracting.

`kit standards --category general|specific|plugins|platform|<lang>` scopes any run.

## Testing

### Test Coverage
- [x] Added new tests
- [x] All tests pass (`npm test`) — full suite **2493/2493**

- P3: declarative fail-closed load matrix + evaluate/exclude/gating/baseline; programmatic real-child-process runs (findings, severity=fail, **non-determinism reject**, **env-stripping proof**, schema fail-closed, applies_to).
- P4: 6 new-language parser fixtures + platform (parser, Dockerfile discovery incl. vendor-skip, gating/baseline/setup-gap).
- P5: orchestrator summary/setup-gap/enforce/unknown-category; MCP tool-count + registration guard; self-audit R8 completeness.

### Manual Testing
Verified against kit's own repo: `kit standards` prints `score 1/2 gates passed · 1 with findings · 4 setup gap(s)`; `tsc` passes clean; `--category typescript|plugins|platform` scope correctly; `kit_standards` MCP tool registers.

## Breaking Changes

None / N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've updated documentation as needed (plan marked P1–P5 shipped)
- [x] All new code has test coverage
- [x] All tests pass locally (`npm test`)
- [x] No new warnings or errors introduced
- [x] Commit messages follow conventions
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

## Performance Impact

- [x] No performance impact — plugins/linters run only when present and applicable; the mjs determinism double-run is bounded by a per-plugin timeout.

## Migration Guide

N/A — additive and opt-in. No `.kit/standards.d` ⇒ no plugins; no Dockerfile ⇒ no platform gate; absent linters ⇒ honest setup gaps.

## Reviewer Notes

- The programmatic-plugin sandbox is env-stripping + child isolation + determinism-verify + schema — deliberately the plan's stated bar; the header documents the network caveat honestly.
- `standards-run.ts` is the single source of truth for the gate; CLI and MCP both call it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_