### PR TITLE
feat(triage): kit triage vault-config — backend-selection triage (last Pillar 4 BYO-gap)

### DIFF
--- a/src/commands/triage.ts
+++ b/src/commands/triage.ts
@@ -6,6 +6,7 @@ import { SKIPPED_COMMITS_LOG } from "../hooks.js";
 import { triageMcpTools, extractToolDefs } from "../mcp-triage.js";
 import { discoverPlugins } from "../agent-sbom.js";
 import { scanPluginManifest, manifestHasHighRisk } from "../plugin-triage.js";
+import { triageVaultConfig } from "../vault-triage.js";
 
 export async function cmdTriage(): Promise<boolean> {
   const args = process.argv.slice(3);
@@ -22,6 +23,9 @@ export async function cmdTriage(): Promise<boolean> {
   }
   if (typeArg === "plugin") {
     return cmdTriagePlugin(filtered.slice(1));
+  }
+  if (typeArg === "vault-config") {
+    return cmdTriageVaultConfig();
   }
   const type = typeArg as TriageType;
   const target = filtered[1];
@@ -45,6 +49,9 @@ export async function cmdTriage(): Promise<boolean> {
     );
     console.log(
       "  kit triage plugin [name]             Triage kitPlugins (npm supply-chain + manifest-poisoning scan); all declared if no name",
+    );
+    console.log(
+      "  kit triage vault-config              Triage the secret-backend selection (.kit.toml secrets.store + per-key source); never reads secret values",
     );
     console.log("  kit triage all <target>              Auto-detect and run all checks");
     console.log("  kit triage tools                     Show installed security tools");
@@ -134,6 +141,51 @@ export async function cmdTriage(): Promise<boolean> {
   }
 
   return overall;
+}
+
+/**
+ * `kit triage vault-config` — triage the project's secret-backend SELECTION (`.kit.toml`
+ * `secrets.store` + per-key `source`): flag an unknown/typo'd backend (silently no vault) and
+ * surface local/plaintext sources. Never reads a secret value. Deterministic, zero-LLM.
+ */
+async function cmdTriageVaultConfig(): Promise<boolean> {
+  const { loadConfig } = await import("../config.js");
+  const { resolve } = await import("node:path");
+  let secrets;
+  try {
+    const cfg = await loadConfig(resolve(process.cwd(), ".kit.toml"));
+    secrets = cfg.secrets;
+  } catch {
+    console.log(`${c.dim}no readable .kit.toml — nothing to triage.${c.reset}`);
+    return true;
+  }
+  const { findings, passed } = triageVaultConfig(secrets);
+  if (findings.length === 0) {
+    console.log(
+      `${c.dim}no secret-backend selection configured (.kit.toml [secrets]) — nothing to triage.${c.reset}`,
+    );
+    return true;
+  }
+  console.log(
+    `${c.bold}kit triage vault-config${c.reset} ${c.dim}(backend selection only — no secret values read)${c.reset}`,
+  );
+  for (const f of findings) {
+    const mark =
+      f.assurance === "vault-backed"
+        ? `${c.green}✓${c.reset}`
+        : f.assurance === "local-plaintext"
+          ? `${c.yellow}!${c.reset}`
+          : `${c.red}✗${c.reset}`;
+    console.log(
+      `  ${mark} ${f.scope}  ${c.bold}${f.source}${c.reset}  ${c.dim}${f.note}${c.reset}`,
+    );
+  }
+  if (!passed) {
+    console.log(
+      `\n${c.red}✗ unknown backend id(s) — a typo or unsupported backend means secrets silently fall through.${c.reset}`,
+    );
+  }
+  return passed;
 }
 
 /**

--- a/src/vault-triage.test.ts
+++ b/src/vault-triage.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { triageVaultConfig, classifyBackend } from "./vault-triage.js";
+import type { SecretsConfig } from "./config.js";
+
+describe("classifyBackend", () => {
+  it("classifies vault-backed / local-plaintext / unknown", () => {
+    assert.equal(classifyBackend("1password"), "vault-backed");
+    assert.equal(classifyBackend("vault"), "vault-backed");
+    assert.equal(classifyBackend("env"), "local-plaintext");
+    assert.equal(classifyBackend("dotenvx"), "local-plaintext");
+    assert.equal(classifyBackend("nope-store"), "unknown");
+  });
+});
+
+describe("triageVaultConfig", () => {
+  it("passes a vault-backed store + keys and labels assurance", () => {
+    const secrets: SecretsConfig = {
+      store: "1password",
+      keys: { DATABASE_URL: { source: "vault" } },
+    };
+    const r = triageVaultConfig(secrets);
+    assert.equal(r.passed, true);
+    assert.equal(r.findings[0].scope, "store"); // store sorted first
+    assert.equal(r.findings[0].assurance, "vault-backed");
+    assert.equal(r.findings[1].scope, "key:DATABASE_URL");
+  });
+
+  it("FAILS on an unknown/typo backend id (silently no vault)", () => {
+    const r = triageVaultConfig({ store: "onepassword" } as unknown as SecretsConfig);
+    assert.equal(r.passed, false);
+    assert.equal(r.findings[0].assurance, "unknown");
+    assert.match(r.findings[0].note, /known:/);
+  });
+
+  it("surfaces a local/plaintext source but does not fail on it (valid dev choice)", () => {
+    const r = triageVaultConfig({ store: "env" });
+    assert.equal(r.passed, true);
+    assert.equal(r.findings[0].assurance, "local-plaintext");
+    assert.match(r.findings[0].note, /prefer a vault backend/);
+  });
+
+  it("sorts store first, then keys by name; empty config → passed with no findings", () => {
+    const r = triageVaultConfig({
+      keys: { ZED: { source: "vault" }, ABLE: { source: "env" } },
+    });
+    assert.deepEqual(
+      r.findings.map((f) => f.scope),
+      ["key:ABLE", "key:ZED"],
+    );
+    const empty = triageVaultConfig(undefined);
+    assert.deepEqual(empty.findings, []);
+    assert.equal(empty.passed, true);
+  });
+
+  it("is pure/deterministic — same config, same result", () => {
+    const s: SecretsConfig = { store: "vault", keys: { A: { source: "env" } } };
+    assert.deepEqual(triageVaultConfig(s), triageVaultConfig(s));
+  });
+});

--- a/src/vault-triage.ts
+++ b/src/vault-triage.ts
@@ -1,0 +1,78 @@
+/**
+ * kit — vault-config triage (Pillar 4 BYO-gap).
+ *
+ * `kit triage vault-config` closes the last BYO-triage gap: kit triages the packages, images,
+ * skills, MCP servers and plugins you bring, but not the *secret-backend selection* itself —
+ * the `secrets.store` and per-key `source` declared in `.kit.toml`. A typo'd or unsupported
+ * backend id silently means "no vault", and a plaintext/local source for a shared secret is a
+ * lower-assurance choice worth surfacing.
+ *
+ * This is deterministic, zero-LLM, and touches ONLY the backend SELECTION — never a secret
+ * value (kit never reads plaintext secrets; the `.env*` write-gate stays in force). The pure
+ * classification lives here; only the command reads `.kit.toml`.
+ */
+import { BACKENDS } from "./secret-backends.js";
+import type { SecretsConfig } from "./config.js";
+
+export type BackendAssurance = "vault-backed" | "local-plaintext" | "unknown";
+
+export interface VaultConfigFinding {
+  /** "store" (the global default) or "key:<NAME>" (a per-key override). */
+  scope: string;
+  /** The configured backend id. */
+  source: string;
+  assurance: BackendAssurance;
+  note: string;
+}
+
+export interface VaultTriageResult {
+  findings: VaultConfigFinding[];
+  /** Fails only on an UNKNOWN backend id (a typo / unsupported backend = silently no vault). A
+   *  local-plaintext source is surfaced but not a failure — it's a legitimate dev choice. */
+  passed: boolean;
+}
+
+/** Local/plaintext-assurance sources: values come from the local env/files, not a vault. */
+const LOCAL_PLAINTEXT = new Set(["env", "dotenvx", "config"]);
+
+/** Classify a backend id by assurance. Unknown = not a registered kit backend. */
+export function classifyBackend(source: string): BackendAssurance {
+  if (!(source in BACKENDS)) return "unknown";
+  if (LOCAL_PLAINTEXT.has(source)) return "local-plaintext";
+  return "vault-backed";
+}
+
+function noteFor(assurance: BackendAssurance): string {
+  switch (assurance) {
+    case "vault-backed":
+      return "vault-backed";
+    case "local-plaintext":
+      return "local/plaintext source — fine for dev; prefer a vault backend for shared/prod";
+    case "unknown":
+      return `unknown backend id (known: ${Object.keys(BACKENDS).sort().join(", ")})`;
+  }
+}
+
+/**
+ * Triage a project's secret-backend selection. Pure + deterministic: same config → same
+ * findings (sorted store-first, then keys by name). Empty when nothing is configured.
+ */
+export function triageVaultConfig(secrets: SecretsConfig | undefined): VaultTriageResult {
+  const findings: VaultConfigFinding[] = [];
+  if (secrets?.store) {
+    const assurance = classifyBackend(secrets.store);
+    findings.push({ scope: "store", source: secrets.store, assurance, note: noteFor(assurance) });
+  }
+  for (const [name, cfg] of Object.entries(secrets?.keys ?? {})) {
+    const source = cfg?.source;
+    if (!source) continue;
+    const assurance = classifyBackend(source);
+    findings.push({ scope: `key:${name}`, source, assurance, note: noteFor(assurance) });
+  }
+  findings.sort((a, b) => {
+    if (a.scope === "store") return b.scope === "store" ? 0 : -1;
+    if (b.scope === "store") return 1;
+    return a.scope.localeCompare(b.scope);
+  });
+  return { findings, passed: !findings.some((f) => f.assurance === "unknown") };
+}


