### PR TITLE
feat(doctor): exec-broker runtime-mediation posture row (MCP-runtime adoption step 5)

### DIFF
--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -145,6 +145,43 @@ describe("runDoctor", () => {
     }
   });
 
+  it("exec-broker runtime: skips when enforce_runtime is not opted in", async () => {
+    const tmpDir = join(tmpdir(), `kit-doctor-test-${process.pid}-rt-skip`);
+    await mkdir(tmpDir, { recursive: true });
+    try {
+      const result = await runDoctor({}, tmpDir);
+      const rt = result.checks.find((c) => c.name === "exec-broker runtime");
+      assert.ok(rt, "exec-broker runtime check should always be present");
+      assert.equal(rt.status, "skip");
+      assert.ok(rt.detail.includes("enforce_runtime"), `unexpected detail: ${rt.detail}`);
+    } finally {
+      await rm(tmpDir, { recursive: true });
+    }
+  });
+
+  it("exec-broker runtime: fails when opted in but the scope is unsigned (fail-closed)", async () => {
+    const tmpDir = join(tmpdir(), `kit-doctor-test-${process.pid}-rt-fail`);
+    await mkdir(tmpDir, { recursive: true });
+    // enforce_runtime declared but the profile is NOT signed → runtime denies governed ops.
+    await writeFile(
+      join(tmpDir, ".kit-profile.toml"),
+      `version = 1\n[scope]\negress = ["api.acme.com"]\nenforce_runtime = true\n`,
+      "utf-8",
+    );
+    try {
+      const result = await runDoctor({}, tmpDir);
+      const rt = result.checks.find((c) => c.name === "exec-broker runtime");
+      assert.ok(rt, "exec-broker runtime check should be present");
+      assert.equal(rt.status, "fail");
+      assert.ok(
+        rt.detail.includes("fail-closed-denied") || rt.detail.includes("unsigned"),
+        `detail should explain the fail-closed posture: ${rt.detail}`,
+      );
+    } finally {
+      await rm(tmpDir, { recursive: true });
+    }
+  });
+
   it("surfaces the identity keystore posture (Pelare 1 — never silent)", async () => {
     const tmpDir = join(tmpdir(), `kit-doctor-test-${process.pid}-9`);
     await mkdir(tmpDir, { recursive: true });

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -294,6 +294,44 @@ async function scopeDegradationStatus(cwd: string): Promise<"warn" | "fail"> {
   }
 }
 
+/**
+ * Exec-broker MCP-RUNTIME mediation posture (Pillar 3 adoption). The scope row above says whether a
+ * signed scope EXISTS; this says whether the RUNTIME actually mediates governed MCP ops against it —
+ * "delivered but not opted in" must never read as "enforcing":
+ *   skip  enforce_runtime not set — the runtime is NOT mediating (opt in with `[scope].enforce_runtime = true`)
+ *   pass  enforce_runtime set + scope verified — governed MCP ops are mediated against the signed scope
+ *   fail  enforce_runtime set + scope unsigned/tampered — opted in but untrustworthy: governed ops fail-closed-denied
+ */
+async function checkBrokerRuntime(cwd: string): Promise<DoctorCheck> {
+  const name = "exec-broker runtime";
+  const category = "security";
+  const { enforceRuntime, policy } = await profileBrokerPolicy(cwd);
+  if (!enforceRuntime) {
+    return {
+      name,
+      status: "skip",
+      detail:
+        "MCP-runtime mediation not opted in — set [scope].enforce_runtime = true and re-sign to mediate governed MCP ops against the scope",
+      category,
+    };
+  }
+  if (policy) {
+    return {
+      name,
+      status: "pass",
+      detail: "runtime mediation active — governed MCP ops are mediated against the signed scope",
+      category,
+    };
+  }
+  return {
+    name,
+    status: "fail",
+    detail:
+      "runtime mediation opted in but the scope is unsigned/invalid — governed MCP ops are fail-closed-denied; run 'kit profile sign'",
+    category,
+  };
+}
+
 export async function runDoctor(config: kitConfig, cwd: string): Promise<DoctorResult> {
   const allChecks: DoctorCheck[] = [];
 
@@ -321,6 +359,7 @@ export async function runDoctor(config: kitConfig, cwd: string): Promise<DoctorR
   allChecks.push(checkIdentityKeystore());
 
   allChecks.push(await checkBrokerScope(cwd));
+  allChecks.push(await checkBrokerRuntime(cwd));
 
   const passed = allChecks.filter((c) => c.status === "pass").length;
   const warnings = allChecks.filter((c) => c.status === "warn").length;


### PR DESCRIPTION
## MCP-runtime adoption — step 5 of 5 (final)

Last increment of `pillar3-mcp-runtime-adoption-5.0.md` §5. Closes out the A/A/A plan.

### What changed
Adds an **`exec-broker runtime`** `kit doctor` row that honestly surfaces whether the MCP runtime *actually* mediates governed ops — "delivered but not opted in" must never read as "enforcing". It complements the existing `exec-broker scope` row (which says whether a signed scope *exists*):

- **skip** — `enforce_runtime` not set → the runtime is **not** mediating (opt in with `[scope].enforce_runtime = true` and re-sign);
- **pass** — `enforce_runtime` set + scope verified → governed MCP ops are mediated;
- **fail** — `enforce_runtime` set + scope unsigned/tampered → opted in but untrustworthy; governed ops are **fail-closed-denied**.

Sourced from the same canonical `profileBrokerPolicy` provider as the gates, the governance floor, and the scope row — one broker.

### Verification
- `tsc` clean · `eslint src` 0 errors · build clean
- Full suite **2716 pass / 0 fail** — 2 new doctor tests: skips when not opted in; fails (fail-closed) when opted in but unsigned.

### This completes the MCP-runtime adoption
With #312–#316, the signed exec-broker is now consumed at the MCP runtime behind the `enforce_runtime` opt-in: `secrets.generate` mediated (fs), `tools.install`/`fix` infra-exempted (audited), `kit_run` egress-mediated per-command, and `kit doctor` reports the true posture. Non-breaking throughout — a project without `enforce_runtime` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_