### PR TITLE
feat(sbom): G5 — agent-toolchain SBOM (skills, MCP servers, plugins)

### DIFF
--- a/src/agent-sbom.test.ts
+++ b/src/agent-sbom.test.ts
@@ -1,0 +1,97 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { agentToolchainComponents, mcpServersFromConfig } from "./agent-sbom.js";
+import { toCycloneDX, toSpdx, type Component } from "./sbom.js";
+
+describe("agentToolchainComponents", () => {
+  it("maps skills / mcp-servers / plugins to components with generic purls + provenance", () => {
+    const comps = agentToolchainComponents({
+      skills: [{ name: "triage", version: "1.2.0", source: ".claude/skills/triage" }],
+      mcpServers: [{ name: "github", source: "npx gh-mcp" }],
+      plugins: [{ name: "acme" }],
+    });
+    const byName = Object.fromEntries(comps.map((c) => [c.name, c]));
+    assert.equal(byName.triage.purl, "pkg:generic/skill/triage@1.2.0");
+    assert.equal(byName.triage.type, "application");
+    assert.equal(byName.triage.provenance, "skill: .claude/skills/triage");
+    assert.equal(byName.github.purl, "pkg:generic/mcp-server/github@0.0.0"); // unversioned → 0.0.0
+    assert.equal(byName.acme.purl, "pkg:generic/plugin/acme@0.0.0");
+  });
+
+  it("dedups by (kind,name,version) and is deterministically sorted", () => {
+    const a = agentToolchainComponents({
+      skills: [{ name: "x" }, { name: "x" }],
+      plugins: [{ name: "a" }],
+    });
+    assert.equal(a.filter((c) => c.name === "x").length, 1);
+    const purls = a.map((c) => c.purl);
+    assert.deepEqual(purls, [...purls].sort());
+  });
+
+  it("drops nameless entries and returns [] for empty input", () => {
+    assert.deepEqual(agentToolchainComponents({}), []);
+    assert.deepEqual(agentToolchainComponents({ skills: [{ name: "  " }] }), []);
+  });
+});
+
+describe("mcpServersFromConfig", () => {
+  it("reads mcpServers with command/url as source", () => {
+    const s = mcpServersFromConfig({
+      mcpServers: {
+        gh: { command: "npx", args: ["gh-mcp"] },
+        remote: { url: "https://mcp.example.com" },
+      },
+    });
+    const byName = Object.fromEntries(s.map((x) => [x.name, x]));
+    assert.equal(byName.gh.source, "npx");
+    assert.equal(byName.remote.source, "https://mcp.example.com");
+  });
+  it("also accepts the `servers` key and tolerates garbage", () => {
+    assert.equal(mcpServersFromConfig({ servers: { a: {} } }).length, 1);
+    assert.deepEqual(mcpServersFromConfig("nope"), []);
+    assert.deepEqual(mcpServersFromConfig({ mcpServers: null }), []);
+  });
+});
+
+describe("SBOM emitters honor Component.type / purl (backward-compatible)", () => {
+  const npm: Component = { name: "lodash", version: "4.17.21" };
+  const skill: Component = {
+    name: "triage",
+    version: "1.0.0",
+    type: "application",
+    purl: "pkg:generic/skill/triage@1.0.0",
+    provenance: "skill: .claude/skills/triage",
+  };
+
+  it("CycloneDX: npm stays library+pkg:npm; agent piece carries type+generic purl+provenance", () => {
+    const doc = toCycloneDX([npm, skill]) as {
+      components: {
+        name: string;
+        type: string;
+        purl: string;
+        properties?: { name: string; value: string }[];
+      }[];
+    };
+    const lodash = doc.components.find((c) => c.name === "lodash");
+    const triage = doc.components.find((c) => c.name === "triage");
+    assert.ok(lodash && triage);
+    assert.equal(lodash.type, "library");
+    assert.equal(lodash.purl, "pkg:npm/lodash@4.17.21");
+    assert.equal(lodash.properties, undefined); // no provenance on plain npm dep
+    assert.equal(triage.type, "application");
+    assert.equal(triage.purl, "pkg:generic/skill/triage@1.0.0");
+    assert.deepEqual(triage.properties, [
+      { name: "kit:provenance", value: "skill: .claude/skills/triage" },
+    ]);
+  });
+
+  it("SPDX: externalRef purl respects the override", () => {
+    const doc = toSpdx([skill]) as {
+      packages: { externalRefs: { referenceLocator: string }[] }[];
+    };
+    assert.equal(
+      doc.packages[0].externalRefs[0].referenceLocator,
+      "pkg:generic/skill/triage@1.0.0",
+    );
+  });
+});

