### PR TITLE
feat(profile): versioned KitProfile schema + canonical serialization (Pillar 4 step 1)

### DIFF
--- a/src/profile/schema.test.ts
+++ b/src/profile/schema.test.ts
@@ -1,0 +1,195 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parseProfile,
+  loadProfile,
+  saveProfile,
+  canonicalProfileBytes,
+  profileFingerprint,
+  InvalidProfileError,
+  PROFILE_FILE,
+  PROFILE_SCHEMA_VERSION,
+  type KitProfile,
+} from "./schema.js";
+
+function tmp(): string {
+  return mkdtempSync(join(tmpdir(), "kit-profile-"));
+}
+
+const MINIMAL = `version = 1\n`;
+
+const FULL = `
+version = 1
+name = "acme-api"
+
+[[skills]]
+name = "api-test"
+source = "github:acme/skills#api-test"
+version = "1.4.0"
+
+[[mcp]]
+name = "postgres"
+source = "npx @acme/mcp-postgres"
+
+[[workflows]]
+name = "release"
+
+[vault]
+store = "1password"
+keys = { DATABASE_URL = "vault" }
+
+[gates]
+baseline = ".kit-baseline.json"
+standards = true
+security = true
+
+[scope]
+egress = ["api.acme.com"]
+fs = ["."]
+secrets = ["DATABASE_URL"]
+`;
+
+describe("parseProfile", () => {
+  it("parses a minimal version-1 profile", () => {
+    const p = parseProfile(MINIMAL);
+    assert.equal(p.version, 1);
+    assert.equal(typeof p.generated, "string"); // defaulted when absent
+  });
+
+  it("parses a full profile with every section", () => {
+    const p = parseProfile(FULL);
+    assert.equal(p.name, "acme-api");
+    assert.equal(p.skills?.[0]?.name, "api-test");
+    assert.equal(p.skills?.[0]?.version, "1.4.0");
+    assert.equal(p.mcp?.[0]?.source, "npx @acme/mcp-postgres");
+    assert.equal(p.workflows?.[0]?.name, "release");
+    assert.equal(p.vault?.store, "1password");
+    assert.equal(p.vault?.keys?.DATABASE_URL, "vault");
+    assert.equal(p.gates?.standards, true);
+    assert.deepEqual(p.scope?.egress, ["api.acme.com"]);
+  });
+
+  it("throws InvalidProfileError on unparseable TOML", () => {
+    assert.throws(() => parseProfile("version = = 1"), InvalidProfileError);
+  });
+
+  it("throws when version is missing (can't be safely interpreted)", () => {
+    assert.throws(() => parseProfile(`name = "x"\n`), InvalidProfileError);
+  });
+
+  it("refuses a schema version newer than this kit understands", () => {
+    assert.throws(
+      () => parseProfile(`version = ${PROFILE_SCHEMA_VERSION + 1}\n`),
+      /newer than this kit understands/,
+    );
+  });
+
+  it("rejects unknown top-level keys (strict — catches typos)", () => {
+    assert.throws(() => parseProfile(`version = 1\nskils = []\n`), InvalidProfileError);
+  });
+
+  it("rejects a component without a name", () => {
+    assert.throws(
+      () => parseProfile(`version = 1\n[[skills]]\nsource = "x"\n`),
+      InvalidProfileError,
+    );
+  });
+});
+
+describe("loadProfile", () => {
+  it("returns null when no profile is declared (honest skip, not empty profile)", async () => {
+    const dir = tmp();
+    try {
+      assert.equal(await loadProfile(dir), null);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads a declared profile", async () => {
+    const dir = tmp();
+    try {
+      writeFileSync(join(dir, PROFILE_FILE), FULL);
+      const p = await loadProfile(dir);
+      assert.equal(p?.name, "acme-api");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws (fail-closed) on a malformed profile that exists", async () => {
+    const dir = tmp();
+    try {
+      writeFileSync(join(dir, PROFILE_FILE), "not = = toml");
+      await assert.rejects(loadProfile(dir), InvalidProfileError);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("saveProfile", () => {
+  it("round-trips through disk and refreshes the generated stamp", async () => {
+    const dir = tmp();
+    try {
+      const p: KitProfile = {
+        version: 1,
+        generated: new Date(0).toISOString(),
+        name: "rt",
+        skills: [{ name: "a", version: "1.0.0" }],
+      };
+      await saveProfile(p, dir);
+      assert.notEqual(p.generated, new Date(0).toISOString()); // stamped on save
+      const loaded = await loadProfile(dir);
+      assert.equal(loaded?.name, "rt");
+      assert.equal(loaded?.skills?.[0]?.name, "a");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("canonicalProfileBytes", () => {
+  it("excludes the volatile generated stamp", () => {
+    const a: KitProfile = { version: 1, generated: "2020-01-01T00:00:00.000Z", name: "x" };
+    const b: KitProfile = { version: 1, generated: "2026-07-09T00:00:00.000Z", name: "x" };
+    assert.equal(canonicalProfileBytes(a), canonicalProfileBytes(b));
+  });
+
+  it("is stable under key/section reordering (parse two orderings → same bytes)", () => {
+    const one = parseProfile(
+      `version = 1\nname = "x"\n[gates]\nstandards = true\nsecurity = false\n`,
+    );
+    const two = parseProfile(
+      `name = "x"\nversion = 1\n[gates]\nsecurity = false\nstandards = true\n`,
+    );
+    assert.equal(canonicalProfileBytes(one), canonicalProfileBytes(two));
+  });
+
+  it("moves when a real declaration changes", () => {
+    const base = parseProfile(FULL);
+    const changed = parseProfile(FULL.replace("1.4.0", "1.5.0"));
+    assert.notEqual(canonicalProfileBytes(base), canonicalProfileBytes(changed));
+  });
+});
+
+describe("profileFingerprint", () => {
+  it("is a sha256: short hash, stable for the same content", () => {
+    const p = parseProfile(FULL);
+    const fp = profileFingerprint(p);
+    assert.match(fp, /^sha256:[0-9a-f]{16}$/);
+    assert.equal(fp, profileFingerprint(parseProfile(FULL)));
+  });
+
+  it("changes when content changes but not when only generated changes", () => {
+    const p = parseProfile(FULL);
+    const sameContent = parseProfile(FULL);
+    sameContent.generated = "2099-01-01T00:00:00.000Z";
+    assert.equal(profileFingerprint(p), profileFingerprint(sameContent));
+    const changed = parseProfile(FULL.replace("acme-api", "acme-web"));
+    assert.notEqual(profileFingerprint(p), profileFingerprint(changed));
+  });
+});

--- a/src/profile/schema.ts
+++ b/src/profile/schema.ts
@@ -1,0 +1,243 @@
+/**
+ * kit project profile — the versioned, traveling setup declaration (Pillar 4, 5.0).
+ *
+ * Design: `kit-research/docs/research/pillar4-traveling-profile-5.0.md`.
+ *
+ * kit's setup-state is today scattered across ≥6 files (`.kit.toml`, `.kit-baseline.json`,
+ * `skills-lock.json`, `.mcp.json`/`.claude.json`, `.kit-policy.*`) with nothing binding,
+ * versioning, or auditing it as a whole. The profile is a single versioned DECLARATION of
+ * `{skills, workflows, MCP, plugins, vault-config, gates, scope}` that TRAVELS with the repo
+ * and that kit challenges against reality over time (declared-vs-discovered drift, a later
+ * step). It REFERENCES those artifacts; it does not duplicate their contents.
+ *
+ * This module is the pure floor: the type, its Zod schema, load/save of `.kit-profile.toml`,
+ * and a CANONICAL byte form for signing/diffing (recursively key-sorted JSON, `generated`
+ * excluded) — the same signing discipline as `.kit-policy.toml` (`canonicalPolicyBytes`).
+ * No CLI, no discovery, no drift here (later steps). Zero-LLM, deterministic.
+ *
+ * WHY A SEPARATE FILE (`.kit-profile.toml`): it is signed and travels as one unit; mixing a
+ * signed declaration into the editable `.kit.toml` would blur the signature surface. Same
+ * reasoning kit already applies to `.kit-policy.toml`.
+ *
+ * NO SECRET VALUES live here — only backend *selection* and key *names*; plaintext values
+ * remain blocked by the `.env*` write-gate.
+ */
+import { readFile, writeFile, access } from "node:fs/promises";
+import { resolve } from "node:path";
+import { createHash } from "node:crypto";
+import { parse, stringify } from "smol-toml";
+import { z } from "zod";
+
+export const PROFILE_FILE = ".kit-profile.toml";
+/** Schema version this kit understands. A profile declaring a higher version is refused (upgrade kit). */
+export const PROFILE_SCHEMA_VERSION = 1;
+
+/** A declared toolchain component (skill / MCP server / workflow / plugin). */
+export interface ProfileComponent {
+  /** Unique name/slug within its kind. */
+  name: string;
+  /** Where it comes from (e.g. `github:org/repo#skill`, `npx @scope/pkg`, a local path). */
+  source?: string;
+  /** Declared version, if pinned. */
+  version?: string;
+}
+
+/** Vault/secrets backend DECLARATION — selection only, never values. */
+export interface ProfileVault {
+  /** Global default store (mirrors `.kit.toml` `secrets.store`). */
+  store?: string;
+  /** Per-key backend source, keyed by env-var name (mirrors per-key `secrets.<KEY>.source`). */
+  keys?: Record<string, string>;
+}
+
+/** Which gates the profile declares in force (references, does not inline, the baseline). */
+export interface ProfileGates {
+  /** Path to the findings baseline this profile expects (default `.kit-baseline.json`). */
+  baseline?: string;
+  /** Standards gate expected on. */
+  standards?: boolean;
+  /** Security gate expected on. */
+  security?: boolean;
+}
+
+/**
+ * Signed scope / rules-of-engagement. Feeds Pillar 3's exec-broker SCOPE once signed
+ * (`.kit-profile.sig`, a later step). Declaration only here.
+ */
+export interface ProfileScope {
+  /** Egress allowlist (hosts the agent may reach). */
+  egress?: string[];
+  /** Filesystem write-scope (paths writes are confined to; default project root `.`). */
+  fs?: string[];
+  /** Secret-scope: env-var names the operation is allowed to see. */
+  secrets?: string[];
+}
+
+export interface KitProfile {
+  /** Schema version (integer). Required. */
+  version: number;
+  /** ISO timestamp of last freeze. The ONLY non-deterministic field — excluded from canonical bytes. */
+  generated: string;
+  /** Human label for the profile. */
+  name?: string;
+  skills?: ProfileComponent[];
+  mcp?: ProfileComponent[];
+  workflows?: ProfileComponent[];
+  plugins?: ProfileComponent[];
+  vault?: ProfileVault;
+  gates?: ProfileGates;
+  scope?: ProfileScope;
+}
+
+/**
+ * A `.kit-profile.toml` that exists but is unparseable or fails schema validation. Tagged so
+ * gate paths can fail CLOSED with a clean message instead of letting a raw TomlError / ZodError
+ * crash the process — the same discipline as `InvalidConfigError` for `.kit.toml`.
+ */
+export class InvalidProfileError extends Error {
+  readonly code = "KIT_INVALID_PROFILE";
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidProfileError";
+  }
+}
+
+const componentSchema = z
+  .object({
+    name: z.string().min(1),
+    source: z.string().optional(),
+    version: z.string().optional(),
+  })
+  .strict();
+
+const kitProfileSchema = z
+  .object({
+    version: z.number().int(),
+    generated: z.string().optional(),
+    name: z.string().optional(),
+    skills: z.array(componentSchema).optional(),
+    mcp: z.array(componentSchema).optional(),
+    workflows: z.array(componentSchema).optional(),
+    plugins: z.array(componentSchema).optional(),
+    vault: z
+      .object({
+        store: z.string().optional(),
+        keys: z.record(z.string(), z.string()).optional(),
+      })
+      .strict()
+      .optional(),
+    gates: z
+      .object({
+        baseline: z.string().optional(),
+        standards: z.boolean().optional(),
+        security: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    scope: z
+      .object({
+        egress: z.array(z.string()).optional(),
+        fs: z.array(z.string()).optional(),
+        secrets: z.array(z.string()).optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Recursively key-sort a value so serialization is stable across key reorder / TOML reformat. */
+function sortDeep(v: unknown): unknown {
+  if (Array.isArray(v)) return v.map(sortDeep);
+  if (v && typeof v === "object") {
+    const out: Record<string, unknown> = {};
+    for (const k of Object.keys(v as Record<string, unknown>).sort()) {
+      out[k] = sortDeep((v as Record<string, unknown>)[k]);
+    }
+    return out;
+  }
+  return v;
+}
+
+/**
+ * Strict parse of profile file content. Throws `InvalidProfileError` on malformed TOML, a
+ * failed schema, or a version this kit is too old to understand. A missing `version` is
+ * rejected (a profile without a schema version can't be safely interpreted).
+ */
+export function parseProfile(raw: string): KitProfile {
+  let doc: unknown;
+  try {
+    doc = parse(raw);
+  } catch (err) {
+    throw new InvalidProfileError(
+      `unparseable ${PROFILE_FILE}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  const result = kitProfileSchema.safeParse(doc);
+  if (!result.success) {
+    const first = result.error.issues[0];
+    const where = first?.path?.length ? ` at ${first.path.join(".")}` : "";
+    throw new InvalidProfileError(
+      `invalid ${PROFILE_FILE}${where}: ${first?.message ?? "schema error"}`,
+    );
+  }
+  const profile = result.data as KitProfile;
+  if (profile.version > PROFILE_SCHEMA_VERSION) {
+    throw new InvalidProfileError(
+      `${PROFILE_FILE} schema version ${profile.version} is newer than this kit understands (${PROFILE_SCHEMA_VERSION}) — upgrade kit`,
+    );
+  }
+  if (typeof profile.generated !== "string") profile.generated = new Date(0).toISOString();
+  return profile;
+}
+
+/**
+ * Load `.kit-profile.toml`. Returns `null` when no profile is declared (so callers can
+ * `skip` honestly rather than treat "no profile" as "empty profile"). Throws
+ * `InvalidProfileError` when a profile exists but is malformed.
+ */
+export async function loadProfile(cwd = process.cwd()): Promise<KitProfile | null> {
+  const path = resolve(cwd, PROFILE_FILE);
+  if (!(await pathExists(path))) return null;
+  const raw = await readFile(path, "utf-8");
+  return parseProfile(raw);
+}
+
+/**
+ * Serialize a profile to TOML with a fresh `generated` stamp and write it. Keys are emitted in
+ * a stable (sorted) order so unrelated re-freezes produce minimal diffs. The signed/diffed
+ * surface is `canonicalProfileBytes`, not this text.
+ */
+export async function saveProfile(profile: KitProfile, cwd = process.cwd()): Promise<void> {
+  profile.generated = new Date().toISOString();
+  const ordered = sortDeep(profile) as Record<string, unknown>;
+  const path = resolve(cwd, PROFILE_FILE);
+  await writeFile(path, stringify(ordered) + "\n", "utf-8");
+}
+
+/**
+ * Canonical signing/diffing bytes: JSON of the recursively key-sorted profile with the
+ * volatile `generated` stamp removed. Stable across TOML reformatting, comment edits, and key
+ * reordering — only a real declaration change moves the bytes (and thus invalidates a
+ * `.kit-profile.sig`). Same discipline as `canonicalPolicyBytes`.
+ */
+export function canonicalProfileBytes(profile: KitProfile): string {
+  const { generated: _generated, ...rest } = profile;
+  return JSON.stringify(sortDeep(rest));
+}
+
+/** Short content fingerprint of a profile (for display / pinning). */
+export function profileFingerprint(profile: KitProfile): string {
+  return (
+    "sha256:" +
+    createHash("sha256").update(canonicalProfileBytes(profile)).digest("hex").slice(0, 16)
+  );
+}


### PR DESCRIPTION
## Description

First build step of the **versioned, traveling project profile** (Pillar 4 of the kit 5.0 North Star). Design note: `kit-research/docs/research/pillar4-traveling-profile-5.0.md` (merged as kit-research #27).

kit's setup-state is today scattered across ≥6 files (`.kit.toml`, `.kit-baseline.json`, `skills-lock.json`, `.mcp.json`/`.claude.json`, `.kit-policy.*`) with nothing binding, versioning, or auditing it as a whole. This PR adds the **pure floor** — the type, schema, load/save, and a canonical signing/diffing byte form — with **no CLI, no discovery, and no drift logic yet** (those are later steps). Zero-LLM, deterministic.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

- Related to the kit 5.0 North Star, Pillar 4 (traveling project profile)
- Design: `kit-research/docs/research/pillar4-traveling-profile-5.0.md`

## Changes Made

- `src/profile/schema.ts`:
  - `KitProfile` type declaring `{skills, mcp, workflows, plugins, vault, gates, scope}` — each section a **reference** to the scattered setup-state, not a copy of it.
  - `.kit-profile.toml` load/save via `smol-toml`; `PROFILE_SCHEMA_VERSION = 1` with fail-closed refusal of a newer schema (mirrors `.kit-policy.toml`'s version gate).
  - Zod validation (**strict** — a signed artifact should reject typos) with a tagged `InvalidProfileError` so gate paths fail closed with a clean message, exactly like `InvalidConfigError` for `.kit.toml`.
  - `loadProfile` returns `null` when no profile is declared → callers can `skip` honestly instead of treating "no profile" as "empty profile".
  - `canonicalProfileBytes`: recursively key-sorted JSON with the volatile `generated` stamp excluded — stable across TOML reformatting / key reorder, same discipline as `canonicalPolicyBytes`. Plus `profileFingerprint` (`sha256:...`).
- `src/profile/schema.test.ts`: 16 unit tests (parse valid/invalid/version-gate/strict-typo/missing-name; load null/present/fail-closed; save round-trip + stamp; canonical bytes exclude `generated`, order-independent, move on real change; fingerprint stability).

## Testing

### Test Coverage
- [x] Added new tests (16)
- [x] All tests pass (`npm test`) — full suite **2620 pass / 0 fail** (2604 baseline + 16 new)

### Manual Testing
1. `npx tsc --noEmit` → clean.
2. `npx eslint src/profile/*.ts` → clean.
3. `npm run build && node scripts/test.mjs` → 2620 pass, 0 fail.
4. `npx prettier --check src/profile/*.ts` → formatted.

## Breaking Changes

None / N/A — new module, nothing else imports it yet.

## Checklist

- [x] My code follows the project's style guidelines
- [x] All new code has test coverage
- [x] All tests pass locally (`npm test`)
- [x] No new warnings or errors introduced
- [x] No hardcoded secrets or sensitive data — the profile carries backend *selection* and key *names* only; plaintext values remain blocked by the `.env*` write-gate
- [x] Code has been self-reviewed

## Performance Impact

- [x] No performance impact

## Reviewer Notes

Deliberate design choices worth a look: **strict** Zod (vs. `.kit.toml`'s `.passthrough()`) — justified because the profile is a fresh 5.0 artifact that will be signed, and within a schema version an unknown key is a typo, not forward-compat (a real new field bumps `version`, which is refused by older kit). The `[scope]`/RoE section is declared here but signing (`.kit-profile.sig`, reusing `signWithIdentity`/`verifyPolicy`) and drift reconciliation land in later steps per the design note's incremental plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_