### PR TITLE
refactor(cli): extract info batch → commands/info.ts (5.0-alpha)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-import { readFileSync, existsSync, realpathSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { resolve, dirname, join } from "node:path";
-import { loadConfig, type kitConfig } from "./config.js";
+import { loadConfig } from "./config.js";
 import { checkTools } from "./check-tools.js";
 import { checkServices } from "./check-services.js";
 import { checkSecrets } from "./check-secrets.js";
@@ -13,8 +13,6 @@ import { analyzeRepo, renderClaudeMd, renderRulesMd } from "./analyze.js";
 import { scanTranscripts } from "./scan-transcripts.js";
 import { generateCompletions } from "./completions.js";
 import { checkForUpdate, printUpdateNotice } from "./update-check.js";
-import { resolveMode, modeScore } from "./setup-modes.js";
-import { quickSubsystems } from "./statusline.js";
 import { checkSkills } from "./check-skills.js";
 import { collectEscalations, formatEscalationMessage } from "./escalate.js";
 import { checkRevocationStatus } from "./revocation.js";
@@ -31,8 +29,7 @@ import {
 } from "./agent-config.js";
 import { cmdFix } from "./fix.js";
 import { c } from "./utils/colors.js";
-import { gatherStatus } from "./status.js";
-import { KIT_FILE, resolveConfigPath, buildHealthCtx } from "./cli-shared.js";
+import { KIT_FILE, resolveConfigPath } from "./cli-shared.js";
 import { cmdEnv } from "./commands/env.js";
 import { cmdContext } from "./commands/context.js";
 import { cmdConfig } from "./commands/config.js";
@@ -49,6 +46,15 @@ import { cmdSecrets } from "./commands/secrets.js";
 import { cmdUpgrade } from "./commands/upgrade.js";
 import { cmdDoctor, cmdAdd, cmdSetup, cmdInit } from "./commands/setup.js";
 import { cmdReview } from "./commands/review.js";
+import {
+  cmdStatus,
+  cmdHealth,
+  cmdIngest,
+  cmdSupplyChain,
+  cmdAgentAudit,
+  cmdWhoami,
+  cmdVersion,
+} from "./commands/info.js";
 import { cmdCi } from "./commands/ci.js";
 import { cmdSentinel } from "./commands/sentinel.js";
 import { cmdStandards, cmdBaseline } from "./commands/standards.js";
@@ -946,272 +952,6 @@ async function cmdOpen(): Promise<boolean> {
     console.error(`${c.red}✗${c.reset} ${result.message}`);
     return false;
   }
-}
-
-async function cmdStatus(): Promise<boolean> {
-  const items = await gatherStatus();
-  if (hasFlag(process.argv, "--json")) {
-    console.log(JSON.stringify(items, null, 2));
-    return true;
-  }
-  const done = items.filter((i) => i.ok).length;
-  console.log(`${c.bold}kit status${c.reset}  ${c.dim}${done}/${items.length} set up${c.reset}`);
-  // Mode-aware score: how many of the active mode's expected subsystems are in place.
-  let cfgMode: string | undefined;
-  try {
-    cfgMode = (await loadConfig(resolveConfigPath())).setup?.mode;
-  } catch {
-    /* no/invalid .kit.toml */
-  }
-  const { profile } = resolveMode(flagValue(process.argv, "--mode"), cfgMode);
-  const ms = modeScore(profile, quickSubsystems(process.cwd()));
-  const nextGaps = ms.gaps
-    .map((g) => g.next)
-    .filter(Boolean)
-    .slice(0, 3)
-    .join(", ");
-  console.log(
-    `${c.dim}mode ${c.reset}${c.bold}${profile.mode}${c.reset}${c.dim}: ${ms.done}/${ms.total} subsystems${ms.gaps.length ? ` — next: ${nextGaps}` : " ✓"}${c.reset}\n`,
-  );
-  for (const item of items) {
-    const mark = item.ok ? `${c.green}✓${c.reset}` : `${c.yellow}○${c.reset}`;
-    const hint = !item.ok && item.hint ? `  ${c.dim}→ ${item.hint}${c.reset}` : "";
-    console.log(`  ${mark} ${item.label}  ${c.dim}${item.detail}${c.reset}${hint}`);
-  }
-  return true;
-}
-
-async function cmdHealth(): Promise<boolean> {
-  const jsonMode = hasFlag(process.argv, "--json");
-  const config = await loadConfig(resolveConfigPath());
-
-  return await withGovernance(
-    config,
-    { operation: "health", operationType: "read", metadata: {} },
-    async () => {
-      const { runHealth, selectSensors, defaultHealthDeps, formatHealth } =
-        await import("./health.js");
-      const { syncHealthFindings } = await import("./health-track.js");
-
-      const ctx = await buildHealthCtx(config);
-
-      const sensors = selectSensors(ctx);
-      const findings = await runHealth(ctx, sensors, defaultHealthDeps);
-      await syncHealthFindings(findings); // mirror red into PAL (fail-open)
-
-      if (jsonMode) {
-        const redCount = findings.filter((f) => f.status === "red").length;
-        console.log(JSON.stringify({ ok: redCount === 0, findings }, null, 2));
-        return redCount === 0;
-      }
-
-      const { lines, redCount } = formatHealth(findings);
-      console.log(`${c.bold}kit health${c.reset}  ${c.dim}${sensors.length} sensor(s)${c.reset}`);
-      if (findings.length === 0) {
-        console.log(`  ${c.dim}no connected external systems detected${c.reset}`);
-      }
-      for (const line of lines) {
-        const color = line.startsWith("✗") ? c.red : line.startsWith("?") ? c.yellow : c.green;
-        console.log(`  ${color}${line}${c.reset}`);
-      }
-      if (redCount > 0) console.log(`${c.red}${redCount} red${c.reset}`);
-      return redCount === 0;
-    },
-  );
-}
-
-async function cmdIngest(): Promise<boolean> {
-  const jsonMode = hasFlag(process.argv, "--json");
-  const args = process.argv.slice(3).filter((a) => !a.startsWith("-"));
-  const format = args[0];
-  const file = args[1];
-  if (format !== "sarif" && format !== "osv") {
-    console.error(`${c.red}usage: kit ingest <sarif|osv> <file>${c.reset}`);
-    process.exitCode = 1;
-    return false;
-  }
-  if (!file) {
-    console.error(`${c.red}usage: kit ingest ${format} <file>${c.reset}`);
-    process.exitCode = 1;
-    return false;
-  }
-  let json: string;
-  try {
-    json = readFileSync(resolve(process.cwd(), file), "utf8");
-  } catch {
-    console.error(`${c.red}could not read ${file}${c.reset}`);
-    process.exitCode = 1;
-    return false;
-  }
-
-  const { ingest } = await import("./adapters/ingest.js");
-  const findings = ingest(format, json);
-
-  if (jsonMode) {
-    console.log(JSON.stringify({ count: findings.length, findings }, null, 2));
-    return true;
-  }
-
-  console.log(
-    `${c.bold}kit ingest${c.reset}  ${c.dim}${format} · ${findings.length} finding(s)${c.reset}`,
-  );
-  const order: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3 };
-  const sorted = [...findings].sort(
-    (a, b) => (order[a.severity ?? "low"] ?? 9) - (order[b.severity ?? "low"] ?? 9),
-  );
-  for (const f of sorted) {
-    const sev = f.severity ?? "low";
-    const color =
-      sev === "critical" || sev === "high" ? c.red : sev === "medium" ? c.yellow : c.dim;
-    const cite = f.rule ? ` ${c.dim}[${f.rule.id}]${c.reset}` : "";
-    console.log(`  ${color}${sev.toUpperCase().padEnd(8)}${c.reset} ${f.name}${cite}`);
-    console.log(`    ${c.dim}${f.detail}${c.reset}`);
-  }
-  return true;
-}
-
-async function cmdSupplyChain(): Promise<boolean> {
-  const jsonMode = hasFlag(process.argv, "--json");
-  // Config-free: supply-chain triage is project-agnostic (it reads the lockfile,
-  // not .kit.toml), so a missing config is not an error — mirror `kit scan`.
-  const config = existsSync(resolveConfigPath())
-    ? await loadConfig(resolveConfigPath())
-    : ({} as kitConfig);
-  const scopes = config.supply_chain?.internal_scopes ?? [];
-  const { runSupplyChain } = await import("./supply-chain.js");
-  const results = runSupplyChain(process.cwd(), scopes);
-  const fails = results.filter((r) => r.status === "fail").length;
-
-  if (jsonMode) {
-    console.log(JSON.stringify({ ok: fails === 0, results }, null, 2));
-    return fails === 0;
-  }
-
-  console.log(`${c.bold}kit supply-chain${c.reset}`);
-  for (const r of results) {
-    const mark =
-      r.status === "fail"
-        ? `${c.red}✗${c.reset}`
-        : r.status === "warn"
-          ? `${c.yellow}!${c.reset}`
-          : r.status === "skip"
-            ? `${c.dim}−${c.reset}`
-            : `${c.green}✓${c.reset}`;
-    console.log(`  ${mark} ${r.name}  ${c.dim}${r.detail}${c.reset}`);
-    if (r.suggestion) console.log(`      ${c.dim}${r.suggestion}${c.reset}`);
-  }
-  if (fails > 0) console.log(`${c.red}${fails} fail${c.reset}`);
-  return fails === 0;
-}
-
-async function cmdAgentAudit(): Promise<boolean> {
-  const jsonMode = hasFlag(process.argv, "--json");
-  const { runAgentAudit } = await import("./agent-audit.js");
-  const results = runAgentAudit(process.cwd());
-  const fails = results.filter((r) => r.status === "fail").length;
-
-  if (jsonMode) {
-    console.log(JSON.stringify({ ok: fails === 0, results }, null, 2));
-    return fails === 0;
-  }
-
-  console.log(
-    `${c.bold}kit agent-audit${c.reset}  ${c.dim}agent/MCP configs + git hooks${c.reset}`,
-  );
-  for (const r of results) {
-    const mark =
-      r.status === "fail"
-        ? `${c.red}✗${c.reset}`
-        : r.status === "warn"
-          ? `${c.yellow}!${c.reset}`
-          : `${c.green}✓${c.reset}`;
-    console.log(`  ${mark} ${r.name}  ${c.dim}${r.detail}${c.reset}`);
-    if (r.suggestion) console.log(`      ${c.dim}${r.suggestion}${c.reset}`);
-  }
-  if (fails > 0) console.log(`${c.red}${fails} fail${c.reset}`);
-  return fails === 0;
-}
-
-async function cmdWhoami(): Promise<boolean> {
-  const jsonMode = hasFlag(process.argv, "--json");
-
-  let config: ReturnType<typeof Object.create> = {};
-  try {
-    config = await loadConfig(resolveConfigPath());
-  } catch {
-    // Works without .kit.toml
-  }
-
-  const { detectEnvironment } = await import("./environment.js");
-  const envInfo = detectEnvironment(config.governance);
-
-  const agent = config.governance?.agent;
-  const budgetEnabled =
-    config.governance?.enabled && (agent?.max_tokens_per_day || agent?.max_operations_per_hour);
-
-  let budget: Awaited<ReturnType<typeof getBudgetStatus>> | null = null;
-  if (budgetEnabled) {
-    budget = await getBudgetStatus(config.governance);
-  }
-
-  if (jsonMode) {
-    console.log(
-      JSON.stringify(
-        {
-          agent: agent ? { id: agent.id, name: agent.name } : null,
-          environment: envInfo.environment,
-          environment_source: envInfo.source,
-          budget: budget
-            ? {
-                tokens_used: budget.tokens_used,
-                tokens_limit: budget.tokens_limit,
-                operations_used: budget.operations_used,
-                operations_limit: budget.operations_limit,
-              }
-            : null,
-        },
-        null,
-        2,
-      ),
-    );
-    return true;
-  }
-
-  console.log(`${c.bold}${c.cyan}kit whoami${c.reset}`);
-  console.log(`${c.dim}${"─".repeat(50)}${c.reset}\n`);
-
-  if (agent?.id || agent?.name) {
-    if (agent.name) console.log(`  ${c.bold}Agent:${c.reset}  ${agent.name}`);
-    if (agent.id) console.log(`  ${c.bold}ID:${c.reset}     ${c.dim}${agent.id}${c.reset}`);
-  } else {
-    console.log(`  ${c.dim}No agent configured in [governance.agent]${c.reset}`);
-  }
-
-  const envColor =
-    envInfo.environment === "prod" ? c.red : envInfo.environment === "staging" ? c.yellow : c.green;
-  console.log(
-    `  ${c.bold}Env:${c.reset}    ${envColor}${envInfo.environment}${c.reset}  ${c.dim}(via ${envInfo.source})${c.reset}`,
-  );
-
-  if (budget) {
-    console.log();
-    const tokensLine = budget.tokens_limit
-      ? `${budget.tokens_used.toLocaleString()} / ${budget.tokens_limit.toLocaleString()} tokens today`
-      : `${budget.tokens_used.toLocaleString()} tokens today`;
-    const opsLine = budget.operations_limit
-      ? `${budget.operations_used} / ${budget.operations_limit} operations this hour`
-      : `${budget.operations_used} operations this hour`;
-    console.log(`  ${c.bold}Budget:${c.reset} ${c.dim}${tokensLine}${c.reset}`);
-    console.log(`          ${c.dim}${opsLine}${c.reset}`);
-  }
-
-  console.log();
-  return true;
-}
-
-function cmdVersion(): boolean {
-  console.log(KIT_VERSION);
-  return true;
 }
 
 export const COMMAND_HELP: Record<string, string> = {

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,0 +1,284 @@
+/**
+ * Read-only status/inspection commands, extracted from cli.ts (5.0-alpha
+ * god-module split). `kit status`, `health`, `ingest`, `supply-chain`,
+ * `agent-audit`, `whoami`, `version` — all independent leaves (no cross-cluster
+ * cmd* calls), each returning a boolean verdict for the COMMANDS dispatch table.
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { c } from "../utils/colors.js";
+import { hasFlag, flagValue } from "../utils/flags.js";
+import { loadConfig, type kitConfig } from "../config.js";
+import { resolveConfigPath, buildHealthCtx } from "../cli-shared.js";
+import { resolveMode, modeScore } from "../setup-modes.js";
+import { quickSubsystems } from "../statusline.js";
+import { gatherStatus } from "../status.js";
+import { withGovernance } from "../governance-middleware.js";
+import { getBudgetStatus } from "../budget.js";
+import { KIT_VERSION } from "../cli-checks-shared.js";
+
+export async function cmdStatus(): Promise<boolean> {
+  const items = await gatherStatus();
+  if (hasFlag(process.argv, "--json")) {
+    console.log(JSON.stringify(items, null, 2));
+    return true;
+  }
+  const done = items.filter((i) => i.ok).length;
+  console.log(`${c.bold}kit status${c.reset}  ${c.dim}${done}/${items.length} set up${c.reset}`);
+  // Mode-aware score: how many of the active mode's expected subsystems are in place.
+  let cfgMode: string | undefined;
+  try {
+    cfgMode = (await loadConfig(resolveConfigPath())).setup?.mode;
+  } catch {
+    /* no/invalid .kit.toml */
+  }
+  const { profile } = resolveMode(flagValue(process.argv, "--mode"), cfgMode);
+  const ms = modeScore(profile, quickSubsystems(process.cwd()));
+  const nextGaps = ms.gaps
+    .map((g) => g.next)
+    .filter(Boolean)
+    .slice(0, 3)
+    .join(", ");
+  console.log(
+    `${c.dim}mode ${c.reset}${c.bold}${profile.mode}${c.reset}${c.dim}: ${ms.done}/${ms.total} subsystems${ms.gaps.length ? ` — next: ${nextGaps}` : " ✓"}${c.reset}\n`,
+  );
+  for (const item of items) {
+    const mark = item.ok ? `${c.green}✓${c.reset}` : `${c.yellow}○${c.reset}`;
+    const hint = !item.ok && item.hint ? `  ${c.dim}→ ${item.hint}${c.reset}` : "";
+    console.log(`  ${mark} ${item.label}  ${c.dim}${item.detail}${c.reset}${hint}`);
+  }
+  return true;
+}
+
+export async function cmdHealth(): Promise<boolean> {
+  const jsonMode = hasFlag(process.argv, "--json");
+  const config = await loadConfig(resolveConfigPath());
+
+  return await withGovernance(
+    config,
+    { operation: "health", operationType: "read", metadata: {} },
+    async () => {
+      const { runHealth, selectSensors, defaultHealthDeps, formatHealth } =
+        await import("../health.js");
+      const { syncHealthFindings } = await import("../health-track.js");
+
+      const ctx = await buildHealthCtx(config);
+
+      const sensors = selectSensors(ctx);
+      const findings = await runHealth(ctx, sensors, defaultHealthDeps);
+      await syncHealthFindings(findings); // mirror red into PAL (fail-open)
+
+      if (jsonMode) {
+        const redCount = findings.filter((f) => f.status === "red").length;
+        console.log(JSON.stringify({ ok: redCount === 0, findings }, null, 2));
+        return redCount === 0;
+      }
+
+      const { lines, redCount } = formatHealth(findings);
+      console.log(`${c.bold}kit health${c.reset}  ${c.dim}${sensors.length} sensor(s)${c.reset}`);
+      if (findings.length === 0) {
+        console.log(`  ${c.dim}no connected external systems detected${c.reset}`);
+      }
+      for (const line of lines) {
+        const color = line.startsWith("✗") ? c.red : line.startsWith("?") ? c.yellow : c.green;
+        console.log(`  ${color}${line}${c.reset}`);
+      }
+      if (redCount > 0) console.log(`${c.red}${redCount} red${c.reset}`);
+      return redCount === 0;
+    },
+  );
+}
+
+export async function cmdIngest(): Promise<boolean> {
+  const jsonMode = hasFlag(process.argv, "--json");
+  const args = process.argv.slice(3).filter((a) => !a.startsWith("-"));
+  const format = args[0];
+  const file = args[1];
+  if (format !== "sarif" && format !== "osv") {
+    console.error(`${c.red}usage: kit ingest <sarif|osv> <file>${c.reset}`);
+    process.exitCode = 1;
+    return false;
+  }
+  if (!file) {
+    console.error(`${c.red}usage: kit ingest ${format} <file>${c.reset}`);
+    process.exitCode = 1;
+    return false;
+  }
+  let json: string;
+  try {
+    json = readFileSync(resolve(process.cwd(), file), "utf8");
+  } catch {
+    console.error(`${c.red}could not read ${file}${c.reset}`);
+    process.exitCode = 1;
+    return false;
+  }
+
+  const { ingest } = await import("../adapters/ingest.js");
+  const findings = ingest(format, json);
+
+  if (jsonMode) {
+    console.log(JSON.stringify({ count: findings.length, findings }, null, 2));
+    return true;
+  }
+
+  console.log(
+    `${c.bold}kit ingest${c.reset}  ${c.dim}${format} · ${findings.length} finding(s)${c.reset}`,
+  );
+  const order: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3 };
+  const sorted = [...findings].sort(
+    (a, b) => (order[a.severity ?? "low"] ?? 9) - (order[b.severity ?? "low"] ?? 9),
+  );
+  for (const f of sorted) {
+    const sev = f.severity ?? "low";
+    const color =
+      sev === "critical" || sev === "high" ? c.red : sev === "medium" ? c.yellow : c.dim;
+    const cite = f.rule ? ` ${c.dim}[${f.rule.id}]${c.reset}` : "";
+    console.log(`  ${color}${sev.toUpperCase().padEnd(8)}${c.reset} ${f.name}${cite}`);
+    console.log(`    ${c.dim}${f.detail}${c.reset}`);
+  }
+  return true;
+}
+
+export async function cmdSupplyChain(): Promise<boolean> {
+  const jsonMode = hasFlag(process.argv, "--json");
+  // Config-free: supply-chain triage is project-agnostic (it reads the lockfile,
+  // not .kit.toml), so a missing config is not an error — mirror `kit scan`.
+  const config = existsSync(resolveConfigPath())
+    ? await loadConfig(resolveConfigPath())
+    : ({} as kitConfig);
+  const scopes = config.supply_chain?.internal_scopes ?? [];
+  const { runSupplyChain } = await import("../supply-chain.js");
+  const results = runSupplyChain(process.cwd(), scopes);
+  const fails = results.filter((r) => r.status === "fail").length;
+
+  if (jsonMode) {
+    console.log(JSON.stringify({ ok: fails === 0, results }, null, 2));
+    return fails === 0;
+  }
+
+  console.log(`${c.bold}kit supply-chain${c.reset}`);
+  for (const r of results) {
+    const mark =
+      r.status === "fail"
+        ? `${c.red}✗${c.reset}`
+        : r.status === "warn"
+          ? `${c.yellow}!${c.reset}`
+          : r.status === "skip"
+            ? `${c.dim}−${c.reset}`
+            : `${c.green}✓${c.reset}`;
+    console.log(`  ${mark} ${r.name}  ${c.dim}${r.detail}${c.reset}`);
+    if (r.suggestion) console.log(`      ${c.dim}${r.suggestion}${c.reset}`);
+  }
+  if (fails > 0) console.log(`${c.red}${fails} fail${c.reset}`);
+  return fails === 0;
+}
+
+export async function cmdAgentAudit(): Promise<boolean> {
+  const jsonMode = hasFlag(process.argv, "--json");
+  const { runAgentAudit } = await import("../agent-audit.js");
+  const results = runAgentAudit(process.cwd());
+  const fails = results.filter((r) => r.status === "fail").length;
+
+  if (jsonMode) {
+    console.log(JSON.stringify({ ok: fails === 0, results }, null, 2));
+    return fails === 0;
+  }
+
+  console.log(
+    `${c.bold}kit agent-audit${c.reset}  ${c.dim}agent/MCP configs + git hooks${c.reset}`,
+  );
+  for (const r of results) {
+    const mark =
+      r.status === "fail"
+        ? `${c.red}✗${c.reset}`
+        : r.status === "warn"
+          ? `${c.yellow}!${c.reset}`
+          : `${c.green}✓${c.reset}`;
+    console.log(`  ${mark} ${r.name}  ${c.dim}${r.detail}${c.reset}`);
+    if (r.suggestion) console.log(`      ${c.dim}${r.suggestion}${c.reset}`);
+  }
+  if (fails > 0) console.log(`${c.red}${fails} fail${c.reset}`);
+  return fails === 0;
+}
+
+export async function cmdWhoami(): Promise<boolean> {
+  const jsonMode = hasFlag(process.argv, "--json");
+
+  let config: ReturnType<typeof Object.create> = {};
+  try {
+    config = await loadConfig(resolveConfigPath());
+  } catch {
+    // Works without .kit.toml
+  }
+
+  const { detectEnvironment } = await import("../environment.js");
+  const envInfo = detectEnvironment(config.governance);
+
+  const agent = config.governance?.agent;
+  const budgetEnabled =
+    config.governance?.enabled && (agent?.max_tokens_per_day || agent?.max_operations_per_hour);
+
+  let budget: Awaited<ReturnType<typeof getBudgetStatus>> | null = null;
+  if (budgetEnabled) {
+    budget = await getBudgetStatus(config.governance);
+  }
+
+  if (jsonMode) {
+    console.log(
+      JSON.stringify(
+        {
+          agent: agent ? { id: agent.id, name: agent.name } : null,
+          environment: envInfo.environment,
+          environment_source: envInfo.source,
+          budget: budget
+            ? {
+                tokens_used: budget.tokens_used,
+                tokens_limit: budget.tokens_limit,
+                operations_used: budget.operations_used,
+                operations_limit: budget.operations_limit,
+              }
+            : null,
+        },
+        null,
+        2,
+      ),
+    );
+    return true;
+  }
+
+  console.log(`${c.bold}${c.cyan}kit whoami${c.reset}`);
+  console.log(`${c.dim}${"─".repeat(50)}${c.reset}\n`);
+
+  if (agent?.id || agent?.name) {
+    if (agent.name) console.log(`  ${c.bold}Agent:${c.reset}  ${agent.name}`);
+    if (agent.id) console.log(`  ${c.bold}ID:${c.reset}     ${c.dim}${agent.id}${c.reset}`);
+  } else {
+    console.log(`  ${c.dim}No agent configured in [governance.agent]${c.reset}`);
+  }
+
+  const envColor =
+    envInfo.environment === "prod" ? c.red : envInfo.environment === "staging" ? c.yellow : c.green;
+  console.log(
+    `  ${c.bold}Env:${c.reset}    ${envColor}${envInfo.environment}${c.reset}  ${c.dim}(via ${envInfo.source})${c.reset}`,
+  );
+
+  if (budget) {
+    console.log();
+    const tokensLine = budget.tokens_limit
+      ? `${budget.tokens_used.toLocaleString()} / ${budget.tokens_limit.toLocaleString()} tokens today`
+      : `${budget.tokens_used.toLocaleString()} tokens today`;
+    const opsLine = budget.operations_limit
+      ? `${budget.operations_used} / ${budget.operations_limit} operations this hour`
+      : `${budget.operations_used} operations this hour`;
+    console.log(`  ${c.bold}Budget:${c.reset} ${c.dim}${tokensLine}${c.reset}`);
+    console.log(`          ${c.dim}${opsLine}${c.reset}`);
+  }
+
+  console.log();
+  return true;
+}
+
+export function cmdVersion(): boolean {
+  console.log(KIT_VERSION);
+  return true;
+}


