### PR TITLE
feat(insight): deterministic transcript tool-usage scanner (Pillar 4 step 1)

### DIFF
--- a/src/insight/usage-scan.test.ts
+++ b/src/insight/usage-scan.test.ts
@@ -1,0 +1,92 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { openMemoryDb } from "../memory/db.js";
+import { mcpServerOf, tallyToolUsage, scanToolUsage, hasIndexedToolUsage } from "./usage-scan.js";
+
+describe("mcpServerOf", () => {
+  it("extracts the server slug from an mcp__server__tool name", () => {
+    assert.equal(mcpServerOf("mcp__github__create_issue"), "github");
+    assert.equal(mcpServerOf("mcp__some-server__do_thing"), "some-server");
+  });
+  it("returns null for non-MCP tools", () => {
+    assert.equal(mcpServerOf("kit_check"), null);
+    assert.equal(mcpServerOf("Bash"), null);
+    assert.equal(mcpServerOf(""), null);
+  });
+  it("handles a server with no tool segment", () => {
+    assert.equal(mcpServerOf("mcp__lonely"), "lonely");
+    assert.equal(mcpServerOf("mcp__"), null);
+  });
+});
+
+describe("tallyToolUsage", () => {
+  it("counts, skips null/blank, and sorts by count desc then name asc", () => {
+    const out = tallyToolUsage([
+      "Bash",
+      "Bash",
+      "kit_check",
+      null,
+      "  ",
+      undefined,
+      "kit_check",
+      "Bash",
+      "mcp__github__x",
+    ]);
+    assert.deepEqual(
+      out.map((e) => [e.tool, e.count]),
+      [
+        ["Bash", 3],
+        ["kit_check", 2],
+        ["mcp__github__x", 1],
+      ],
+    );
+    // mcpServer is derived per entry.
+    assert.equal(out.find((e) => e.tool === "mcp__github__x")?.mcpServer, "github");
+    assert.equal(out.find((e) => e.tool === "Bash")?.mcpServer, null);
+  });
+  it("is deterministic for ties (name asc)", () => {
+    const out = tallyToolUsage(["b", "a", "c"]);
+    assert.deepEqual(
+      out.map((e) => e.tool),
+      ["a", "b", "c"],
+    );
+  });
+  it("returns [] for no input", () => {
+    assert.deepEqual(tallyToolUsage([]), []);
+  });
+});
+
+describe("scanToolUsage", () => {
+  it("groups tool_uses rows from the memory DB", () => {
+    const db = openMemoryDb(":memory:");
+    const insert = db.prepare(
+      "INSERT INTO tool_uses (message_uuid, session_id, tool_name, tool_input, timestamp) VALUES (?, ?, ?, ?, ?)",
+    );
+    let i = 0;
+    const add = (tool: string) => insert.run(`m${i++}`, "s1", tool, "{}", "2026-01-01T00:00:00Z");
+    add("Bash");
+    add("Bash");
+    add("mcp__github__create_issue");
+    add("kit_check");
+
+    assert.equal(hasIndexedToolUsage(db), true);
+    const out = scanToolUsage(db);
+    assert.deepEqual(
+      out.map((e) => [e.tool, e.count]),
+      [
+        ["Bash", 2],
+        ["kit_check", 1],
+        ["mcp__github__create_issue", 1],
+      ],
+    );
+    assert.equal(out.find((e) => e.tool === "mcp__github__create_issue")?.mcpServer, "github");
+    db.close();
+  });
+
+  it("reports no indexed usage for an empty DB (caller must skip, not claim all-unused)", () => {
+    const db = openMemoryDb(":memory:");
+    assert.equal(hasIndexedToolUsage(db), false);
+    assert.deepEqual(scanToolUsage(db), []);
+    db.close();
+  });
+});

