### PR TITLE
refactor(cli): extract sentinel cluster + hoist buildHealthCtx (5.0-alpha)

### DIFF
--- a/src/cli-shared.ts
+++ b/src/cli-shared.ts
@@ -2,6 +2,9 @@
 // without a circular dependency back through the entrypoint. Step 1 of splitting
 // the (large) cli.ts into per-area command modules under src/commands/.
 import { resolve } from "node:path";
+import { readFileSync, existsSync } from "node:fs";
+import type { kitConfig } from "./config.js";
+import type { HealthCtx } from "./health.js";
 
 /** The project config file name. */
 export const KIT_FILE = ".kit.toml";
@@ -9,4 +12,50 @@ export const KIT_FILE = ".kit.toml";
 /** Absolute path to the project's .kit.toml in the current working directory. */
 export function resolveConfigPath(): string {
   return resolve(process.cwd(), KIT_FILE);
+}
+
+/**
+ * Build the runtime context the health sensors + sentinel consume: git remote
+ * presence, CI host files, Vercel linkage, and detected services. Co-owned by
+ * `kit health` (cmdHealth, in cli.ts) and `kit sentinel` (commands/sentinel.ts),
+ * so it lives here in the neutral seam rather than in either command module.
+ */
+export async function buildHealthCtx(config: kitConfig): Promise<HealthCtx> {
+  const { execFileNoThrow } = await import("./utils/execFileNoThrow.js");
+  const remote = await execFileNoThrow("git", ["remote"], { timeout: 5_000 });
+  const cwd = process.cwd();
+  let vercel: { orgId?: string; projectId?: string } | undefined;
+  try {
+    const vj = JSON.parse(readFileSync(resolve(cwd, ".vercel", "project.json"), "utf8")) as {
+      orgId?: string;
+      projectId?: string;
+    };
+    if (vj.projectId) vercel = { orgId: vj.orgId, projectId: vj.projectId };
+  } catch {
+    vercel = undefined;
+  }
+  let services: string[] = [];
+  try {
+    const pkg = JSON.parse(readFileSync(resolve(cwd, "package.json"), "utf8")) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const deps = [
+      ...Object.keys(pkg.dependencies ?? {}),
+      ...Object.keys(pkg.devDependencies ?? {}),
+    ];
+    const { detectServices } = await import("./service-registry.js");
+    services = await detectServices({ deps, fileExists: async (p) => existsSync(resolve(cwd, p)) });
+  } catch {
+    services = [];
+  }
+  return {
+    cwd,
+    config,
+    gitRemote: remote.ok && remote.stdout.trim().length > 0,
+    gitlabCi: existsSync(resolve(cwd, ".gitlab-ci.yml")),
+    bitbucketPipelines: existsSync(resolve(cwd, "bitbucket-pipelines.yml")),
+    vercel,
+    services,
+  };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFileSync, writeFileSync, existsSync, realpathSync } from "node:fs";
+import { readFileSync, existsSync, realpathSync } from "node:fs";
 import { writeFile, access, mkdir } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { resolve, dirname, join } from "node:path";
@@ -11,8 +11,6 @@ import { checkTools } from "./check-tools.js";
 import { checkServices } from "./check-services.js";
 import { checkSecrets } from "./check-secrets.js";
 import { checkSecurity, type SecurityCheckResult } from "./check-security.js";
-import type { HealthCtx } from "./health.js";
-import type { SentinelSummary } from "./sentinel.js";
 import { syncSecurityFindings } from "./findings-track.js";
 import { checkWebSearch } from "./check-web-search.js";
 import { installTools } from "./install.js";
@@ -72,7 +70,7 @@ import { cmdFix } from "./fix.js";
 import { promptConfirm } from "./utils/prompt.js";
 import { c } from "./utils/colors.js";
 import { gatherStatus } from "./status.js";
