### PR TITLE
feat(mcp): mediate secrets.generate against the signed scope + thread cwd (MCP-runtime adoption step 2)

### DIFF
--- a/src/governance-middleware.ts
+++ b/src/governance-middleware.ts
@@ -14,6 +14,7 @@ import {
   hasExpiredSecrets,
 } from "./secret-expiration.js";
 import { checkScopeNeeds, type ScopeNeeds } from "./exec-broker/scope-needs.js";
+import type { BrokerContext } from "./exec-broker/broker.js";
 
 export interface OperationContext {
   operation: string;
@@ -323,26 +324,33 @@ export async function runGoverned<T>(
  * BEFORE governance (identity / budget / permission) runs; the two are separate
  * concerns that stack.
  *
- * OPT-IN and non-breaking: `runBrokered` is a passthrough unless a broker policy
- * file (`.kit-exec-broker.json` / `KIT_EXEC_BROKER_POLICY`) is present, so a call
- * site swapping `runGoverned` → `runGovernedBrokered` behaves IDENTICALLY until a
- * user opts in by dropping a policy in. A present-but-malformed policy fails
- * closed (deny). Returns the same {@link GovernedOutcome} shape callers already
- * render.
+ * OPT-IN and non-breaking: `runBrokered` is a passthrough unless a policy source is opted into —
+ * a signed profile scope with `[scope].enforce_runtime = true`, or a `.kit-exec-broker.json` /
+ * `KIT_EXEC_BROKER_POLICY` file. A call site swapping `runGoverned` → `runGovernedBrokered`
+ * behaves IDENTICALLY until a user opts in. A present-but-malformed policy fails closed (deny).
+ * Returns the same {@link GovernedOutcome} shape callers already render.
+ *
+ * `opts.cwd` is the project directory whose signed profile governs — pass the tool's own `cwd`
+ * (not the process cwd) so the RIGHT project's `[scope]` is resolved. Defaults to `process.cwd()`.
  */
 export async function runGovernedBrokered<T>(
   config: kitConfig,
-  context: OperationContext,
+  context: BrokerContext,
   operation: () => Promise<T>,
+  opts: { cwd?: string } = {},
 ): Promise<GovernedOutcome<T>> {
   const { runBrokered } = await import("./exec-broker/index.js");
-  const outcome = await runBrokered(context, async () => {
-    const gov = await runGoverned(config, context, operation);
-    // Signal a governance denial (or op error) as a throw so the broker layer
-    // surfaces it as a not-ok outcome with the same reason.
-    if (!gov.ok) throw new Error(gov.reason ?? "denied");
-    return gov.result as T;
-  });
+  const outcome = await runBrokered(
+    context,
+    async () => {
+      const gov = await runGoverned(config, context, operation);
+      // Signal a governance denial (or op error) as a throw so the broker layer
+      // surfaces it as a not-ok outcome with the same reason.
+      if (!gov.ok) throw new Error(gov.reason ?? "denied");
+      return gov.result as T;
+    },
+    { cwd: opts.cwd },
+  );
   return outcome.ok ? { ok: true, result: outcome.result } : { ok: false, reason: outcome.reason };
 }
 

--- a/src/mcp-server.test.ts
+++ b/src/mcp-server.test.ts
@@ -7,6 +7,9 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createMcpServer, KIT_MCP_TOOLS } from "./mcp-server.js";
 import { mcpExposedToolNames } from "./cli.js";
+import { loadOrCreateIdentity } from "./identity.js";
+import { signProfile } from "./profile/sign.js";
+import { PROFILE_FILE } from "./profile/schema.js";
 
 // Standard .gitignore so security check passes in temp dirs
 const GITIGNORE = ".env\n.env.local\n.env.*.local\n";
@@ -348,6 +351,94 @@ describe("kit_secrets", () => {
       const result = await client.callTool({ name: "kit_secrets", arguments: { cwd: tempDir } });
       const data = parseResult(result) as { ok: boolean; writtenKeys: string[] };
       assert.equal(data.ok, true);
+      assert.ok(data.writtenKeys.includes("APP_KEY"));
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
+// ─── kit_secrets under [scope].enforce_runtime (exec-broker at the MCP runtime) ──────────
+describe("kit_secrets + signed-scope runtime enforcement (MCP-runtime adoption step 2)", () => {
+  let tempDir: string;
+  let idDir: string;
+  let savedId: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "kit-mcp-secfs-"));
+    idDir = await mkdtemp(join(tmpdir(), "kit-mcp-id-"));
+    savedId = process.env.KIT_IDENTITY_DIR;
+    process.env.KIT_IDENTITY_DIR = idDir;
+    loadOrCreateIdentity();
+    await writeFile(join(tempDir, ".kit.toml"), FIXTURE_CONFIG_SECRET, "utf-8");
+  });
+
+  afterEach(async () => {
+    if (savedId === undefined) delete process.env.KIT_IDENTITY_DIR;
+    else process.env.KIT_IDENTITY_DIR = savedId;
+    await rm(tempDir, { recursive: true, force: true });
+    await rm(idDir, { recursive: true, force: true });
+  });
+
+  it("ALLOWS the .env.local write when it is inside the signed [scope].fs (default root)", async () => {
+    await writeFile(join(tempDir, PROFILE_FILE), `version = 1\n[scope]\nenforce_runtime = true\n`);
+    await signProfile(tempDir);
+    const { client, cleanup } = await createTestClient();
+    try {
+      const result = await client.callTool({ name: "kit_secrets", arguments: { cwd: tempDir } });
+      const data = parseResult(result) as { ok: boolean; writtenKeys: string[] };
+      assert.equal(data.ok, true);
+      assert.ok(data.writtenKeys.includes("APP_KEY"));
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("DENIES the .env.local write when it is outside the signed [scope].fs", async () => {
+    // fs scope is "src" only ⇒ the root .env.local write is off-scope ⇒ broker default-denies.
+    await writeFile(
+      join(tempDir, PROFILE_FILE),
+      `version = 1\n[scope]\nfs = ["src"]\nenforce_runtime = true\n`,
+    );
+    await signProfile(tempDir);
+    const { client, cleanup } = await createTestClient();
+    try {
+      const result = await client.callTool({ name: "kit_secrets", arguments: { cwd: tempDir } });
+      assert.equal(result.isError, true, "off-scope .env.local write must be denied");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("fail-closed deny when enforce_runtime is declared but the scope is UNSIGNED", async () => {
+    await writeFile(join(tempDir, PROFILE_FILE), `version = 1\n[scope]\nenforce_runtime = true\n`);
+    // Deliberately NOT signed — opted into runtime enforcement but the scope is untrustworthy.
+    const { client, cleanup } = await createTestClient();
+    try {
+      const result = await client.callTool({ name: "kit_secrets", arguments: { cwd: tempDir } });
+      assert.equal(
+        result.isError,
+        true,
+        "opted into runtime enforcement + unsigned ⇒ default-deny",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("without enforce_runtime the runtime is unchanged (write proceeds)", async () => {
+    // A signed scope that does NOT opt in ⇒ migration passthrough ⇒ secrets still written.
+    await writeFile(join(tempDir, PROFILE_FILE), `version = 1\n[scope]\nfs = ["src"]\n`);
+    await signProfile(tempDir);
+    const { client, cleanup } = await createTestClient();
+    try {
+      const result = await client.callTool({ name: "kit_secrets", arguments: { cwd: tempDir } });
+      const data = parseResult(result) as { ok: boolean; writtenKeys: string[] };
+      assert.equal(
+        data.ok,
+        true,
+        "no enforce_runtime ⇒ not gated even though .env.local is off the fs scope",
+      );
       assert.ok(data.writtenKeys.includes("APP_KEY"));
     } finally {
       await cleanup();

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -296,6 +296,7 @@ function register_kit_install(server: McpServer): void {
             metadata: { tools: Object.keys(config.tools) },
           },
           () => installTools(config.tools!),
+          { cwd: cwd ?? process.cwd() },
         );
         if (!gov.ok) return governanceRefusal(gov.reason ?? "denied");
         const results = gov.result!;
@@ -382,10 +383,22 @@ function register_kit_secrets(server: McpServer): void {
           };
         }
 
+        const envLocalPath = join(cwd ?? process.cwd(), ".env.local");
         const gov = await runGovernedBrokered(
           config,
-          { operation: "secrets.generate", operationType: "write", metadata: {} },
-          () => generateSecrets(config.secrets!, join(cwd ?? process.cwd(), ".env.local")),
+          {
+            operation: "secrets.generate",
+            operationType: "write",
+            metadata: {},
+            // Honest effect declaration (MCP-runtime adoption step 2): kit's OWN direct effect is
+            // the .env.local write. The configured vault CLI resolves secrets in ITS OWN
+            // subprocess, whose network I/O is the CLI's — not kit's — and thus out of the
+            // exec-broker's reach (a documented limit, like kit_run's command). So fs is the
+            // declarable effect here; egress/env are not kit's to claim.
+            fsWrites: [envLocalPath],
+          },
+          () => generateSecrets(config.secrets!, envLocalPath),
+          { cwd: cwd ?? process.cwd() },
         );
         if (!gov.ok) return governanceRefusal(gov.reason ?? "denied");
         const { results, written } = gov.result!;
@@ -488,6 +501,7 @@ function register_kit_fix(server: McpServer): void {
 
             return actions;
           },
+          { cwd: cwd ?? process.cwd() },
         );
         if (!gov.ok) return governanceRefusal(gov.reason ?? "denied");
         const actions = gov.result!;
@@ -860,6 +874,7 @@ function register_kit_run(server: McpServer): void {
               cwd: workDir,
               inheritEnv: true,
             }),
+          { cwd: workDir },
         );
         if (!gov.ok) return governanceRefusal(gov.reason ?? "denied");
         const result = gov.result!;


### PR DESCRIPTION
## MCP-runtime adoption — step 2 of 5

Second increment of `pillar3-mcp-runtime-adoption-5.0.md` §5. Builds on #312 (the `[scope].enforce_runtime` opt-in).

### What changed
- **`secrets.generate` declares its honest own effect** — the `.env.local` write. So under `enforce_runtime` it's now *mediated* against the signed `[scope].fs` instead of migration-passthrough. The configured **vault CLI resolves secrets in its own subprocess**, whose network I/O is the CLI's — not kit's — and out of the exec-broker's reach (documented, like `kit_run`'s command). So `fs` is the declarable effect; egress/env are **not** falsely claimed.
- **`cwd` threaded** through `runGovernedBrokered` → `runBrokered` so the *right* project's `[scope]` governs (previously the signed source resolved against the MCP server's process cwd). All four governed ops now pass their tool `cwd`; `runGovernedBrokered`'s `context` widened to `BrokerContext` so call sites can declare effects.

### Non-breaking
Without `enforce_runtime`, everything is migration-passthrough (unchanged). The `fsWrites` declaration is inert until a signed scope opts in.

### Verification
- `tsc` clean · `eslint src` 0 errors · build clean
- Full suite **2709 pass / 0 fail** — 4 new end-to-end tests via the in-memory MCP client:
  - in-scope `.env.local` write **allowed**;
  - off-scope (`[scope].fs = ["src"]`) write **denied**;
  - `enforce_runtime` + **unsigned** → fail-closed **denied**;
  - **no** `enforce_runtime` → unchanged (write proceeds).

### Next
Step 3–4: `tools.install`/`fix` (infra-exemption) and `run` (per-command extraction reusing the gate's `extractHostsFromCommand`); step 5: the `kit doctor` runtime-mediation row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_