### PR TITLE
feat(exec-broker): signed profile scope → BrokerPolicy bridge (reconciliation R2)

### DIFF
--- a/src/exec-broker/profile-policy.test.ts
+++ b/src/exec-broker/profile-policy.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { loadOrCreateIdentity } from "../identity.js";
+import { PROFILE_FILE } from "../profile/schema.js";
+import { signProfile } from "../profile/sign.js";
+import { profileBrokerPolicy } from "./profile-policy.js";
+
+let idDir: string;
+let proj: string;
+let savedIdEnv: string | undefined;
+
+const SCOPED = `version = 1
+[scope]
+egress = ["api.acme.com"]
+fs = ["src", "dist"]
+secrets = ["DATABASE_URL"]
+`;
+
+beforeEach(() => {
+  idDir = mkdtempSync(join(tmpdir(), "kit-id-"));
+  proj = mkdtempSync(join(tmpdir(), "kit-profpol-"));
+  savedIdEnv = process.env.KIT_IDENTITY_DIR;
+  process.env.KIT_IDENTITY_DIR = idDir;
+  loadOrCreateIdentity();
+});
+
+afterEach(() => {
+  if (savedIdEnv === undefined) delete process.env.KIT_IDENTITY_DIR;
+  else process.env.KIT_IDENTITY_DIR = savedIdEnv;
+  rmSync(idDir, { recursive: true, force: true });
+  rmSync(proj, { recursive: true, force: true });
+});
+
+describe("profileBrokerPolicy", () => {
+  it("regime none when no profile is declared", async () => {
+    const r = await profileBrokerPolicy(proj);
+    assert.equal(r.regime, "none");
+    assert.equal(r.policy, null);
+  });
+
+  it("regime none when the profile declares no [scope]", async () => {
+    writeFileSync(join(proj, PROFILE_FILE), `version = 1\nname = "x"\n`);
+    assert.equal((await profileBrokerPolicy(proj)).regime, "none");
+  });
+
+  it("maps a verified [scope] onto a BrokerPolicy (fs paths resolved to roots)", async () => {
+    writeFileSync(join(proj, PROFILE_FILE), SCOPED);
+    await signProfile(proj);
+    const r = await profileBrokerPolicy(proj);
+    assert.equal(r.regime, "active");
+    assert.deepEqual(r.policy?.egress.allow, ["api.acme.com"]);
+    assert.equal(r.policy?.fs.root, resolve(proj, "src"));
+    assert.deepEqual(r.policy?.fs.roots, [resolve(proj, "dist")]);
+    assert.deepEqual(r.policy?.env.declared, ["DATABASE_URL"]);
+  });
+
+  it("active + null policy (default-deny) when the scope is declared but unsigned", async () => {
+    writeFileSync(join(proj, PROFILE_FILE), SCOPED);
+    const r = await profileBrokerPolicy(proj);
+    assert.equal(r.regime, "active");
+    assert.equal(r.policy, null);
+    assert.match(r.detail, /fail-closed/);
+  });
+
+  it("active + null policy when the profile was tampered after signing", async () => {
+    writeFileSync(join(proj, PROFILE_FILE), SCOPED);
+    await signProfile(proj);
+    writeFileSync(join(proj, PROFILE_FILE), SCOPED.replace("api.acme.com", "evil.com"));
+    const r = await profileBrokerPolicy(proj);
+    assert.equal(r.regime, "active");
+    assert.equal(r.policy, null);
+  });
+
+  it("defaults fs to the project root when [scope].fs is omitted", async () => {
+    writeFileSync(join(proj, PROFILE_FILE), `version = 1\n[scope]\negress = ["h.io"]\n`);
+    await signProfile(proj);
+    const r = await profileBrokerPolicy(proj);
+    assert.equal(r.policy?.fs.root, resolve(proj, "."));
+  });
+});