-import { KIT_FILE, resolveConfigPath } from "./cli-shared.js";
+import { KIT_FILE, resolveConfigPath, buildHealthCtx } from "./cli-shared.js";
 import { collectHints } from "./hints.js";
 import {
   gatherLive,
@@ -96,6 +94,7 @@ import { cmdSecrets } from "./commands/secrets.js";
 import { cmdUpgrade, selfUpgrade } from "./commands/upgrade.js";
 import { cmdDoctor, cmdAdd } from "./commands/setup.js";
 import { cmdCi } from "./commands/ci.js";
+import { cmdSentinel } from "./commands/sentinel.js";
 import {
   type CiFormat,
   type JsonCheck,
@@ -2652,47 +2651,6 @@ async function cmdStatus(): Promise<boolean> {
   return true;
 }
 
-/** Build the health context (sensor selection inputs) — shared by health + sentinel. */
-async function buildHealthCtx(config: kitConfig): Promise<HealthCtx> {
-  const { execFileNoThrow } = await import("./utils/execFileNoThrow.js");
-  const remote = await execFileNoThrow("git", ["remote"], { timeout: 5_000 });
-  const cwd = process.cwd();
-  let vercel: { orgId?: string; projectId?: string } | undefined;
-  try {
-    const vj = JSON.parse(readFileSync(resolve(cwd, ".vercel", "project.json"), "utf8")) as {
-      orgId?: string;
-      projectId?: string;
-    };
-    if (vj.projectId) vercel = { orgId: vj.orgId, projectId: vj.projectId };
-  } catch {
-    vercel = undefined;
-  }
-  let services: string[] = [];
-  try {
-    const pkg = JSON.parse(readFileSync(resolve(cwd, "package.json"), "utf8")) as {
-      dependencies?: Record<string, string>;
-      devDependencies?: Record<string, string>;
-    };
-    const deps = [
-      ...Object.keys(pkg.dependencies ?? {}),
-      ...Object.keys(pkg.devDependencies ?? {}),
-    ];
-    const { detectServices } = await import("./service-registry.js");
-    services = await detectServices({ deps, fileExists: async (p) => existsSync(resolve(cwd, p)) });
-  } catch {
-    services = [];
-  }
-  return {
-    cwd,
-    config,
-    gitRemote: remote.ok && remote.stdout.trim().length > 0,
-    gitlabCi: existsSync(resolve(cwd, ".gitlab-ci.yml")),
-    bitbucketPipelines: existsSync(resolve(cwd, "bitbucket-pipelines.yml")),
-    vercel,
-    services,
-  };
-}
-
 async function cmdHealth(): Promise<boolean> {
   const jsonMode = hasFlag(process.argv, "--json");
   const config = await loadConfig(resolveConfigPath());
@@ -2842,141 +2800,6 @@ async function cmdAgentAudit(): Promise<boolean> {
   }
   if (fails > 0) console.log(`${c.red}${fails} fail${c.reset}`);
   return fails === 0;
-}
-
-async function cmdSentinel(): Promise<boolean> {
-  const sub = process.argv[3];
-  if (sub === "install") return cmdSentinelInstall();
-  if (sub === "status") return cmdSentinelStatus();
-  if (sub !== "run") {
-    console.error(`${c.red}usage: kit sentinel <run|install|status> [--json]${c.reset}`);
-    process.exitCode = 1;
-    return false;
-  }
-  const jsonMode = hasFlag(process.argv, "--json");
-  // Config-free: sentinel proposes fixes from codebase analysis; the optional
-  // [sentinel] block only adds integrations. Missing .kit.toml is not an error.
-  const config = existsSync(resolveConfigPath())
-    ? await loadConfig(resolveConfigPath())
-    : ({} as kitConfig);
-  const { runSentinel, healthToRedFindings, proposalSummary, SENTINEL_CACHE } =
-    await import("./sentinel.js");
-  const { runHealth, selectSensors, defaultHealthDeps } = await import("./health.js");
-  const { execFileNoThrow } = await import("./utils/execFileNoThrow.js");
-
-  const proposals = await runSentinel(process.cwd(), {
-    gatherRed: async () => {
-      const ctx = await buildHealthCtx(config);
-      return healthToRedFindings(await runHealth(ctx, selectSensors(ctx), defaultHealthDeps));
-    },
-    openMarkers: async () => {
-      // Read-only dedup: open issues + PRs labeled kit-sentinel, scrape findingId markers.
-      const out = new Set<string>();
-      for (const base of [
-        ["issue", "list"],
-        ["pr", "list"],
-      ]) {
-        const res = await execFileNoThrow(
-          "gh",
-          [
-            ...base,
-            "--label",
-            "kit-sentinel",
-            "--state",
-            "open",
-            "--json",
-            "body",
-            "--limit",
-            "200",
-          ],
-          { timeout: 15_000 },
-        );
-        if (!res.ok) return null; // gh absent/unauth → agent dedups (fail-open)
-        try {
-          for (const it of JSON.parse(res.stdout) as { body?: string }[]) {
-            for (const g of (it.body ?? "").matchAll(/kit-sentinel:([^\s]+?)\s*-->/g))
-              out.add(g[1]);
-          }
-        } catch {
-          return null;
-        }
-      }
-      return out;
-    },
-  });
-
-  // L3: cache a compact summary for the SessionStart surface (#53). Best-effort —
-  // a cache-write failure must never fail the run itself.
-  try {
-    const cachePath = resolve(process.cwd(), SENTINEL_CACHE);
-    await mkdir(dirname(cachePath), { recursive: true });
-    writeFileSync(cachePath, JSON.stringify(proposalSummary(proposals), null, 2) + "\n");
-  } catch {
-    // no cache → status surface simply stays quiet
-  }
-
-  if (jsonMode) {
-    console.log(JSON.stringify({ proposals }, null, 2));
-    return true;
-  }
-
-  const fresh = proposals.filter((p) => p.alreadyOpen !== true);
-  console.log(
-    `${c.bold}kit sentinel${c.reset}  ${c.dim}${proposals.length} proposal(s), ${fresh.length} fresh${c.reset}`,
-  );
-  if (proposals.length === 0)
-    console.log(`  ${c.dim}no red findings — nothing to propose${c.reset}`);
-  for (const p of proposals) {
-    const tag = p.alreadyOpen === true ? ` ${c.dim}(already open)${c.reset}` : "";
-    const color = p.class === "human" ? c.red : p.class === "code" ? c.yellow : c.dim;
-    console.log(`  ${color}${p.artifact}${c.reset} ${p.title}${tag}`);
-    console.log(`    ${c.dim}${p.findingId} — your agent opens this with its own creds${c.reset}`);
-  }
-  if (proposals.length > 0)
-    console.log(`${c.dim}run with --json and have any agent act on the fresh proposals${c.reset}`);
-  return true;
-}
-
-/** `kit sentinel install` — scaffold the L3 scheduler (GitHub Actions) (#53). */
-async function cmdSentinelInstall(): Promise<boolean> {
-  const { sentinelWorkflow } = await import("./sentinel.js");
-  const dest = resolve(process.cwd(), ".github/workflows/kit-sentinel.yml");
-  if (existsSync(dest) && !hasFlag(process.argv, "--force")) {
-    console.error(
-      `${c.yellow}.github/workflows/kit-sentinel.yml exists — re-run with --force to overwrite${c.reset}`,
-    );
-    process.exitCode = 1;
-    return false;
-  }
-  const si = process.argv.indexOf("--schedule");
-  const schedule = si >= 0 ? process.argv[si + 1] : undefined;
-  await mkdir(dirname(dest), { recursive: true });
-  writeFileSync(dest, schedule ? sentinelWorkflow(schedule) : sentinelWorkflow());
-  console.log(`${c.green}✓${c.reset} wrote .github/workflows/kit-sentinel.yml`);
-  console.log(
-    `  ${c.dim}recurs \`kit sentinel run --json\`; an agent (or a downstream step) acts on the JSON${c.reset}`,
-  );
-  return true;
-}
-
-/** `kit sentinel status` — print the cached one-line surface for a SessionStart hook (#53). */
-async function cmdSentinelStatus(): Promise<boolean> {
-  const { SENTINEL_CACHE, sentinelStatusLine } = await import("./sentinel.js");
-  let summary: SentinelSummary | null = null;
-  try {
-    summary = JSON.parse(readFileSync(resolve(process.cwd(), SENTINEL_CACHE), "utf8"));
-  } catch {
-    // no cache yet (sentinel never run) → nothing to surface
-  }
-  if (hasFlag(process.argv, "--json")) {
-    console.log(
-      JSON.stringify(summary ?? { total: 0, fresh: 0, byClass: { code: 0, human: 0, noise: 0 } }),
-    );
-    return true;
-  }
-  const line = sentinelStatusLine(summary);
-  if (line) console.log(line); // silent when nothing fresh → clean SessionStart surface
-  return true;
 }
 
 async function cmdWhoami(): Promise<boolean> {

--- a/src/commands/sentinel.ts
+++ b/src/commands/sentinel.ts
@@ -1,0 +1,149 @@
+/**
+ * `kit sentinel` command cluster — extracted from cli.ts (5.0-alpha god-module
+ * split). cmdSentinel routes `run|install|status` to the module-private handlers
+ * below. buildHealthCtx is shared with `kit health` (cmdHealth stays in cli.ts),
+ * so it lives in the neutral cli-shared module. Imports only sibling core modules.
+ */
+import { resolve, dirname } from "node:path";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { c } from "../utils/colors.js";
+import { hasFlag } from "../utils/flags.js";
+import { loadConfig, type kitConfig } from "../config.js";
+import { resolveConfigPath, buildHealthCtx } from "../cli-shared.js";
+import type { SentinelSummary } from "../sentinel.js";
+
+export async function cmdSentinel(): Promise<boolean> {
+  const sub = process.argv[3];
+  if (sub === "install") return cmdSentinelInstall();
+  if (sub === "status") return cmdSentinelStatus();
+  if (sub !== "run") {
+    console.error(`${c.red}usage: kit sentinel <run|install|status> [--json]${c.reset}`);
+    process.exitCode = 1;
+    return false;
+  }
+  const jsonMode = hasFlag(process.argv, "--json");
+  // Config-free: sentinel proposes fixes from codebase analysis; the optional
+  // [sentinel] block only adds integrations. Missing .kit.toml is not an error.
+  const config = existsSync(resolveConfigPath())
+    ? await loadConfig(resolveConfigPath())
+    : ({} as kitConfig);
+  const { runSentinel, healthToRedFindings, proposalSummary, SENTINEL_CACHE } =
+    await import("../sentinel.js");
+  const { runHealth, selectSensors, defaultHealthDeps } = await import("../health.js");
+  const { execFileNoThrow } = await import("../utils/execFileNoThrow.js");
+
+  const proposals = await runSentinel(process.cwd(), {
+    gatherRed: async () => {
+      const ctx = await buildHealthCtx(config);
+      return healthToRedFindings(await runHealth(ctx, selectSensors(ctx), defaultHealthDeps));
+    },
+    openMarkers: async () => {
+      // Read-only dedup: open issues + PRs labeled kit-sentinel, scrape findingId markers.
+      const out = new Set<string>();
+      for (const base of [
+        ["issue", "list"],
+        ["pr", "list"],
+      ]) {
+        const res = await execFileNoThrow(
+          "gh",
+          [
+            ...base,
+            "--label",
+            "kit-sentinel",
+            "--state",
+            "open",
+            "--json",
+            "body",
+            "--limit",
+            "200",
+          ],
+          { timeout: 15_000 },
+        );
+        if (!res.ok) return null; // gh absent/unauth → agent dedups (fail-open)
+        try {
+          for (const it of JSON.parse(res.stdout) as { body?: string }[]) {
+            for (const g of (it.body ?? "").matchAll(/kit-sentinel:([^\s]+?)\s*-->/g))
+              out.add(g[1]);
+          }
+        } catch {
+          return null;
+        }
+      }
+      return out;
+    },
+  });
+
+  // L3: cache a compact summary for the SessionStart surface (#53). Best-effort —
+  // a cache-write failure must never fail the run itself.
+  try {
+    const cachePath = resolve(process.cwd(), SENTINEL_CACHE);
+    await mkdir(dirname(cachePath), { recursive: true });
+    writeFileSync(cachePath, JSON.stringify(proposalSummary(proposals), null, 2) + "\n");
+  } catch {
+    // no cache → status surface simply stays quiet
+  }
+
+  if (jsonMode) {
+    console.log(JSON.stringify({ proposals }, null, 2));
+    return true;
+  }
+
+  const fresh = proposals.filter((p) => p.alreadyOpen !== true);
+  console.log(
+    `${c.bold}kit sentinel${c.reset}  ${c.dim}${proposals.length} proposal(s), ${fresh.length} fresh${c.reset}`,
+  );
+  if (proposals.length === 0)
+    console.log(`  ${c.dim}no red findings — nothing to propose${c.reset}`);
+  for (const p of proposals) {
+    const tag = p.alreadyOpen === true ? ` ${c.dim}(already open)${c.reset}` : "";
+    const color = p.class === "human" ? c.red : p.class === "code" ? c.yellow : c.dim;
+    console.log(`  ${color}${p.artifact}${c.reset} ${p.title}${tag}`);
+    console.log(`    ${c.dim}${p.findingId} — your agent opens this with its own creds${c.reset}`);
+  }
+  if (proposals.length > 0)
+    console.log(`${c.dim}run with --json and have any agent act on the fresh proposals${c.reset}`);
+  return true;
+}
+
+/** `kit sentinel install` — scaffold the L3 scheduler (GitHub Actions) (#53). */
+async function cmdSentinelInstall(): Promise<boolean> {
+  const { sentinelWorkflow } = await import("../sentinel.js");
+  const dest = resolve(process.cwd(), ".github/workflows/kit-sentinel.yml");
+  if (existsSync(dest) && !hasFlag(process.argv, "--force")) {
+    console.error(
+      `${c.yellow}.github/workflows/kit-sentinel.yml exists — re-run with --force to overwrite${c.reset}`,
+    );
+    process.exitCode = 1;
+    return false;
+  }
+  const si = process.argv.indexOf("--schedule");
+  const schedule = si >= 0 ? process.argv[si + 1] : undefined;
+  await mkdir(dirname(dest), { recursive: true });
+  writeFileSync(dest, schedule ? sentinelWorkflow(schedule) : sentinelWorkflow());
+  console.log(`${c.green}✓${c.reset} wrote .github/workflows/kit-sentinel.yml`);
+  console.log(
+    `  ${c.dim}recurs \`kit sentinel run --json\`; an agent (or a downstream step) acts on the JSON${c.reset}`,
+  );
+  return true;
+}
+
+/** `kit sentinel status` — print the cached one-line surface for a SessionStart hook (#53). */
+async function cmdSentinelStatus(): Promise<boolean> {
+  const { SENTINEL_CACHE, sentinelStatusLine } = await import("../sentinel.js");
+  let summary: SentinelSummary | null = null;
+  try {
+    summary = JSON.parse(readFileSync(resolve(process.cwd(), SENTINEL_CACHE), "utf8"));
+  } catch {
+    // no cache yet (sentinel never run) → nothing to surface
+  }
+  if (hasFlag(process.argv, "--json")) {
+    console.log(
+      JSON.stringify(summary ?? { total: 0, fresh: 0, byClass: { code: 0, human: 0, noise: 0 } }),
+    );
+    return true;
+  }
+  const line = sentinelStatusLine(summary);
+  if (line) console.log(line); // silent when nothing fresh → clean SessionStart surface
+  return true;
+}


### PR DESCRIPTION
Sixth PR of the **5.0-alpha** `cli.ts` god-module split (follows #271–#275).

## What changed

- **Hoisted `buildHealthCtx`** into the neutral `src/cli-shared.ts` — it's co-owned by `cmdHealth` (stays in `cli.ts`) and `cmdSentinel`. Both import it from there, so no `commands → cli.ts` cycle.
- **New `src/commands/sentinel.ts`** — `cmdSentinel` (exported) + its `run`/`install`/`status` sub-handlers (module-private, routed via `process.argv[3]`).
- **`cli.ts`** imports `cmdSentinel` + `buildHealthCtx` back; `COMMANDS` table unchanged. Pruned now-unused imports (`SentinelSummary`, `HealthCtx` type, `writeFileSync`).
- Dynamic imports re-pathed `./` → `../` (`sentinel.js`, `health.js`, `execFileNoThrow`).

## Verification

- `tsc --noEmit`: clean
- eslint: 0 errors
- full test suite: **2580 passing**
- prettier: clean
- runtime smoke: `kit sentinel status` (correctly silent, no cache), `kit health` (uses the hoisted `buildHealthCtx`) both dispatch correctly

**`cli.ts`: 3966 → 3789 lines (−177; −2541 cumulative across PRs 1–6, from the original 6330 — ~40% smaller).** No behavior change.

Roadmap remaining: **standards** (`cmdStandards` + `cmdBaseline` + `freezeStandardsBaseline`; `cmdReview` stays until check/design extracted) — the last cluster before setup Phase B / cmdReview, which are deferred by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_