### PR TITLE
release: kit 4.4.0 — standards dimension · prose→enforcement · PAL scope fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,79 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [4.4.0] - 2026-07-07
+
+### Added — `kit standards`: the third quality dimension (P1–P5, #255–#257)
+
+- **General gate (P1).** Language-agnostic code-quality metrics, measured the same
+  way on every stack: complexity + function length (lizard), duplication (jscpd),
+  file size / god-files (scc). Calibrated conservative defaults, overridable via
+  `[standards.general]`. Pure parsers unit-tested against fixtures; tool runners
+  resolve mise-first.
+- **Per-language gate (P2 + P4).** Delegates to each ecosystem's canonical linter
+  in report mode: eslint + `tsc --noEmit` (TS/JS), ruff + mypy (Python),
+  `go vet` + `gofmt -l` (Go), clippy + `cargo fmt --check` (Rust), rubocop (Ruby),
+  phpstan (PHP), ktlint (Kotlin), checkstyle (Java), `dotnet format` (C#),
+  cppcheck (C/C++). Node-ecosystem tools resolve the PROJECT-LOCAL
+  `node_modules/.bin` first — a global tsc resolves types against the wrong tree
+  and floods phantom errors (a false positive is as harmful as a false green).
+- **User plugins (P3).** Teams encode subjective standards under
+  `.kit/standards.d/`; kit ships none. Declarative TOML rules (strict
+  schema-validated, fail-closed on malformed/duplicate/bad-regex) and
+  programmatic `*.mjs` `evaluate(ctx)` run in a restricted child (env allowlist —
+  no secrets, hard timeout, output schema) and DETERMINISM-VERIFIED: each plugin
+  runs twice and divergent output is rejected.
+- **Platform gate (P4).** Container: hadolint over discovered Dockerfiles
+  (bounded-depth, vendor-excluded). No Dockerfile ⇒ the gate honestly doesn't apply.
+- **Ergonomics + parity (P5).** `kit standards freeze` (standards-only baseline);
+  a score summary that counts SETUP GAPS (tool not installed) separately from real
+  findings — the score is over gates that actually ran; MCP `kit_standards` tool
+  sharing ONE orchestrator with the CLI (`standards-run.ts`) so the two surfaces
+  can never disagree. `kit review` is now check + design + standards.
+- Everywhere: baseline-aware net-new gating, warn-by-default, `--enforce` fails
+  net-new findings AND setup gaps (fail-closed for CI).
+
+### Added — detection past the manifest ceiling (#255)
+
+- **Linguist-style source census.** When manifests mislead (polyglot repos, bare
+  `package.json` over a php/ruby tree), a bounded file-count census (≤6000 files,
+  vendor-excluded, JS+TS folded) breaks the tie. Conservative: only overrides a
+  weak/bare package.json or fills the no-manifest fallback.
+
+### Added — memory sync options (#255)
+
+- **`[memory.sync] encrypt = false`** — the low-ceremony plaintext path: a plain
+  SQLite snapshot (`VACUUM INTO`, 0600), no passphrase, no recipient. Secure by
+  default: anything but the literal boolean `false` keeps encryption ON. No false
+  green: `kit memory push` reports PLAINTEXT + "keep destination PRIVATE" instead
+  of claiming the blob is encrypted; the pull path still injection-scans (R7)
+  before merge.
+
+### Changed — prose → enforcement (#258)
+
+- **Statusline is injected, not requested.** The memory SessionStart hook now
+  prints `kit statusline: …` to stdout (injected as agent context); the managed
+  rules block no longer asks the agent to run it.
+- **`kit gate-env`** — new PreToolUse gate: blocks a Write/Edit that puts a
+  plaintext secret into a real `.env*` file BEFORE it lands (same detector as the
+  plaintext scan; `.env.example`/templates exempt; placeholders allowed).
+- **Gates are default-on in `kit agent teach`** (`--no-install-gate` opts out):
+  un-triaged installs + plaintext .env\* secrets are blocked, not advised against.
+  The generated "use kit" block shrank accordingly — it now states what is
+  enforced; rules migrate out of prose as their gate ships.
+
+### Fixed
+
+- **PAL scope unification — statusline ⚠ and `pal list` can no longer disagree.**
+  Three surfaces used three scope definitions (auto-tracker: absolute root;
+  `pal add`: basename; statusline: unscoped) — a statusline showed ⚠156 (mostly
+  dead temp-dir scopes) while `pal list` showed 0, hiding the project's own 6 open
+  items. Canonical scope is the ABSOLUTE project root; `palList` also matches
+  legacy basename rows; `quickPalCount` uses the same filter as `pal list`.
+- `kit check --json` no longer leaks the update banner into the JSON envelope.
+- `execFileNoThrow` gains `maxBuffer`/`cwd` options (large linter output;
+  gate children).
+
 ## [4.3.0] - 2026-07-07
 
 ### Fixed — dogfood findings from real projects (a Turborepo + a Firebase repo)

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -39,12 +39,14 @@
 
 ## Code quality + reviews
 
-| Command                 | Purpose                                                                |
-| ----------------------- | ---------------------------------------------------------------------- |
-| `kit design`            | A11y + design-token checks, baseline-aware.                            |
-| `kit review`            | Meta-runner — `check + design + tests` gate for PR.                    |
-| `kit baseline [freeze]` | Snapshot current acceptable warnings to `.kit-baseline.json`.          |
-| `kit analyze [--write]` | Mine git history + framework markers → draft `CLAUDE.md` / `RULES.md`. |
+| Command                                                                               | Purpose                                                                                                                                                                                                                                                   |
+| ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kit design`                                                                          | A11y + design-token checks, baseline-aware.                                                                                                                                                                                                               |
+| `kit standards [--category general\|specific\|plugins\|platform\|<lang>] [--enforce]` | Dev-standards gate: general metrics (complexity/duplication/size via lizard/jscpd/scc) + per-language linters (11 langs) + user plugins (`.kit/standards.d/`) + container (hadolint). Warn by default; `--enforce` fails net-new findings AND setup gaps. |
+| `kit standards freeze`                                                                | Snapshot only the standards dimensions into `.kit-baseline.json`.                                                                                                                                                                                         |
+| `kit review`                                                                          | Meta-runner — `check + design + standards` gate for PR.                                                                                                                                                                                                   |
+| `kit baseline [freeze]`                                                               | Snapshot current acceptable warnings to `.kit-baseline.json`.                                                                                                                                                                                             |
+| `kit analyze [--write]`                                                               | Mine git history + framework markers → draft `CLAUDE.md` / `RULES.md`.                                                                                                                                                                                    |
 
 ## Secrets
 
@@ -188,18 +190,21 @@
 
 Local-first second brain — SQLite + FTS5, deterministic, zero model calls. Full guide: `docs/MEMORY.md`.
 
-| Command                                                                     | Purpose                                                                                                                  |
-| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `kit memory index`                                                          | Index `~/.claude` transcripts into `~/.kit/memory.db` (idempotent).                                                      |
-| `kit memory search <query>`                                                 | Full-text recall; defaults to the current project, `--global` across all.                                                |
-| `kit memory stats`                                                          | Sessions / messages / tool-uses / DB size.                                                                               |
-| `kit memory suggest [--limit N] [--json]`                                   | Emit a BYO-LLM review prompt (recent activity + open items) to stdout — pipe to your own model. kit never calls a model. |
-| `kit memory install` / `uninstall`                                          | Wire (or remove) the `UserPromptSubmit` + `SessionEnd` hooks in `~/.claude/settings.json`.                               |
-| `kit memory scan`                                                           | Scan the store for stored secrets (masked; exits 1 if any found).                                                        |
-| `kit memory backup <file>` / `restore <file>`                               | Encrypted AES-256-GCM backup/restore (`KIT_MEMORY_PASSPHRASE`).                                                          |
-| `kit memory pal [list\|add\|done\|snooze\|verify\|import]`                  | Pending-action ledger; auto-closes on verify. Project-scoped (`--global` for all).                                       |
-| `kit memory save <name>` / `threads` / `resume <name\|n>` / `forget <name>` | Named copilots — bookmark + resume sessions.                                                                             |
-| `kit memory share …` / `areas` / `area <name>`                              | Shared, area-organized team memory (committed, secret-scanned, reviewed like code).                                      |
+| Command                                                                     | Purpose                                                                                                                                                                                                      |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `kit memory index`                                                          | Index `~/.claude` transcripts into `~/.kit/memory.db` (idempotent).                                                                                                                                          |
+| `kit memory search <query>`                                                 | Full-text recall; defaults to the current project, `--global` across all.                                                                                                                                    |
+| `kit memory stats`                                                          | Sessions / messages / tool-uses / DB size.                                                                                                                                                                   |
+| `kit memory suggest [--limit N] [--json]`                                   | Emit a BYO-LLM review prompt (recent activity + open items) to stdout — pipe to your own model. kit never calls a model.                                                                                     |
+| `kit memory install` / `uninstall`                                          | Wire (or remove) the `UserPromptSubmit` + `SessionEnd` hooks in `~/.claude/settings.json`.                                                                                                                   |
+| `kit memory scan`                                                           | Scan the store for stored secrets (masked; exits 1 if any found).                                                                                                                                            |
+| `kit memory backup <file>` / `restore <file>`                               | Encrypted AES-256-GCM backup/restore (`KIT_MEMORY_PASSPHRASE`).                                                                                                                                              |
+| `kit memory sync init <remote> [--auto]`                                    | Write `~/.kit/sync.toml` (LOCAL, never committed). `--auto` = pull at session start + push at session end via the hooks.                                                                                     |
+| `kit memory push` / `pull`                                                  | Sync the store to/from your PRIVATE remote. Encrypted by default (passphrase or `recipient` public key — `kit memory keygen`); `encrypt = false` opts into a plaintext blob (destination must stay private). |
+| `kit memory keygen`                                                         | X25519 recipient keypair: ephemeral sessions push encrypted with NO secret; only holders of the private key decrypt.                                                                                         |
+| `kit memory pal [list\|add\|done\|snooze\|verify\|import]`                  | Pending-action ledger; auto-closes on verify. Project-scoped (`--global` for all).                                                                                                                           |
+| `kit memory save <name>` / `threads` / `resume <name\|n>` / `forget <name>` | Named copilots — bookmark + resume sessions.                                                                                                                                                                 |
+| `kit memory share …` / `areas` / `area <name>`                              | Shared, area-organized team memory (committed, secret-scanned, reviewed like code).                                                                                                                          |
 
 ## Exit codes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -3,7 +3,7 @@
 import { c } from "../utils/colors.js";
 import { hasFlag, flagValue } from "../utils/flags.js";
 import { existsSync } from "node:fs";
-import { basename, join } from "node:path";
+import { join } from "node:path";
 import {
   openMemoryDb,
   getStats,
@@ -150,9 +150,9 @@ async function memPal(): Promise<boolean> {
   const db = openMemoryDb();
   try {
     if (action === "list") {
-      const scope = hasFlag(process.argv, "--global")
-        ? undefined
-        : basename(getCurrentProjectRoot());
+      // Canonical scope = ABSOLUTE project root (same as the auto-tracker writes —
+      // basenames collide across repos); palList also matches legacy basename rows.
+      const scope = hasFlag(process.argv, "--global") ? undefined : getCurrentProjectRoot();
       // Device-coupled by default: only THIS device's items (+ legacy rows) show,
       // so an ephemeral session's items don't nag here. --all opts back in.
       const items = palList(db, { scope, allDevices: hasFlag(process.argv, "--all") });
@@ -201,7 +201,9 @@ async function memPal(): Promise<boolean> {
       const id = palAdd(db, {
         title,
         check,
-        scope: flagValue(process.argv, "--scope") ?? basename(getCurrentProjectRoot()),
+        // Same canonical scope as the auto-tracker (absolute root), so manual and
+        // auto items live under ONE scope definition and every surface agrees.
+        scope: flagValue(process.argv, "--scope") ?? getCurrentProjectRoot(),
       });
       console.log(`${c.green}✓${c.reset} added ${c.bold}${id}${c.reset}`);
       return true;

--- a/src/memory/pal.test.ts
+++ b/src/memory/pal.test.ts
@@ -39,6 +39,34 @@ describe("PAL — pending actions", () => {
     db.close();
   });
 
+  it("scope: an absolute-root scope matches canonical, legacy-basename, and NULL rows — never other projects", () => {
+    const db = fresh();
+    // canonical (what the auto-tracker + fixed `pal add` write)
+    palAdd(db, { title: "canonical", scope: "/home/me/work/api" });
+    // legacy (pre-fix `pal add` stored the basename)
+    palAdd(db, { title: "legacy", scope: "api" });
+    // global (no scope) — always shown
+    palAdd(db, { title: "global" });
+    // a DIFFERENT project that happens to share the basename must NOT match by path
+    palAdd(db, { title: "other-project", scope: "/home/me/scratch/web" });
+
+    const items = palList(db, { scope: "/home/me/work/api" });
+    const titles = items.map((p) => p.title).sort();
+    assert.deepEqual(titles, ["canonical", "global", "legacy"]);
+    db.close();
+  });
+
+  it("scope: statusline count and pal list agree by construction (same filter)", () => {
+    const db = fresh();
+    palAdd(db, { title: "mine", scope: "/repo/kit" });
+    palAdd(db, { title: "ghost from temp-dir run", scope: "/tmp/kit-integ-check-xyz" });
+    // The unscoped count (old statusline behavior) sees both; the scoped one — the
+    // definition both surfaces now share — sees only this project's item + globals.
+    assert.equal(palList(db).length, 2);
+    assert.equal(palList(db, { scope: "/repo/kit" }).length, 1);
+    db.close();
+  });
+
   it("done closes; closed leaves the open list", () => {
     const db = fresh();
     const id = palAdd(db, { title: "x" });

--- a/src/memory/pal.ts
+++ b/src/memory/pal.ts
@@ -18,7 +18,7 @@
 import { randomBytes, createHash } from "node:crypto";
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { homedir, hostname, userInfo } from "node:os";
-import { join, dirname } from "node:path";
+import { join, dirname, basename } from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 
 /** A device id is an opaque, filesystem- and SQL-safe token. We validate any
@@ -211,8 +211,17 @@ export function palList(db: DatabaseSync, opts: PalListOptions = {}): PendingAct
   const where: string[] = ["status = ?"];
   const params: unknown[] = [status];
   if (opts.scope !== undefined) {
-    where.push("(scope = ? OR scope IS NULL)");
-    params.push(opts.scope);
+    // Canonical scope is the ABSOLUTE project root (see syncSecurityFindings —
+    // basenames collide across repos). Legacy rows (pre-fix `pal add`) stored the
+    // basename, so a path scope also matches its basename form; NULL = global.
+    const alias = basename(opts.scope);
+    if (alias && alias !== opts.scope) {
+      where.push("(scope = ? OR scope = ? OR scope IS NULL)");
+      params.push(opts.scope, alias);
+    } else {
+      where.push("(scope = ? OR scope IS NULL)");
+      params.push(opts.scope);
+    }
   }
   if (!opts.allDevices) {
     // NULL origin_device = legacy/pre-v5 row → always shown (backward-compatible).

--- a/src/statusline.ts
+++ b/src/statusline.ts
@@ -89,14 +89,18 @@ export function quickSubsystems(cwd: string): SubsystemStatus[] {
 }
 
 /** Open-PAL ("blocked on you") count — cheap, 0 on any error. Memory modules are
- *  dynamically imported so the sqlite dependency stays off other commands' startup. */
-export async function quickPalCount(): Promise<number> {
+ *  dynamically imported so the sqlite dependency stays off other commands' startup.
+ *  Scoped to the CURRENT project (same definition as `kit memory pal list`) so the
+ *  statusline ⚠ and the list can never disagree — an unscoped count once showed
+ *  ⚠156 (mostly dead temp-dir scopes) while the list correctly showed 0. */
+export async function quickPalCount(cwd?: string): Promise<number> {
   try {
     const { openMemoryDb } = await import("./memory/db.js");
     const { palList } = await import("./memory/pal.js");
+    const { getCurrentProjectRoot } = await import("./memory/project.js");
     const db = openMemoryDb();
     try {
-      return palList(db).length;
+      return palList(db, { scope: getCurrentProjectRoot(cwd) }).length;
     } finally {
       db.close();
     }
@@ -127,6 +131,6 @@ export async function buildStatuslineText(
     mode: profile.mode,
     score: { done, total },
     update: update?.latest ?? null,
-    pal: await quickPalCount(),
+    pal: await quickPalCount(cwd),
   });
 }


### PR DESCRIPTION
## Description

Release housekeeping for 4.4.0 (rolling up #255–#258) plus a live-found bug fix: PAL scope unification so the statusline ⚠ count and `kit memory pal list` can never disagree.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Related Issues

- Rolls up #255 (census + sync option + standards P1), #256 (standards P2), #257 (standards P3–P5), #258 (agent gates).

## Changes Made

- **CHANGELOG 4.4.0**: full notes for the standards dimension (P1–P5), Linguist census, `encrypt = false` sync option, statusline injection, `gate-env`, default-on gates.
- **docs/COMMANDS.md**: `kit standards` / `standards freeze` rows (previously zero mentions), `kit review` updated to check + design + standards, memory sync rows (`sync init --auto`, `push`/`pull`, `keygen`).
- **Version bump** 4.3.0 → 4.4.0.
- **Fixed — PAL scope unification.** Three surfaces used three scope definitions (auto-tracker: absolute root; `pal add`: basename; statusline: unscoped). Live symptom in this session: statusline showed **⚠156** (dominated by dead temp-dir scopes from integration runs) while `pal list` showed **0** — hiding the project's own 6 open items. Canonical scope is now the absolute project root everywhere; `palList` also matches legacy basename rows; `quickPalCount` shares the exact filter with `pal list`.

## Testing

### Test Coverage
- [x] Added new tests
- [x] All tests pass (`npm test`) — full suite **2505/2505**

- Scope-matching matrix: canonical path / legacy basename / global (NULL) rows match; a different project sharing the basename does NOT match by path.
- Statusline-parity regression: the scoped count (shared definition) vs the old unscoped count.

### Manual Testing
1. Before fix: `kit statusline` → `⚠156`, `kit memory pal list` → "no open action items".
2. After fix: statusline → `⚠6`, pal list → the same 6 items. Verified live in this repo.

## Breaking Changes

None / N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've updated documentation as needed
- [x] All new code has test coverage
- [x] All tests pass locally (`npm test`)
- [x] No new warnings or errors introduced
- [x] Commit messages follow conventions
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

## Performance Impact

- [x] No performance impact — the scope filter adds one indexed WHERE clause.

## Migration Guide

N/A — legacy basename-scoped PAL rows keep matching via the compatibility clause in `palList`.

## Reviewer Notes

- The canonical-scope choice (absolute root, not basename) follows the documented rationale in `findings-track.ts`: two repos sharing a directory name must not reconcile into each other's findings. Cross-machine isolation is already handled by the device fence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_