### PR TITLE
refactor(cli): extract doctor+add → commands/setup.ts (5.0-alpha setup Phase A)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -68,7 +68,6 @@ import {
   updateSkillsLock,
   updateCliLock,
 } from "./lock.js";
-import { provisionService, listAvailableServices, getServiceInfo } from "./provision.js";
 import { cmdFix } from "./fix.js";
 import { promptConfirm } from "./utils/prompt.js";
 import { c } from "./utils/colors.js";
@@ -96,12 +95,12 @@ import { cmdSbom } from "./commands/sbom.js";
 import { cmdSecurity } from "./commands/security.js";
 import { cmdSecrets } from "./commands/secrets.js";
 import { cmdUpgrade, selfUpgrade } from "./commands/upgrade.js";
+import { cmdDoctor, cmdAdd } from "./commands/setup.js";
 import { cmdAuth } from "./commands/auth.js";
 import { cmdAudit } from "./commands/audit.js";
 import { cmdMcp } from "./commands/mcp.js";
 import { cmdHooks } from "./commands/hooks.js";
 import { resolveAllAuth } from "./service-auth.js";
-import { runDoctor } from "./doctor.js";
 import { detectStack } from "./stack-detector.js";
 import { generateToml, parseEnvTemplateKeys } from "./toml-generator.js";
 import { vaultMeta, detectSecretStore } from "./vault-meta.js";
@@ -2051,105 +2050,6 @@ async function offerFirstInstallPrescan(): Promise<void> {
     console.log(`\n${c.dim}Full report:${c.reset} ${report.summaryPath}`);
   }
   console.log();
