### PR TITLE
feat(exec-broker): wire signed profile scope into the MCP runtime behind [scope].enforce_runtime (adoption step 1)

### DIFF
--- a/src/exec-broker/broker.test.ts
+++ b/src/exec-broker/broker.test.ts
@@ -13,6 +13,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { brokerExec, runBrokered, type BrokerContext } from "./broker.js";
 import type { BrokerPolicy } from "./policy.js";
+import { loadOrCreateIdentity } from "../identity.js";
+import { PROFILE_FILE } from "../profile/schema.js";
+import { signProfile } from "../profile/sign.js";
 
 const POLICY: BrokerPolicy = {
   egress: { allow: ["api.example.com"] },
@@ -353,6 +356,96 @@ describe("runBrokered opt-in (policy file present/absent)", () => {
     });
     assert.equal(out.ok, false, "a broken policy fails closed, not open");
     assert.equal(ran, false);
+  });
+});
+
+describe("runBrokered signed-scope runtime enforcement (opt-in via enforce_runtime)", () => {
+  const SIGNED_ENFORCED = `version = 1
+[scope]
+egress = ["api.acme.com"]
+enforce_runtime = true
+`;
+
+  async function writeSignedProfile(body: string, sign: boolean): Promise<void> {
+    loadOrCreateIdentity();
+    writeFileSync(join(sandbox, PROFILE_FILE), body);
+    if (sign) await signProfile(sandbox);
+    delete process.env.KIT_EXEC_BROKER_POLICY; // isolate: the signed path must not depend on JSON
+  }
+
+  it("verified scope + declared IN-scope egress → mediates and runs", async () => {
+    await writeSignedProfile(SIGNED_ENFORCED, true);
+    let ran = false;
+    const out = await runBrokered(
+      CTX({ egressTargets: ["https://api.acme.com/v1"] }),
+      async () => {
+        ran = true;
+        return "ok";
+      },
+      { cwd: sandbox },
+    );
+    assert.equal(out.ok, true);
+    assert.equal(ran, true);
+  });
+
+  it("verified scope + declared OFF-scope egress → denied, never runs", async () => {
+    await writeSignedProfile(SIGNED_ENFORCED, true);
+    let ran = false;
+    const out = await runBrokered(
+      CTX({ egressTargets: ["https://evil.com"] }),
+      async () => {
+        ran = true;
+        return 1;
+      },
+      { cwd: sandbox },
+    );
+    assert.equal(out.ok, false);
+    assert.equal(ran, false);
+  });
+
+  it("verified scope + op declares NO effects → MIGRATION passthrough (runs, unchanged)", async () => {
+    await writeSignedProfile(SIGNED_ENFORCED, true);
+    let ran = false;
+    const out = await runBrokered(
+      CTX(),
+      async () => {
+        ran = true;
+        return "ok";
+      },
+      { cwd: sandbox },
+    );
+    assert.equal(out.ok, true, "an undeclared op is not yet mediated at the runtime (migration)");
+    assert.equal(ran, true);
+  });
+
+  it("enforce_runtime declared but UNSIGNED → declared op fail-closed denied (policy null)", async () => {
+    await writeSignedProfile(SIGNED_ENFORCED, false);
+    let ran = false;
+    const out = await runBrokered(
+      CTX({ egressTargets: ["https://api.acme.com/v1"] }),
+      async () => {
+        ran = true;
+        return 1;
+      },
+      { cwd: sandbox },
+    );
+    assert.equal(out.ok, false, "opted into runtime enforcement but scope unsigned → default-deny");
+    assert.equal(ran, false);
+  });
+
+  it("signed scope WITHOUT enforce_runtime → runtime unchanged (falls through to passthrough)", async () => {
+    await writeSignedProfile(`version = 1\n[scope]\negress = ["api.acme.com"]\n`, true);
+    let ran = false;
+    const out = await runBrokered(
+      CTX({ egressTargets: ["https://evil.com"] }), // off-scope, but no runtime opt-in → not gated
+      async () => {
+        ran = true;
+        return "ok";
+      },
+      { cwd: sandbox },
+    );
+    assert.equal(out.ok, true, "a signed scope alone does not gate the MCP runtime");
+    assert.equal(ran, true);
   });
 });
 

