### PR TITLE
feat(cli): registry owns MCP exposure + CLI=MCP drift test (surface-unification step 3)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -393,10 +393,34 @@ async function main(): Promise<void> {
  * help (multi-word keys like "memory search") has no handler or tier of its own,
  * so it lives in SUBCOMMAND_HELP and is merged into COMMAND_HELP.
  */
-interface CommandDescriptor {
+export interface CommandDescriptor {
   handler: () => boolean | Promise<boolean>;
   stability: CommandTier;
   help: string;
+  /**
+   * When true, this verb is ALSO exposed as an MCP tool (named `kit_<verb>` with
+   * `-` → `_`). The MCP server (mcp-server.ts) hand-registers each such tool with
+   * its input schema, but which verbs are exposed is owned here — a drift test
+   * (mcp-server.test.ts) asserts KIT_MCP_TOOLS matches this set, so "CLI = MCP"
+   * is a provable invariant. mcp-server.ts can't import this registry (it would
+   * cycle via commands/mcp.ts), hence the test-time cross-check rather than a
+   * runtime derivation.
+   */
+  mcp?: boolean;
+}
+
+/** CLI verb → MCP tool name (`add` → `kit_add`, `supply-chain` → `kit_supply_chain`). */
+export function mcpToolName(verb: string): string {
+  return `kit_${verb.replace(/-/g, "_")}`;
+}
+
+/** The MCP tool names derived from every registry verb marked `mcp: true`, sorted.
+ *  The mcp-server.test.ts drift guard asserts KIT_MCP_TOOLS equals this set. */
+export function mcpExposedToolNames(): string[] {
+  return Object.entries(COMMAND_REGISTRY)
+    .filter(([, d]) => d.mcp)
+    .map(([verb]) => mcpToolName(verb))
+    .sort();
 }
 
 const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
@@ -415,6 +439,7 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
     handler: cmdCheck,
     stability: "stable",
     help: "Check status of all tools, services, secrets, and lock files",
+    mcp: true,
   },
   health: {
     handler: cmdHealth,
@@ -466,18 +491,26 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
     handler: cmdInit,
     stability: "stable",
     help: "Detect stack, generate .kit.toml, and run full setup (--no-setup: config + lock files only)",
+    mcp: true,
   },
   upgrade: { handler: cmdUpgrade, stability: "stable", help: "Update lock files from .kit.toml" },
-  install: { handler: cmdInstall, stability: "stable", help: "Install missing tools via mise" },
+  install: {
+    handler: cmdInstall,
+    stability: "stable",
+    help: "Install missing tools via mise",
+    mcp: true,
+  },
   login: {
     handler: cmdLogin,
     stability: "stable",
     help: "Guided login to all configured services",
+    mcp: true,
   },
   secrets: {
     handler: cmdSecrets,
     stability: "stable",
     help: "Generate .env.local from template + secret store",
+    mcp: true,
   },
   setup: {
     handler: cmdSetup,
@@ -485,7 +518,7 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
     help: "Full pipeline: install → login → secrets → agent config → verify",
   },
   skills: { handler: cmdSkills, stability: "stable", help: "Check status of agent skills" },
-  fix: { handler: cmdFix, stability: "stable", help: "Auto-fix what is possible" },
+  fix: { handler: cmdFix, stability: "stable", help: "Auto-fix what is possible", mcp: true },
   heal: {
     handler: cmdHeal,
     stability: "stable",
@@ -507,6 +540,7 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
     handler: cmdAdd,
     stability: "stable",
     help: "Provision a service (kit add --list to see all adapters)",
+    mcp: true,
   },
   audit: { handler: cmdAudit, stability: "stable", help: "View audit log of kit operations" },
   auth: {
@@ -519,7 +553,7 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
     stability: "stable",
     help: "MCP server over stdio (Claude Code/Cursor/Codex); 'kit mcp list|auth|set-token|clear' manages declared servers",
   },
-  env: { handler: cmdEnv, stability: "stable", help: "Show current environment info" },
+  env: { handler: cmdEnv, stability: "stable", help: "Show current environment info", mcp: true },
   doctor: {
     handler: cmdDoctor,
     stability: "stable",
@@ -549,6 +583,7 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
     handler: cmdCi,
     stability: "stable",
     help: "CI-native check: GitHub Actions annotations, GitLab JUnit, JSON (--init gitlab|bitbucket scaffolds a pipeline)",
+    mcp: true,
   },
   "self-audit": {
     handler: cmdSelfAudit,
@@ -584,6 +619,7 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
     handler: cmdRun,
     stability: "stable",
     help: "Execute a command with project env vars loaded",
+    mcp: true,
   },
   open: {
     handler: cmdOpen,
@@ -594,6 +630,7 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
     handler: cmdContext,
     stability: "stable",
     help: "Show project context: tools, services, secrets, environment",
+    mcp: true,
   },
   config: {
     handler: cmdConfig,
@@ -624,6 +661,7 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
     handler: cmdStandards,
     stability: "stable",
     help: "Dev-standards gate: general metrics + per-language linters + user plugins vs the baseline (--category general|specific|plugins|<lang>, --enforce fails CI)",
+    mcp: true,
   },
   review: {
     handler: cmdReview,

--- a/src/mcp-server.test.ts
+++ b/src/mcp-server.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createMcpServer, KIT_MCP_TOOLS } from "./mcp-server.js";
+import { mcpExposedToolNames } from "./cli.js";
 
 // Standard .gitignore so security check passes in temp dirs
 const GITIGNORE = ".env\n.env.local\n.env.*.local\n";
@@ -95,6 +96,16 @@ describe("MCP server tool registration", () => {
     } finally {
       await cleanup();
     }
+  });
+
+  // CLI = MCP: which verbs are exposed as MCP tools is OWNED by the CLI
+  // COMMAND_REGISTRY (each descriptor's `mcp: true`), and mcpExposedToolNames()
+  // derives the `kit_<verb>` names from it. This asserts KIT_MCP_TOOLS — and
+  // therefore the actually-registered tools (guarded above) — match that single
+  // source, so a verb can't be MCP-exposed without a registry entry, nor a
+  // registry `mcp` marker exist without a registered tool.
+  it("KIT_MCP_TOOLS matches the CLI COMMAND_REGISTRY mcp-exposed verbs (CLI = MCP)", () => {
+    assert.deepEqual([...KIT_MCP_TOOLS].sort(), mcpExposedToolNames());
   });
 });
 


