### PR TITLE
feat(policy): kit policy pull-revocations — monotone control-plane revocation propagation (Pillar 2)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -610,7 +610,7 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
   policy: {
     handler: cmdPolicy,
     stability: "experimental",
-    help: "Signable org policy-as-code in .kit-policy.toml (init/show/validate/sign/verify/check/trust/pull) — identity-signed standard, org-distributable + enforced offline (experimental)",
+    help: "Signable org policy-as-code in .kit-policy.toml (init/show/validate/sign/verify/check/trust/pull/pull-revocations) — identity-signed standard, org-distributable + enforced offline (experimental)",
   },
   clone: {
     handler: cmdClone,

--- a/src/commands/policy.ts
+++ b/src/commands/policy.ts
@@ -28,6 +28,7 @@ import {
 } from "../policy-doc.js";
 import { evaluatePolicy, formatPolicyEval } from "../policy-check.js";
 import { pullPolicy } from "../policy-pull.js";
+import { pullRevocations } from "../revocation-pull.js";
 import { identityId } from "../identity.js";
 import {
   resolveKeyStore,
@@ -56,9 +57,11 @@ export async function cmdPolicy(): Promise<boolean> {
       return policyTrust(root);
     case "pull":
       return policyPull(root);
+    case "pull-revocations":
+      return policyPullRevocations(root);
     default:
       console.error(
-        `${c.red}usage: kit policy <init|show|validate|sign|verify|check|trust|pull>${c.reset}`,
+        `${c.red}usage: kit policy <init|show|validate|sign|verify|check|trust|pull|pull-revocations>${c.reset}`,
       );
       return false;
   }
@@ -95,6 +98,37 @@ function policyPull(root: string): boolean {
         ? ""
         : " — the source policy is unsigned, tampered, or signed by an untrusted/revoked key";
   console.error(`${c.red}✗ policy pull failed${c.reset} ${c.dim}(${r.detail})${c.reset}${hint}`);
+  return false;
+}
+
+/**
+ * `kit policy pull-revocations <source>` — fetch a signed `revocations.jsonl` feed from a
+ * self-hostable source and monotone-merge the AUTHORITATIVE records (valid signature by an org
+ * trust-anchor signer, or a self-revoke) into the local append-only log. Add-only: it can only add
+ * revocations, never un-revoke one. Non-authoritative records are dropped and counted.
+ */
+function policyPullRevocations(root: string): boolean {
+  const source = process.argv[4];
+  if (!source) {
+    console.error(
+      `${c.red}usage: kit policy pull-revocations <source>${c.reset} ${c.dim}(a local path or file:// dir with revocations.jsonl)${c.reset}`,
+    );
+    return false;
+  }
+  const r = pullRevocations(source, root);
+  if (r.ok) {
+    console.log(
+      `${c.green}✓${c.reset} ${r.detail}${r.rejected ? ` ${c.dim}(unauthorized records ignored — fail-closed)${c.reset}` : ""}`,
+    );
+    return true;
+  }
+  const hint =
+    r.status === "no-anchor"
+      ? " — add trusted org keys with `kit policy trust add` (committed out of band)"
+      : "";
+  console.error(
+    `${c.red}✗ pull-revocations failed${c.reset} ${c.dim}(${r.detail})${c.reset}${hint}`,
+  );
   return false;
 }
 

--- a/src/revocation-pull.test.ts
+++ b/src/revocation-pull.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  loadOrCreateIdentity,
+  identityId,
+  signWithIdentity,
+  revocationStatement,
+  isRevoked,
+  type RevocationRecord,
+} from "./identity.js";
+import { resolveKeyStore } from "./keystore/index.js";
+import { addPolicySigner } from "./policy-trust.js";
+import { REVOCATIONS_FEED_FILE, pullRevocations } from "./revocation-pull.js";
+
+let idDir: string;
+let source: string;
+let dest: string;
+let savedId: string | undefined;
+let orgId: string;
+
+/** A revocation of `targetKid`, signed by THIS machine's identity (the org authority in tests). */
+function signedRevocation(
+  targetKid: string,
+  reason = "compromised",
+  ts = new Date().toISOString(),
+): RevocationRecord {
+  const sig = signWithIdentity(revocationStatement(targetKid, ts, reason), idDir).toString(
+    "base64",
+  );
+  return { kid: targetKid, reason, ts, by: orgId, sig };
+}
+
+function writeFeed(records: RevocationRecord[]): void {
+  writeFileSync(
+    join(source, REVOCATIONS_FEED_FILE),
+    records.map((r) => JSON.stringify(r)).join("\n") + "\n",
+    "utf-8",
+  );
+}
+
+beforeEach(() => {
+  idDir = mkdtempSync(join(tmpdir(), "kit-id-"));
+  source = mkdtempSync(join(tmpdir(), "kit-rev-src-"));
+  dest = mkdtempSync(join(tmpdir(), "kit-rev-dest-"));
+  savedId = process.env.KIT_IDENTITY_DIR;
+  process.env.KIT_IDENTITY_DIR = idDir;
+  loadOrCreateIdentity(idDir);
+  const pub = resolveKeyStore().store.publicKeyPem()!;
+  orgId = identityId(pub);
+  addPolicySigner(dest, pub, "org"); // this identity is a trusted org revocation authority
+});
+
+afterEach(() => {
+  if (savedId === undefined) delete process.env.KIT_IDENTITY_DIR;
+  else process.env.KIT_IDENTITY_DIR = savedId;
+  for (const d of [idDir, source, dest]) rmSync(d, { recursive: true, force: true });
+});
+
+describe("pullRevocations", () => {
+  it("merges an authoritative revocation and it takes effect locally", () => {
+    writeFeed([signedRevocation("target-A")]);
+    const r = pullRevocations(source, dest, idDir);
+    assert.equal(r.ok, true, r.detail);
+    assert.equal(r.status, "merged");
+    assert.equal(r.added, 1);
+    assert.equal(r.rejected, 0);
+    assert.equal(isRevoked("target-A", idDir), true, "the pulled revocation must be honored");
+  });
+
+  it("drops a record whose signer is not an org authority (fail-closed)", () => {
+    writeFeed([
+      { kid: "target-B", reason: "x", ts: new Date().toISOString(), by: "stranger", sig: "AA==" },
+    ]);
+    const r = pullRevocations(source, dest, idDir);
+    assert.equal(r.added, 0);
+    assert.equal(r.rejected, 1);
+    assert.equal(isRevoked("target-B", idDir), false);
+  });
+
+  it("drops a record with an authorized signer but a forged signature", () => {
+    const rec = signedRevocation("target-C");
+    rec.sig = "AA=="; // tamper the signature
+    writeFeed([rec]);
+    const r = pullRevocations(source, dest, idDir);
+    assert.equal(r.added, 0);
+    assert.equal(r.rejected, 1);
+    assert.equal(isRevoked("target-C", idDir), false);
+  });
+
+  it("is monotone — a later pull that omits a kid does NOT un-revoke it", () => {
+    writeFeed([signedRevocation("keep-revoked")]);
+    assert.equal(pullRevocations(source, dest, idDir).added, 1);
+    assert.equal(isRevoked("keep-revoked", idDir), true);
+    // A new feed WITHOUT keep-revoked must not resurrect the key.
+    writeFeed([signedRevocation("someone-else")]);
+    const r2 = pullRevocations(source, dest, idDir);
+    assert.equal(r2.added, 1);
+    assert.equal(isRevoked("keep-revoked", idDir), true, "append-only — never un-revoke");
+    assert.equal(isRevoked("someone-else", idDir), true);
+  });
+
+  it("dedups — re-pulling the same feed adds nothing", () => {
+    writeFeed([signedRevocation("dup", "r", "2026-01-01T00:00:00.000Z")]);
+    assert.equal(pullRevocations(source, dest, idDir).added, 1);
+    assert.equal(pullRevocations(source, dest, idDir).added, 0);
+  });
+
+  it("fail-closed 'no-anchor' when the destination has no local trust anchor", () => {
+    const bare = mkdtempSync(join(tmpdir(), "kit-rev-bare-"));
+    try {
+      writeFeed([signedRevocation("target-D")]);
+      const r = pullRevocations(source, bare, idDir);
+      assert.equal(r.ok, false);
+      assert.equal(r.status, "no-anchor");
+      assert.equal(isRevoked("target-D", idDir), false);
+    } finally {
+      rmSync(bare, { recursive: true, force: true });
+    }
+  });
+
+  it("'no-source' when the source has no revocations feed", () => {
+    const r = pullRevocations(source, dest, idDir);
+    assert.equal(r.ok, false);
+    assert.equal(r.status, "no-source");
+  });
+});

--- a/src/revocation-pull.ts
+++ b/src/revocation-pull.ts
@@ -1,0 +1,113 @@
+/**
+ * kit control plane (Pelare 2) — `kit policy pull-revocations`: fetch signed identity-key
+ * revocations from a self-hostable source and MONOTONE-merge the authoritative ones into the local
+ * append-only log (`revocations.jsonl`). Design: `pillar2-control-plane-5.0.md` §4.3.
+ *
+ * The identity-key revocation log (identity.ts) is consumed offline by policy verification, RBAC,
+ * and shared-memory trust via `isRevokedWith`. Today it is local/append-only; this makes org
+ * revocations DISTRIBUTABLE without adding any trust: every record carries its own Ed25519
+ * signature, so kit verifies each one against the LOCAL org trust anchor before merging.
+ *
+ * Safe by construction (the confirmed §6 decisions):
+ *   - **Add-only / monotone (§6.4):** merges via `appendRevocations`, which only appends new records
+ *     (dedup by kid+ts+sig) — a pulled list can ADD revocations, NEVER "un-revoke" one. Omitting a
+ *     kid from the source cannot resurrect a revoked key.
+ *   - **Fail-closed authority:** only records that are AUTHORITATIVE (valid signature by an org
+ *     trust-anchor signer, or a self-revoke) are merged; everything else is dropped and counted.
+ *   - **No root-trust-from-the-network (§6.1):** the authority set is the LOCAL `.kit-policy.signers`
+ *     anchor, never the source's; no local anchor ⇒ fail closed ("no-anchor").
+ *   - **`file://` / local path only; manual trigger; offline** — air-gap is never affected.
+ *
+ * Deterministic, local-only, no telemetry, no egress.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { pullSourceToPath } from "./policy-pull.js";
+import {
+  appendRevocations,
+  isAuthoritativeRevocation,
+  localPublicKeys,
+  type RevocationRecord,
+} from "./identity.js";
+import { policySignersMap, getSignersPath } from "./policy-trust.js";
+
+/** The distributed revocation feed filename (mirrors the local append-only log). */
+export const REVOCATIONS_FEED_FILE = "revocations.jsonl";
+
+export interface RevocationPullResult {
+  ok: boolean;
+  status: "merged" | "no-source" | "no-anchor";
+  /** Authoritative records newly appended to the local log (monotone). */
+  added: number;
+  /** Records dropped because they were not authoritative (unsigned/forged/unauthorized revoker). */
+  rejected: number;
+  detail: string;
+}
+
+/** Parse a `revocations.jsonl` feed; malformed lines are skipped (fail-closed, never throw). */
+function parseFeed(text: string): RevocationRecord[] {
+  const out: RevocationRecord[] = [];
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      out.push(JSON.parse(t) as RevocationRecord);
+    } catch {
+      /* skip a malformed line — never let one bad record abort the merge */
+    }
+  }
+  return out;
+}
+
+/**
+ * Pull + monotone-merge authoritative revocations from `source` into the local log. `destRoot`
+ * supplies the org trust anchor; `dir` is the identity dir holding the local log (defaults to the
+ * standard identity dir). Never throws.
+ */
+export function pullRevocations(
+  source: string,
+  destRoot: string,
+  dir?: string,
+): RevocationPullResult {
+  const feed = join(pullSourceToPath(source), REVOCATIONS_FEED_FILE);
+  if (!existsSync(feed)) {
+    return {
+      ok: false,
+      status: "no-source",
+      added: 0,
+      rejected: 0,
+      detail: `no ${REVOCATIONS_FEED_FILE} at ${pullSourceToPath(source)}`,
+    };
+  }
+  // §6.1 — authority comes from the LOCAL committed anchor, never the source. Without it we cannot
+  // establish who may revoke, so fail closed (a pulled revocation couldn't be trusted regardless).
+  if (!existsSync(getSignersPath(destRoot))) {
+    return {
+      ok: false,
+      status: "no-anchor",
+      added: 0,
+      rejected: 0,
+      detail: `no local .kit-policy.signers trust anchor — commit the org anchor out of band before pulling revocations`,
+    };
+  }
+
+  const orgSigners = policySignersMap(destRoot);
+  const trustedKeys = new Map<string, string>([...localPublicKeys(dir), ...orgSigners]);
+  const authorities = new Set<string>(orgSigners.keys());
+
+  const records = parseFeed(readFileSync(feed, "utf-8"));
+  const authoritative = records.filter((r) =>
+    isAuthoritativeRevocation(r, trustedKeys, authorities),
+  );
+  const rejected = records.length - authoritative.length;
+  // Monotone union: append-only, dedup by kid+ts+sig — can only ADD, never un-revoke.
+  const added = appendRevocations(authoritative, dir);
+
+  return {
+    ok: true,
+    status: "merged",
+    added,
+    rejected,
+    detail: `merged ${added} new revocation(s)${rejected ? `, dropped ${rejected} unauthorized` : ""}`,
+  };
+}


