### PR TITLE
feat(memory): repeat→codify skill-draft scaffold (Pillar 4 step 4)

### DIFF
--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -2,8 +2,8 @@
 // subcommand dispatcher; restructured to a handler table in a follow-up.
 import { c } from "../utils/colors.js";
 import { hasFlag, flagValue } from "../utils/flags.js";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, resolve } from "node:path";
 import {
   openMemoryDb,
   getStats,
@@ -20,6 +20,7 @@ import { indexAllHarnesses } from "../memory/parser.js";
 import { mergeDb } from "../memory/merge.js";
 import { buildSuggestPrompt } from "../memory/suggest.js";
 import { learnRecurring } from "../memory/learn.js";
+import { scaffoldFromCandidate } from "../insight/scaffold.js";
 import { getCurrentProjectRoot } from "../memory/project.js";
 import { scanDbForSecrets, scanDbForInjection } from "../memory/scan.js";
 import { sanitizeForPrompt } from "../memory/injection.js";
@@ -324,8 +325,28 @@ async function memLearn(): Promise<boolean> {
         `  ${c.bold}${cand.count}×${c.reset} ${c.dim}(${cand.sessions} ${s})${c.reset}${flag}  ${cand.example}`,
       );
     }
+
+    // --scaffold [dir]: codify — write a reviewable skill DRAFT per candidate.
+    // Deterministic skeletons (.draft.md, never a live skill); default dir cwd.
+    if (hasFlag(process.argv, "--scaffold")) {
+      const dirArg = flagValue(process.argv, "--scaffold");
+      const outDir = resolve(process.cwd(), dirArg && !dirArg.startsWith("-") ? dirArg : ".");
+      mkdirSync(outDir, { recursive: true });
+      console.log(`\n${c.bold}Scaffolding drafts${c.reset} ${c.dim}→ ${outDir}${c.reset}`);
+      for (const cand of candidates) {
+        const { filename, content } = scaffoldFromCandidate(cand);
+        const path = join(outDir, filename);
+        writeFileSync(path, content, { encoding: "utf-8" });
+        console.log(`  ${c.green}✓${c.reset} ${filename}`);
+      }
+      console.log(
+        `${c.dim}Drafts only — review + fill the steps, then move a keeper into place. kit installs nothing.${c.reset}`,
+      );
+      return true;
+    }
+
     console.log(
-      `\n${c.dim}You keep re-typing these. Record the ones worth keeping with ${c.reset}kit memory share${c.dim} or in your rules file (CLAUDE.md / AGENTS.md) so you stop repeating them.${c.reset}`,
+      `\n${c.dim}You keep re-typing these. Record the ones worth keeping with ${c.reset}kit memory share${c.dim}, scaffold skill drafts with ${c.reset}kit memory learn --scaffold${c.dim}, or add them to your rules file (CLAUDE.md / AGENTS.md).${c.reset}`,
     );
     return true;
   } finally {

--- a/src/insight/scaffold.test.ts
+++ b/src/insight/scaffold.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { slugify, scaffoldFromCandidate } from "./scaffold.js";
+import type { LearnCandidate } from "../memory/learn.js";
+
+const cand = (over: Partial<LearnCandidate> = {}): LearnCandidate => ({
+  normalized: "run the tests before committing",
+  example: "Run the tests before committing",
+  count: 5,
+  sessions: 3,
+  correction: false,
+  ...over,
+});
+
+describe("slugify", () => {
+  it("lowercases, collapses non-alphanumerics to single dashes, trims", () => {
+    assert.equal(slugify("Run the tests before committing!"), "run-the-tests-before-committing");
+    assert.equal(slugify("  Foo / Bar__baz  "), "foo-bar-baz");
+  });
+  it("falls back for empty/symbol-only input", () => {
+    assert.equal(slugify(""), "recurring-instruction");
+    assert.equal(slugify("!!!"), "recurring-instruction");
+  });
+  it("caps length and has no trailing dash", () => {
+    const s = slugify("a".repeat(80) + " !!!");
+    assert.ok(s.length <= 60);
+    assert.ok(!s.endsWith("-"));
+  });
+});
+
+describe("scaffoldFromCandidate", () => {
+  it("produces a .draft.md skeleton with frontmatter, intent, and recurrence", () => {
+    const { filename, content } = scaffoldFromCandidate(cand());
+    assert.equal(filename, "run-the-tests-before-committing.skill.draft.md");
+    assert.match(content, /^---\nname: run-the-tests-before-committing\n/);
+    assert.match(content, /DRAFT/);
+    assert.match(content, /Run the tests before committing/); // intent = example
+    assert.match(content, /\*\*5×\*\* across \*\*3 sessions\*\*/);
+    assert.match(content, /## Steps/);
+  });
+  it("is deterministic (no timestamps/randomness) — same candidate, same output", () => {
+    assert.deepEqual(scaffoldFromCandidate(cand()), scaffoldFromCandidate(cand()));
+  });
+  it("notes the correction signal and singular session", () => {
+    const { content } = scaffoldFromCandidate(cand({ sessions: 1, correction: true, count: 2 }));
+    assert.match(content, /\*\*2×\*\* across \*\*1 session\*\*/);
+    assert.match(content, /correction/);
+  });
+});

--- a/src/insight/scaffold.ts
+++ b/src/insight/scaffold.ts
@@ -1,0 +1,70 @@
+/**
+ * Repeat→codify scaffold for Pelare 4's insight loop
+ * (`pillar4-insight-loop-5.0.md`, step 4). `memory learn` already FINDS recurring
+ * instructions deterministically (learnRecurring — pure counting, no ML); this
+ * turns a found LearnCandidate into a skill-DRAFT skeleton the operator reviews.
+ *
+ * Deterministic + pure (candidate → text): the *detection* and the *skeleton* are
+ * core/free. Only the eventual filling-in of the skill body may be model-assisted,
+ * opt-in and AROUND the core — never here. Output is a `.draft.md` (never a live
+ * skill) so nothing is auto-installed.
+ */
+import type { LearnCandidate } from "../memory/learn.js";
+
+export interface SkillScaffold {
+  /** Suggested draft filename, e.g. "run-tests-before-committing.skill.draft.md". */
+  filename: string;
+  /** The skeleton markdown (frontmatter + intent + step stubs). */
+  content: string;
+}
+
+/**
+ * Deterministic slug from free text: lowercased, non-alphanumerics collapsed to
+ * single dashes, trimmed, capped to 60 chars. Empty input → "recurring-instruction".
+ */
+export function slugify(text: string): string {
+  const s = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60)
+    .replace(/-+$/g, "");
+  return s.length > 0 ? s : "recurring-instruction";
+}
+
+/**
+ * Turn a recurring-instruction candidate into a reviewable skill draft. Pure:
+ * same candidate → same scaffold (no timestamps/randomness), so it is safe to
+ * regenerate and diff.
+ */
+export function scaffoldFromCandidate(candidate: LearnCandidate): SkillScaffold {
+  const slug = slugify(candidate.normalized || candidate.example);
+  const sessions = `${candidate.sessions} session${candidate.sessions === 1 ? "" : "s"}`;
+  const kind = candidate.correction ? "correction/redirection" : "instruction";
+  const content = `---
+name: ${slug}
+description: "DRAFT — auto-scaffolded from a recurring ${kind}; edit before use"
+---
+
+# ${slug}
+
+> Scaffolded by \`kit memory learn --scaffold\` from an instruction you repeated
+> **${candidate.count}×** across **${sessions}**. This is a DRAFT, not an installed
+> skill — review, fill the steps, then move it into place if it is worth keeping.
+
+## Intent
+
+${candidate.example}
+
+## Steps
+
+1. TODO: first concrete step
+2. TODO: …
+
+## Notes
+
+- Recurrence: ${candidate.count}× across ${sessions}${candidate.correction ? " (often phrased as a correction — you keep having to redirect toward this)" : ""}.
+- kit found this by counting; it did not judge whether it *should* be a skill. That is your call.
+`;
+  return { filename: `${slug}.skill.draft.md`, content };
+}


### PR DESCRIPTION
Fourth **Pillar 4** step: turn a recurring instruction that `memory learn` already detects into a reviewable **skill draft**. Deterministic, zero-LLM — detection *and* skeleton are core/free; only filling the skill body may later be model-assisted, around the core.

## What changed
- **New `src/insight/scaffold.ts`** — `slugify` + `scaffoldFromCandidate(LearnCandidate)`: pure (`candidate → {filename, content}`), emits a `.draft.md` skeleton (frontmatter + intent = the recurring example + step stubs + recurrence note). No timestamps/randomness → regenerates identically.
- **`commands/memory.ts`** — `kit memory learn --scaffold [dir]` writes one draft per candidate (default cwd). **Drafts only** (`.skill.draft.md`), never a live skill; kit installs nothing. Updated the `learn` hint.

## Verification
Fresh `npm run build` + `node scripts/test.mjs`: `tsc` clean · eslint **0 errors** · full suite **2604 passing** (+6 scaffold tests) · prettier clean. Smoke: `kit memory learn --scaffold` wrote a reviewable draft from a real recurring instruction.

## Pillar 4 deterministic insight loop — complete
This closes the design note's core plan: usage scanner (#291) → MCP unused (#292) → skill unused (#293) → **repeat→codify scaffold** (here). Remaining Pillar 4 items (versioned traveling project profile, signed scope/RoE) are larger, separate tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_