--- a/src/insight/usage-scan.ts
+++ b/src/insight/usage-scan.ts
@@ -1,0 +1,72 @@
+/**
+ * Deterministic tool-usage scanner — the "used" signal for Pelare 4's
+ * loaded-but-unused insight (`pillar4-insight-loop-5.0.md`).
+ *
+ * Zero-LLM, pure counting: kit's memory index already normalizes every agent's
+ * transcript into the `tool_uses` table (one row per tool call, cross-agent), so
+ * "was this tool/MCP-server actually called?" is a GROUP BY, not a re-parse of
+ * each agent's JSONL format. Given the same DB, output is identical — safe to
+ * diff in CI. Detection lives here (core, deterministic); only the eventual
+ * skill-*authoring* may be model-assisted, around the core (never in this path).
+ *
+ * This module is the scanner only — the loaded-vs-used correlation + the
+ * `kit insight` surface land in later steps.
+ */
+import type { DatabaseSync } from "node:sqlite";
+
+export interface ToolUsageEntry {
+  /** The recorded tool name, e.g. "kit_check", "Bash", "mcp__github__create_issue". */
+  tool: string;
+  /** How many times it was invoked across all indexed transcripts. */
+  count: number;
+  /** For an MCP tool (`mcp__<server>__<tool>`), the server slug; else null. */
+  mcpServer: string | null;
+}
+
+/**
+ * The MCP server slug behind a namespaced tool name. Claude Code / MCP name
+ * tools `mcp__<server>__<tool>`; this returns `<server>` (which may itself
+ * contain `__`-free segments). Returns null for non-MCP tools (Bash, kit_*, …).
+ */
+export function mcpServerOf(tool: string): string | null {
+  if (!tool.startsWith("mcp__")) return null;
+  const rest = tool.slice("mcp__".length);
+  const sep = rest.indexOf("__");
+  const server = sep === -1 ? rest : rest.slice(0, sep);
+  return server.length > 0 ? server : null;
+}
+
+/**
+ * Pure tally: count occurrences of each tool name, skipping null/blank, sorted
+ * deterministically (count desc, then tool name asc) so the report is stable.
+ */
+export function tallyToolUsage(names: (string | null | undefined)[]): ToolUsageEntry[] {
+  const counts = new Map<string, number>();
+  for (const raw of names) {
+    if (raw == null) continue;
+    const tool = raw.trim();
+    if (tool.length === 0) continue;
+    counts.set(tool, (counts.get(tool) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([tool, count]) => ({ tool, count, mcpServer: mcpServerOf(tool) }))
+    .sort((a, b) => b.count - a.count || (a.tool < b.tool ? -1 : a.tool > b.tool ? 1 : 0));
+}
+
+/**
+ * Scan the memory DB's `tool_uses` table for every recorded tool invocation.
+ * Deterministic given the DB. Returns [] when nothing has been indexed — callers
+ * MUST treat "no rows" as "can't judge usage" (skip), never as "all unused".
+ */
+export function scanToolUsage(db: DatabaseSync): ToolUsageEntry[] {
+  const rows = db.prepare("SELECT tool_name FROM tool_uses").all() as {
+    tool_name: string | null;
+  }[];
+  return tallyToolUsage(rows.map((r) => r.tool_name));
+}
+
+/** Fast "is anything indexed?" guard so callers can emit an honest skip. */
+export function hasIndexedToolUsage(db: DatabaseSync): boolean {
+  const row = db.prepare("SELECT COUNT(*) AS n FROM tool_uses").get() as { n: number };
+  return row.n > 0;
+}


### PR DESCRIPTION
First implementation step of **Pillar 4's insight loop** (`kit-research/docs/research/pillar4-insight-loop-5.0.md`) — the missing **"used" signal** that loaded-but-unused needs.

## Approach (zero-LLM, pure counting)
kit's memory index already normalizes every agent's transcript into the `tool_uses` table (cross-agent, indexed on `tool_name`), so "was this tool / MCP server actually called?" is a `GROUP BY` — **not** a re-parse of each agent's JSONL format. Given the same DB, output is identical (safe to diff in CI). Detection stays deterministic/core; the ML boundary is honored (only eventual skill *authoring* may be model-assisted, around the core).

## New `src/insight/usage-scan.ts`
- `mcpServerOf(tool)` — server slug from `mcp__<server>__<tool>` (else null)
- `tallyToolUsage(names)` — pure count; skips null/blank; deterministic sort (count desc, then name asc)
- `scanToolUsage(db)` — `GROUP BY` over `tool_uses`
- `hasIndexedToolUsage(db)` — so callers emit an **honest skip** on an empty index (no transcripts ⇒ "can't judge usage", never a silent "all unused")

Scanner only — the loaded-vs-used correlation and the `kit insight` surface land in later steps.

## Verification
Fresh `npm run build` + `node scripts/test.mjs`: `tsc` clean · eslint **0 errors** · full suite **2591 passing** (+8 usage-scan tests) · prettier clean.

## Next
Step 2 — `kit insight unused`: correlate the loaded toolchain (`agent-sbom`) against this usage, report prune *suggestions* (never auto-remove), `skip` when no transcripts. Wired via `COMMAND_REGISTRY` (the new `insight` verb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_