### PR TITLE
refactor(cli): extract design cluster → commands/design.ts (5.0-alpha)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -81,6 +81,7 @@ import { cmdCi } from "./commands/ci.js";
 import { cmdSentinel } from "./commands/sentinel.js";
 import { cmdStandards, cmdBaseline } from "./commands/standards.js";
 import { cmdCheck } from "./commands/check.js";
+import { cmdDesign } from "./commands/design.js";
 import {
   type CiFormat,
   type JsonCheck,
@@ -190,49 +191,6 @@ async function cmdHeal(): Promise<boolean> {
     );
   }
   return green;
-}
-
-/**
- * `kit design` — a11y + design-token consistency, baseline-aware.
- */
-async function cmdDesign(): Promise<boolean> {
-  const enforce = hasFlag(process.argv, "--enforce");
-  const jsonMode = hasFlag(process.argv, "--json");
-  const { checkDesign } = await import("./check-design.js");
-  const { loadBaselineForGate, baselineGet, BASELINE_FILE } = await import("./baseline.js");
-  const { baseline, ignored: baselineIgnored } = await loadBaselineForGate();
-  if (baselineIgnored) {
-    console.error(
-      `${c.yellow}!${c.reset} ${BASELINE_FILE} ignored (${baselineIgnored}) — gating on all findings`,
-    );
-  }
-  const results = await checkDesign({
-    enforce,
-    baseline: {
-      a11y: baselineGet(baseline, "design", "a11y"),
-      tokens: baselineGet(baseline, "design", "tokens"),
-    },
-  });
-  if (jsonMode) {
-    console.log(
-      JSON.stringify({ ok: results.every((r) => r.status !== "fail"), checks: results }, null, 2),
-    );
-    return results.every((r) => r.status !== "fail");
-  }
-  console.log(`${c.bold}Design${c.reset}`);
-  for (const r of results) {
-    const icon =
-      r.status === "pass"
-        ? `${c.green}✓${c.reset}`
-        : r.status === "fail"
-          ? `${c.red}✗${c.reset}`
-          : r.status === "warn"
-            ? `${c.yellow}!${c.reset}`
-            : `${c.dim}-${c.reset}`;
-    console.log(`  ${icon} ${r.name}  ${c.dim}${r.detail}${c.reset}`);
-    if (r.files) for (const f of r.files) console.log(`      ${c.dim}- ${f}${c.reset}`);
-  }
-  return results.every((r) => r.status !== "fail");
 }
 
 /**

--- a/src/commands/design.ts
+++ b/src/commands/design.ts
@@ -1,0 +1,50 @@
+/**
+ * `kit design` command — extracted from cli.ts (5.0-alpha god-module split).
+ * Self-contained (a11y + design-token consistency, baseline-aware). cmdReview
+ * (still in cli.ts) calls the exported cmdDesign. Imports only sibling core modules.
+ */
+import { c } from "../utils/colors.js";
+import { hasFlag } from "../utils/flags.js";
+
+/**
+ * `kit design` — a11y + design-token consistency, baseline-aware.
+ */
+export async function cmdDesign(): Promise<boolean> {
+  const enforce = hasFlag(process.argv, "--enforce");
+  const jsonMode = hasFlag(process.argv, "--json");
+  const { checkDesign } = await import("../check-design.js");
+  const { loadBaselineForGate, baselineGet, BASELINE_FILE } = await import("../baseline.js");
+  const { baseline, ignored: baselineIgnored } = await loadBaselineForGate();
+  if (baselineIgnored) {
+    console.error(
+      `${c.yellow}!${c.reset} ${BASELINE_FILE} ignored (${baselineIgnored}) — gating on all findings`,
+    );
+  }
+  const results = await checkDesign({
+    enforce,
+    baseline: {
+      a11y: baselineGet(baseline, "design", "a11y"),
+      tokens: baselineGet(baseline, "design", "tokens"),
+    },
+  });
+  if (jsonMode) {
+    console.log(
+      JSON.stringify({ ok: results.every((r) => r.status !== "fail"), checks: results }, null, 2),
+    );
+    return results.every((r) => r.status !== "fail");
+  }
+  console.log(`${c.bold}Design${c.reset}`);
+  for (const r of results) {
+    const icon =
+      r.status === "pass"
+        ? `${c.green}✓${c.reset}`
+        : r.status === "fail"
+          ? `${c.red}✗${c.reset}`
+          : r.status === "warn"
+            ? `${c.yellow}!${c.reset}`
+            : `${c.dim}-${c.reset}`;
+    console.log(`  ${icon} ${r.name}  ${c.dim}${r.detail}${c.reset}`);
+    if (r.files) for (const f of r.files) console.log(`      ${c.dim}- ${f}${c.reset}`);
+  }
+  return results.every((r) => r.status !== "fail");
+}


### PR DESCRIPTION
Ninth cut of the `cli.ts` god-module split (entangled chain: check → **design** → install → login → setup Phase B + review).

## What changed
- **New `src/commands/design.ts`** — `cmdDesign` (exported), the self-contained a11y + design-token gate (baseline-aware).
- `cli.ts` imports `cmdDesign` back; the still-inline `cmdReview` calls the imported `cmdDesign`. `COMMANDS` table unchanged.
- Dynamic imports re-pathed `./` → `../` (`check-design.js`, `baseline.js`).

## Verification
`tsc` clean · eslint 0 errors · full suite **2580 passing** · prettier clean · `kit design --json` smoke-tested.

**`cli.ts`: 3219 → 3177 lines (−42; −3153 cumulative from 6330).**

Remaining: install → login → setup Phase B (`cmdSetup`/`cmdInit`) + `cmdReview` → leaf batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_