--- a/src/exec-broker/broker.ts
+++ b/src/exec-broker/broker.ts
@@ -184,22 +184,45 @@ function collectDenials(context: BrokerContext, policy: BrokerPolicy): string[] 
 }
 
 /**
- * OPT-IN entry point. The broker only mediates when a policy FILE is present:
- *   - No `.kit-exec-broker.json` (nor `KIT_EXEC_BROKER_POLICY`) → run UNMEDIATED,
- *     exactly like before the broker existed (this is the opt-in switch — a fresh
- *     install is never silently gated).
- *   - File present but malformed → `loadBrokerPolicy` returns null → `brokerExec`
- *     default-DENIES. A broken gate fails closed; it never silently disables
- *     enforcement (no false-green).
- *   - File present + valid → full `brokerExec` mediation.
- * This is the drop-in every call site adopts to become broker-aware without
- * changing behavior for users who haven't opted in.
+ * OPT-IN entry point. Policy-source precedence (reconciliation §4 / MCP-runtime adoption):
+ *
+ *   1. SIGNED profile scope with `[scope].enforce_runtime = true` (the explicit runtime opt-in):
+ *      - op DECLARES its effects → mediate against the signed policy (`policy` is null when the
+ *        scope is unsigned/tampered, so `brokerExec` default-DENIES — fail-closed);
+ *      - op declares NO effects → MIGRATION passthrough. A governed op is only mediated at the
+ *        runtime once it honestly declares what it touches; until each op opts in, its behavior is
+ *        unchanged (deliberate — see `pillar3-mcp-runtime-adoption-5.0.md` §5 step 1). This is NOT
+ *        the false-green of a JSON policy waving an undeclared op through: that path stays
+ *        fail-closed below.
+ *   2. Else the unsigned `.kit-exec-broker.json` (nor `KIT_EXEC_BROKER_POLICY`):
+ *      - absent → run UNMEDIATED (the original opt-in switch — a fresh install is never gated);
+ *      - present but malformed → `loadBrokerPolicy` returns null → `brokerExec` default-DENIES;
+ *      - present + valid → full `brokerExec` mediation.
+ *
+ * This is the drop-in every call site adopts to become broker-aware without changing behavior for
+ * users who haven't opted in to EITHER source.
  */
 export async function runBrokered<T>(
   context: BrokerContext,
   run: (scopedEnv: Record<string, string>) => Promise<T>,
-  opts: { policyOverride?: string } = {},
+  opts: { policyOverride?: string; cwd?: string } = {},
 ): Promise<BrokerOutcome<T>> {
+  // 1. Signed profile scope at the runtime — only when the scope explicitly opted in.
+  const { profileBrokerPolicy } = await import("./profile-policy.js");
+  const signed = await profileBrokerPolicy(opts.cwd ?? process.cwd());
+  if (signed.enforceRuntime) {
+    if (hasDeclaredEffects(context)) {
+      return brokerExec(context, signed.policy, run);
+    }
+    // Undeclared op under runtime enforcement → migration passthrough (unchanged behavior).
+    try {
+      return { ok: true, result: await run(scopeEnv(Object.keys(process.env), process.env)) };
+    } catch (err) {
+      return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  // 2. Unsigned JSON policy (original opt-in via file presence).
   if (!existsSync(brokerPolicyPath(opts.policyOverride))) {
     // Not configured → unmediated passthrough (full env, no scoping).
     try {

--- a/src/exec-broker/profile-policy.test.ts
+++ b/src/exec-broker/profile-policy.test.ts
@@ -80,4 +80,24 @@ describe("profileBrokerPolicy", () => {
     const r = await profileBrokerPolicy(proj);
     assert.equal(r.policy?.fs.root, resolve(proj, "."));
   });
+
+  it("enforceRuntime is false unless the scope opts in", async () => {
+    writeFileSync(join(proj, PROFILE_FILE), SCOPED);
+    await signProfile(proj);
+    assert.equal((await profileBrokerPolicy(proj)).enforceRuntime, false);
+  });
+
+  it("enforceRuntime reflects [scope].enforce_runtime — even before signing (opt-in is the declaration)", async () => {
+    const body = `version = 1\n[scope]\negress = ["api.acme.com"]\nenforce_runtime = true\n`;
+    writeFileSync(join(proj, PROFILE_FILE), body);
+    // Unsigned: opted in, but policy is null (fail-closed) — the runtime default-denies declared ops.
+    const unsigned = await profileBrokerPolicy(proj);
+    assert.equal(unsigned.enforceRuntime, true);
+    assert.equal(unsigned.policy, null);
+    // Signed: opted in AND a governing policy is present.
+    await signProfile(proj);
+    const signed = await profileBrokerPolicy(proj);
+    assert.equal(signed.enforceRuntime, true);
+    assert.deepEqual(signed.policy?.egress.allow, ["api.acme.com"]);
+  });
 });

--- a/src/exec-broker/profile-policy.ts
+++ b/src/exec-broker/profile-policy.ts
@@ -28,14 +28,25 @@ export interface ProfilePolicyResult {
   regime: "none" | "active";
   /** The governing policy — non-null ONLY when regime is "active" AND the signature verified. */
   policy: BrokerPolicy | null;
+  /**
+   * Did the scope opt IN to enforcement at the MCP runtime (`[scope].enforce_runtime = true`)?
+   * Read from the DECLARATION regardless of signature status: opted-in + unsigned ⇒ this is true
+   * AND `policy` is null, so the runtime default-denies declared ops (fail-closed). False when no
+   * scope is declared or the profile is unreadable.
+   */
+  enforceRuntime: boolean;
   detail: string;
 }
 
+interface ScopeShape {
+  egress?: string[];
+  fs?: string[];
+  secrets?: string[];
+  enforce_runtime?: boolean;
+}
+
 /** Map a verified profile `[scope]` onto a BrokerPolicy (fs paths resolved against `cwd`). */
-function scopeToPolicy(
-  scope: { egress?: string[]; fs?: string[]; secrets?: string[] },
-  cwd: string,
-): BrokerPolicy {
+function scopeToPolicy(scope: ScopeShape, cwd: string): BrokerPolicy {
   const roots = (scope.fs && scope.fs.length > 0 ? scope.fs : ["."]).map((p) => resolve(cwd, p));
   return {
     egress: { allow: scope.egress ? [...scope.egress] : [] },
@@ -49,33 +60,47 @@ function scopeToPolicy(
  * profile surfaces as regime "active" with a null policy (fail-closed), never as "none".
  */
 export async function profileBrokerPolicy(cwd = process.cwd()): Promise<ProfilePolicyResult> {
-  let scope: { egress?: string[]; fs?: string[]; secrets?: string[] } | undefined;
+  let scope: ScopeShape | undefined;
   try {
     const profile = await loadProfile(cwd);
-    if (!profile) return { regime: "none", policy: null, detail: "no profile declared" };
+    if (!profile) {
+      return { regime: "none", policy: null, enforceRuntime: false, detail: "no profile declared" };
+    }
     scope = profile.scope;
   } catch (err) {
     // A profile exists but is malformed — a declared-but-broken RoE. Treat as active+deny, never
-    // "none" (a broken artifact must not silently disable enforcement).
+    // "none" (a broken artifact must not silently disable enforcement). enforceRuntime is false: the
+    // opt-in flag is unreadable, and the broken profile is surfaced as a hard fail by `kit doctor`.
     return {
       regime: "active",
       policy: null,
+      enforceRuntime: false,
       detail: `profile unreadable — ${err instanceof Error ? err.message : String(err)} (default-deny)`,
     };
   }
-  if (!scope) return { regime: "none", policy: null, detail: "profile declares no [scope]/RoE" };
+  if (!scope) {
+    return {
+      regime: "none",
+      policy: null,
+      enforceRuntime: false,
+      detail: "profile declares no [scope]/RoE",
+    };
+  }
 
+  const enforceRuntime = scope.enforce_runtime === true;
   const v = await verifyProfileSignature(cwd);
   if (v.status === "valid") {
     return {
       regime: "active",
       policy: scopeToPolicy(scope, cwd),
+      enforceRuntime,
       detail: `scope verified (${v.detail})`,
     };
   }
   return {
     regime: "active",
     policy: null,
+    enforceRuntime,
     detail: `scope declared but ${v.status} — ${v.detail}; grants nothing (fail-closed)`,
   };
 }

--- a/src/profile/schema.ts
+++ b/src/profile/schema.ts
@@ -71,6 +71,13 @@ export interface ProfileScope {
   fs?: string[];
   /** Secret-scope: env-var names the operation is allowed to see. */
   secrets?: string[];
+  /**
+   * Explicit opt-in to exec-broker enforcement AT THE MCP RUNTIME (not just the PreToolUse gates /
+   * governance floor). When true and the scope is verified, governed MCP ops that declare their
+   * effects are mediated against this scope; when false/absent, the runtime is unchanged. Being
+   * inside `[scope]`, this flag is covered by the signature — it cannot be flipped without re-signing.
+   */
+  enforce_runtime?: boolean;
 }
 
 export interface KitProfile {
@@ -139,6 +146,7 @@ const kitProfileSchema = z
         egress: z.array(z.string()).optional(),
         fs: z.array(z.string()).optional(),
         secrets: z.array(z.string()).optional(),
+        enforce_runtime: z.boolean().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## MCP-runtime adoption — step 1 of 5

First increment of `pillar3-mcp-runtime-adoption-5.0.md` §5 (approved A/A/A). Closes the gap where the signed profile scope drove the PreToolUse gates and the governance floor but **not** the MCP runtime — `runBrokered` read only the unsigned `.kit-exec-broker.json`.

`runBrokered` now consults the signed source first, gated on an explicit opt-in: **`[scope].enforce_runtime = true`** (decision 3A). The flag lives inside the signed bytes, so it can't be flipped without re-signing.

### Precedence (non-breaking)
1. **Signed scope + `enforce_runtime`:**
   - op **declares** effects → mediate against the signed policy (`policy` is null when unsigned/tampered → `brokerExec` default-denies, **fail-closed**);
   - op declares **no** effects → **migration passthrough** — an op is mediated only once it honestly declares its effects; until then its behavior is unchanged. This is *not* the false-green of a JSON policy waving an undeclared op through (that path stays fail-closed).
2. Else the unsigned `.kit-exec-broker.json` — unchanged.
3. Else passthrough — unchanged.

So a user who hasn't set `enforce_runtime` (everyone today) sees zero behavior change.

### Changes
- `profile/schema.ts` — `enforce_runtime?: boolean` on `ProfileScope` + zod schema.
- `exec-broker/profile-policy.ts` — `enforceRuntime` on the result, read from the declaration regardless of signature (opted-in + unsigned ⇒ `enforceRuntime` true **and** `policy` null → fail-closed).
- `exec-broker/broker.ts` — the precedence above in `runBrokered` (+ `opts.cwd` for testability).

### Verification
- `tsc` clean · `eslint src` 0 errors · build clean
- Full suite **2705 pass / 0 fail** (7 new: 5 runBrokered signed-scope cases + 2 `enforceRuntime`)

### Next
Step 2 declares honest effects on `secrets.generate`; steps 3–4 handle `tools.install`/`fix` (infra-exemption) and `run` (per-command extraction); step 5 adds the `kit doctor` runtime-mediation row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_