-}
-
-async function cmdDoctor(): Promise<boolean> {
-  console.log(`${c.bold}${c.cyan}kit doctor${c.reset}`);
-  console.log(`${c.dim}${"─".repeat(50)}${c.reset}\n`);
-
-  let config: ReturnType<typeof Object.create> = {};
-  try {
-    config = await loadConfig(resolveConfigPath());
-  } catch {
-    // Doctor works even without .kit.toml — skip config-dependent checks
-  }
-
-  const result = await runDoctor(config, process.cwd());
-
-  for (const check of result.checks) {
-    const icon =
-      check.status === "pass"
-        ? `${c.green}✓${c.reset}`
-        : check.status === "warn"
-          ? `${c.yellow}⚠${c.reset}`
-          : check.status === "fail"
-            ? `${c.red}✗${c.reset}`
-            : `${c.dim}–${c.reset}`;
-    console.log(`  ${icon} ${check.name}  ${c.dim}${check.detail}${c.reset}`);
-  }
-
-  console.log();
-  console.log(`${c.dim}${"─".repeat(50)}${c.reset}`);
-
-  const summaryParts: string[] = [];
-  if (result.passed > 0) summaryParts.push(`${c.green}${result.passed} passed${c.reset}`);
-  if (result.warnings > 0)
-    summaryParts.push(
-      `${c.yellow}${result.warnings} warning${result.warnings === 1 ? "" : "s"}${c.reset}`,
-    );
-  if (result.failed > 0) summaryParts.push(`${c.red}${result.failed} failed${c.reset}`);
-  if (summaryParts.length === 0) summaryParts.push(`${c.dim}no checks ran${c.reset}`);
-
-  console.log(`\n  ${summaryParts.join(" · ")}\n`);
-
-  return result.failed === 0;
-}
-
-async function cmdAdd(): Promise<boolean> {
-  const serviceName = process.argv[3];
-
-  if (!serviceName) {
-    console.log(`${c.bold}${c.cyan}Available services:${c.reset}\n`);
-
-    const services = listAvailableServices();
-    for (const svc of services) {
-      const info = getServiceInfo(svc);
-      if (info) {
-        console.log(`  ${c.green}${svc}${c.reset}  ${c.dim}${info.description}${c.reset}`);
-        console.log(`    ${c.dim}Requires: ${info.tools.join(", ")}${c.reset}`);
-      }
-    }
-
-    console.log();
-    console.log(`${c.dim}Usage: kit add <service>${c.reset}`);
-    console.log(`${c.dim}Example: kit add stripe/payments${c.reset}`);
-    console.log();
-    return false;
-  }
-
-  console.log(`${c.bold}${c.cyan}Provisioning ${serviceName}...${c.reset}\n`);
-
-  const projectPath = process.cwd();
-  const projectName = process.cwd().split("/").pop();
-
-  const result = await provisionService(serviceName, projectPath, projectName);
-
-  if (result.success) {
-    console.log(`  ${c.green}✓${c.reset} ${result.message}`);
-
-    if (result.secrets && Object.keys(result.secrets).length > 0) {
-      console.log();
-      console.log(`  ${c.dim}Added secrets to .env.local:${c.reset}`);
-      for (const key of Object.keys(result.secrets)) {
-        console.log(`    ${c.cyan}${key}${c.reset}`);
-      }
-    }
-
-    if (result.config) {
-      console.log();
-      console.log(`  ${c.dim}Updated skills-lock.json${c.reset}`);
-    }
-
-    console.log();
-    return true;
-  } else {
-    console.log(`  ${c.red}✗${c.reset} ${result.message}`);
-    if (result.error) {
-      console.log(`  ${c.dim}Error: ${result.error}${c.reset}`);
-    }
-    console.log();
-    return false;
-  }
 }
 
 type CiFormat = "github" | "gitlab" | "json" | "text";

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1,0 +1,113 @@
+/**
+ * `kit doctor` + `kit add` — first slice of the setup cluster, extracted from
+ * cli.ts (5.0-alpha god-module split). These two handlers are self-contained
+ * (no cross-cluster cmd* calls), so they lead the setup module.
+ *
+ * Phase B (cmdSetup + cmdInit) stays in cli.ts until the install/login/check
+ * clusters are extracted — cmdSetup orchestrates those, so moving it now would
+ * force a commands -> cli.ts back-import. Imports only sibling core modules.
+ */
+import { c } from "../utils/colors.js";
+import { loadConfig } from "../config.js";
+import { resolveConfigPath } from "../cli-shared.js";
+import { runDoctor } from "../doctor.js";
+import { provisionService, listAvailableServices, getServiceInfo } from "../provision.js";
+
+export async function cmdDoctor(): Promise<boolean> {
+  console.log(`${c.bold}${c.cyan}kit doctor${c.reset}`);
+  console.log(`${c.dim}${"─".repeat(50)}${c.reset}\n`);
+
+  let config: ReturnType<typeof Object.create> = {};
+  try {
+    config = await loadConfig(resolveConfigPath());
+  } catch {
+    // Doctor works even without .kit.toml — skip config-dependent checks
+  }
+
+  const result = await runDoctor(config, process.cwd());
+
+  for (const check of result.checks) {
+    const icon =
+      check.status === "pass"
+        ? `${c.green}✓${c.reset}`
+        : check.status === "warn"
+          ? `${c.yellow}⚠${c.reset}`
+          : check.status === "fail"
+            ? `${c.red}✗${c.reset}`
+            : `${c.dim}–${c.reset}`;
+    console.log(`  ${icon} ${check.name}  ${c.dim}${check.detail}${c.reset}`);
+  }
+
+  console.log();
+  console.log(`${c.dim}${"─".repeat(50)}${c.reset}`);
+
+  const summaryParts: string[] = [];
+  if (result.passed > 0) summaryParts.push(`${c.green}${result.passed} passed${c.reset}`);
+  if (result.warnings > 0)
+    summaryParts.push(
+      `${c.yellow}${result.warnings} warning${result.warnings === 1 ? "" : "s"}${c.reset}`,
+    );
+  if (result.failed > 0) summaryParts.push(`${c.red}${result.failed} failed${c.reset}`);
+  if (summaryParts.length === 0) summaryParts.push(`${c.dim}no checks ran${c.reset}`);
+
+  console.log(`\n  ${summaryParts.join(" · ")}\n`);
+
+  return result.failed === 0;
+}
+
+export async function cmdAdd(): Promise<boolean> {
+  const serviceName = process.argv[3];
+
+  if (!serviceName) {
+    console.log(`${c.bold}${c.cyan}Available services:${c.reset}\n`);
+
+    const services = listAvailableServices();
+    for (const svc of services) {
+      const info = getServiceInfo(svc);
+      if (info) {
+        console.log(`  ${c.green}${svc}${c.reset}  ${c.dim}${info.description}${c.reset}`);
+        console.log(`    ${c.dim}Requires: ${info.tools.join(", ")}${c.reset}`);
+      }
+    }
+
+    console.log();
+    console.log(`${c.dim}Usage: kit add <service>${c.reset}`);
+    console.log(`${c.dim}Example: kit add stripe/payments${c.reset}`);
+    console.log();
+    return false;
+  }
+
+  console.log(`${c.bold}${c.cyan}Provisioning ${serviceName}...${c.reset}\n`);
+
+  const projectPath = process.cwd();
+  const projectName = process.cwd().split("/").pop();
+
+  const result = await provisionService(serviceName, projectPath, projectName);
+
+  if (result.success) {
+    console.log(`  ${c.green}✓${c.reset} ${result.message}`);
+
+    if (result.secrets && Object.keys(result.secrets).length > 0) {
+      console.log();
+      console.log(`  ${c.dim}Added secrets to .env.local:${c.reset}`);
+      for (const key of Object.keys(result.secrets)) {
+        console.log(`    ${c.cyan}${key}${c.reset}`);
+      }
+    }
+
+    if (result.config) {
+      console.log();
+      console.log(`  ${c.dim}Updated skills-lock.json${c.reset}`);
+    }
+
+    console.log();
+    return true;
+  } else {
+    console.log(`  ${c.red}✗${c.reset} ${result.message}`);
+    if (result.error) {
+      console.log(`  ${c.dim}Error: ${result.error}${c.reset}`);
+    }
+    console.log();
+    return false;
+  }
+}


