### PR TITLE
feat(profile): plugin discovery closes the unaudited gap (Pillar 4 step 4a)

### DIFF
--- a/src/agent-sbom.test.ts
+++ b/src/agent-sbom.test.ts
@@ -1,6 +1,9 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { agentToolchainComponents, mcpServersFromConfig } from "./agent-sbom.js";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { agentToolchainComponents, mcpServersFromConfig, discoverPlugins } from "./agent-sbom.js";
 import { toCycloneDX, toSpdx, type Component } from "./sbom.js";
 
 describe("agentToolchainComponents", () => {
@@ -50,6 +53,44 @@ describe("mcpServersFromConfig", () => {
     assert.equal(mcpServersFromConfig({ servers: { a: {} } }).length, 1);
     assert.deepEqual(mcpServersFromConfig("nope"), []);
     assert.deepEqual(mcpServersFromConfig({ mcpServers: null }), []);
+  });
+});
+
+describe("discoverPlugins", () => {
+  it("reads kitPlugins from package.json and resolves installed versions", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-plugins-"));
+    try {
+      writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify({ kitPlugins: ["@acme/kit-railway", "kit-plugin-x"] }),
+      );
+      // one plugin installed (version resolvable), one not
+      mkdirSync(join(dir, "node_modules/@acme/kit-railway"), { recursive: true });
+      writeFileSync(
+        join(dir, "node_modules/@acme/kit-railway/package.json"),
+        JSON.stringify({ name: "@acme/kit-railway", version: "2.3.0" }),
+      );
+      const plugins = discoverPlugins(dir);
+      const byName = Object.fromEntries(plugins.map((p) => [p.name, p]));
+      assert.equal(byName["@acme/kit-railway"].version, "2.3.0");
+      assert.equal(byName["@acme/kit-railway"].source, "package.json:kitPlugins");
+      assert.equal(byName["kit-plugin-x"].version, undefined); // declared but not installed
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns [] when there is no package.json or no kitPlugins (never throws)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-plugins-"));
+    try {
+      assert.deepEqual(discoverPlugins(dir), []);
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "p" }));
+      assert.deepEqual(discoverPlugins(dir), []);
+      writeFileSync(join(dir, "package.json"), "{ not json");
+      assert.deepEqual(discoverPlugins(dir), []);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/agent-sbom.ts
+++ b/src/agent-sbom.ts
@@ -127,3 +127,39 @@ export function discoverAgentToolchain(cwd: string): {
   }
   return { skills, mcpServers };
 }
+
+/**
+ * Best-effort discovery of the plugins a project loads: the `kitPlugins` array in
+ * `package.json` (npm package names; the same list `loadPluginAdapters` consumes). When the
+ * plugin is installed, its version is read from `node_modules/<name>/package.json`. Pure
+ * filesystem read; missing/malformed inputs yield `[]`, never throw — matching
+ * `discoverAgentToolchain`'s defensive posture. Kept separate so it can be composed without
+ * changing `discoverAgentToolchain`'s shape (and its `kit sbom --agent` / `kit insight` callers).
+ */
+export function discoverPlugins(cwd: string): AgentComponentInput[] {
+  let names: string[];
+  try {
+    const pkg = JSON.parse(readFileSync(resolve(cwd, "package.json"), "utf8")) as Record<
+      string,
+      unknown
+    >;
+    const raw = pkg.kitPlugins;
+    names = Array.isArray(raw) ? raw.filter((p): p is string => typeof p === "string") : [];
+  } catch {
+    return [];
+  }
+  const out: AgentComponentInput[] = [];
+  for (const name of names) {
+    let version: string | undefined;
+    try {
+      const dep = JSON.parse(
+        readFileSync(resolve(cwd, "node_modules", name, "package.json"), "utf8"),
+      ) as Record<string, unknown>;
+      if (typeof dep.version === "string") version = dep.version;
+    } catch {
+      /* plugin not installed — declared name only */
+    }
+    out.push({ name, version, source: "package.json:kitPlugins" });
+  }
+  return out;
+}

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -17,7 +17,7 @@
  */
 import { c } from "../utils/colors.js";
 import { hasFlag } from "../utils/flags.js";