### PR DESCRIPTION
## Description

Closes the **final** Pillar 4 BYO-triage gap. kit triaged the packages, images, skills, MCP servers, and plugins you bring — but never the *secret-backend selection* itself. A typo'd or unsupported backend id in `.kit.toml` silently means "no vault"; a plaintext/local source for a shared secret is a lower-assurance choice worth surfacing. This adds that triage, touching **only the backend selection — never a secret value**.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

- Final Pillar 4 BYO-triage item (after `kit triage plugin`, #300).

## Changes Made

- `src/vault-triage.ts` — pure, zero-LLM **`triageVaultConfig`** over `.kit.toml` `secrets.store` + per-key `source`. `classifyBackend` → `vault-backed` / `local-plaintext` / `unknown`, checked against the real `BACKENDS` registry. **Fails on an unknown/typo'd backend id** (silently no vault); surfaces `local-plaintext` sources (`env`/`dotenvx`/`config`) as a warning, not a failure (a valid dev choice).
- `src/commands/triage.ts` — **`kit triage vault-config`**: loads `.kit.toml`, reports per-scope assurance (store first, then keys), honest skip when there's no `[secrets]` config or no readable `.kit.toml`; exits non-zero on an unknown backend. Wired into dispatch + help.
- Tests: `classifyBackend` + `triageVaultConfig` (vault-backed pass / unknown fail / plaintext warn / sort + empty / determinism).

## Testing

### Test Coverage
- [x] Added new tests
- [x] All tests pass (`npm test`) — full suite **2664 pass / 0 fail** (2658 baseline + 6)

### Manual Testing
1. `npx tsc --noEmit` → clean.
2. `npx eslint src` → 0 errors.
3. `npm run build && node scripts/test.mjs` → 2664 pass, 0 fail.
4. `npx prettier --check` → formatted.

## Breaking Changes

None / N/A — new `triage` subcommand.

## Checklist

- [x] All new code has test coverage
- [x] All tests pass locally (`npm test`)
- [x] No new warnings or errors introduced
- [x] No hardcoded secrets or sensitive data — inspects backend *selection* and key *names* only; never reads a secret value
- [x] Code has been self-reviewed

## Performance Impact

- [x] No performance impact

## Reviewer Notes

The pass/fail line is deliberate: an **unknown backend id fails** (it's a misconfiguration that silently drops secrets through), but a **plaintext/local source only warns** — `env`/`dotenvx` are legitimate for local dev, so failing them would punish a valid setup. This is the last BYO-triage gap; with it, `kit triage` covers packages, images, skills, MCP, plugins, and the vault selection, and Pillar 4's traveling-profile track is fully complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_