### PR TITLE
feat(broker): pure scope-decision core (Pillar 3 step 1)

### DIFF
--- a/src/broker/scope.test.ts
+++ b/src/broker/scope.test.ts
@@ -1,0 +1,85 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { hostInScope, pathInScope, secretInScope, isLoopbackOrPrivate } from "./scope.js";
+import type { ProfileScope } from "../profile/schema.js";
+
+describe("hostInScope", () => {
+  const scope: ProfileScope = { egress: ["api.acme.com", "acme.io"] };
+
+  it("allows an exact allowlisted host", () => {
+    assert.equal(hostInScope("api.acme.com", scope), true);
+  });
+  it("allows a subdomain of an allowlisted entry", () => {
+    assert.equal(hostInScope("eu.acme.io", scope), true);
+    assert.equal(hostInScope("a.b.acme.io", scope), true);
+  });
+  it("denies an unrelated host and a sibling/suffix trick", () => {
+    assert.equal(hostInScope("evil.com", scope), false);
+    assert.equal(hostInScope("notacme.io", scope), false); // suffix without a dot boundary
+    assert.equal(hostInScope("acme.io.evil.com", scope), false);
+  });
+  it("denies everything when egress is undefined or empty", () => {
+    assert.equal(hostInScope("api.acme.com", {}), false);
+    assert.equal(hostInScope("api.acme.com", { egress: [] }), false);
+  });
+  it("never subdomain-matches loopback/private, but honors an exact listing", () => {
+    assert.equal(hostInScope("127.0.0.1", { egress: ["0.0.0.1"] }), false);
+    assert.equal(hostInScope("localhost", { egress: ["host"] }), false); // no subdomain match to loopback
+    assert.equal(hostInScope("localhost", { egress: ["localhost"] }), true); // explicit wins
+  });
+  it("is case-insensitive and tolerates a trailing FQDN dot", () => {
+    assert.equal(hostInScope("API.ACME.COM.", scope), true);
+  });
+});
+
+describe("isLoopbackOrPrivate", () => {
+  it("flags loopback, link-local, and RFC1918 ranges", () => {
+    for (const h of [
+      "localhost",
+      "127.0.0.1",
+      "::1",
+      "10.1.2.3",
+      "192.168.0.5",
+      "172.16.0.1",
+      "169.254.1.1",
+    ]) {
+      assert.equal(isLoopbackOrPrivate(h), true, h);
+    }
+  });
+  it("does not flag public hosts or 172.15/172.32 (outside the private block)", () => {
+    for (const h of ["api.acme.com", "8.8.8.8", "172.15.0.1", "172.32.0.1"]) {
+      assert.equal(isLoopbackOrPrivate(h), false, h);
+    }
+  });
+});
+
+describe("pathInScope", () => {
+  const root = "/proj";
+
+  it("allows writes inside the default root when fs is unspecified", () => {
+    assert.equal(pathInScope("src/x.ts", {}, root), true);
+    assert.equal(pathInScope("/proj/src/x.ts", {}, root), true);
+  });
+  it("denies a traversal escape out of the root", () => {
+    assert.equal(pathInScope("../etc/passwd", {}, root), false);
+    assert.equal(pathInScope("/etc/passwd", {}, root), false);
+  });
+  it("honors an explicit fs sub-scope", () => {
+    const scope: ProfileScope = { fs: ["src", "dist"] };
+    assert.equal(pathInScope("src/a.ts", scope, root), true);
+    assert.equal(pathInScope("dist/b.js", scope, root), true);
+    assert.equal(pathInScope("secrets/c", scope, root), false);
+  });
+  it("treats the scope root itself as in-scope", () => {
+    assert.equal(pathInScope(".", {}, root), true);
+  });
+});
+
+describe("secretInScope", () => {
+  it("permits only declared keys; empty/undefined ⇒ none", () => {
+    assert.equal(secretInScope("DATABASE_URL", { secrets: ["DATABASE_URL"] }), true);
+    assert.equal(secretInScope("AWS_SECRET", { secrets: ["DATABASE_URL"] }), false);
+    assert.equal(secretInScope("ANY", {}), false);
+    assert.equal(secretInScope("ANY", { secrets: [] }), false);
+  });
+});

