### PR TITLE
feat(policy): kit policy pull — offline-verified control-plane distribution (Pillar 2 MVP)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -610,7 +610,7 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
   policy: {
     handler: cmdPolicy,
     stability: "experimental",
-    help: "Signable org policy-as-code in .kit-policy.toml (init/show/validate/sign/verify/check/trust) — identity-signed standard, org-distributable + enforced offline (experimental)",
+    help: "Signable org policy-as-code in .kit-policy.toml (init/show/validate/sign/verify/check/trust/pull) — identity-signed standard, org-distributable + enforced offline (experimental)",
   },
   clone: {
     handler: cmdClone,

--- a/src/commands/policy.ts
+++ b/src/commands/policy.ts
@@ -27,6 +27,7 @@ import {
   type PolicySignature,
 } from "../policy-doc.js";
 import { evaluatePolicy, formatPolicyEval } from "../policy-check.js";
+import { pullPolicy } from "../policy-pull.js";
 import { identityId } from "../identity.js";
 import {
   resolveKeyStore,
@@ -53,12 +54,48 @@ export async function cmdPolicy(): Promise<boolean> {
       return policyCheck(root);
     case "trust":
       return policyTrust(root);
+    case "pull":
+      return policyPull(root);
     default:
       console.error(
-        `${c.red}usage: kit policy <init|show|validate|sign|verify|check|trust>${c.reset}`,
+        `${c.red}usage: kit policy <init|show|validate|sign|verify|check|trust|pull>${c.reset}`,
       );
       return false;
   }
+}
+
+/**
+ * `kit policy pull <source>` — fetch an org-signed policy from a self-hostable source (a local
+ * path or `file://` dir holding `.kit-policy.toml` + `.kit-policy.sig`) and apply it ONLY if it
+ * verifies offline against this project's LOCAL `.kit-policy.signers` anchor. Fail-closed: anything
+ * short of a valid signature keeps the existing policy. The trust anchor is never fetched.
+ */
+function policyPull(root: string): boolean {
+  const source = process.argv[4];
+  if (!source) {
+    console.error(
+      `${c.red}usage: kit policy pull <source>${c.reset} ${c.dim}(a local path or file:// dir with .kit-policy.toml + .kit-policy.sig)${c.reset}`,
+    );
+    return false;
+  }
+  const r = pullPolicy(source, root);
+  if (r.ok) {
+    console.log(
+      `${c.green}✓${c.reset} ${r.detail}  ${c.dim}${r.fingerprint ?? ""} → ${getPolicyPath(root)}${c.reset}`,
+    );
+    console.log(
+      `${c.dim}verify anytime with ${c.reset}${c.bold}kit policy verify${c.reset}${c.dim}; commit the applied .kit-policy.toml + .kit-policy.sig${c.reset}`,
+    );
+    return true;
+  }
+  const hint =
+    r.status === "no-anchor"
+      ? " — add trusted org keys with `kit policy trust add` (committed out of band)"
+      : r.status === "no-source"
+        ? ""
+        : " — the source policy is unsigned, tampered, or signed by an untrusted/revoked key";
+  console.error(`${c.red}✗ policy pull failed${c.reset} ${c.dim}(${r.detail})${c.reset}${hint}`);
+  return false;
 }
 
 function policyInit(root: string): boolean {

--- a/src/policy-pull.test.ts
+++ b/src/policy-pull.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadOrCreateIdentity, identityId } from "./identity.js";
+import { resolveKeyStore } from "./keystore/index.js";
+import {
+  POLICY_TEMPLATE,
+  loadPolicy,
+  canonicalPolicyBytes,
+  policyFingerprint,
+  getPolicyPath,
+  getPolicySigPath,
+  verifyPolicy,
+  type PolicySignature,
+} from "./policy-doc.js";
+import { addPolicySigner, getSignersPath } from "./policy-trust.js";
+import { pullPolicy } from "./policy-pull.js";
+
+let idDir: string;
+let source: string;
+let dest: string;
+let savedId: string | undefined;
+
+/** Sign the policy already written in `dir` with the active identity; returns the signer's PEM. */
+function signPolicyInDir(dir: string): string {
+  const doc = loadPolicy(dir)!;
+  const pub = resolveKeyStore().store.publicKeyPem()!;
+  const record: PolicySignature = {
+    kid: identityId(pub),
+    sig: resolveKeyStore().store.sign(canonicalPolicyBytes(doc)).toString("base64"),
+    ts: new Date().toISOString(),
+    fingerprint: policyFingerprint(doc),
+  };
+  writeFileSync(getPolicySigPath(dir), JSON.stringify(record, null, 2) + "\n", "utf-8");
+  return pub;
+}
+
+beforeEach(() => {
+  idDir = mkdtempSync(join(tmpdir(), "kit-id-"));
+  source = mkdtempSync(join(tmpdir(), "kit-pull-src-"));
+  dest = mkdtempSync(join(tmpdir(), "kit-pull-dest-"));
+  savedId = process.env.KIT_IDENTITY_DIR;
+  process.env.KIT_IDENTITY_DIR = idDir;
+  loadOrCreateIdentity();
+});
+
+afterEach(() => {
+  if (savedId === undefined) delete process.env.KIT_IDENTITY_DIR;
+  else process.env.KIT_IDENTITY_DIR = savedId;
+  for (const d of [idDir, source, dest]) rmSync(d, { recursive: true, force: true });
+});
+
+describe("pullPolicy", () => {
+  it("applies a source policy that verifies against the LOCAL anchor", () => {
+    writeFileSync(getPolicyPath(source), POLICY_TEMPLATE, "utf-8");
+    const pub = signPolicyInDir(source);
+    addPolicySigner(dest, pub, "org"); // local anchor trusts the signer
+
+    const r = pullPolicy(source, dest);
+    assert.equal(r.ok, true, r.detail);
+    assert.equal(r.status, "applied");
+    assert.ok(existsSync(getPolicyPath(dest)));
+    assert.ok(existsSync(getPolicySigPath(dest)));
+    // The applied policy verifies in its new home.
+    assert.equal(verifyPolicy(dest).status, "valid");
+  });
+
+  it("fail-closed (no write) when the source policy was tampered after signing", () => {
+    writeFileSync(getPolicyPath(source), POLICY_TEMPLATE, "utf-8");
+    const pub = signPolicyInDir(source);
+    addPolicySigner(dest, pub, "org");
+    // Tamper AFTER signing → a real content change (a new key, not a comment) so the canonical
+    // bytes and thus the fingerprint no longer match the signature.
+    writeFileSync(getPolicyPath(source), POLICY_TEMPLATE + '\nx_tamper = "evil"\n', "utf-8");
+
+    const r = pullPolicy(source, dest);
+    assert.equal(r.ok, false);
+    assert.equal(r.status, "invalid");
+    assert.equal(existsSync(getPolicyPath(dest)), false, "must not write an unverified policy");
+  });
+
+  it("fail-closed 'no-anchor' when the destination has no local trust anchor (root trust is never fetched)", () => {
+    writeFileSync(getPolicyPath(source), POLICY_TEMPLATE, "utf-8");
+    signPolicyInDir(source);
+    // No addPolicySigner(dest, …) → dest has no .kit-policy.signers.
+
+    const r = pullPolicy(source, dest);
+    assert.equal(r.ok, false);
+    assert.equal(r.status, "no-anchor");
+    assert.equal(existsSync(getPolicyPath(dest)), false);
+  });
+
+  it("'no-source' when the source has no signed policy pair", () => {
+    addPolicySigner(dest, resolveKeyStore().store.publicKeyPem()!, "org");
+    const r = pullPolicy(source, dest);
+    assert.equal(r.ok, false);
+    assert.equal(r.status, "no-source");
+  });
+
+  it("NEVER overwrites the local trust anchor from the source (decision §6.1)", () => {
+    writeFileSync(getPolicyPath(source), POLICY_TEMPLATE, "utf-8");
+    const pub = signPolicyInDir(source);
+    addPolicySigner(dest, pub, "org");
+    const localAnchorBefore = readFileSync(getSignersPath(dest), "utf-8");
+    // The source also ships a (different/adversarial) anchor — it must be ignored.
+    writeFileSync(getSignersPath(source), JSON.stringify({ signers: [] }) + "\n", "utf-8");
+
+    const r = pullPolicy(source, dest);
+    assert.equal(r.ok, true, r.detail);
+    assert.equal(
+      readFileSync(getSignersPath(dest), "utf-8"),
+      localAnchorBefore,
+      "the local anchor must be untouched — root trust is never pulled",
+    );
+  });
+
+  it("resolves a file:// source URI", () => {
+    writeFileSync(getPolicyPath(source), POLICY_TEMPLATE, "utf-8");
+    const pub = signPolicyInDir(source);
+    addPolicySigner(dest, pub, "org");
+
+    const r = pullPolicy(`file://${source}`, dest);
+    assert.equal(r.ok, true, r.detail);
+    assert.equal(r.status, "applied");
+  });
+});

--- a/src/policy-pull.ts
+++ b/src/policy-pull.ts
@@ -1,0 +1,122 @@
+/**
+ * kit control plane (Pelare 2) — `kit policy pull`: fetch an org-signed policy from a self-hostable
+ * source and APPLY it only if it verifies OFFLINE against the LOCAL trust anchor.
+ *
+ * Design: `kit-research/docs/research/pillar2-control-plane-5.0.md` (MVP, §4.1). This is a
+ * "dumb pipe, smart verifier": the source ships bytes (`.kit-policy.toml` + `.kit-policy.sig`);
+ * kit verifies them with the existing `verifyPolicy` before anything is written. Deliberately
+ * SMALL and safe:
+ *
+ *   - **No root-trust-from-the-network (§6.1):** the trust anchor `.kit-policy.signers` is NEVER
+ *     pulled. It must already exist LOCALLY (committed / bootstrapped out of band). A pull with no
+ *     local anchor fails closed — a pulled policy that only this machine could verify is not "org
+ *     distribution", and letting the fetch carry the root of trust would make the chain only as
+ *     strong as the fetch.
+ *   - **Verify-before-write, fail-closed:** the pulled policy+sig are staged in a temp dir WITH the
+ *     LOCAL anchor and run through `verifyPolicy`; only `status === "valid"` writes to the project.
+ *     Anything else keeps the existing policy untouched. Revocations are still consulted (they come
+ *     from the identity store, not the staged dir), so a revoked org signer is rejected.
+ *   - **`file://` / local path source only (§6.2):** no new network client in the MVP; a git remote
+ *     is a follow-up. Air-gap stays green because pull is manual and never runs during verification.
+ *
+ * Deterministic, local-only, no telemetry, no egress.
+ */
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  copyFileSync,
+  mkdtempSync,
+  rmSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  POLICY_FILE,
+  POLICY_SIG_FILE,
+  getPolicyPath,
+  getPolicySigPath,
+  verifyPolicy,
+  type PolicyVerifyStatus,
+} from "./policy-doc.js";
+import { POLICY_SIGNERS_FILE, getSignersPath } from "./policy-trust.js";
+
+export type PullStatus =
+  /** Verified against the local anchor and written to the project. */
+  | "applied"
+  /** The source has no `.kit-policy.toml` + `.kit-policy.sig` pair. */
+  | "no-source"
+  /** No local `.kit-policy.signers` anchor — root trust is never fetched (§6.1), so fail closed. */
+  | "no-anchor"
+  /** Verification did not return "valid"; the policy was NOT applied (kept existing). */
+  | PolicyVerifyStatus;
+
+export interface PullResult {
+  ok: boolean;
+  status: PullStatus;
+  detail: string;
+  fingerprint?: string;
+}
+
+/** Strip a leading `file://` and resolve to an absolute filesystem path. */
+export function pullSourceToPath(source: string): string {
+  const s = source.startsWith("file://") ? source.slice("file://".length) : source;
+  return resolve(s);
+}
+
+/**
+ * Pull the signed policy at `source` into `destRoot`, applying it only if it verifies against
+ * `destRoot`'s LOCAL trust anchor. Never throws; never writes `.kit-policy.signers`.
+ */
+export function pullPolicy(source: string, destRoot: string): PullResult {
+  const srcDir = pullSourceToPath(source);
+  const srcPolicy = join(srcDir, POLICY_FILE);
+  const srcSig = join(srcDir, POLICY_SIG_FILE);
+  if (!existsSync(srcPolicy) || !existsSync(srcSig)) {
+    return {
+      ok: false,
+      status: "no-source",
+      detail: `no signed policy at ${srcDir} — expected ${POLICY_FILE} + ${POLICY_SIG_FILE}`,
+    };
+  }
+
+  // §6.1 — the anchor is NEVER pulled; it must exist locally, committed out of band.
+  if (!existsSync(getSignersPath(destRoot))) {
+    return {
+      ok: false,
+      status: "no-anchor",
+      detail: `no local ${POLICY_SIGNERS_FILE} trust anchor — commit the org anchor out of band before pulling (root trust is never fetched)`,
+    };
+  }
+
+  // Stage pulled policy+sig WITH the LOCAL anchor and verify OFFLINE before writing anything.
+  const stage = mkdtempSync(join(tmpdir(), "kit-policy-pull-"));
+  try {
+    copyFileSync(srcPolicy, join(stage, POLICY_FILE));
+    copyFileSync(srcSig, join(stage, POLICY_SIG_FILE));
+    // The LOCAL anchor — deliberately not the source's — is what the pulled policy must satisfy.
+    copyFileSync(getSignersPath(destRoot), join(stage, POLICY_SIGNERS_FILE));
+
+    const v = verifyPolicy(stage);
+    if (v.status !== "valid") {
+      return {
+        ok: false,
+        status: v.status,
+        detail: `pulled policy NOT applied — ${v.detail} (fail-closed; kept existing)`,
+        fingerprint: v.fingerprint,
+      };
+    }
+
+    // Verified → apply. Write ONLY the policy + its signature; never the trust anchor.
+    writeFileSync(getPolicyPath(destRoot), readFileSync(srcPolicy));
+    writeFileSync(getPolicySigPath(destRoot), readFileSync(srcSig));
+    return {
+      ok: true,
+      status: "applied",
+      detail: `applied org policy — ${v.detail}`,
+      fingerprint: v.fingerprint,
+    };
+  } finally {
+    rmSync(stage, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## Pillar 2 — MVP (`kit policy pull`)

First increment of the self-hostable control plane (`pillar2-control-plane-5.0.md` §4.1), built on the confirmed **safest** §6 decisions.

`kit policy pull <source>` fetches an org-signed policy from a local / `file://` dir (`.kit-policy.toml` + `.kit-policy.sig`) and **applies it only if it verifies offline** against this project's **local** `.kit-policy.signers` anchor — reusing the existing `verifyPolicy`. **No new crypto.**

### Safe by construction
- **No root-trust-from-the-network** — the anchor is *never* pulled; a pull with no local anchor fails closed (`no-anchor`). A signers file shipped by the source is ignored; the local anchor is left untouched (test-enforced).
- **Verify-before-write, fail-closed** — pulled policy+sig are staged *with the local anchor* and run through `verifyPolicy`; only `status === "valid"` writes to the project, anything else keeps the existing policy. Revocations still apply (read from the identity store, not the staged dir), so a revoked org signer is rejected.
- **`file://` / local path only** (no new network client), **manual trigger**, **air-gap unaffected** (pull never runs during verification).

### Changes
- New `src/policy-pull.ts` (`pullPolicy`, `pullSourceToPath`).
- `kit policy pull` subcommand + usage/help text.

### Verification
- `tsc` clean · `eslint src` 0 errors · build clean
- Full suite **2722 pass / 0 fail** — 6 new tests: apply; tampered→`invalid` (no write); `no-anchor`; `no-source`; anchor-never-overwritten; `file://` URI.

### Next (per §4)
Air-gap-stays-green guarantee test, then revocation propagation (monotone union), fleet-RBAC distribution, approval routing, `kit doctor` row + self-host protocol docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_