### PR TITLE
fix(upgrade): no stale 'Update available' banner after self-upgrade + pre-commit stamps hook sentinel

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
 # pre-commit — block internal references in staged content before they land.
 # Term list is resolved outside this repo (see no-internal-leaks.sh header).
-exec "$(git rev-parse --show-toplevel)/.githooks/no-internal-leaks.sh" --staged
+"$(git rev-parse --show-toplevel)/.githooks/no-internal-leaks.sh" --staged || exit 1
+# Receipt for kit's post-commit skip-detector (.kit-hook-ran): prove that
+# pre-commit actually ran, so honest commits stop logging as "bypassed".
+date -u +"%Y-%m-%dT%H:%M:%SZ" > "$(git rev-parse --git-dir)/.kit-hook-ran" 2>/dev/null || true

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -67,6 +67,11 @@ export async function selfUpgrade(): Promise<boolean> {
     console.log(
       `\n${c.green}${c.bold}✓ kit upgraded${c.reset} — run ${c.bold}kit --version${c.reset} to confirm.`,
     );
+    // The RUNNING process is still the old version — without this, the exit
+    // banner would announce "Update available: old → new" right after a
+    // successful upgrade, reading as "the upgrade didn't take".
+    const { suppressUpdateNotice } = await import("../update-check.js");
+    suppressUpdateNotice();
     return true;
   } catch (err: unknown) {
     const { redactSecrets } = await import("../utils/redactSecrets.js");

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -56,6 +56,7 @@ export async function checkForUpdate(currentVersion: string): Promise<UpdateInfo
     // what makes "no outbound network by default" / air-gap mode a COMPLETE
     // posture, not one with a lone npm-registry beacon poking through.
     if (
+      noticeSuppressed ||
       process.env.KIT_NO_UPDATE_CHECK === "1" ||
       process.env.CI === "true" ||
       process.env.GITHUB_ACTIONS === "true" ||
@@ -116,6 +117,17 @@ export async function checkForUpdate(currentVersion: string): Promise<UpdateInfo
   } catch {
     return null;
   }
+}
+
+/**
+ * Suppress this invocation's update notice. Called after a successful
+ * `kit upgrade --self`: the RUNNING process still reports the pre-upgrade
+ * version, so the exit banner would announce "Update available: old → new"
+ * immediately after installing new — a false "the upgrade didn't take" signal.
+ */
+let noticeSuppressed = false;
+export function suppressUpdateNotice(): void {
+  noticeSuppressed = true;
 }
 
 /** Current kit version from the installed package.json (sync, fail-safe). */


### PR DESCRIPTION
Two confusing signals from one `kit upgrade --self` run (dogfood report):

**1. Stale update banner.** The exit banner compared the RUNNING process's version against the registry cache — so right after successfully installing 4.3.0 it printed "Update available: 4.0.0 → 4.3.0", reading as "the upgrade didn't take". `selfUpgrade` now calls `suppressUpdateNotice()` on success.

**2. False 'bypassed pre-commit' audits.** Every local commit in kit's own repo logged `sentinel-missing`: `.githooks/pre-commit` (leak-guard) never stamped `.git/.kit-hook-ran`, while the managed post-commit requires it. The hook now writes the receipt after the leak-guard passes. Proof: this PR's own commit produced no skip warning.

Verification: build green, update-check tests 11/11, live-verified both behaviors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)