### PR DESCRIPTION
Fourth PR of the **5.0-alpha** `cli.ts` god-module split (follows #271 security, #272 secrets, #273 upgrade).

## What changed

- **New `src/commands/setup.ts`** — creates the setup module with its two self-contained handlers: `cmdDoctor` and `cmdAdd` (neither calls another `cmd*`).
- **Phase A only.** `cmdSetup` + `cmdInit` intentionally **stay in `cli.ts`** — `cmdSetup` orchestrates `cmdInstall`/`cmdLogin`/`cmdCheck`, which are still inline; moving it now would force a `commands → cli.ts` back-import. They join `setup.ts` in **Phase B**, once those downstream clusters are extracted.
- `cmdDoctor` + `cmdAdd` exported; `cli.ts` imports them back. `COMMANDS` dispatch table unchanged.
- **Pruned now-unused `cli.ts` imports** (`runDoctor` from `doctor.js`; `provisionService`/`listAvailableServices`/`getServiceInfo` from `provision.js`) — doctor+add were their only users (confirmed by eslint).

## Verification

- `tsc --noEmit`: clean
- eslint: 0 errors
- full test suite: **2580 passing**
- prettier: clean
- runtime smoke: `kit doctor`, `kit add` dispatch correctly

**`cli.ts`: 4422 → 4322 lines (−100; −2008 cumulative across PRs 1–4, from the original 6330 — ~32% smaller).** No behavior change — pure structural extraction.

Roadmap remaining: ci (needs a shared-symbol prep PR: `JsonCheck`/`maybeEmitCheckAttestation`/`autoInstallScanners` → neutral module) → sentinel (needs `buildHealthCtx` prep) → standards. setup Phase B + `cmdReview` deferred until install/login/check/design clusters land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_