### PR TITLE
feat(memory): G2 — write-gate flags plaintext secrets

### DIFF
--- a/src/memory/write-gate.test.ts
+++ b/src/memory/write-gate.test.ts
@@ -79,6 +79,25 @@ describe("evaluateWriteGate (pure verdict)", () => {
     );
   });
 
+  it("flags a plaintext secret (G2) — quarantine in warn, reject in enforce", () => {
+    const withKey = "here is the key sk-ant-api03-abc123def456ghi789jkl012mno345pqr678stu";
+    const warn = evaluateWriteGate(base({ content: withKey }), withKey, { enforce: false });
+    assert.equal(warn.decision, "quarantine");
+    assert.ok(warn.reasons.some((r) => r.code === "secret"));
+    assert.equal(
+      evaluateWriteGate(base({ content: withKey }), withKey, { enforce: true }).decision,
+      "reject",
+    );
+  });
+
+  it("secret reason never echoes the raw secret (masked label/preview only)", () => {
+    const raw = "AKIAIOSFODNN7EXAMPLE and more";
+    const v = evaluateWriteGate(base({ content: raw }), raw);
+    const secretReason = v.reasons.find((r) => r.code === "secret");
+    assert.ok(secretReason);
+    assert.ok(!secretReason!.detail.includes("AKIAIOSFODNN7EXAMPLE"));
+  });
+
   it("is deterministic — identical input yields identical verdict", () => {
     const a = evaluateWriteGate(base({ content: INJECTION }), INJECTION);
     const b = evaluateWriteGate(base({ content: INJECTION }), INJECTION);

--- a/src/memory/write-gate.ts
+++ b/src/memory/write-gate.ts
@@ -6,8 +6,10 @@
  * agent memory: rows are stored first and inspected later, so a poisoned or malformed
  * line lands in the store before anything vets it. This module is the deterministic,
  * fail-closed authorization a memory row must pass BEFORE it is persisted — the
- * "Write Authorization" primitive, reusing kit's existing R7 injection detector
- * (no LLM in the verdict path).
+ * "Write Authorization" primitive, reusing kit's existing R7 injection detector and
+ * (G2) its plaintext-secret pattern detector (no LLM in the verdict path). Flagging a
+ * secret-bearing row keeps a credential from being persisted and later re-injected
+ * into a prompt via recall — the stdout→context leak the gap analysis §2.2 measures.
  *
  * Two modes, secure-by-default (warn), matching the warn→enforce ramp `kit standards`
  * uses:
@@ -23,10 +25,11 @@
  * the prompt on any unexpected evaluation error (quarantine in warn, reject in enforce).
  */
 import { findInjection } from "./injection.js";
+import { findSecrets } from "../utils/redactSecrets.js";
 import type { MessageInput } from "./types.js";
 
 export type WriteGateDecision = "allow" | "quarantine" | "reject";
-export type WriteGateReasonCode = "injection" | "oversize" | "schema";
+export type WriteGateReasonCode = "injection" | "oversize" | "schema" | "secret";
 
 export interface WriteGateReason {
   code: WriteGateReasonCode;
@@ -96,10 +99,21 @@ export function evaluateWriteGate(
     reasons.push({ code: "injection", detail: "high-confidence prompt-injection pattern" });
   }
 
+  // 4. Secret (G2) — a plaintext credential that would otherwise be persisted and
+  //    could ride back into a later prompt via recall (the stdout→context leak the
+  //    gap analysis §2.2 measures). Reuses kit's pattern detector; the detail carries
+  //    only a masked label/preview, never the raw secret. Skipped when capture-time
+  //    redaction already masked it (findSecrets then finds nothing).
+  const secrets = content ? findSecrets(content) : [];
+  if (secrets.length > 0) {
+    const labels = [...new Set(secrets.map((s) => s.label))].join(", ");
+    reasons.push({ code: "secret", detail: `plaintext secret(s): ${labels}` });
+  }
+
   let decision: WriteGateDecision;
   if (schemaBad) {
     decision = "reject"; // unstorable in any mode
-  } else if (injected || oversize) {
+  } else if (injected || oversize || secrets.length > 0) {
     decision = enforce ? "reject" : "quarantine";
   } else {
     decision = "allow";


### PR DESCRIPTION
First increment of **G2** (secrets in the agent loop) from the buildout plan, building directly on G1's write-gate.

## What
Extends `evaluateWriteGate` with a deterministic **`secret`** reason, reusing kit's existing `findSecrets` pattern detector (zero-LLM). A memory row carrying a plaintext credential is now flagged at capture time, so it can't be persisted and later re-injected into a prompt via recall — the **stdout→context leak** the gap analysis §2.2 (**verified 3-0**) measures.

- **warn (default):** secret-bearing row is quarantined (stored, excluded from recall).
- **enforce (`KIT_MEMORY_WRITE_ENFORCE=1`):** rejected (never persisted).
- The reason `detail` carries only **masked labels/previews**, never the raw secret.
- **No-op** when capture-time redaction (`KIT_MEMORY_REDACT`) already masked the content (`findSecrets` then finds nothing).

## Scope note
This is the "secret-shaped strings entering the store/context" half of G2. The remaining G2 surface — **live stdout/log gating** and **rotation/remediation tracking** (a secret isn't "handled" until rotated — the 64%-still-live gap) — are larger and tracked as follow-ups, not in this PR.

## Tests
Added secret cases to `write-gate.test.ts` (quarantine/warn, reject/enforce, and a "never echoes the raw secret" assertion). Full suite **2532/2532**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_