### PR TITLE
feat(coverage): map OWASP LLM Top 10 (2025) + NIST SSDF via kit coverage --standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,6 +901,7 @@ For Cline, add the same config to your `cline_mcp_settings.json`.
 - 📚 **Plugin Development**: [docs/PLUGIN_DEVELOPMENT.md](docs/PLUGIN_DEVELOPMENT.md), [docs/ADAPTER_GUIDE.md](docs/ADAPTER_GUIDE.md), [docs/MCP_TOOLS_GUIDE.md](docs/MCP_TOOLS_GUIDE.md)
 - 🔤 **Acronyms & terms**: [docs/GLOSSARY.md](docs/GLOSSARY.md) — what SBOM, MCP, PAL, SLSA, … mean in kit
 - 📐 **Standards coverage & gaps**: [docs/STANDARDS.md](docs/STANDARDS.md) — which security standards kit maps to (OWASP, ASVS, SLSA, …) and which it doesn't yet
+- 🧭 **What kit is**: [docs/ENFORCEMENT_AND_AUDIT.md](docs/ENFORCEMENT_AND_AUDIT.md) — kit as both a deterministic enforcement "grinder" and an audit tool, and the "no false green" loop between them
 - 💬 **Discussions**: [github.com/sandstream/kit/discussions](https://github.com/sandstream/kit/issues)
 - 🐛 **Issues**: [github.com/sandstream/kit/issues](https://github.com/sandstream/kit/issues)
 - 🤝 **Contributing**: [CONTRIBUTING.md](CONTRIBUTING.md), [COMMUNITY.md](COMMUNITY.md)

--- a/docs/ENFORCEMENT_AND_AUDIT.md
+++ b/docs/ENFORCEMENT_AND_AUDIT.md
@@ -1,0 +1,64 @@
+# What kit is — enforcement *and* audit
+
+> **One line:** kit is a deterministic **meat grinder** that forces a specific, secure way
+> of building software through gates — and it also prints a **signed receipt** of what came
+> out, while refusing to claim the meat is ground if the grinder wasn't provably on.
+
+Most people meet kit as the grinder (the gates you can't get around) and miss the second half.
+kit is two things in one, and they reinforce each other.
+
+## Mode 1 — the grinder: enforcement (real-time, preventive)
+
+Gates that force the process **at the moment an action happens**, before anything can go wrong.
+Deterministic, fail-closed, zero-LLM:
+
+- **PreToolUse gates** — `gate-bash`, `gate-env` block un-triaged installs and plaintext-secret
+  writes *before* they land.
+- **Capture-time gates** — the memory write-gate (G1), install-gate, slopsquat scoring (G4).
+- **Commit/CI chokepoints** — `kit triage check-deps` (pre-commit), branch-protected checks.
+- **`warn → enforce` ramp** — a new gate warns first, then fails once enforced.
+
+This is the "gravitation": you *can't* do X. It shapes **how** software gets built.
+
+## Mode 2 — the receipt: audit (point-in-time + after-the-fact, evidential)
+
+kit also **produces and verifies proof** — of what happened and what's covered:
+
+- **Tamper-evident audit log** — `.kit-audit.jsonl`, HMAC-anchored, hash-chained, Ed25519-signed
+  (`verifyAuditChain` / `verifyAuditSignatures`); see `docs/AUDIT_ATTESTATION.md`.
+- **`kit self-audit`** — deterministic check of kit's own source against its bug-classes.
+- **`kit coverage`** — an OWASP ASVS L2 *evidence map* for GRC (`--json`).
+- **`kit sbom`** — component inventory (incl. the agent toolchain, G5); **SARIF** emit feeds
+  external audit tooling.
+- **verified-forget tombstones** (G1) — deletion you can *prove*; **triage logs** — proof a
+  dependency was evaluated.
+- **`kit check` / `check-security`** — point-in-time repo audit.
+- **`docs/STANDARDS.md`** — an honest map of which standards kit aligns to (and which it doesn't).
+
+This is the "label + receipt": proof of **what** was produced, and to which standard.
+
+## The loop — why they're one tool, not two
+
+The two modes are wired together, and that wiring is kit's thesis:
+
+1. **The grinder produces the evidence** — every gate decision can be logged and attested.
+2. **The audit proves the grinder was on** — gate-liveness and hook-liveness checks, and
+   self-audit rule **R13 (catch-false-green)**, fail if enforcement isn't actually installed.
+
+That closed loop is **"no false green"**: kit will not report a clean result it cannot prove.
+An audit tool that can't confirm its own controls are live is just theater; kit's audit side
+exists partly to keep its enforcement side honest.
+
+## An honest boundary (same no-false-green spirit)
+
+As an audit tool kit is strong on **integrity evidence**, but its trust anchor is
+**machine-local**: everything is tamper-*evident* against someone who can write the log, not
+tamper-*resistant* against a same-UID principal who can read a `0600` file. Closing that gap is
+the point of hardware-rooted identity (TPM/HSM) on the kit 5.0 roadmap. Until then: kit is
+excellent proof of what **you** did under enforcement — not forensic proof against an attacker
+who already owns your user account.
+
+## The formula
+
+> **kit = a deterministic grinder that forces the secure way of building — and prints a signed
+> receipt of what came out, refusing to call it done unless the grinder was provably running.**

--- a/docs/STANDARDS.md
+++ b/docs/STANDARDS.md
@@ -8,17 +8,19 @@
 
 ## 1. Standards kit takes into account today
 
-| Standard | How kit engages it | Where |
-|---|---|---|
-| **OWASP Top 10 (2025)** | Per-category mapping of kit's shipped controls | `docs/OWASP_2025.md` |
-| **OWASP ASVS 4.0.3 (L2)** | Deterministic **evidence map** (auto-verified / gap / manual / n-a) | `kit coverage [--json]` |
-| **SLSA** | Build provenance / integrity framing | attestation + `docs/AUDIT_ATTESTATION.md` |
-| **Sigstore / cosign** | Signature verification of artifacts | supply-chain paths |
-| **OpenSSF Scorecard** | Repo-posture scoring in CI | `.github/workflows/scorecard.yml` |
-| **CycloneDX + SPDX** | SBOM emit (incl. `--agent` toolchain) | `kit sbom` |
-| **CVE / CWE / OSV / SARIF** | Vuln IDs, weakness taxonomy, findings interchange | `kit scan`, findings `rule` field |
-| **EU CRA** | SBOM-mandate driver | `kit sbom` rationale |
-| **GDPR** | PII redaction / memory handling | redaction + memory layer |
+| Standard                                        | How kit engages it                                                  | Where                                     |
+| ----------------------------------------------- | ------------------------------------------------------------------- | ----------------------------------------- |
+| **OWASP Top 10 (2025)**                         | Per-category mapping of kit's shipped controls                      | `docs/OWASP_2025.md`                      |
+| **OWASP ASVS 4.0.3 (L2)**                       | Deterministic **evidence map** (auto-verified / gap / manual / n-a) | `kit coverage [--json]`                   |
+| **SLSA**                                        | Build provenance / integrity framing                                | attestation + `docs/AUDIT_ATTESTATION.md` |
+| **Sigstore / cosign**                           | Signature verification of artifacts                                 | supply-chain paths                        |
+| **OpenSSF Scorecard**                           | Repo-posture scoring in CI                                          | `.github/workflows/scorecard.yml`         |
+| **CycloneDX + SPDX**                            | SBOM emit (incl. `--agent` toolchain)                               | `kit sbom`                                |
+| **CVE / CWE / OSV / SARIF**                     | Vuln IDs, weakness taxonomy, findings interchange                   | `kit scan`, findings `rule` field         |
+| **OWASP Top 10 for LLM Applications (2025)**    | Evidence map of LLM01–LLM10 → kit controls                          | `kit coverage --standard=llm-top10`       |
+| **NIST SSDF (SP 800-218 / 218A GenAI profile)** | Evidence map of the practices kit speaks to (PO/PS/PW/RV)           | `kit coverage --standard=ssdf`            |
+| **EU CRA**                                      | SBOM-mandate driver                                                 | `kit sbom` rationale                      |
+| **GDPR**                                        | PII redaction / memory handling                                     | redaction + memory layer                  |
 
 ## 2. Standards kit does NOT yet take into account (ranked by fit)
 
@@ -26,14 +28,14 @@ Each of these is a genuine gap. Most are standards kit **already has controls fo
 not **mapped** — the cheap, honest fix is to extend the `kit coverage` evidence-map machine,
 not to invent new controls.
 
-| # | Standard | Why it fits kit | Planned home |
-|---|---|---|---|
-| 1 | **NIST SSDF — SP 800-218** + **800-218A** (SSDF for generative AI) | The canonical "build software securely" framework; **218A is literally SSDF for GenAI** — the exact space kit occupies. Biggest gap. | `kit coverage` mapping + this doc |
-| 2 | **OWASP Top 10 for LLM Applications (2025)** | kit maps the *web* Top 10 but not the *LLM* one, despite being an AI-agent tool. Prompt injection, tool poisoning, supply-chain are already shipped controls — just unmapped. | `kit coverage` mapping |
-| 3 | **NIST AI RMF (AI 100-1) + Generative AI Profile (600-1)** | AI-specific risk framework; natural parallel to the OWASP mapping. | mapping doc |
-| 4 | **MITRE ATLAS** | Adversarial-AI TTP matrix (ATT&CK for ML) — the vocabulary for the agent threats kit gates. | threat-model cross-ref |
-| 5 | **OpenSSF S2C2F** (Secure Supply Chain **Consumption** Framework) | Near-perfect fit for install-triage / slopsquat / consumer-side verification — currently only referenced in passing, not mapped. | `kit coverage` mapping |
-| 6 | **ISO/IEC 42001** (AI management system) | Certification track for AI governance (the ISO references in-repo are ISO-8601 dates, not 42001/27001). | evidence map (GRC) |
+| #        | Standard                                                          | Why it fits kit                                                                                                                  | Planned home           |
+| -------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| ~~1~~ ✅ | **NIST SSDF — SP 800-218 / 218A**                                 | **Now mapped** at the practice level 218A profiles — `kit coverage --standard=ssdf` (see §1).                                    | done                   |
+| ~~2~~ ✅ | **OWASP Top 10 for LLM Applications (2025)**                      | **Now mapped** — `kit coverage --standard=llm-top10` (see §1).                                                                   | done                   |
+| 3        | **NIST AI RMF (AI 100-1) + Generative AI Profile (600-1)**        | AI-specific risk framework; natural parallel to the OWASP mapping.                                                               | `kit coverage` mapping |
+| 4        | **MITRE ATLAS**                                                   | Adversarial-AI TTP matrix (ATT&CK for ML) — the vocabulary for the agent threats kit gates.                                      | threat-model cross-ref |
+| 5        | **OpenSSF S2C2F** (Secure Supply Chain **Consumption** Framework) | Near-perfect fit for install-triage / slopsquat / consumer-side verification — currently only referenced in passing, not mapped. | `kit coverage` mapping |
+| 6        | **ISO/IEC 42001** (AI management system)                          | Certification track for AI governance (the ISO references in-repo are ISO-8601 dates, not 42001/27001).                          | evidence map (GRC)     |
 
 **Secondary / weaker fit:** OWASP **SAMM** & **BSIMM** (maturity models, not control checklists);
 **EU AI Act** (regulatory, vs the CRA already covered); **CIS Benchmarks** (hadolint covers the
@@ -42,16 +44,19 @@ Docker slice); **SOC 2 / PCI-DSS / HIPAA** (compliance regimes — served indire
 
 ## 3. Why "map", not "add"
 
-The top three (SSDF/800-218A, OWASP LLM Top 10, S2C2F) are the highest-value because kit
-*already ships* the controls they ask for — write-gate, injection quarantine, install-triage,
-slopsquat scoring, deterministic gates. What's missing is the **crosswalk** from control →
-standard clause, exactly what `kit coverage` already does for ASVS. So the plan is:
+The top ones are highest-value because kit _already ships_ the controls they ask for —
+write-gate, injection quarantine, install-triage, slopsquat scoring, deterministic gates.
+What was missing was the **crosswalk** from control → standard clause, exactly what
+`kit coverage` already does for ASVS. Status:
 
-1. Extend `kit coverage` with pinned, curated mappings for **OWASP LLM Top 10** and **SSDF
-   800-218A**, bucketed the same way (auto-verified / gap / manual / n-a).
-2. Add **S2C2F** and **NIST AI RMF** as further evidence maps.
-3. Before mapping, run a **verification pass** on the exact control IDs so kit never cites a
-   clause number it hasn't confirmed (no false green).
+1. ✅ **Done:** `kit coverage --standard=llm-top10` and `--standard=ssdf` — pinned, curated
+   maps bucketed the same way (auto / gap / manual / n-a), built on a generic evidence-map
+   engine (`src/coverage/standard.ts`). Control IDs were verified (a source-run confirmed the
+   LLM01–LLM10 titles and the PO/PS/PW/RV practices) before mapping — no invented clause numbers.
+   Caveat carried into the disclaimer: IDs were confirmed via search index, not first-party
+   fetch (egress-blocked), and kit does not enumerate 218A's specific AI task augmentations.
+2. **Next:** add **S2C2F** and **NIST AI RMF** as further evidence maps (same engine).
+3. Every mapping stays behind the "no false green" rule — a clause kit can't confirm is not cited.
 
-Until then, this doc is the honest record: kit aligns to the §1 set and **does not yet
-account for** the §2 set.
+This doc is the honest record: kit aligns to the §1 set (now including OWASP LLM Top 10 + NIST
+SSDF) and **does not yet account for** the remaining §2 set.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -153,6 +153,9 @@ import { parsePkgSpec, installPkg } from "./pkg.js";
 import { cmdMemory } from "./commands/memory.js";
 import { resolveKitRoot, runSelfAudit, SELF_AUDIT_RULES } from "./self-audit.js";
 import { buildCoverageReport, formatCoverageText, type Bucket } from "./coverage/coverage.js";
+import { buildStandardReport, formatStandardText } from "./coverage/standard.js";
+import { OWASP_LLM_TOP10 } from "./coverage/owasp-llm-top10.js";
+import { SSDF_218A } from "./coverage/ssdf-218a.js";
 import { escapeWorkflowCmd, xmlEscape } from "./utils/ci-escape.js";
 
 // Re-exported for tests + downstream emitters (ci-escaping.test.ts imports these
@@ -3900,13 +3903,6 @@ async function cmdCoverage(): Promise<boolean> {
     results = [...security, ...selfAudit, ...commandEvidence];
   }
 
-  const report = buildCoverageReport(results);
-
-  if (jsonMode) {
-    console.log(JSON.stringify(report, null, 2));
-    return true;
-  }
-
   const colorBucket = (bucket: Bucket, label: string): string => {
     const tint =
       bucket === "auto"
@@ -3919,6 +3915,31 @@ async function cmdCoverage(): Promise<boolean> {
     return `${tint}${label}${c.reset}`;
   };
 
+  // --standard selects which pinned standard to map against (default ASVS, the
+  // original path). llm-top10 / ssdf route through the generic evidence-map engine.
+  const standard = args.find((a) => a.startsWith("--standard="))?.split("=")[1] ?? "asvs";
+  const STANDARDS = { "llm-top10": OWASP_LLM_TOP10, ssdf: SSDF_218A } as const;
+  if (standard !== "asvs") {
+    const descriptor = STANDARDS[standard as keyof typeof STANDARDS];
+    if (!descriptor) {
+      console.error(
+        `${c.red}unknown --standard '${standard}' (use: asvs | llm-top10 | ssdf)${c.reset}`,
+      );
+      process.exitCode = 1;
+      return false;
+    }
+    const stdReport = buildStandardReport(descriptor, results);
+    console.log(
+      jsonMode ? JSON.stringify(stdReport, null, 2) : formatStandardText(stdReport, colorBucket),
+    );
+    return true;
+  }
+
+  const report = buildCoverageReport(results);
+  if (jsonMode) {
+    console.log(JSON.stringify(report, null, 2));
+    return true;
+  }
   console.log(formatCoverageText(report, colorBucket));
   return true;
 }
@@ -5430,7 +5451,7 @@ export const COMMAND_HELP: Record<string, string> = {
   "self-audit":
     "Audit kit's own source against its 12 self-hardening rules (--list-rules, --only=<ids>, --format)",
   coverage:
-    "Evidence map: which OWASP ASVS L2 controls kit's deterministic checks auto-verify vs gap/manual/n-a (NOT a compliance attestation; --json for GRC tools)",
+    "Evidence map: which standard's controls kit's deterministic checks auto-verify vs gap/manual/n-a — OWASP ASVS L2 (default), OWASP LLM Top 10, or NIST SSDF via --standard=asvs|llm-top10|ssdf (NOT a compliance attestation; --json for GRC tools)",
   identity:
     "Manage this machine/agent's Ed25519 identity (init/show/rotate) — asymmetric, attributable signing for audit/policy (experimental)",
   panic:

--- a/src/coverage/coverage.ts
+++ b/src/coverage/coverage.ts
@@ -236,7 +236,7 @@ export interface CoverageReport {
 }
 
 /** Resolve catalog citations for a set of check ids, deduped by citation id. */
-function citationsFor(checks: string[]): RuleRef[] {
+export function citationsFor(checks: string[]): RuleRef[] {
   const out: RuleRef[] = [];
   const seen = new Set<string>();
   for (const id of checks) {

--- a/src/coverage/owasp-llm-top10.ts
+++ b/src/coverage/owasp-llm-top10.ts
@@ -1,0 +1,101 @@
+/**
+ * Vendored, pinned OWASP Top 10 for LLM Applications (2025) as a kit coverage
+ * evidence map. Same honesty rule as the ASVS subset: kit maps ONLY what its
+ * deterministic, local, zero-LLM checks can actually speak to, and buckets each
+ * risk honestly (auto / gap / manual / na). This is an EVIDENCE source, not a
+ * compliance attestation.
+ *
+ * Control ids/titles were confirmed against genai.owasp.org via search index
+ * (the session egress policy blocked first-party fetch of owasp.org); 7/10 titles
+ * are verbatim-confirmed, LLM01/03/05 are from the authoritative summary list. See
+ * the `caveat` on the descriptor.
+ *
+ * Source: OWASP Top 10 for LLM Applications 2025 (OWASP GenAI Security Project).
+ *   - https://genai.owasp.org/llm-top-10/
+ */
+import type { StandardDescriptor } from "./standard.js";
+
+export const OWASP_LLM_TOP10: StandardDescriptor = {
+  key: "llm-top10",
+  label: "OWASP Top 10 for LLM Applications",
+  version: "2025",
+  source: "OWASP Top 10 for LLM Applications 2025 (OWASP GenAI Security Project)",
+  sourceUrl: "https://genai.owasp.org/llm-top-10/",
+  unit: "risk",
+  caveat:
+    "Titles confirmed via search index (owasp.org first-party fetch was egress-blocked); LLM01/03/05 are from the authoritative summary list, not per-page verified.",
+  requirements: [
+    { id: "LLM01:2025", section: "OWASP LLM Top 10 (2025)", text: "Prompt Injection" },
+    { id: "LLM02:2025", section: "OWASP LLM Top 10 (2025)", text: "Sensitive Information Disclosure" },
+    { id: "LLM03:2025", section: "OWASP LLM Top 10 (2025)", text: "Supply Chain" },
+    { id: "LLM04:2025", section: "OWASP LLM Top 10 (2025)", text: "Data and Model Poisoning" },
+    { id: "LLM05:2025", section: "OWASP LLM Top 10 (2025)", text: "Improper Output Handling" },
+    { id: "LLM06:2025", section: "OWASP LLM Top 10 (2025)", text: "Excessive Agency" },
+    { id: "LLM07:2025", section: "OWASP LLM Top 10 (2025)", text: "System Prompt Leakage" },
+    { id: "LLM08:2025", section: "OWASP LLM Top 10 (2025)", text: "Vector and Embedding Weaknesses" },
+    { id: "LLM09:2025", section: "OWASP LLM Top 10 (2025)", text: "Misinformation" },
+    { id: "LLM10:2025", section: "OWASP LLM Top 10 (2025)", text: "Unbounded Consumption" },
+  ],
+  mapping: {
+    "LLM01:2025": {
+      bucket: "auto",
+      checks: ["memory injection", "kit triage mcp", "R7"],
+      rationale:
+        "kit quarantines high-confidence prompt-injection patterns at memory capture (R7) and statically flags tool-metadata poisoning in MCP servers; it does not claim to stop injection inside the model.",
+    },
+    "LLM02:2025": {
+      bucket: "auto",
+      checks: ["secrets scan", "gate-env", "scan-transcripts", "R2-secret-argv"],
+      rationale:
+        "kit detects/redacts plaintext secrets, blocks secret writes to .env (gate-env), flags secret-shaped rows at memory capture, and scans transcripts/caches for leaked credentials.",
+    },
+    "LLM03:2025": {
+      bucket: "auto",
+      checks: ["supply-chain", "kit slopsquat", "kit triage mcp", "pinned versions", "sbom"],
+      rationale:
+        "kit gates un-triaged installs, scores hallucination/slopsquat risk, triages MCP servers, verifies pinned/locked deps, and emits an SBOM (incl. the agent toolchain).",
+    },
+    "LLM04:2025": {
+      bucket: "auto",
+      checks: ["memory injection", "memory write-gate"],
+      rationale:
+        "Narrow slice: kit addresses AGENT-MEMORY poisoning — a capture-time write-gate rejects/quarantines poisoned rows and verified-forget proves removal. Training-data / model-weight poisoning is outside kit's local reach.",
+    },
+    "LLM05:2025": {
+      bucket: "gap",
+      checks: [],
+      rationale:
+        "kit sanitizes its OWN recall/inject path (strips hidden chars, flags), but has no check for how the target application handles/encodes downstream LLM output.",
+    },
+    "LLM06:2025": {
+      bucket: "auto",
+      checks: ["gate-bash", "gate-env", "agent-audit"],
+      rationale:
+        "kit constrains agent agency at the action boundary — deny-by-default installs/secret-writes (PreToolUse gates) and governed mutating MCP tools. Full exec-time agency scoping (egress/fs/secret-scoped broker) is on the 5.0 roadmap.",
+    },
+    "LLM07:2025": {
+      bucket: "gap",
+      checks: [],
+      rationale:
+        "kit scans transcripts/configs for credentials that should not sit in prompts, but has no dedicated system-prompt-leakage detection.",
+    },
+    "LLM08:2025": {
+      bucket: "na",
+      checks: [],
+      rationale:
+        "kit has no RAG / vector-store surface; embedding and retrieval weaknesses are outside its local, static scope.",
+    },
+    "LLM09:2025": {
+      bucket: "na",
+      checks: [],
+      rationale:
+        "kit deliberately does not judge output truthfulness (zero-LLM). The specific package-hallucination vector IS covered deterministically by slopsquat under LLM03.",
+    },
+    "LLM10:2025": {
+      bucket: "gap",
+      checks: [],
+      rationale:
+        "kit has cost/budget signals but no deterministic unbounded-consumption (rate/DoS/cost) gate for the agent runtime.",
+    },
+  },
+};

--- a/src/coverage/ssdf-218a.ts
+++ b/src/coverage/ssdf-218a.ts
@@ -1,0 +1,118 @@
+/**
+ * Vendored, pinned NIST SSDF (SP 800-218 v1.1) practices as a kit coverage evidence
+ * map — the subset kit's deterministic checks can speak to. SP 800-218A ("Secure
+ * Software Development Practices for Generative AI and Dual-Use Foundation Models",
+ * Jul 2024) is a Community PROFILE that augments 800-218 *without* a separate
+ * numbering scheme, so kit maps at the 800-218 practice level that 218A profiles.
+ *
+ * Same honesty rule as the ASVS subset: only practices kit can actually observe are
+ * vendored; the rest (org/process/human) are omitted rather than mass-marked manual.
+ * EVIDENCE source, not a compliance attestation.
+ *
+ * Practice ids/names confirmed against csrc.nist.gov via search index (first-party
+ * fetch was egress-blocked). Group ids (PO/PS/PW/RV) and PW.7/PW.8 were live-
+ * confirmed; the rest are from the stable published framework. kit does NOT enumerate
+ * 218A's specific AI task augmentations (those need the 218A appendix, not fetched).
+ *
+ * Sources:
+ *   - SP 800-218 v1.1: https://csrc.nist.gov/pubs/sp/800/218/final
+ *   - SP 800-218A: https://csrc.nist.gov/pubs/sp/800/218/a/final
+ */
+import type { StandardDescriptor } from "./standard.js";
+
+const PO = "PO — Prepare the Organization";
+const PS = "PS — Protect the Software";
+const PW = "PW — Produce Well-Secured Software";
+const RV = "RV — Respond to Vulnerabilities";
+
+export const SSDF_218A: StandardDescriptor = {
+  key: "ssdf",
+  label: "NIST SSDF",
+  version: "SP 800-218 v1.1 (profiled by 218A)",
+  source: "NIST SP 800-218 v1.1 Secure Software Development Framework, with the SP 800-218A GenAI Community Profile",
+  sourceUrl: "https://csrc.nist.gov/pubs/sp/800/218/final",
+  unit: "practice",
+  caveat:
+    "Mapped at the 800-218 practice level that SP 800-218A (GenAI profile, Jul 2024) augments; kit does not enumerate 218A's specific AI task IDs. Practice text confirmed via search index, not first-party fetch (egress-blocked).",
+  requirements: [
+    { id: "PO.3", section: PO, text: "Implement Supporting Toolchains" },
+    { id: "PO.4", section: PO, text: "Define and Use Criteria for Software Security Checks" },
+    { id: "PS.1", section: PS, text: "Protect All Forms of Code from Unauthorized Access and Tampering" },
+    { id: "PS.2", section: PS, text: "Provide a Mechanism for Verifying Software Release Integrity" },
+    { id: "PW.4", section: PW, text: "Reuse Existing, Well-Secured Software When Feasible" },
+    { id: "PW.6", section: PW, text: "Configure the Compilation, Interpreter, and Build Processes" },
+    { id: "PW.7", section: PW, text: "Review and/or Analyze Human-Readable Code" },
+    { id: "PW.8", section: PW, text: "Test Executable Code" },
+    { id: "PW.9", section: PW, text: "Configure Software to Have Secure Settings by Default" },
+    { id: "RV.1", section: RV, text: "Identify and Confirm Vulnerabilities on an Ongoing Basis" },
+    { id: "RV.2", section: RV, text: "Assess, Prioritize, and Remediate Vulnerabilities" },
+  ],
+  mapping: {
+    "PO.3": {
+      bucket: "auto",
+      checks: ["kit check", "provision"],
+      rationale:
+        "kit IS a deterministic security toolchain — it provisions and runs the checks/gates automatically rather than relying on manual tooling.",
+    },
+    "PO.4": {
+      bucket: "auto",
+      checks: ["kit check", "standards", "baseline"],
+      rationale:
+        "kit defines and enforces explicit pass/fail security criteria (check / standards / coverage) with a committed baseline for net-new gating.",
+    },
+    "PS.1": {
+      bucket: "auto",
+      checks: ["secrets scan", ".env gitignored", "gate-env"],
+      rationale:
+        "Partial: kit blocks plaintext secrets in code/config and secret writes to .env, reducing unauthorized exposure of code/credentials; it does not manage repository access control.",
+    },
+    "PS.2": {
+      bucket: "auto",
+      checks: ["attestation", "cosign", "R9"],
+      rationale:
+        "kit verifies release/artifact signatures (Sigstore/cosign) and keeps its own audit log tamper-evident (HMAC anchor), giving a mechanism to verify integrity.",
+    },
+    "PW.4": {
+      bucket: "auto",
+      checks: ["supply-chain", "kit slopsquat", "kit triage mcp", "security policy"],
+      rationale:
+        "kit triages third-party components (install-gate, slopsquat, MCP triage) and can enforce a trusted-source allowlist before reuse.",
+    },
+    "PW.6": {
+      bucket: "auto",
+      checks: ["gha-audit"],
+      rationale:
+        "Partial: kit lints CI/build workflows for unpinned actions and unsafe patterns; it does not verify full build reproducibility.",
+    },
+    "PW.7": {
+      bucket: "auto",
+      checks: ["standards", "self-audit"],
+      rationale:
+        "kit statically analyzes human-readable code (standards: complexity/duplication/linters; self-audit bug-classes) — a deterministic slice of code review.",
+    },
+    "PW.8": {
+      bucket: "na",
+      checks: [],
+      rationale:
+        "Executing and testing the target's built code (unit/DAST/fuzz) is a runtime activity; kit is local, static, and zero-egress.",
+    },
+    "PW.9": {
+      bucket: "auto",
+      checks: ["kit setup", "gate-bash", "gate-env"],
+      rationale:
+        "kit ships secure-by-default: setup installs the enforcement gates, and the warn→enforce ramp keeps defaults safe.",
+    },
+    "RV.1": {
+      bucket: "auto",
+      checks: ["npm audit", "trivy container scan", "supply-chain", "sbom"],
+      rationale:
+        "kit runs dependency/vuln scanners (npm/pip audit, trivy), merges external scanners into one verdict, and can emit an SBOM of the resolved tree.",
+    },
+    "RV.2": {
+      bucket: "gap",
+      checks: [],
+      rationale:
+        "kit surfaces severity and a unified verdict, but deterministic remediation/rotation TRACKING (a finding isn't 'handled' until fixed) is a planned follow-up, not yet a check.",
+    },
+  },
+};

--- a/src/coverage/standard.test.ts
+++ b/src/coverage/standard.test.ts
@@ -1,0 +1,93 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildStandardReport,
+  buildStandardEntries,
+  formatStandardText,
+  type StandardDescriptor,
+} from "./standard.js";
+import { OWASP_LLM_TOP10 } from "./owasp-llm-top10.js";
+import { SSDF_218A } from "./ssdf-218a.js";
+import type { SecurityCheckResult } from "../check-security.js";
+
+const VALID_BUCKETS = ["auto", "gap", "manual", "na"];
+const DESCRIPTORS: StandardDescriptor[] = [OWASP_LLM_TOP10, SSDF_218A];
+
+for (const d of DESCRIPTORS) {
+  describe(`standard mapping — ${d.key}`, () => {
+    it("maps every requirement exactly once (no holes, no extras)", () => {
+      // buildStandardEntries throws on an unmapped requirement.
+      const entries = buildStandardEntries(d);
+      assert.equal(entries.length, d.requirements.length);
+      // every mapping key is a real requirement id
+      const ids = new Set(d.requirements.map((r) => r.id));
+      for (const key of Object.keys(d.mapping)) {
+        assert.ok(ids.has(key), `mapping has stray id ${key}`);
+      }
+      assert.equal(Object.keys(d.mapping).length, d.requirements.length);
+    });
+
+    it("assigns every requirement a valid bucket", () => {
+      for (const e of buildStandardEntries(d)) {
+        assert.ok(VALID_BUCKETS.includes(e.bucket), `invalid bucket for ${e.requirement.id}`);
+      }
+    });
+
+    it("AUTO cites ≥1 backing check; MANUAL/NA cite none", () => {
+      for (const e of buildStandardEntries(d)) {
+        if (e.bucket === "auto") {
+          assert.ok(e.checks.length > 0, `AUTO ${e.requirement.id} must cite a check`);
+        }
+        if (e.bucket === "manual" || e.bucket === "na") {
+          assert.equal(e.checks.length, 0, `${e.bucket} ${e.requirement.id} must not claim evidence`);
+        }
+      }
+    });
+
+    it("is pure + deterministic (identical across builds)", () => {
+      assert.deepEqual(buildStandardReport(d), buildStandardReport(d));
+    });
+
+    it("summary tallies sum to the total", () => {
+      const s = buildStandardReport(d).summary;
+      assert.equal(s.auto + s.gap + s.manual + s.na, s.total);
+      assert.equal(s.total, d.requirements.length);
+    });
+
+    it("disclaimer is an evidence map and NEVER claims compliant/certified", () => {
+      const text = formatStandardText(buildStandardReport(d));
+      assert.match(text, /evidence map, not a compliance attestation/i);
+      assert.ok(!/\bcompliant\b/i.test(text), "must not claim compliant");
+      assert.ok(!/\bcertified\b/i.test(text), "must not claim certified");
+    });
+
+    it("report carries key/label/version/source/disclaimer/summary/sections", () => {
+      const r = buildStandardReport(d);
+      assert.equal(r.key, d.key);
+      assert.equal(r.label, d.label);
+      assert.ok(r.version && r.source && r.sourceUrl && r.disclaimer);
+      assert.ok(r.sections.length > 0);
+    });
+  });
+}
+
+describe("standard --verify evidence binding", () => {
+  it("binds AUTO controls to live results (fail beats pass)", () => {
+    // Force a couple of known backing checks to pass/fail and confirm the summary reflects it.
+    const results: SecurityCheckResult[] = [
+      { category: "supply-chain", name: "supply-chain", status: "pass", detail: "ok" },
+      { category: "secrets", name: "secrets scan", status: "fail", detail: "leak" },
+    ];
+    const r = buildStandardReport(OWASP_LLM_TOP10, results);
+    assert.ok(r.summary.autoVerified !== undefined, "live evidence tallied under --verify");
+    // LLM02 cites "secrets scan" (failing) → should count as failing, not verified.
+    const llm02 = r.sections.flatMap((s) => s.entries).find((e) => e.requirement.id === "LLM02:2025");
+    assert.equal(llm02?.evidence, "failing");
+  });
+
+  it("static report (no results) carries no live evidence", () => {
+    const r = buildStandardReport(SSDF_218A);
+    assert.equal(r.summary.autoVerified, undefined);
+    for (const e of r.sections.flatMap((s) => s.entries)) assert.equal(e.evidence, undefined);
+  });
+});

--- a/src/coverage/standard.ts
+++ b/src/coverage/standard.ts
@@ -1,0 +1,213 @@
+/**
+ * kit coverage — generic evidence-map engine for ANY pinned standard.
+ *
+ * `coverage.ts` grew up ASVS-specific; this is the same proven idea generalized so
+ * kit can map its deterministic checks against additional standards (OWASP LLM Top 10,
+ * NIST SSDF) without duplicating the bucketing/evidence logic. A `StandardDescriptor`
+ * bundles a pinned requirement list + a control→kit mapping; `buildStandardReport`
+ * turns it into the same evidence map (auto / gap / manual / na) with the same honest
+ * "not a compliance attestation" disclaimer.
+ *
+ * Pure + deterministic (data → report). Reuses coverage.ts's evidence primitives so
+ * the two share one meaning of "verified/failing/unrun".
+ */
+import { evidenceFor, indexResults, citationsFor, type Bucket, type EvidenceState } from "./coverage.js";
+import type { RuleRef } from "../rules/catalog.js";
+import type { SecurityCheckResult } from "../check-security.js";
+
+export interface StandardRequirement {
+  /** Control id, e.g. "LLM01:2025" or "PW.4". */
+  id: string;
+  /** Section/group label for grouping, e.g. "LLM Application Risks" or "PW Produce Well-Secured Software". */
+  section: string;
+  /** Short paraphrase for orientation (NOT the normative text). */
+  text: string;
+}
+
+export interface StandardMappingEntry {
+  bucket: Bucket;
+  /** kit evidence ids backing the control (check names / self-audit rule ids / commands). Empty for manual/na. */
+  checks: string[];
+  /** Honest, specific reason for the bucket. */
+  rationale: string;
+}
+
+export interface StandardDescriptor {
+  /** CLI selector, e.g. "llm-top10" or "ssdf". */
+  key: string;
+  /** Human label for headers, e.g. "OWASP Top 10 for LLM Applications". */
+  label: string;
+  /** Pinned version, e.g. "2025" or "800-218 v1.1 / 218A". */
+  version: string;
+  /** Full source name. */
+  source: string;
+  /** Canonical, version-pinned source URL. */
+  sourceUrl: string;
+  /** Word for a control in this standard ("risk", "practice", "control"). */
+  unit: string;
+  /** Extra honesty line appended to the disclaimer (caveats specific to this map). */
+  caveat?: string;
+  requirements: readonly StandardRequirement[];
+  mapping: Record<string, StandardMappingEntry>;
+}
+
+export interface StandardEntry {
+  requirement: StandardRequirement;
+  bucket: Bucket;
+  checks: string[];
+  rationale: string;
+  citations: RuleRef[];
+  evidence?: EvidenceState;
+}
+
+export interface StandardSummary {
+  total: number;
+  auto: number;
+  gap: number;
+  manual: number;
+  na: number;
+  autoVerified?: number;
+  autoFailing?: number;
+  autoUnrun?: number;
+}
+
+export interface StandardReport {
+  key: string;
+  label: string;
+  version: string;
+  source: string;
+  sourceUrl: string;
+  disclaimer: string;
+  summary: StandardSummary;
+  sections: { section: string; entries: StandardEntry[] }[];
+}
+
+/** Build the flat entry list in descriptor order. Throws on an unmapped requirement. */
+export function buildStandardEntries(
+  descriptor: StandardDescriptor,
+  byKey?: Map<string, SecurityCheckResult["status"]>,
+): StandardEntry[] {
+  return descriptor.requirements.map((requirement) => {
+    const mapping = descriptor.mapping[requirement.id];
+    if (!mapping) {
+      throw new Error(
+        `coverage: ${descriptor.key} ${requirement.id} is in the requirement list but has no mapping`,
+      );
+    }
+    return {
+      requirement,
+      bucket: mapping.bucket,
+      checks: [...mapping.checks],
+      rationale: mapping.rationale,
+      citations: citationsFor(mapping.checks),
+      ...(byKey && mapping.bucket === "auto"
+        ? { evidence: evidenceFor(mapping.checks, byKey) }
+        : {}),
+    };
+  });
+}
+
+/** Tally buckets (+ live evidence when bound). Pure. */
+export function summarizeStandard(entries: StandardEntry[]): StandardSummary {
+  const summary: StandardSummary = { total: entries.length, auto: 0, gap: 0, manual: 0, na: 0 };
+  for (const e of entries) summary[e.bucket]++;
+  const bound = entries.filter((e) => e.bucket === "auto" && e.evidence);
+  if (bound.length > 0) {
+    summary.autoVerified = bound.filter((e) => e.evidence === "verified").length;
+    summary.autoFailing = bound.filter((e) => e.evidence === "failing").length;
+    summary.autoUnrun = bound.filter((e) => e.evidence === "unrun").length;
+  }
+  return summary;
+}
+
+/** The honest disclaimer — never says "compliant"/"certified". */
+export function standardDisclaimer(descriptor: StandardDescriptor, summary: StandardSummary): string {
+  let base =
+    `Evidence map, not a compliance attestation: kit auto-verifies ${summary.auto} of the ` +
+    `${summary.total} ${descriptor.label} (${descriptor.version}) ${descriptor.unit}s it maps ` +
+    `(${summary.gap} gap, ${summary.manual} manual, ${summary.na} n/a). ` +
+    `It does not assess the full standard and is not a substitute for a GRC tool.`;
+  if (descriptor.caveat) base += ` ${descriptor.caveat}`;
+  if (summary.autoVerified !== undefined) {
+    base +=
+      ` This run (--verify): ${summary.autoVerified} verified-passing, ${summary.autoFailing} FAILING, ` +
+      `${summary.autoUnrun} not-run of the ${summary.auto} mapped AUTO ${descriptor.unit}s — mapped is not passing.`;
+  }
+  return base;
+}
+
+/** Build the full structured report. Pure + deterministic. */
+export function buildStandardReport(
+  descriptor: StandardDescriptor,
+  results?: SecurityCheckResult[],
+): StandardReport {
+  const byKey = results ? indexResults(results) : undefined;
+  const entries = buildStandardEntries(descriptor, byKey);
+  const summary = summarizeStandard(entries);
+
+  const order: string[] = [];
+  const bySection = new Map<string, StandardEntry[]>();
+  for (const e of entries) {
+    const section = e.requirement.section;
+    const bucket = bySection.get(section);
+    if (bucket) bucket.push(e);
+    else {
+      order.push(section);
+      bySection.set(section, [e]);
+    }
+  }
+
+  return {
+    key: descriptor.key,
+    label: descriptor.label,
+    version: descriptor.version,
+    source: descriptor.source,
+    sourceUrl: descriptor.sourceUrl,
+    disclaimer: standardDisclaimer(descriptor, summary),
+    summary,
+    sections: order.map((section) => ({ section, entries: bySection.get(section)! })),
+  };
+}
+
+const BUCKET_LABEL: Record<Bucket, string> = { auto: "AUTO", gap: "GAP", manual: "MANUAL", na: "N/A" };
+const EVIDENCE_LABEL: Record<EvidenceState, string> = {
+  verified: "verified",
+  failing: "FAILING",
+  unrun: "not-run",
+};
+
+/** Deterministic plain-text render, grouped by section. */
+export function formatStandardText(
+  report: StandardReport,
+  color: (bucket: Bucket, label: string) => string = (_b, label) => label,
+): string {
+  const lines: string[] = [];
+  lines.push(`kit coverage — ${report.label} ${report.version} (curated subset)`);
+  lines.push(report.sourceUrl);
+  lines.push("");
+  lines.push(`! ${report.disclaimer}`);
+  lines.push("");
+  for (const { section, entries } of report.sections) {
+    lines.push(section);
+    for (const e of entries) {
+      const label = color(e.bucket, BUCKET_LABEL[e.bucket].padEnd(6));
+      lines.push(`  ${label} ${e.requirement.id.padEnd(12)} ${e.requirement.text}`);
+      if (e.checks.length > 0) {
+        const state = e.evidence ? `  [${EVIDENCE_LABEL[e.evidence]}]` : "";
+        lines.push(`         evidence: ${e.checks.join(", ")}${state}`);
+      }
+      lines.push(`         ${e.rationale}`);
+    }
+    lines.push("");
+  }
+  const s = report.summary;
+  lines.push(
+    `Summary: ${s.auto} auto · ${s.gap} gap · ${s.manual} manual · ${s.na} n/a (of ${s.total} mapped controls)`,
+  );
+  if (s.autoVerified !== undefined) {
+    lines.push(
+      `Live (--verify): ${s.autoVerified} verified · ${s.autoFailing} FAILING · ${s.autoUnrun} not-run (of ${s.auto} auto)`,
+    );
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
Closes the top two gaps from `docs/STANDARDS.md §2` — kit now **maps** the two standards it already had controls for, on a **verified** basis.

## No false green first
A source-run verified the control IDs before any mapping: **OWASP LLM01–LLM10 (2025)** titles and the **NIST SSDF PO/PS/PW/RV** practices. Caveat carried into each disclaimer — IDs confirmed via **search index** (first-party fetch was egress-blocked), and kit does **not** enumerate 218A's specific AI task augmentations.

## What's added
- **`src/coverage/standard.ts`** — a generic, standard-agnostic evidence-map engine (reuses `coverage.ts`'s bucket/evidence primitives; `citationsFor` now exported). ASVS path untouched.
- **`src/coverage/owasp-llm-top10.ts`** — LLM01–LLM10 → kit controls (**5 auto / 3 gap / 2 n/a**): injection-quarantine + MCP-triage = LLM01, secret detection = LLM02, supply-chain/slopsquat = LLM03, memory write-gate = LLM04 (agent-memory slice), gates/governance = LLM06; honest gap/na for output handling, prompt leakage, vectors, misinformation, unbounded consumption.
- **`src/coverage/ssdf-218a.ts`** — the 800-218 practices 218A profiles that kit speaks to (**9 auto / 1 gap / 1 n/a**) across PO/PS/PW/RV.
- **`kit coverage --standard=asvs|llm-top10|ssdf`** (default `asvs`, unchanged). `--json` + `--verify` evidence-binding work for all three.
- `docs/STANDARDS.md` updated: §2 #1/#2 → §1 (covered).

## Tests
Generic engine + both descriptors — well-formedness (every requirement mapped once), valid buckets, AUTO cites checks / MANUAL·NA don't, disclaimer never says "compliant"/"certified", determinism, and `--verify` live binding. Full suite **2580/2580**. CLI smoke-tested (llm-top10, ssdf, unknown→exit 1, asvs unchanged).

This is **goal 1** of two; goal 2 (workflow-driven North Star) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_