--- a/src/broker/scope.ts
+++ b/src/broker/scope.ts
@@ -1,0 +1,76 @@
+/**
+ * kit exec-broker — the pure scope-decision core (Pillar 3, 5.0-rc).
+ *
+ * Design: `kit-research/docs/research/pillar3-exec-broker-5.0.md` §3.1.
+ *
+ * Three deterministic, zero-LLM predicates that answer "is this action inside the agent's
+ * SCOPE?" against a `ProfileScope` (the signed RoE from Pillar 4). No I/O — the caller supplies
+ * the already-resolved inputs; the enforcement points (PreToolUse hooks, `withGovernance`) sit
+ * ABOVE this and feed it the scope via `verifiedScope()` (fail-closed: a null scope never
+ * reaches here). Pure ⇒ fully unit-testable and safe to diff in CI.
+ *
+ * Fail-closed field semantics (within a valid scope):
+ *   - egress: undefined/empty ⇒ NO host allowed (network must be declared explicitly);
+ *   - fs: undefined/empty ⇒ default to the project root ".";
+ *   - secrets: undefined/empty ⇒ NO secret exposed (secret-scoped by default).
+ */
+import { resolve, relative, isAbsolute } from "node:path";
+import type { ProfileScope } from "../profile/schema.js";
+
+/**
+ * True when `host` is loopback / link-local / an RFC1918 private address. Such hosts are denied
+ * by SUBDOMAIN matching (they may only be reached if listed VERBATIM in the egress allowlist),
+ * so a broad `example.com` entry can never be tricked into permitting an internal target.
+ */
+export function isLoopbackOrPrivate(host: string): boolean {
+  const h = host.toLowerCase();
+  if (h === "localhost" || h.endsWith(".localhost")) return true;
+  if (h === "0.0.0.0" || h === "::1" || h === "[::1]") return true;
+  if (/^127\./.test(h)) return true;
+  if (/^10\./.test(h)) return true;
+  if (/^192\.168\./.test(h)) return true;
+  if (/^169\.254\./.test(h)) return true; // link-local
+  if (/^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(h)) return true; // 172.16.0.0 – 172.31.255.255
+  return false;
+}
+
+/**
+ * Is `host` reachable under this scope's egress allowlist? An exact allowlist entry always wins
+ * (even a deliberately-listed internal host). Otherwise a host matches an entry when it equals it
+ * or is a subdomain of it (`api.acme.com` matches entry `acme.com`) — but loopback/private hosts
+ * are never subdomain-matched. Undefined/empty egress ⇒ nothing is reachable.
+ */
+export function hostInScope(host: string, scope: ProfileScope): boolean {
+  const egress = scope.egress ?? [];
+  const h = host.toLowerCase().replace(/\.$/, ""); // drop a trailing FQDN dot
+  const entries = egress.map((e) => e.toLowerCase().replace(/\.$/, ""));
+  if (entries.includes(h)) return true;
+  if (isLoopbackOrPrivate(h)) return false;
+  return entries.some((e) => e.length > 0 && h.endsWith(`.${e}`));
+}
+
+/**
+ * Is a write to `targetPath` inside this scope's filesystem write-scope? Paths are resolved
+ * against `root` and compared with a traversal-safe containment check (a `..` escape lands
+ * outside and is denied). Undefined/empty `fs` defaults to the project root ".".
+ */
+export function pathInScope(targetPath: string, scope: ProfileScope, root: string): boolean {
+  const base = resolve(root);
+  const target = isAbsolute(targetPath) ? resolve(targetPath) : resolve(base, targetPath);
+  const fsScopes = scope.fs && scope.fs.length > 0 ? scope.fs : ["."];
+  return fsScopes.some((entry) => {
+    const allowed = isAbsolute(entry) ? resolve(entry) : resolve(base, entry);
+    if (target === allowed) return true;
+    const rel = relative(allowed, target);
+    // Inside `allowed` iff the relative path doesn't climb out (no leading "..") and isn't absolute.
+    return rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
+  });
+}
+
+/**
+ * Is the secret `key` allowed to be exposed for an operation under this scope? Secret-scoped by
+ * default: only keys listed in `scope.secrets` are permitted; undefined/empty ⇒ none.
+ */
+export function secretInScope(key: string, scope: ProfileScope): boolean {
+  return (scope.secrets ?? []).includes(key);
+}


### PR DESCRIPTION
## Description

First build step of the **Pillar 3 exec-broker** (5.0-rc). The deterministic, zero-LLM floor: three pure predicates that answer "is this action inside the agent's SCOPE?" against a `ProfileScope` (Pillar 4's signed RoE). No I/O, no CLI, no enforcement yet — those sit above this in later steps and feed the scope via `verifiedScope()` (fail-closed).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

- Design: `kit-research/docs/research/pillar3-exec-broker-5.0.md` §3.1 (merged as kit-research #30)
- Consumes Pillar 4's `verifiedScope()` (#298) as its scope source (in later steps).

## Changes Made

- `src/broker/scope.ts`:
  - **`hostInScope`** — egress allowlist with exact + subdomain match; an exact entry always wins, but loopback / RFC1918 / link-local hosts are **never subdomain-matched** (a broad `example.com` entry can't be tricked into permitting an internal target). Undefined/empty egress ⇒ nothing reachable.
  - **`pathInScope`** — traversal-safe containment against the fs write-scope (a `..` escape resolves outside and is denied); undefined/empty `fs` defaults to the project root `.`.
  - **`secretInScope`** — secret-scoped by default: only declared keys; undefined/empty ⇒ none.
  - **`isLoopbackOrPrivate`** (exported) for the egress guard.
- `src/broker/scope.test.ts` — 13 tests (exact/subdomain/suffix-trick/empty egress; loopback never subdomain-matched but honored if exact; case + trailing-dot; fs default-root / traversal-escape / explicit sub-scope / root-itself; secret declared-only; RFC1918 boundary cases).

## Testing

### Test Coverage
- [x] Added new tests (13)
- [x] All tests pass (`npm test`) — full suite **2677 pass / 0 fail** (2664 baseline + 13)

### Manual Testing
1. `npx tsc --noEmit` → clean.
2. `npx eslint src` → 0 errors.
3. `npm run build && node scripts/test.mjs` → 2677 pass, 0 fail.
4. `npx prettier --check` → formatted.

## Breaking Changes

None / N/A — new module; nothing imports it yet.

## Checklist

- [x] All new code has test coverage
- [x] All tests pass locally (`npm test`)
- [x] No new warnings or errors introduced
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

## Performance Impact

- [x] No performance impact

## Reviewer Notes

The security-relevant subtlety is in `hostInScope`: subdomain matching is convenient but must never widen to internal targets, so loopback/private hosts are matchable **only** by a verbatim allowlist entry — a broad public entry can't be leveraged into SSRF against an internal host. Next steps: fail-closed scope source (`brokerScope` = `verifiedScope` → scope|null) + `kit doctor` status, then the PreToolUse enforcer, then integration into `withGovernance`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_