### PR TITLE
feat(identity): kit identity migrate — revoke old file key on move to hardware (Pillar 1)

### DIFF
--- a/src/commands/identity.test.ts
+++ b/src/commands/identity.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { cmdIdentity } from "./identity.js";
+
+// `kit identity migrate` must FAIL CLOSED unless an external/hardware keystore is
+// actually active — it revokes the old file key, so running it while still on the
+// file backend (the default) would be meaningless and must refuse. The happy path
+// (revocation signed by the active hardware key) is covered by the keystore suite's
+// keystoreRecordRevocation tests; here we lock the safety guard.
+describe("kit identity migrate", () => {
+  const savedArgv = process.argv;
+  const savedKs = process.env.KIT_KEYSTORE;
+
+  before(() => {
+    delete process.env.KIT_KEYSTORE; // force the file backend (not hardware-rooted)
+  });
+  after(() => {
+    process.argv = savedArgv;
+    if (savedKs === undefined) delete process.env.KIT_KEYSTORE;
+    else process.env.KIT_KEYSTORE = savedKs;
+  });
+
+  it("fails closed when no external/hardware backend is active", async () => {
+    process.argv = ["node", "kit", "identity", "migrate"];
+    const ok = await cmdIdentity();
+    assert.equal(ok, false, "migrate must refuse to run on the file backend");
+  });
+});

--- a/src/commands/identity.ts
+++ b/src/commands/identity.ts
@@ -8,6 +8,7 @@ import {
   hardwareRequired,
   policyRequiresHardware,
 } from "../keystore/index.js";
+import { keystoreRecordRevocation } from "../keystore/revoke.js";
 
 /** `kit identity keystore` — surface the active signing backend, honestly. */
 function identityKeystore(): boolean {
@@ -48,10 +49,56 @@ function identityKeystore(): boolean {
   return true;
 }
 
+/**
+ * `kit identity migrate` — you've provisioned an external/hardware-held key
+ * (KIT_KEYSTORE=command → your TPM/HSM/enclave/YubiKey) and made it active; this
+ * records a signed revocation of the OLD kit-managed file key, SIGNED BY and
+ * ATTRIBUTED TO the new active key, so verifiers learn the file key is
+ * superseded. kit never mints hardware keys (they are operator-fronted), so
+ * "migration" is revoke-the-old, not a kit-run rotation. Past signatures by the
+ * file key stay verifiable via its archived public key; the file key is revoked.
+ * Fail-closed: refuses unless a hardware/external backend is actually active.
+ */
+async function identityMigrate(): Promise<boolean> {
+  const st = activeKeyStoreStatus();
+  if (!st.hardwareRooted) {
+    console.error(
+      `${c.red}✗ no external/hardware backend active${c.reset} — set ${c.bold}KIT_KEYSTORE=command${c.reset} ${c.dim}(+ KIT_KEYSTORE_SIGN_CMD + KIT_KEYSTORE_PUBKEY, fronting your TPM/HSM/enclave/YubiKey)${c.reset} first; kit won't "migrate" onto a file key`,
+    );
+    return false;
+  }
+  const fileId = tryLoadIdentity();
+  if (!fileId) {
+    console.log(
+      `${c.dim}no kit-managed file key found — nothing to revoke; the active identity is already ${st.kid ?? "external"}.${c.reset}`,
+    );
+    return true;
+  }
+  if (st.kid && fileId.id === st.kid) {
+    console.error(
+      `${c.red}✗ the active key IS the file key${c.reset} — nothing migrated. Point ${c.bold}KIT_KEYSTORE_PUBKEY${c.reset} at a different (hardware-held) key before migrating.`,
+    );
+    return false;
+  }
+  const rec = keystoreRecordRevocation(fileId.id, "migrated to hardware-rooted identity");
+  console.log(
+    `${c.green}✓${c.reset} migrated to ${c.bold}${st.kind}${c.reset} identity ${c.bold}${st.kid}${c.reset}`,
+  );
+  console.log(
+    `  ${c.yellow}!${c.reset} ${c.dim}revoked old file key ${rec.kid} (revocation signed by the active key ${rec.by}); its past signatures stay verifiable, new ones use ${st.kid}${c.reset}`,
+  );
+  console.log(
+    `  ${c.dim}the old private key file under ~/.kit is now revoked — delete it once you've confirmed the hardware key works everywhere.${c.reset}`,
+  );
+  return true;
+}
+
 export async function cmdIdentity(): Promise<boolean> {
   const sub = process.argv[3] ?? "show";
 
   if (sub === "keystore") return identityKeystore();
+
+  if (sub === "migrate") return await identityMigrate();
 
   if (sub === "init") {
     // Under a hardware mandate (env OR org policy), refuse to mint a same-UID file key —
@@ -117,6 +164,8 @@ export async function cmdIdentity(): Promise<boolean> {
     return true;
   }
 
-  console.error(`${c.red}usage: kit identity <init|show [--public]|rotate|keystore>${c.reset}`);
+  console.error(
+    `${c.red}usage: kit identity <init|show [--public]|rotate|keystore|migrate>${c.reset}`,
+  );
   return false;
 }


### PR DESCRIPTION
Second **5.0-beta / Pillar 1** increment. Fulfils the North Star design principle:

> *Migrering: `kit identity migrate` som roterar från fil- till hårdvarunyckel och emit:ar en signerad revocation av den gamla (återanvänder rotate-maskineriet).*

kit never **mints** hardware keys — they're operator-fronted (`KIT_KEYSTORE=command` → TPM/HSM/enclave/YubiKey) — so "migration" is **revoke-the-old**, not a kit-run rotation:

## `kit identity migrate`
- **fail-closed** unless an external/hardware backend is actually active (won't "migrate" onto a file key)
- refuses if the active key **is** the file key (nothing migrated)
- records a **signed revocation** of the old file kid via `keystoreRecordRevocation` — signed by and attributed to the active hardware key — so verifiers learn the file key is superseded
- old signatures stay verifiable via the archived public key; points the user to delete the revoked file key once the hardware key is confirmed

## What changed
- `src/commands/identity.ts` — new `migrate` subcommand + updated usage.
- `src/commands/identity.test.ts` (new) — locks the fail-closed guard; the happy-path revocation is already covered by the keystore suite's `keystoreRecordRevocation` tests.

## Verification
Fresh `npm run build` + `node scripts/test.mjs`: `tsc` clean · eslint **0 errors** · full suite **2583 passing** (+1) · prettier clean · fail-closed path smoke-tested (`kit identity migrate` on the file backend refuses).

Remaining Pillar 1: native Secure Enclave / TPM bindings behind the existing honest stubs (largest platform-specific surface; not buildable/testable in this Linux CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_