### PR TITLE
feat(broker): fail-closed scope source + honest kit doctor line (Pillar 3 steps 2–3)

### DIFF
--- a/src/broker/decide.test.ts
+++ b/src/broker/decide.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadOrCreateIdentity } from "../identity.js";
+import { PROFILE_FILE } from "../profile/schema.js";
+import { signProfile } from "../profile/sign.js";
+import { brokerStatus, brokerScope } from "./decide.js";
+
+let idDir: string;
+let proj: string;
+let savedIdEnv: string | undefined;
+
+const SCOPED = `version = 1
+name = "acme"
+[scope]
+egress = ["api.acme.com"]
+fs = ["."]
+secrets = ["DATABASE_URL"]
+`;
+
+beforeEach(() => {
+  idDir = mkdtempSync(join(tmpdir(), "kit-id-"));
+  proj = mkdtempSync(join(tmpdir(), "kit-broker-"));
+  savedIdEnv = process.env.KIT_IDENTITY_DIR;
+  process.env.KIT_IDENTITY_DIR = idDir;
+  loadOrCreateIdentity();
+});
+
+afterEach(() => {
+  if (savedIdEnv === undefined) delete process.env.KIT_IDENTITY_DIR;
+  else process.env.KIT_IDENTITY_DIR = savedIdEnv;
+  rmSync(idDir, { recursive: true, force: true });
+  rmSync(proj, { recursive: true, force: true });
+});
+
+describe("brokerStatus", () => {
+  it("reports none when no profile is declared", async () => {
+    const st = await brokerStatus(proj);
+    assert.equal(st.state, "none");
+    assert.equal(st.scope, null);
+  });
+
+  it("reports none when the profile declares no [scope]", async () => {
+    writeFileSync(join(proj, PROFILE_FILE), `version = 1\nname = "no-scope"\n`);
+    const st = await brokerStatus(proj);
+    assert.equal(st.state, "none");
+    assert.match(st.detail, /no \[scope\]/);
+  });
+
+  it("reports unsigned (grants nothing) for a declared-but-unsigned scope", async () => {
+    writeFileSync(join(proj, PROFILE_FILE), SCOPED);
+    const st = await brokerStatus(proj);
+    assert.equal(st.state, "unsigned");
+    assert.equal(st.scope, null);
+    assert.match(st.detail, /fail-closed/);
+  });
+
+  it("reports verified with the governing scope for a signed profile", async () => {
+    writeFileSync(join(proj, PROFILE_FILE), SCOPED);
+    await signProfile(proj);
+    const st = await brokerStatus(proj);
+    assert.equal(st.state, "verified");
+    assert.deepEqual(st.scope?.egress, ["api.acme.com"]);
+    assert.match(st.detail, /1 egress host/);
+  });
+
+  it("reports invalid (grants nothing) when the profile was tampered after signing", async () => {
+    writeFileSync(join(proj, PROFILE_FILE), SCOPED);
+    await signProfile(proj);
+    writeFileSync(join(proj, PROFILE_FILE), SCOPED.replace("api.acme.com", "evil.example.com"));
+    const st = await brokerStatus(proj);
+    assert.equal(st.state, "invalid");
+    assert.equal(st.scope, null);
+  });
+
+  it("reports invalid (never throws) on a malformed profile", async () => {
+    writeFileSync(join(proj, PROFILE_FILE), "not = = toml");
+    const st = await brokerStatus(proj);
+    assert.equal(st.state, "invalid");
+    assert.match(st.detail, /unreadable/);
+  });
+});
+
+describe("brokerScope (fail-closed)", () => {
+  it("returns the scope only for a verified signature", async () => {
+    writeFileSync(join(proj, PROFILE_FILE), SCOPED);
+    await signProfile(proj);
+    const scope = await brokerScope(proj);
+    assert.deepEqual(scope?.secrets, ["DATABASE_URL"]);
+  });
+
+  it("returns null for unsigned, tampered, malformed, and absent profiles", async () => {
+    assert.equal(await brokerScope(proj), null); // absent
+
+    writeFileSync(join(proj, PROFILE_FILE), SCOPED); // unsigned
+    assert.equal(await brokerScope(proj), null);
+
+    await signProfile(proj); // tampered after signing
+    writeFileSync(join(proj, PROFILE_FILE), SCOPED.replace("acme", "evil"));
+    assert.equal(await brokerScope(proj), null);
+
+    writeFileSync(join(proj, PROFILE_FILE), "not = = toml"); // malformed — never throws
+    assert.equal(await brokerScope(proj), null);
+  });
+});