--- a/src/agent-sbom.ts
+++ b/src/agent-sbom.ts
@@ -1,0 +1,86 @@
+/**
+ * kit — agent-toolchain SBOM (G5).
+ *
+ * The LLM supply-chain research agenda (Wang et al., arXiv:2404.12736 / ACM TOSEM
+ * 34(5), doi:10.1145/3708531; verified 3-0 in kit's gap analysis §2.5) names an SBOM
+ * for the AI/LLM *toolchain* as an unrealized transparency/security opportunity: the
+ * pieces an agent actually loads — skills, MCP servers, plugins — are supply-chain
+ * components too, but no lockfile lists them, so today's SBOM can't see them.
+ *
+ * This maps those agent-toolchain pieces into the SAME CycloneDX/SPDX `Component`
+ * shape kit already emits for npm deps, so `kit sbom --agent` produces one BOM that
+ * covers both. Pure + deterministic (data → components); discovery is best-effort and
+ * kept separate.
+ */
+import type { Component } from "./sbom.js";
+
+export type AgentComponentKind = "skill" | "mcp-server" | "plugin";
+
+export interface AgentComponentInput {
+  name: string;
+  version?: string;
+  /** Provenance: a file path, server command, or source string. */
+  source?: string;
+}
+
+export interface AgentToolchainInput {
+  skills?: AgentComponentInput[];
+  mcpServers?: AgentComponentInput[];
+  plugins?: AgentComponentInput[];
+}
+
+const DEFAULT_VERSION = "0.0.0";
+
+/** purl namespace per kind — `pkg:generic/<kind>/<name>@<version>`. */
+function agentPurl(kind: AgentComponentKind, name: string, version: string): string {
+  return `pkg:generic/${kind}/${encodeURIComponent(name)}@${version}`;
+}
+
+/**
+ * Map discovered agent-toolchain pieces into SBOM `Component`s. Pure + deterministic:
+ * de-duplicated by (kind, name, version) and sorted for a stable BOM. An unversioned
+ * piece gets `0.0.0` (the registry/config rarely pins agent components).
+ */
+export function agentToolchainComponents(input: AgentToolchainInput): Component[] {
+  const out: Component[] = [];
+  const seen = new Set<string>();
+  const add = (kind: AgentComponentKind, items: AgentComponentInput[] | undefined) => {
+    for (const it of items ?? []) {
+      if (!it.name || !it.name.trim()) continue;
+      const version = it.version?.trim() || DEFAULT_VERSION;
+      const key = `${kind}:${it.name}@${version}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({
+        name: it.name,
+        version,
+        type: "application",
+        purl: agentPurl(kind, it.name, version),
+        provenance: it.source ? `${kind}: ${it.source}` : kind,
+      });
+    }
+  };
+  add("skill", input.skills);
+  add("mcp-server", input.mcpServers);
+  add("plugin", input.plugins);
+  return out.sort((a, b) => (a.purl ?? a.name).localeCompare(b.purl ?? b.name));
+}
+
+/**
+ * Extract MCP servers from a parsed agent/editor config object (Claude/Cursor/VSCode
+ * nest them under `mcpServers` or `servers`). Pure. Returns [] on anything unexpected.
+ */
+export function mcpServersFromConfig(json: unknown): AgentComponentInput[] {
+  if (!json || typeof json !== "object") return [];
+  const obj = json as Record<string, unknown>;
+  const servers = (obj.mcpServers ?? obj.servers) as Record<string, unknown> | undefined;
+  if (!servers || typeof servers !== "object") return [];
+  const out: AgentComponentInput[] = [];
+  for (const [name, def] of Object.entries(servers)) {
+    const d = (def ?? {}) as Record<string, unknown>;
+    const command = typeof d.command === "string" ? d.command : undefined;
+    const url = typeof d.url === "string" ? d.url : undefined;
+    out.push({ name, source: command ?? url });
+  }
+  return out;
+}

--- a/src/commands/sbom.ts
+++ b/src/commands/sbom.ts
@@ -1,13 +1,15 @@
 // `kit sbom` command — extracted from cli.ts (incremental split).
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { c } from "../utils/colors.js";
-import { flagValue } from "../utils/flags.js";
+import { flagValue, hasFlag } from "../utils/flags.js";
+import type { Component } from "../sbom.js";
+import type { AgentComponentInput } from "../agent-sbom.js";
 
 export async function cmdSbom(): Promise<boolean> {
   const fmt = (flagValue(process.argv, "--format") ?? "cyclonedx").toLowerCase();
   if (fmt !== "cyclonedx" && fmt !== "spdx") {
-    console.error(`${c.red}usage: kit sbom [--format cyclonedx|spdx]${c.reset}`);
+    console.error(`${c.red}usage: kit sbom [--format cyclonedx|spdx] [--agent]${c.reset}`);
     process.exitCode = 1;
     return false;
   }
@@ -22,9 +24,54 @@ export async function cmdSbom(): Promise<boolean> {
     process.exitCode = 1;
     return false;
   }
-  const components = lockComponents(parseLockPkgs(lock));
+  const components: Component[] = lockComponents(parseLockPkgs(lock));
+
+  // --agent (G5): also inventory the agent toolchain — skills, MCP servers, plugins —
+  // which no lockfile lists. Opt-in so the default BOM is unchanged.
+  if (hasFlag(process.argv, "--agent")) {
+    const { agentToolchainComponents, mcpServersFromConfig } = await import("../agent-sbom.js");
+    components.push(...agentToolchainComponents(discoverAgentToolchain(cwd, mcpServersFromConfig)));
+  }
+
   console.log(
     JSON.stringify(fmt === "spdx" ? toSpdx(components) : toCycloneDX(components), null, 2),
   );
   return true;
+}
+
+/** Best-effort, defensive discovery of agent-toolchain pieces under `cwd`. */
+function discoverAgentToolchain(
+  cwd: string,
+  mcpServersFromConfig: (json: unknown) => AgentComponentInput[],
+): { skills: AgentComponentInput[]; mcpServers: AgentComponentInput[] } {
+  const skills: AgentComponentInput[] = [];
+  // Skills: each subdir of .claude/skills holding a SKILL.md is one skill.
+  const skillsDir = resolve(cwd, ".claude/skills");
+  try {
+    for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
+      if (entry.isDirectory() && existsSync(resolve(skillsDir, entry.name, "SKILL.md"))) {
+        skills.push({ name: entry.name, source: `.claude/skills/${entry.name}` });
+      }
+    }
+  } catch {
+    /* no skills dir — fine */
+  }
+
+  // MCP servers: union across the common config locations (reuses agent-sbom's parser).
+  const mcpServers: AgentComponentInput[] = [];
+  const seen = new Set<string>();
+  for (const rel of [".mcp.json", ".claude.json", ".cursor/mcp.json", ".vscode/mcp.json"]) {
+    try {
+      const parsed = JSON.parse(readFileSync(resolve(cwd, rel), "utf8"));
+      for (const s of mcpServersFromConfig(parsed)) {
+        if (!seen.has(s.name)) {
+          seen.add(s.name);
+          mcpServers.push(s);
+        }
+      }
+    } catch {
+      /* missing/malformed config — skip */
+    }
+  }
+  return { skills, mcpServers };
 }

--- a/src/sbom.ts
+++ b/src/sbom.ts
@@ -14,6 +14,12 @@ import type { LockPkg } from "./supply-chain.js";
 export interface Component {
   name: string;
   version: string;
+  /** CycloneDX component type; defaults to "library" (npm deps). */
+  type?: "library" | "application" | "data" | "machine-learning-model";
+  /** Package URL; defaults to `pkg:npm/<name>@<version>` when omitted. */
+  purl?: string;
+  /** Optional provenance note (file path, server command, source) for humans. */
+  provenance?: string;
 }
 
 /** Lock packages → distinct {name, version} components (skips the root + versionless). */
@@ -31,7 +37,7 @@ export function lockComponents(lockPkgs: LockPkg[]): Component[] {
 }
 
 function purl(c: Component): string {
-  return `pkg:npm/${c.name}@${c.version}`;
+  return c.purl ?? `pkg:npm/${c.name}@${c.version}`;
 }
 
 export function toCycloneDX(components: Component[]): unknown {
@@ -40,10 +46,11 @@ export function toCycloneDX(components: Component[]): unknown {
     specVersion: "1.5",
     version: 1,
     components: components.map((c) => ({
-      type: "library",
+      type: c.type ?? "library",
       name: c.name,
       version: c.version,
       purl: purl(c),
+      ...(c.provenance ? { properties: [{ name: "kit:provenance", value: c.provenance }] } : {}),
     })),
   };
 }


### PR DESCRIPTION
Implements the buildout's **final GO item (G5)** — un-blocked by the source-run that confirmed the primary source (**arXiv:2404.12736 / ACM TOSEM 34(5), doi:10.1145/3708531**; gap analysis §2.5, **verified 3-0**): the agenda names an **SBOM for the LLM toolchain** as an unrealized opportunity. The pieces an agent actually loads — skills, MCP servers, plugins — are supply-chain components no lockfile lists, so today's SBOM can't see them.

## Core (`src/agent-sbom.ts`, pure, zero-LLM)
- `agentToolchainComponents` — maps skills / MCP servers / plugins into the **same CycloneDX/SPDX `Component`** shape kit already emits, with `pkg:generic/<kind>/<name>@<version>` purls, `type: application`, and provenance; deduped + sorted.
- `mcpServersFromConfig` — parses `mcpServers`/`servers` config objects.

## SBOM generalization (`src/sbom.ts`, backward-compatible)
`Component` gains optional `type` + `purl` (+ a `kit:provenance` property in CycloneDX). npm deps stay `library` + `pkg:npm/...` exactly as before; `toSpdx` already routed through `purl()`, so it picks up overrides for free.

## CLI
`kit sbom --agent` discovers skills (`.claude/skills/*/SKILL.md`) and MCP servers (`.mcp.json` / `.claude.json` / `.cursor|.vscode/mcp.json`) and folds them into one BOM. **Opt-in — default output is unchanged.**

## Tests
Pure mapper + config parser + emitter backward-compat (npm stays library+pkg:npm; agent piece carries type+generic purl+provenance; SPDX externalRef honors override). CLI smoke-tested: default = npm only, `--agent` adds skill + mcp-server. Full suite **2564/2564**.

## Follow-up
Live plugin discovery (this increment does skills + MCP servers); a first-party read of arXiv:2404.12736 to lift the §2.5 search-index caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_