### PR DESCRIPTION
Thirteenth cut of the `cli.ts` god-module split — the **first of the independent leaf batches**, now that every entangled cluster is out.

## What changed
- **New `src/commands/info.ts`** — the read-only status/inspection commands, all exported: `cmdStatus`, `cmdHealth`, `cmdIngest`, `cmdSupplyChain`, `cmdAgentAudit`, `cmdWhoami`, `cmdVersion`. No cross-cluster `cmd*` calls. `cmdVersion` sources `KIT_VERSION` from the `cli-checks-shared` seam; `cmdHealth` reuses `buildHealthCtx` from `cli-shared` (both already neutral seams — no new hoists needed).
- `cli.ts` imports them back; the `COMMANDS` table is unchanged. Pruned now-unused imports (`gatherStatus`, `quickSubsystems`, `resolveMode`/`modeScore`, `buildHealthCtx`, `existsSync`, `kitConfig` type).

## Verification
`tsc` clean · eslint **0 errors** (only pre-existing complexity/max-lines warnings, carried over verbatim) · full suite **2580 passing** · prettier clean · runtime dispatch smoke-tested (`version` → 4.4.0, `status`/`supply-chain`).

**`cli.ts`: 2119 → 1859 lines (−260; −4471 cumulative from the 6330-line original — ~71% smaller).**

Remaining: two leaf batches — **project** (run/open/clone/create-plugin) and the **standalone leaves** (heal/skills/escalate/agent-config/governance/statusline/coverage/analyze/self-audit/pkg/help/team) — then `cli.ts` is a thin dispatcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_