### PR TITLE
feat(mcp): kit_run per-command egress mediation at the MCP runtime (adoption step 4)

### DIFF
--- a/src/mcp-server.test.ts
+++ b/src/mcp-server.test.ts
@@ -446,6 +446,65 @@ describe("kit_secrets + signed-scope runtime enforcement (MCP-runtime adoption s
   });
 });
 
+// ─── kit_run per-command egress mediation (MCP-runtime adoption step 4) ──────────────────
+describe("kit_run + signed-scope egress mediation", () => {
+  let tempDir: string;
+  let idDir: string;
+  let savedId: string | undefined;
+
+  const SCOPED = `version = 1\n[scope]\negress = ["api.acme.com"]\nenforce_runtime = true\n`;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "kit-mcp-run-"));
+    idDir = await mkdtemp(join(tmpdir(), "kit-mcp-id-"));
+    savedId = process.env.KIT_IDENTITY_DIR;
+    process.env.KIT_IDENTITY_DIR = idDir;
+    loadOrCreateIdentity();
+    await writeFile(join(tempDir, ".kit.toml"), FIXTURE_EMPTY, "utf-8");
+    await writeFile(join(tempDir, PROFILE_FILE), SCOPED);
+    await signProfile(tempDir);
+  });
+
+  afterEach(async () => {
+    if (savedId === undefined) delete process.env.KIT_IDENTITY_DIR;
+    else process.env.KIT_IDENTITY_DIR = savedId;
+    await rm(tempDir, { recursive: true, force: true });
+    await rm(idDir, { recursive: true, force: true });
+  });
+
+  it("DENIES a command whose explicit URL is outside the signed [scope].egress", async () => {
+    const { client, cleanup } = await createTestClient();
+    try {
+      const result = await client.callTool({
+        name: "kit_run",
+        arguments: { command: "curl https://evil.com/x", cwd: tempDir },
+      });
+      assert.equal(
+        result.isError,
+        true,
+        "off-scope egress in the command must be denied pre-spawn",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("ALLOWS a command with no explicit URL (documented conservative limit)", async () => {
+    const { client, cleanup } = await createTestClient();
+    try {
+      const result = await client.callTool({
+        name: "kit_run",
+        arguments: { command: "echo hello", cwd: tempDir },
+      });
+      assert.notEqual(result.isError, true);
+      const text = (result.content as Array<{ text: string }>)[0].text;
+      assert.match(text, /hello/);
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
 // ─── kit_install ───────────────────────────────────────────────────────────
 
 describe("kit_install", () => {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -870,6 +870,17 @@ function register_kit_run(server: McpServer): void {
         const { shellSplit } = await import("./utils/shellSplit.js");
         const commandArgs = shellSplit(command);
 
+        // Per-command egress extraction (MCP-runtime adoption step 4): kit_run executes an
+        // ARBITRARY command, so its effects can't be fully declared — but the explicit http(s)
+        // URLs in the command text CAN be, using the same conservative extractor the PreToolUse
+        // egress-gate uses. Under [scope].enforce_runtime those hosts are gated against
+        // [scope].egress before the command spawns. Honest limits (documented, not false-greened):
+        // a command that reaches the network without an explicit URL is out of the extractor's
+        // reach, and fs/env are NOT declarable from an arbitrary command (the command inherits env
+        // by design) — those remain un-mediated here; the PreToolUse fs-gate covers Write/Edit.
+        const { extractHostsFromCommand } = await import("./broker/extract.js");
+        const egressTargets = extractHostsFromCommand(command);
+
         // kit_run inherits the secret-loaded env and executes an arbitrary command,
         // so it must pass the same governance floor as a CLI write (revocation,
         // budget, permission, expired-secret block) and be audited — not just gated
@@ -877,7 +888,12 @@ function register_kit_run(server: McpServer): void {
         const config = await loadConfigForGovernance(cwd);
         const gov = await runGovernedBrokered(
           config,
-          { operation: "run", operationType: "write", metadata: { command } },
+          {
+            operation: "run",
+            operationType: "write",
+            metadata: { command, mediation: "egress-only (arbitrary command; fs/env un-mediated)" },
+            egressTargets,
+          },
           () =>
             executeCommand({
               commandArgs,


### PR DESCRIPTION
## MCP-runtime adoption — step 4 of 5

Fourth increment of `pillar3-mcp-runtime-adoption-5.0.md` §5, decision **3c.1** (per-command extraction).

### The problem
`kit_run` executes an **arbitrary command** — its effects can't be fully declared. Claiming `declaredEffects:true` (zero effects) would be a false green.

### The honest fix
The explicit http(s) URLs in the command text **can** be extracted — using the same conservative extractor the PreToolUse egress-gate uses (`broker/extract.ts`). `kit_run` now declares `egressTargets = extractHostsFromCommand(command)`; under `[scope].enforce_runtime` those hosts are gated against `[scope].egress` **before the command spawns** (off-scope URL → denied pre-spawn — the PreToolUse egress-gate's protection, now also at the MCP runtime).

**Documented limits (not false-greened):**
- a command that reaches the network without an explicit URL is out of the extractor's reach;
- fs/env are **not** declarable from an arbitrary command (`kit_run` inherits env by design) → un-mediated here. The metadata records `mediation: "egress-only"`; the PreToolUse fs-gate covers Write/Edit separately.

### Verification
- `tsc` clean · `eslint src` 0 errors · build clean
- Full suite **2714 pass / 0 fail** — 2 new: off-scope URL in the command **denied pre-spawn**; no-URL command **allowed** (conservative limit).

### Next
Step 5 (final): the `kit doctor` runtime-mediation row — surface whether the runtime actually mediates (scope active + ops declared) vs "delivered but not opted in".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_