### PR TITLE
feat(mcp): infrastructure exemption for tools.install/fix at the MCP runtime (adoption step 3)

### DIFF
--- a/src/exec-broker/broker.test.ts
+++ b/src/exec-broker/broker.test.ts
@@ -447,6 +447,65 @@ enforce_runtime = true
     assert.equal(out.ok, true, "a signed scope alone does not gate the MCP runtime");
     assert.equal(ran, true);
   });
+
+  it("infrastructure op under a restrictive enforce_runtime scope → allowed + audited exemption", async () => {
+    // fs scope is "src" only, yet an infra op (tool provisioning) is exempt — allowed, and it goes
+    // through brokerExec (NOT a silent migration passthrough), leaving an explicit exemption entry.
+    await writeSignedProfile(`version = 1\n[scope]\nfs = ["src"]\nenforce_runtime = true\n`, true);
+    let ran = false;
+    const out = await runBrokered(
+      CTX({ infrastructure: true }),
+      async () => {
+        ran = true;
+        return "ok";
+      },
+      { cwd: sandbox },
+    );
+    assert.equal(out.ok, true);
+    assert.equal(ran, true);
+    assert.ok(
+      auditLines().some(
+        (l) => (l.metadata as { exemption?: string })?.exemption === "infrastructure",
+      ),
+      "the exemption must be audited explicitly, not silently passed",
+    );
+  });
+});
+
+describe("brokerExec infrastructure exemption", () => {
+  it("runs an infrastructure op even when policy is null (RoE does not govern it)", async () => {
+    let ran = false;
+    const out = await brokerExec(CTX({ infrastructure: true }), null, async () => {
+      ran = true;
+      return 1;
+    });
+    assert.equal(out.ok, true, "a null policy default-denies every NON-infra op; infra is exempt");
+    assert.equal(ran, true);
+  });
+
+  it("bypasses the resource gates a non-infra op would be denied by, and audits the exemption", async () => {
+    const denyAll: BrokerPolicy = {
+      egress: { allow: [] },
+      fs: { root: sandbox },
+      env: { declared: [] },
+    };
+    let ran = false;
+    const out = await brokerExec(
+      CTX({ infrastructure: true, egressTargets: ["https://evil.com"] }),
+      denyAll,
+      async () => {
+        ran = true;
+        return "ok";
+      },
+    );
+    assert.equal(out.ok, true, "off-scope egress is bypassed for an infrastructure op");
+    assert.equal(ran, true);
+    assert.ok(
+      auditLines().some(
+        (l) => (l.metadata as { exemption?: string })?.exemption === "infrastructure",
+      ),
+    );
+  });
 });
 
 describe("brokerExec is offline", () => {

--- a/src/exec-broker/broker.ts
+++ b/src/exec-broker/broker.ts
@@ -49,12 +49,25 @@ export interface BrokerContext extends OperationContext {
    * it is the "gates are dead code" false-green the audit flagged.
    */
   declaredEffects?: boolean;
+  /**
+   * Infrastructure exemption (MCP-runtime adoption step 3): this op is kit's OWN
+   * tool-provisioning (e.g. `kit install`/`kit fix` shelling out to mise), NOT an
+   * agent project action the `[scope]` RoE is meant to govern — it writes to the
+   * toolchain's data dir under `$HOME` and fetches from tool hosts BY DESIGN, so it
+   * cannot fit a project-scoped `[scope].fs`/egress. Marked ops are ALLOWED but
+   * AUDITED as an explicit exemption (`exemption: "infrastructure"`) — this is the
+   * honest alternative to `declaredEffects:true`, which would falsely claim the op
+   * has no egress/fs effects. Set ONLY by kit's own fixed handlers, never from
+   * agent-controllable input.
+   */
+  infrastructure?: boolean;
 }
 
-/** Did the caller declare this op's effect contract (arrays present, or the flag)? */
+/** Did the caller declare this op's effect contract (arrays present, or a flag)? */
 function hasDeclaredEffects(c: BrokerContext): boolean {
   return (
     c.declaredEffects === true ||
+    c.infrastructure === true ||
     c.egressTargets !== undefined ||
     c.fsWrites !== undefined ||
     c.envRequested !== undefined
@@ -81,6 +94,36 @@ export async function brokerExec<T>(
   policy: BrokerPolicy | null | undefined,
   run: (scopedEnv: Record<string, string>) => Promise<T>,
 ): Promise<BrokerOutcome<T>> {
+  // Infrastructure exemption: kit's OWN tool-provisioning is not governed by the project [scope]
+  // RoE (it writes to $HOME and fetches from tool hosts by design — see BrokerContext.infrastructure).
+  // Allow it, but AUDIT the exemption explicitly (never a silent pass, never a false "no effects"
+  // claim). Runs with full env — provisioning needs its environment. Independent of policy state:
+  // the RoE does not govern this op, so its signature/validity is irrelevant here. Fail-closed
+  // auditability still applies (refuse if the pre-exec authorization entry can't be written).
+  if (context.infrastructure) {
+    const authorized = await appendAuditEventDirect({
+      operation: context.operation,
+      environment: BROKER_ENV,
+      success: true,
+      metadata: { ...context.metadata, phase: "authorized", exemption: "infrastructure" },
+    });
+    if (!authorized) {
+      return {
+        ok: false,
+        reason: "exec-broker: audit-log unavailable; refusing to execute (fail-closed)",
+      };
+    }
+    try {
+      const result = await run(scopeEnv(Object.keys(process.env), process.env));
+      await audit(context, true, undefined, { exemption: "infrastructure" });
+      return { ok: true, result };
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await audit(context, false, reason, { exemption: "infrastructure" });
+      return { ok: false, reason };
+    }
+  }
+
   // Default-deny when policy is absent. run() is NEVER invoked.
   if (!policy) {
     const reason = "exec-broker: no policy (default-deny)";

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -294,6 +294,9 @@ function register_kit_install(server: McpServer): void {
             operation: "tools.install",
             operationType: "write",
             metadata: { tools: Object.keys(config.tools) },
+            // Infrastructure: mise installs to $HOME + fetches from tool hosts by design — not an
+            // agent project action the [scope] RoE governs. Allowed but audited as an exemption.
+            infrastructure: true,
           },
           () => installTools(config.tools!),
           { cwd: cwd ?? process.cwd() },
@@ -443,7 +446,14 @@ function register_kit_fix(server: McpServer): void {
 
         const gov = await runGovernedBrokered(
           config,
-          { operation: "fix", operationType: "write", metadata: {} },
+          {
+            operation: "fix",
+            operationType: "write",
+            metadata: {},
+            // Infrastructure: fix installs tools (mise → $HOME) and writes lock files as kit's own
+            // provisioning — not an agent project action the [scope] RoE governs. Audited exemption.
+            infrastructure: true,
+          },
           async () => {
             const actions: Array<{ name: string; action: string; detail: string }> = [];
 


### PR DESCRIPTION
## MCP-runtime adoption — step 3 of 5

Third increment of `pillar3-mcp-runtime-adoption-5.0.md` §5, decision **3b.1** (infra-exemption).

### The problem
`tools.install` / `fix` write tool binaries to the toolchain data dir under `$HOME` and fetch from tool hosts **by design** — they cannot fit a project-scoped `[scope].fs`/egress. Marking them `declaredEffects:true` would **falsely claim they have no egress/fs effects** (a false green).

### The honest fix
New `BrokerContext.infrastructure` — an **explicit, audited exemption**: `brokerExec` allows an infrastructure op (independent of policy state — the RoE does not govern kit's own provisioning) but records it as `exemption: "infrastructure"` in the audit trail. Fail-closed auditability still applies (refuse if the pre-exec entry can't be written). Set **only by kit's own fixed handlers**, never from agent-controllable input.

`tools.install` and `fix` MCP contexts now carry `infrastructure: true`.

**Before:** undeclared → *silent* migration passthrough. **After:** explicit, audited exemption via `brokerExec`. Same allow/deny outcome; the gain is honesty + an audit record.

### Verification
- `tsc` clean · `eslint src` 0 errors · build clean
- Full suite **2712 pass / 0 fail** — 3 new: infra op runs under a null policy and under a deny-all policy that would deny a non-infra op (with the exemption audited), and under a restrictive `enforce_runtime` scope via `runBrokered`.

### Next
Step 4: `kit_run` per-command extraction (reuse the gate's `extractHostsFromCommand` + write-gate heuristic); step 5: `kit doctor` runtime-mediation row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_