### PR TITLE
feat(insight): skill usage detection — real verdicts for loaded skills (Pillar 4 step 3)

### DIFF
--- a/src/commands/insight.ts
+++ b/src/commands/insight.ts
@@ -1,18 +1,17 @@
 /**
  * `kit insight` — Pelare 4's deterministic lifecycle-insight surface. First
- * subcommand: `unused` — which loaded MCP servers were never actually called,
- * correlating the loaded toolchain (agent-sbom) against recorded tool usage
- * (the memory index's tool_uses table). Zero-LLM, pure counting.
+ * subcommand: `unused` — which loaded MCP servers / skills were never actually
+ * called, correlating the loaded toolchain (agent-sbom) against recorded usage
+ * (the memory index's tool_uses table: MCP tools by `mcp__<server>__<tool>`,
+ * skills by the `Skill` tool's `{skill}` input). Zero-LLM, pure counting.
  *
- * Honesty (no false green): reports SUGGESTIONS, never auto-removes; skills are
- * reported "unknown" (their usage isn't judgeable from tool_uses yet, not
- * "unused"); and with no indexed usage it SKIPS ("can't judge") rather than
- * declaring everything unused.
+ * Honesty (no false green): reports SUGGESTIONS, never auto-removes; and with no
+ * indexed usage it SKIPS ("can't judge") rather than declaring everything unused.
  */
 import { c } from "../utils/colors.js";
 import { hasFlag } from "../utils/flags.js";
 import { discoverAgentToolchain } from "../agent-sbom.js";