--- a/src/exec-broker/profile-policy.ts
+++ b/src/exec-broker/profile-policy.ts
@@ -1,0 +1,81 @@
+/**
+ * kit exec-broker — the SIGNED policy source (reconciliation R2).
+ *
+ * Design: `kit-research/docs/research/pillar3-broker-reconciliation-5.0.md`.
+ *
+ * The exec-broker's original policy source is an UNSIGNED `.kit-exec-broker.json` (`policy.ts`).
+ * This bridges the SIGNED, offline-verified profile scope (`[scope]`/RoE from Pillar 4) into a
+ * `BrokerPolicy`, so the one canonical broker can be driven by a cryptographically attributable
+ * source. It is the shared signed provider for the PreToolUse gates (R3) and `kit doctor`.
+ *
+ * Fail-closed, mirroring the profile's own semantics:
+ *   - no profile / no `[scope]` declared  → regime "none" (no RoE to enforce; caller decides
+ *     whether to fall back to the JSON policy or run unmediated — this module imposes nothing);
+ *   - `[scope]` declared + signature VERIFIED → regime "active" with a BrokerPolicy that governs;
+ *   - `[scope]` declared but unsigned / tampered / revoked → regime "active" with policy `null`
+ *     (declaring a scope is the opt-in; only a verified one grants — a null policy default-denies
+ *     in `brokerExec`).
+ *
+ * Deterministic, zero-LLM, local-only (file reads + offline signature verify). Never throws.
+ */
+import { resolve } from "node:path";
+import { loadProfile } from "../profile/schema.js";
+import { verifyProfileSignature } from "../profile/sign.js";
+import type { BrokerPolicy } from "./policy.js";
+
+export interface ProfilePolicyResult {
+  /** "none" = no RoE declared; "active" = a `[scope]` is declared (policy set iff verified). */
+  regime: "none" | "active";
+  /** The governing policy — non-null ONLY when regime is "active" AND the signature verified. */
+  policy: BrokerPolicy | null;
+  detail: string;
+}
+
+/** Map a verified profile `[scope]` onto a BrokerPolicy (fs paths resolved against `cwd`). */
+function scopeToPolicy(
+  scope: { egress?: string[]; fs?: string[]; secrets?: string[] },
+  cwd: string,
+): BrokerPolicy {
+  const roots = (scope.fs && scope.fs.length > 0 ? scope.fs : ["."]).map((p) => resolve(cwd, p));
+  return {
+    egress: { allow: scope.egress ? [...scope.egress] : [] },
+    fs: roots.length > 1 ? { root: roots[0], roots: roots.slice(1) } : { root: roots[0] },
+    env: { declared: scope.secrets ? [...scope.secrets] : [] },
+  };
+}
+
+/**
+ * Resolve the signed profile scope into a broker-policy regime. Never throws — a malformed
+ * profile surfaces as regime "active" with a null policy (fail-closed), never as "none".
+ */
+export async function profileBrokerPolicy(cwd = process.cwd()): Promise<ProfilePolicyResult> {
+  let scope: { egress?: string[]; fs?: string[]; secrets?: string[] } | undefined;
+  try {
+    const profile = await loadProfile(cwd);
+    if (!profile) return { regime: "none", policy: null, detail: "no profile declared" };
+    scope = profile.scope;
+  } catch (err) {
+    // A profile exists but is malformed — a declared-but-broken RoE. Treat as active+deny, never
+    // "none" (a broken artifact must not silently disable enforcement).
+    return {
+      regime: "active",
+      policy: null,
+      detail: `profile unreadable — ${err instanceof Error ? err.message : String(err)} (default-deny)`,
+    };
+  }
+  if (!scope) return { regime: "none", policy: null, detail: "profile declares no [scope]/RoE" };
+
+  const v = await verifyProfileSignature(cwd);
+  if (v.status === "valid") {
+    return {
+      regime: "active",
+      policy: scopeToPolicy(scope, cwd),
+      detail: `scope verified (${v.detail})`,
+    };
+  }
+  return {
+    regime: "active",
+    policy: null,
+    detail: `scope declared but ${v.status} — ${v.detail}; grants nothing (fail-closed)`,
+  };
+}


### PR DESCRIPTION
## Description

Reconciliation R2 (design: `kit-research/docs/research/pillar3-broker-reconciliation-5.0.md`). The exec-broker's original policy source is an **unsigned** `.kit-exec-broker.json`. This adds the **signed** source: a bridge from the offline-verified profile `[scope]`/RoE (Pillar 4) to a `BrokerPolicy`, so the one canonical broker can be driven by a cryptographically attributable source. It's the shared provider the PreToolUse gates (R3) and `kit doctor` will consume.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

- Reconciliation R2 (kit-research #32); builds on R1 (#308, fs path list).

## Changes Made

- `src/exec-broker/profile-policy.ts` — **`profileBrokerPolicy(cwd)`** → `{ regime, policy, detail }`:
  - maps a **verified** `[scope]` onto a `BrokerPolicy` (egress.allow ← `scope.egress`, fs roots ← `scope.fs` resolved against cwd, default `.`; env.declared ← `scope.secrets`);
  - **fail-closed**, mirroring the profile's own semantics: no `[scope]` → regime `none` (imposes nothing — the caller may fall back to the JSON policy or run unmediated); `[scope]` verified → regime `active` with a governing policy; declared-but-unsigned/tampered/malformed → `active` with **null** policy (default-deny). Never throws.
- `src/exec-broker/profile-policy.test.ts` — 6 tests (none / no-scope / verified-mapping incl. multi-root fs / unsigned / tampered / fs-default-root), via a throwaway `KIT_IDENTITY_DIR`.

## Testing

### Test Coverage
- [x] Added new tests (6)
- [x] All tests pass (`npm test`) — full suite **2719 pass / 0 fail** (2713 baseline + 6)

### Manual Testing
1. `npx tsc --noEmit` → clean; `npx eslint src` → 0 errors.
2. `npm run build && node scripts/test.mjs` → 2719 pass, 0 fail.

## Breaking Changes

None / N/A — new module; **not yet wired into `runBrokered`** (see notes).

## Checklist

- [x] All new code has test coverage
- [x] All tests pass locally (`npm test`)
- [x] No new warnings or errors introduced
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

## Performance Impact

- [x] No performance impact — pure module; consulted only where wired (R3 gates), one profile read + offline verify.

## Reviewer Notes

Deliberately **does not change `runBrokered`'s activation trigger.** The 4 governed MCP ops (`tools.install`/`secrets.generate`/`fix`/`run`) declare **no** effect contract today, so making a signed profile flip `runBrokered` to mediate would fail-closed-**deny** kit's own MCP tools under any signed scope — a real breaking interaction that's a separate product decision (flagged in the reconciliation note's open questions), not part of the dedup. R2 just provides the signed source; R3 points the PreToolUse gates at the canonical `decisions.ts` **via** this bridge (removing the duplicate decision core), and R4 deletes `src/broker/scope.ts` + `needs.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_