--- a/src/broker/decide.ts
+++ b/src/broker/decide.ts
@@ -1,0 +1,102 @@
+/**
+ * kit exec-broker — the fail-closed scope source + honest status (Pillar 3 steps 2–3).
+ *
+ * Design: `kit-research/docs/research/pillar3-exec-broker-5.0.md` §3.2.
+ *
+ * The broker's SCOPE comes from exactly one place: the profile's signed `[scope]`/RoE via
+ * `verifiedScope()` (Pillar 4). This module wraps that source for the ENFORCEMENT paths:
+ *
+ *   - `brokerScope(cwd)` — never-throws: any error (malformed profile, unreadable sig, …)
+ *     resolves to `null`, and a `null` scope GRANTS NOTHING. An enforcement point must never
+ *     crash open — an exception in the trust path is a deny, not a bypass.
+ *   - `brokerStatus(cwd)` — the honest posture for `kit doctor`: verified / unsigned /
+ *     invalid / none. "Enforced" must never silently mean "no-op", and a degradation
+ *     (declared-but-unsigned scope) is surfaced, never swallowed.
+ *
+ * Deterministic, zero-LLM, local-only (file reads + offline signature verify).
+ */
+import { loadProfile, type ProfileScope } from "../profile/schema.js";
+import { verifyProfileSignature } from "../profile/sign.js";
+
+export type BrokerScopeState =
+  /** A `[scope]` is declared and its signature verifies — this scope governs. */
+  | "verified"
+  /** A `[scope]` is declared but unsigned / signer unknown — grants nothing (fail-closed). */
+  | "unsigned"
+  /** Signature invalid/revoked, or the profile itself is malformed — grants nothing. */
+  | "invalid"
+  /** No profile or no `[scope]` section — there is no RoE for the broker to enforce. */
+  | "none";
+
+export interface BrokerStatus {
+  state: BrokerScopeState;
+  /** The governing scope — non-null ONLY when state is "verified". */
+  scope: ProfileScope | null;
+  detail: string;
+}
+
+/**
+ * The broker's honest posture. Never throws — a malformed profile is reported as `invalid`
+ * (a broken artifact must not crash the status surface, and must never read as healthy).
+ */
+export async function brokerStatus(cwd = process.cwd()): Promise<BrokerStatus> {
+  let scope: ProfileScope | undefined;
+  try {
+    const profile = await loadProfile(cwd);
+    if (!profile) return { state: "none", scope: null, detail: "no profile declared" };
+    scope = profile.scope;
+  } catch (err) {
+    return {
+      state: "invalid",
+      scope: null,
+      detail: `profile unreadable — ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (!scope) {
+    return { state: "none", scope: null, detail: "profile declares no [scope]/RoE" };
+  }
+
+  const v = await verifyProfileSignature(cwd);
+  switch (v.status) {
+    case "valid": {
+      const parts = [
+        `${scope.egress?.length ?? 0} egress host(s)`,
+        `${scope.fs?.length ?? 0} fs path(s)`,
+        `${scope.secrets?.length ?? 0} secret key(s)`,
+      ];
+      return {
+        state: "verified",
+        scope,
+        detail: `scope verified — ${parts.join(", ")} (${v.detail})`,
+      };
+    }
+    case "unsigned":
+    case "unverifiable":
+      return {
+        state: "unsigned",
+        scope: null,
+        detail: `scope declared but ${v.detail} — grants nothing (fail-closed)`,
+      };
+    case "invalid":
+    case "revoked":
+      return {
+        state: "invalid",
+        scope: null,
+        detail: `scope signature ${v.status} — ${v.detail}; grants nothing (fail-closed)`,
+      };
+  }
+}
+
+/**
+ * The scope the enforcement points act on: the verified `[scope]`, or `null` when anything
+ * along the trust path is missing, broken, or forged. Never throws — an exception in the
+ * trust path is a deny (`null`), not a bypass.
+ */
+export async function brokerScope(cwd = process.cwd()): Promise<ProfileScope | null> {
+  try {
+    const st = await brokerStatus(cwd);
+    return st.state === "verified" ? st.scope : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -5,6 +5,7 @@ import { promisify } from "node:util";
 import type { kitConfig } from "./config.js";
 import { resolveToolBin } from "./utils/resolveTool.js";
 import { activeKeyStoreStatus, hardwareRequired } from "./keystore/active.js";
+import { brokerStatus } from "./broker/decide.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -247,6 +248,36 @@ function checkIdentityKeystore(): DoctorCheck {
   };
 }
 
+/**
+ * Exec-broker scope posture (Pelare 3). Surfaces the state of the signed [scope]/RoE the
+ * broker enforces against — per the design principle, "enforced" must never silently mean
+ * "no-op" and a degradation is surfaced, never swallowed:
+ *   pass  scope declared + signature verified (this scope governs)
+ *   skip  no profile / no [scope] declared — nothing to enforce yet
+ *   warn  scope declared but unsigned/unverifiable — grants nothing (fail-closed)
+ *   fail  signature invalid/revoked or profile malformed — grants nothing (fail-closed)
+ */
+async function checkBrokerScope(cwd: string): Promise<DoctorCheck> {
+  const name = "exec-broker scope";
+  const category = "security";
+  const st = await brokerStatus(cwd);
+  switch (st.state) {
+    case "verified":
+      return { name, status: "pass", detail: st.detail, category };
+    case "none":
+      return {
+        name,
+        status: "skip",
+        detail: `${st.detail} — declare [scope] in .kit-profile.toml and run 'kit profile sign' to arm the exec-broker`,
+        category,
+      };
+    case "unsigned":
+      return { name, status: "warn", detail: `${st.detail}; run 'kit profile sign'`, category };
+    case "invalid":
+      return { name, status: "fail", detail: st.detail, category };
+  }
+}
+
 export async function runDoctor(config: kitConfig, cwd: string): Promise<DoctorResult> {
   const allChecks: DoctorCheck[] = [];
 
@@ -272,6 +303,8 @@ export async function runDoctor(config: kitConfig, cwd: string): Promise<DoctorR
   if (memoryHooksCheck) allChecks.push(memoryHooksCheck);
 
   allChecks.push(checkIdentityKeystore());
+
+  allChecks.push(await checkBrokerScope(cwd));
 
   const passed = allChecks.filter((c) => c.status === "pass").length;
   const warnings = allChecks.filter((c) => c.status === "warn").length;


### PR DESCRIPTION
## Description

Steps 2–3 of the **Pillar 3 exec-broker** (design: `kit-research/docs/research/pillar3-exec-broker-5.0.md` §3.2). The broker's SCOPE comes from exactly one place — the profile's signed `[scope]`/RoE — and this PR adds the enforcement-facing wrapper plus its honest `kit doctor` surface. Still no enforcement (that's step 4, the PreToolUse gates).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

- Builds on #303 (pure scope core) and #298 (`verifiedScope`)
- Design: kit-research #30

## Changes Made

- `src/broker/decide.ts`:
  - **`brokerScope(cwd)`** — never-throws: any error along the trust path (malformed profile, unreadable sig, forged/revoked signature) resolves to `null`, and a `null` scope **grants nothing**. An exception in the trust path is a deny, not a bypass.
  - **`brokerStatus(cwd)`** — honest posture: `verified` (scope governs) / `unsigned` (declared but not attributable — grants nothing) / `invalid` (tampered / revoked / malformed — grants nothing) / `none` (no RoE declared).
- `src/doctor.ts` — **`exec-broker scope`** check: pass (verified, with scope summary), skip (none, with a how-to-arm hint), warn (unsigned; `run kit profile sign`), fail (invalid). Same honest-degradation posture as the identity-keystore row: "enforced" must never silently mean "no-op".
- `src/broker/decide.test.ts` — 8 tests via a throwaway `KIT_IDENTITY_DIR` (status across none / no-scope / unsigned / verified / tampered / malformed; `brokerScope` fail-closed `null` across absent / unsigned / tampered / malformed).

## Testing

### Test Coverage
- [x] Added new tests (8)
- [x] All tests pass (`npm test`) — full suite **2685 pass / 0 fail** (2677 baseline + 8); doctor tests unaffected (name-based assertions)

### Manual Testing
1. `npx tsc --noEmit` → clean.
2. `npx eslint src` → 0 errors.
3. `npm run build && node scripts/test.mjs` → 2685 pass, 0 fail.
4. `npx prettier --check` → formatted.

## Breaking Changes

None / N/A — new module + one additive doctor row.

## Checklist

- [x] All new code has test coverage
- [x] All tests pass locally (`npm test`)
- [x] No new warnings or errors introduced
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

## Performance Impact

- [x] No performance impact — one local file read + offline signature verify in `kit doctor`

## Reviewer Notes

The distinction worth checking is `unsigned` (warn) vs `invalid` (fail) in doctor: a declared-but-unsigned scope is an incomplete setup (warn + actionable hint), while a *tampered/revoked* signature or malformed profile is a broken trust artifact (fail). Both grant nothing at enforcement time — the doctor severity only differentiates operator action. Next step (4): the PreToolUse enforcers (`gate-egress`/fs/secret) consuming `brokerScope` + the pure predicates from #303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_