### PR TITLE
refactor(broker): rewire gate-egress/gate-fs onto canonical exec-broker decisions (reconciliation R3)

### DIFF
--- a/src/commands/gate.ts
+++ b/src/commands/gate.ts
@@ -173,7 +173,7 @@ async function auditGateDeny(gate: string, reason: string): Promise<void> {
 /**
  * `kit gate-egress` — PreToolUse egress-gate (exec-broker, Pillar 3). Reads the pending tool
  * call on stdin; if it is a Bash command with explicit http(s) network targets, they must all
- * be inside the SIGNED [scope].egress (verified via brokerScope — fail-closed: a wired gate
+ * be inside the SIGNED [scope].egress (via the signed profile policy — fail-closed: a wired gate
  * with no verified scope grants nothing). Off-scope → exit 2 + audit. Commands without an
  * unambiguous URL pass through (conservative extraction; see broker/extract.ts).
  */
@@ -187,16 +187,18 @@ export async function cmdGateEgress(): Promise<boolean> {
   const hosts = extractHostsFromCommand(command);
   if (hosts.length === 0) return true; // no unambiguous network target → allow
 
-  const { brokerScope } = await import("../broker/decide.js");
-  const scope = await brokerScope(process.cwd());
+  // Canonical exec-broker: the signed profile scope → BrokerPolicy, egress checked with the
+  // shared decisions.checkEgress. A wired gate with no VERIFIED scope grants nothing (policy null).
+  const { profileBrokerPolicy } = await import("../exec-broker/profile-policy.js");
+  const { checkEgress } = await import("../exec-broker/decisions.js");
+  const { policy } = await profileBrokerPolicy(process.cwd());
   let denied: string[];
   let why: string;
-  if (!scope) {
+  if (!policy) {
     denied = hosts;
     why = `network egress to ${hosts.join(", ")} denied — no verified scope/RoE (unsigned, tampered, or missing); a wired egress-gate grants nothing`;
   } else {
-    const { hostInScope } = await import("../broker/scope.js");
-    denied = hosts.filter((h) => !hostInScope(h, scope));
+    denied = hosts.filter((h) => !checkEgress(h, { allow: policy.egress.allow }).ok);
     why = `host(s) outside the signed egress scope: ${denied.join(", ")}`;
   }
   if (denied.length === 0) return true;
@@ -210,7 +212,7 @@ export async function cmdGateEgress(): Promise<boolean> {
 /**
  * `kit gate-fs` — PreToolUse fs-gate (exec-broker, Pillar 3). Reads the pending tool call on
  * stdin; a Write/Edit must target a path inside the SIGNED [scope].fs (default: the project
- * root), verified via brokerScope — fail-closed: a wired gate with no verified scope grants
+ * root), via the signed profile policy — fail-closed: a wired gate with no verified scope grants
  * nothing. Off-scope → exit 2 + audit. Non-write tool calls pass through.
  */
 export async function cmdGateFs(): Promise<boolean> {
@@ -220,15 +222,21 @@ export async function cmdGateFs(): Promise<boolean> {
   const write = extractWriteFromHookPayload(payload);
   if (!write) return true; // not a file write → allow
 
-  const { brokerScope } = await import("../broker/decide.js");
-  const scope = await brokerScope(process.cwd());
-  if (!scope) {
+  // Canonical exec-broker: signed profile scope → BrokerPolicy; the write must land under some
+  // allowed root, checked with the shared decisions.checkFsWrite. No verified scope → deny.
+  const { profileBrokerPolicy } = await import("../exec-broker/profile-policy.js");
+  const { checkFsWrite } = await import("../exec-broker/decisions.js");
+  const { policyFsRoots } = await import("../exec-broker/policy.js");
+  const { resolve } = await import("node:path");
+  const { policy } = await profileBrokerPolicy(process.cwd());
+  if (!policy) {
     const why = `write to ${write.filePath} denied — no verified scope/RoE (unsigned, tampered, or missing); a wired fs-gate grants nothing`;
     await auditGateDeny("gate-fs", why);
     return await gateDeny("fs-gate", `${why}\nSign the profile scope: \`kit profile sign\`.`);
   }
-  const { pathInScope } = await import("../broker/scope.js");
-  if (pathInScope(write.filePath, scope, process.cwd())) return true;
+  // Resolve the hook's path against the agent cwd first, then containment-check against each root.
+  const abs = resolve(process.cwd(), write.filePath);
+  if (policyFsRoots(policy).some((root) => checkFsWrite(abs, root).ok)) return true;
   const why = `write outside the signed fs scope: ${write.filePath}`;
   await auditGateDeny("gate-fs", why);
   return await gateDeny(


### PR DESCRIPTION
## Description

Reconciliation R3 (design: `kit-research/docs/research/pillar3-broker-reconciliation-5.0.md`) — the dedup win. The PreToolUse gates now use the **one canonical** exec-broker decision core instead of my parallel one.

## Type of Change

- [x] Refactoring

## Related Issues

- Reconciliation R3 (kit-research #32); builds on R1 (#308) + R2 (#309).

## Changes Made

- `src/commands/gate.ts` — `cmdGateEgress` / `cmdGateFs` now consult:
  - the **signed source** `profileBrokerPolicy` (R2 bridge) → `BrokerPolicy`,
  - `decisions.checkEgress` (the stronger host parser) per host,
  - `decisions.checkFsWrite` across `policyFsRoots` (resolving the hook path against cwd first),
  instead of `src/broker/decide.ts` (`brokerScope`) + `src/broker/scope.ts` (`hostInScope`/`pathInScope`).
- **Fail-closed semantics preserved exactly**: a wired gate with no *verified* scope (policy `null`) grants nothing.

## Testing

### Test Coverage
- [x] Behavior unchanged — all **9 subprocess gate tests** (real compiled CLI, hook payload on stdin) still pass
- [x] All tests pass (`npm test`) — full suite **2719 pass / 0 fail** (no net change; a rewire)

### Manual Testing
1. `npx tsc --noEmit` → clean; `npx eslint src` → 0 errors.
2. `npm run build && node scripts/test.mjs` → 2719 pass, 0 fail.

## Breaking Changes

None / N/A — internal rewire; identical externally-observable gate behavior.

## Checklist

- [x] All tests pass locally (`npm test`)
- [x] No new warnings or errors introduced
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

## Performance Impact

- [x] No performance impact

## Reviewer Notes

After this, `src/broker/decide.ts` + `src/broker/scope.ts` have only `src/broker/needs.ts` left as a consumer — R4 removes `needs.ts` (routing `withGovernance` scope via the existing `runGovernedBrokered`/`BrokerContext`) and deletes the duplicate core, leaving one broker: `src/exec-broker/*` (canonical decisions + signed `profile-policy` provider), with the gates + `kit doctor` + host-extractor as the net-new surfaces on top. The one behavioral nuance to check: the fs gate now resolves the hook's `filePath` against the agent cwd before the containment check (previously done inside `pathInScope`), so absolute and cwd-relative paths are handled identically — covered by the traversal-escape subprocess test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_