-import { scanToolUsage, hasIndexedToolUsage } from "../insight/usage-scan.js";
+import { scanToolUsage, scanSkillUsage, hasIndexedToolUsage } from "../insight/usage-scan.js";
 import { computeUnused } from "../insight/unused.js";
 
 async function insightUnused(): Promise<boolean> {
@@ -37,7 +36,8 @@ async function insightUnused(): Promise<boolean> {
     }
 
     const usage = scanToolUsage(db);
-    const report = computeUnused(loaded, usage);
+    const skillUsage = scanSkillUsage(db);
+    const report = computeUnused(loaded, usage, skillUsage);
 
     if (jsonMode) {
       console.log(JSON.stringify({ skipped: false, ...report }, null, 2));
@@ -65,8 +65,12 @@ async function insightUnused(): Promise<boolean> {
     if (skills.length > 0) {
       console.log(`  ${c.bold}skills${c.reset}`);
       for (const f of skills) {
+        const mark = f.verdict === "used" ? `${c.green}✓${c.reset}` : `${c.yellow}⚠${c.reset}`;
+        const tag =
+          f.verdict === "used" ? `${c.green}used${c.reset}   ` : `${c.yellow}UNUSED${c.reset} `;
+        const note = f.verdict === "unused" ? `  ${c.dim}loaded, never invoked${c.reset}` : "";
         console.log(
-          `    ${c.dim}?${c.reset} ${c.dim}unknown${c.reset} ${f.name}  ${c.dim}usage detection lands next — not judged${c.reset}`,
+          `    ${mark} ${tag} ${f.name}  ${c.dim}${f.refs} invocation(s)${c.reset}${note}`,
         );
       }
     }
@@ -78,7 +82,7 @@ async function insightUnused(): Promise<boolean> {
 
     if (report.pruneCandidates.length > 0) {
       console.log(
-        `  ${c.dim}→ prune candidates (MCP): ${c.reset}${report.pruneCandidates.join(", ")}  ${c.dim}(kit removes nothing automatically)${c.reset}`,
+        `  ${c.dim}→ prune candidates: ${c.reset}${report.pruneCandidates.join(", ")}  ${c.dim}(kit removes nothing automatically)${c.reset}`,
       );
     }
     return true;

--- a/src/insight/unused.test.ts
+++ b/src/insight/unused.test.ts
@@ -32,7 +32,7 @@ describe("computeUnused", () => {
     assert.deepEqual(report.pruneCandidates, ["some-server"]);
   });
 
-  it("never judges a skill 'unused' — verdict is 'unknown' until skill-usage detection lands", () => {
+  it("leaves skill verdict 'unknown' when no skill-usage map is provided (never 'unused')", () => {
     const report = computeUnused(
       { skills: [{ name: "pdf-process" }], mcpServers: [] },
       usage([["Bash", 5]]),
@@ -40,7 +40,22 @@ describe("computeUnused", () => {
     const skill = report.findings.find((f) => f.name === "pdf-process");
     assert.equal(skill?.kind, "skill");
     assert.equal(skill?.verdict, "unknown");
-    assert.deepEqual(report.pruneCandidates, []); // skills are never prune candidates here
+    assert.deepEqual(report.pruneCandidates, []);
+  });
+
+  it("judges skills used/unused from the skill-usage map (exact slug), unused ⇒ prune candidate", () => {
+    const report = computeUnused(
+      { skills: [{ name: "deep-research" }, { name: "pdf-process" }], mcpServers: [] },
+      [],
+      new Map([["deep-research", 4]]),
+    );
+    const dr = report.findings.find((f) => f.name === "deep-research");
+    const pdf = report.findings.find((f) => f.name === "pdf-process");
+    assert.equal(dr?.verdict, "used");
+    assert.equal(dr?.refs, 4);
+    assert.equal(pdf?.verdict, "unused");
+    assert.equal(pdf?.refs, 0);
+    assert.deepEqual(report.pruneCandidates, ["pdf-process"]);
   });
 
   it("orders findings skills-first then mcp-servers, each by name asc (deterministic)", () => {

--- a/src/insight/unused.ts
+++ b/src/insight/unused.ts
@@ -7,9 +7,9 @@
  * Honesty rules (no false green):
  * - MCP servers correlate cleanly (a call is `mcp__<server>__<tool>`), so they get
  *   a real used/unused verdict.
- * - Skills DON'T reliably appear in the tool_uses table (a skill invocation is not
- *   a distinct tool call), so their verdict is "unknown" here — NEVER "unused".
- *   Skill-usage detection lands in a later step; until then we refuse to guess.
+ * - Skills correlate via the `Skill` tool's `{skill:<slug>}` input (exact slug
+ *   match against the loaded skill's directory name) — a real used/unused verdict.
+ *   Passing no skill-usage map falls back to "unknown" (never "unused").
  * - "unused" is a PRUNE SUGGESTION, never an automatic removal.
  */
 import type { AgentComponentInput } from "../agent-sbom.js";
@@ -41,6 +41,7 @@ export interface UnusedReport {
 export function computeUnused(
   loaded: { skills: AgentComponentInput[]; mcpServers: AgentComponentInput[] },
   usage: ToolUsageEntry[],
+  skillUsage?: Map<string, number>,
 ): UnusedReport {
   // Sum recorded refs per MCP server across all its tools.
   const serverRefs = new Map<string, number>();
@@ -53,13 +54,21 @@ export function computeUnused(
     a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
 
   const findings: UnusedFinding[] = [];
+  const pruneCandidates: string[] = [];
 
   for (const s of [...loaded.skills].sort(byName)) {
-    // Skills can't be judged from tool_uses yet — honest "unknown", never "unused".
-    findings.push({ kind: "skill", name: s.name, source: s.source, refs: 0, verdict: "unknown" });
+    // With a skill-usage map, judge by exact-slug invocation count; without one,
+    // stay honest ("unknown" — never "unused").
+    if (skillUsage === undefined) {
+      findings.push({ kind: "skill", name: s.name, source: s.source, refs: 0, verdict: "unknown" });
+      continue;
+    }
+    const refs = skillUsage.get(s.name) ?? 0;
+    const verdict: UsageVerdict = refs > 0 ? "used" : "unused";
+    if (verdict === "unused") pruneCandidates.push(s.name);
+    findings.push({ kind: "skill", name: s.name, source: s.source, refs, verdict });
   }
 
-  const pruneCandidates: string[] = [];
   for (const m of [...loaded.mcpServers].sort(byName)) {
     const refs = serverRefs.get(m.name) ?? 0;
     const verdict: UsageVerdict = refs > 0 ? "used" : "unused";

--- a/src/insight/usage-scan.test.ts
+++ b/src/insight/usage-scan.test.ts
@@ -1,7 +1,14 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { openMemoryDb } from "../memory/db.js";
-import { mcpServerOf, tallyToolUsage, scanToolUsage, hasIndexedToolUsage } from "./usage-scan.js";
+import {
+  mcpServerOf,
+  tallyToolUsage,
+  scanToolUsage,
+  hasIndexedToolUsage,
+  tallySkillUsage,
+  scanSkillUsage,
+} from "./usage-scan.js";
 
 describe("mcpServerOf", () => {
   it("extracts the server slug from an mcp__server__tool name", () => {
@@ -87,6 +94,45 @@ describe("scanToolUsage", () => {
     const db = openMemoryDb(":memory:");
     assert.equal(hasIndexedToolUsage(db), false);
     assert.deepEqual(scanToolUsage(db), []);
+    db.close();
+  });
+});
+
+describe("tallySkillUsage", () => {
+  it("counts skill slugs from Skill tool_input, skipping malformed/blank", () => {
+    const counts = tallySkillUsage([
+      '{"skill":"deep-research","args":"x"}',
+      '{"skill":"deep-research"}',
+      '{"skill":"artifact-design"}',
+      '{"skill":"  "}',
+      "{not json",
+      '{"noskill":true}',
+      null,
+    ]);
+    assert.equal(counts.get("deep-research"), 2);
+    assert.equal(counts.get("artifact-design"), 1);
+    assert.equal(counts.size, 2);
+  });
+});
+
+describe("scanSkillUsage", () => {
+  it("reads only Skill tool_uses and tallies by slug", () => {
+    const db = openMemoryDb(":memory:");
+    const insert = db.prepare(
+      "INSERT INTO tool_uses (message_uuid, session_id, tool_name, tool_input, timestamp) VALUES (?, ?, ?, ?, ?)",
+    );
+    let i = 0;
+    const add = (tool: string, input: string) =>
+      insert.run(`m${i++}`, "s1", tool, input, "2026-01-01T00:00:00Z");
+    add("Skill", '{"skill":"triage"}');
+    add("Skill", '{"skill":"triage"}');
+    add("Bash", "{}"); // not a skill call — ignored
+    add("Skill", '{"skill":"deep-research"}');
+
+    const counts = scanSkillUsage(db);
+    assert.equal(counts.get("triage"), 2);
+    assert.equal(counts.get("deep-research"), 1);
+    assert.equal(counts.size, 2);
     db.close();
   });
 });

--- a/src/insight/usage-scan.ts
+++ b/src/insight/usage-scan.ts
@@ -70,3 +70,38 @@ export function hasIndexedToolUsage(db: DatabaseSync): boolean {
   const row = db.prepare("SELECT COUNT(*) AS n FROM tool_uses").get() as { n: number };
   return row.n > 0;
 }
+
+/**
+ * Pure skill-usage tally. A skill invocation is recorded as a `Skill` tool call
+ * whose `tool_input` JSON carries `{ "skill": "<slug>", ... }`; count per slug,
+ * skipping unparseable/blank inputs. Deterministic (Map insertion is not relied
+ * on — callers look up by slug). Zero-LLM: pure JSON + counting.
+ */
+export function tallySkillUsage(toolInputs: (string | null | undefined)[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const raw of toolInputs) {
+    if (raw == null) continue;
+    let slug: unknown;
+    try {
+      slug = (JSON.parse(raw) as { skill?: unknown }).skill;
+    } catch {
+      continue; // malformed tool_input — skip
+    }
+    if (typeof slug !== "string") continue;
+    const s = slug.trim();
+    if (s.length === 0) continue;
+    counts.set(s, (counts.get(s) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/**
+ * Scan the memory DB for skill invocations (`tool_name = 'Skill'`), returning a
+ * slug → invocation-count map. Deterministic given the DB.
+ */
+export function scanSkillUsage(db: DatabaseSync): Map<string, number> {
+  const rows = db.prepare("SELECT tool_input FROM tool_uses WHERE tool_name = 'Skill'").all() as {
+    tool_input: string | null;
+  }[];
+  return tallySkillUsage(rows.map((r) => r.tool_input));
+}


### PR DESCRIPTION
Third **Pillar 4** step: turn loaded **skills** from "unknown" into real used/unused verdicts. A skill invocation is recorded as a `Skill` tool call whose `tool_input` carries `{ "skill": "<slug>" }` — so, like MCP servers, usage is a deterministic count. No ML.

## What changed
- **`usage-scan.ts`** — `tallySkillUsage` (pure: parse `{skill}` inputs, skip malformed, count per slug) + `scanSkillUsage(db)` (reads `tool_name='Skill'` rows).
- **`unused.ts`** — `computeUnused` takes an optional skill-usage map; loaded skills get used/unused by **exact-slug** invocation count (unused ⇒ prune candidate). With no map it still falls back to "unknown" (never "unused") — no false green.
- **`commands/insight.ts`** — scans skill usage, renders real skill verdicts alongside MCP; prune suggestions now span both surfaces. Skip/JSON semantics unchanged.

## Verification
Fresh `npm run build` + `node scripts/test.mjs`: `tsc` clean · eslint **0 errors** · full suite **2598 passing** (+3 skill-usage tests) · prettier clean.

This completes the loaded-but-unused report for both surfaces kit discovers today (**MCP servers + skills**). Plugins aren't discovered into the loaded set yet, so they're out of scope until BYO plugin-discovery lands.

## Next (step 4)
The repeat→codify **scaffold** on `learnRecurring` (deterministic skill/workflow skeleton from a recurring instruction; model-assisted *authoring* stays opt-in, around the core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_