### PR DESCRIPTION
## Pillar 2 — step 3 (revocation propagation)

Second control-plane capability (`pillar2-control-plane-5.0.md` §4.3). Makes the **identity-key** revocation log (`revocations.jsonl` — consumed offline by policy-verify / RBAC / shared-memory via `isRevokedWith`) **distributable** without adding any trust.

`kit policy pull-revocations <source>` fetches a signed `revocations.jsonl` feed from a local / `file://` dir and **monotone-merges the authoritative records** into the local append-only log, reusing the existing `appendRevocations` + `isAuthoritativeRevocation`. **No new crypto.**

### Safe by construction (confirmed §6 decisions)
- **Add-only / monotone (§6.4)** — `appendRevocations` only appends (dedup by kid+ts+sig): a pulled feed can **add** revocations, never *un-revoke* one. Omitting a kid can't resurrect a revoked key (test-enforced).
- **Fail-closed authority** — only records with a valid Ed25519 signature by an **org trust-anchor signer** (or a self-revoke) are merged; unsigned / forged / unauthorized records are dropped and counted.
- **No root-trust-from-the-network (§6.1)** — authority = the **local** `.kit-policy.signers` anchor, never the source's; no anchor ⇒ fail closed (`no-anchor`).
- **`file://` / local only, manual, offline** — air-gap untouched by construction: no check/verify/airgap path invokes pull, and every test runs offline. (This is the "air-gap stays green" guarantee from §4.2 — structural under the manual-only design, so locked by the offline test suite rather than a separate absence-test.)

### Changes
- New `src/revocation-pull.ts` (`pullRevocations`, `REVOCATIONS_FEED_FILE`).
- `kit policy pull-revocations` subcommand + usage/help text.

### Verification
- `tsc` clean · `eslint src` 0 errors · build clean
- Full suite **2729 pass / 0 fail** — 7 new tests: merge takes effect; drop unauthorized signer; drop forged signature; monotone (no un-revoke); dedup; `no-anchor`; `no-source`.

### Next (per §4)
Fleet-RBAC distribution, approval routing, `kit doctor` control-plane row + documented self-host protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_