-import { discoverAgentToolchain } from "../agent-sbom.js";
+import { discoverAgentToolchain, discoverPlugins } from "../agent-sbom.js";
 import {
   loadProfile,
   saveProfile,
@@ -165,16 +165,17 @@ async function profileFreeze(jsonMode: boolean): Promise<boolean> {
   const { skills, mcpServers } = discoverAgentToolchain(cwd);
   const actual = await discoverActualState(cwd);
 
-  // Snapshot the discoverable dimensions; preserve operator-authored sections verbatim.
+  // Snapshot the discoverable dimensions (skills/mcp/plugins/vault); preserve the
+  // non-discoverable, operator-authored sections (workflows/gates/scope) verbatim.
   const next: KitProfile = {
     version: existing?.version ?? 1,
     generated: existing?.generated ?? new Date(0).toISOString(),
     skills: toComponents(skills),
     mcp: toComponents(mcpServers),
+    plugins: toComponents(discoverPlugins(cwd)),
   };
   if (existing?.name) next.name = existing.name;
   if (existing?.workflows) next.workflows = existing.workflows;
-  if (existing?.plugins) next.plugins = existing.plugins;
   if (existing?.gates) next.gates = existing.gates;
   if (existing?.scope) next.scope = existing.scope;
   const vaultStore = actual.vaultStore ?? existing?.vault?.store;
@@ -188,13 +189,13 @@ async function profileFreeze(jsonMode: boolean): Promise<boolean> {
   }
   console.log(`${c.bold}kit profile freeze${c.reset} → ${c.bold}${PROFILE_FILE}${c.reset}`);
   console.log(
-    `  ${c.green}✓${c.reset} ${next.skills?.length ?? 0} skill(s), ${next.mcp?.length ?? 0} mcp server(s)${
+    `  ${c.green}✓${c.reset} ${next.skills?.length ?? 0} skill(s), ${next.mcp?.length ?? 0} mcp server(s), ${next.plugins?.length ?? 0} plugin(s)${
       next.vault?.store ? `, vault store=${next.vault.store}` : ""
     }`,
   );
-  if (existing?.workflows || existing?.plugins || existing?.scope || existing?.gates) {
+  if (existing?.workflows || existing?.scope || existing?.gates) {
     console.log(
-      `  ${c.dim}preserved operator-authored sections (workflows/plugins/scope/gates) unchanged${c.reset}`,
+      `  ${c.dim}preserved operator-authored sections (workflows/scope/gates) unchanged${c.reset}`,
     );
   }
   console.log(`  ${c.dim}${profileFingerprint(next)}${c.reset}`);

--- a/src/profile/reconcile.test.ts
+++ b/src/profile/reconcile.test.ts
@@ -128,7 +128,7 @@ describe("computeProfileDrift", () => {
 });
 
 describe("discoverActualState", () => {
-  it("discovers skills + MCP servers + vault store; workflows/plugins remain unknown", async () => {
+  it("discovers skills + MCP servers + plugins + vault store; workflows remain unknown", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kit-reconcile-"));
     try {
       mkdirSync(join(dir, ".claude/skills/api-test"), { recursive: true });
@@ -137,6 +137,7 @@ describe("discoverActualState", () => {
         join(dir, ".mcp.json"),
         JSON.stringify({ mcpServers: { postgres: { command: "npx x" } } }),
       );
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ kitPlugins: ["@acme/kit-x"] }));
       writeFileSync(join(dir, ".kit.toml"), `[secrets]\nstore = "1password"\n`);
 
       const state = await discoverActualState(dir);
@@ -148,9 +149,12 @@ describe("discoverActualState", () => {
         state.mcp.map((s) => s.name),
         ["postgres"],
       );
+      assert.deepEqual(
+        state.plugins?.map((p) => p.name),
+        ["@acme/kit-x"],
+      );
       assert.equal(state.vaultStore, "1password");
-      assert.equal(state.workflows, null);
-      assert.equal(state.plugins, null);
+      assert.equal(state.workflows, null); // no on-disk workflow convention yet
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -176,6 +180,24 @@ describe("discoverActualState", () => {
       const state = await discoverActualState(dir);
       const d = computeProfileDrift(profile({ skills: [{ name: "api-test" }] }), state);
       assert.equal(d.clean, true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("audits plugin drift now that plugins are discoverable (was previously unaudited)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-reconcile-"));
+    try {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ kitPlugins: ["@acme/kit-x"] }));
+      const state = await discoverActualState(dir);
+      // declared a DIFFERENT plugin → the declared one is removed, the present one is added
+      const d = computeProfileDrift(profile({ plugins: [{ name: "@acme/kit-old" }] }), state);
+      assert.deepEqual(d.unaudited, []); // no longer unaudited
+      const statuses = Object.fromEntries(
+        d.entries.filter((e) => e.kind === "plugin").map((e) => [e.name, e.status]),
+      );
+      assert.equal(statuses["@acme/kit-old"], "removed");
+      assert.equal(statuses["@acme/kit-x"], "added");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/profile/reconcile.ts
+++ b/src/profile/reconcile.ts
@@ -21,7 +21,7 @@
  */
 import { resolve } from "node:path";
 import { loadConfig } from "../config.js";
-import { discoverAgentToolchain } from "../agent-sbom.js";
+import { discoverAgentToolchain, discoverPlugins } from "../agent-sbom.js";
 import type { KitProfile, ProfileComponent } from "./schema.js";
 
 export type ComponentKind = "skill" | "mcp" | "workflow" | "plugin";
@@ -171,12 +171,14 @@ export function computeProfileDrift(declared: KitProfile, actual: DiscoveredStat
 
 /**
  * Best-effort snapshot of the ACTUAL project state, mirroring `discoverAgentToolchain`'s
- * defensive posture: missing/malformed inputs degrade to "unknown", never throw. Workflows and
- * plugins are `null` (their discovery lands in step 4) so drift honestly reports them unaudited
- * rather than pretending they are absent.
+ * defensive posture: missing/malformed inputs degrade to "unknown", never throw. Plugins are
+ * discovered from `package.json` `kitPlugins` (so plugin drift is auditable); workflows remain
+ * `null` — there is no on-disk workflow convention to reconcile against yet, so drift honestly
+ * reports declared workflows as unaudited rather than pretending they are absent.
  */
 export async function discoverActualState(cwd = process.cwd()): Promise<DiscoveredState> {
   const { skills, mcpServers } = discoverAgentToolchain(cwd);
+  const plugins = discoverPlugins(cwd);
   let vaultStore: string | undefined;
   try {
     const cfg = await loadConfig(resolve(cwd, ".kit.toml"));
@@ -188,7 +190,7 @@ export async function discoverActualState(cwd = process.cwd()): Promise<Discover
     skills: skills.map((s) => ({ name: s.name, version: s.version })),
     mcp: mcpServers.map((s) => ({ name: s.name, version: s.version })),
     workflows: null,
-    plugins: null,
+    plugins: plugins.map((p) => ({ name: p.name, version: p.version })),
     vaultStore,
   };
 }


### PR DESCRIPTION
## Description

Closes the honesty gap step 2 deliberately left open: plugins were reported **unaudited** (`DiscoveredState.plugins = null`) because discovery didn't exist. This adds plugin discovery so `kit profile check` audits plugin drift like it already does skills/mcp. Workflows remain honestly unaudited (no on-disk convention to reconcile against yet).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

- Part of the traveling-profile track (#295 schema, #296 drift, #297 command, #298 signing)
- Design: `kit-research/docs/research/pillar4-traveling-profile-5.0.md` §5

## Changes Made

- `src/agent-sbom.ts` — **`discoverPlugins(cwd)`**: reads `kitPlugins` from `package.json` (the same list `loadPluginAdapters` consumes) and resolves each installed version from `node_modules/<name>/package.json`. Best-effort, never throws (missing/malformed → `[]`), matching `discoverAgentToolchain`. Kept as a **separate** function so `kit sbom --agent` / `kit insight` (which call `discoverAgentToolchain`) are untouched.
- `src/profile/reconcile.ts` — `discoverActualState` now populates `plugins` (no longer `null`) → plugin drift (added / removed / version) is audited. **Workflows stay `null`** — there's no on-disk workflow convention to reconcile against yet, so they remain honestly unaudited rather than faked.
- `src/commands/profile.ts` — `kit profile freeze` now snapshots discovered plugins alongside skills/mcp; operator-authored `workflows`/`gates`/`scope` are still preserved verbatim.
- Tests: `discoverPlugins` (installed + uninstalled versions, empty/garbage `package.json`); reconcile audits plugin drift end-to-end; `discoverActualState` discovers plugins.

## Testing

### Test Coverage
- [x] Added new tests
- [x] Updated existing tests (the `discoverActualState` assertion that plugins were `null`)
- [x] All tests pass (`npm test`) — full suite **2652 pass / 0 fail** (2649 baseline + 3)

### Manual Testing
1. `npx tsc --noEmit` → clean.
2. `npx eslint src` → 0 errors.
3. `npm run build && node scripts/test.mjs` → 2652 pass, 0 fail.
4. `npx prettier --check` → formatted.

## Breaking Changes

None / N/A — additive discovery; `discoverAgentToolchain` and its consumers are unchanged.

## Checklist

- [x] All new code has test coverage
- [x] All tests pass locally (`npm test`)
- [x] No new warnings or errors introduced
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

## Performance Impact

- [x] No performance impact

## Reviewer Notes

The deliberate asymmetry — plugins now discovered, workflows still `null` — is the no-false-green stance: I only flip a kind from "unaudited" to audited when there is a real on-disk source of truth to compare against (`kitPlugins` for plugins). Inventing a workflow-file convention just to make workflows "audited" would fake a signal, so they stay honestly unaudited until such a convention exists. This leaves `kit triage plugin` and vault-config triage as the remaining step-4 items (separate PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_