### PR DESCRIPTION
Completes **surface-unification** (5.0-alpha part 2): the CLI `COMMAND_REGISTRY` is now the single source of truth for **which verbs are exposed as MCP tools**, and a drift test makes **"CLI = MCP" a provable invariant**.

## What changed
- `CommandDescriptor` gains `mcp?: boolean`; the 12 verb-backed MCP tools (`check`, `standards`, `install`, `login`, `secrets`, `fix`, `add`, `env`, `init`, `ci`, `run`, `context`) are marked `mcp: true` in the registry.
- New exports `mcpToolName(verb)` (`add` → `kit_add`, `supply-chain` → `kit_supply_chain`) and `mcpExposedToolNames()` (sorted `kit_*` names derived from the registry markers).
- `mcp-server.test.ts` — new guard asserts `KIT_MCP_TOOLS === mcpExposedToolNames()`. Chained with the existing "registered tools === KIT_MCP_TOOLS" guard, this proves the full chain:

  **registry `mcp` markers ⇔ `KIT_MCP_TOOLS` ⇔ live registered tools.**

  A verb can't be MCP-exposed without a registry entry, nor a marker exist without a live tool.

## Why a test-time cross-check (not runtime generation)
`mcp-server.ts` intentionally does **not** import the registry at runtime — that would cycle (`cli.ts → commands/mcp.ts → mcp-server.ts`). So MCP exposure is *owned* in the registry and *enforced* by the drift test, rather than generated. (Full runtime generation would require hoisting the registry to a neutral seam — deferred; the invariant is already provable.)

## Verification
Fresh `npm run build` + `node scripts/test.mjs`: `tsc` clean · eslint **0 errors** · full suite **2581 passing** (+1 drift test) · prettier clean.

## 5.0-alpha surface-unification: done
With this, the North Star's 5.0-alpha is complete end to end — `cli.ts` split (6330 → ~700, thin dispatcher) **and** surface-unification (one `COMMAND_REGISTRY` core; CLI's `COMMANDS`/`TIERS`/`HELP` derived; MCP exposure owned by it and drift-guarded; the fabricated MCP stubs removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_