### PR TITLE
feat(policy): fleet-RBAC distribution via policy pull + summary (Pillar 2 step 4)

### DIFF
--- a/src/commands/policy.ts
+++ b/src/commands/policy.ts
@@ -29,6 +29,7 @@ import {
 import { evaluatePolicy, formatPolicyEval } from "../policy-check.js";
 import { pullPolicy } from "../policy-pull.js";
 import { pullRevocations } from "../revocation-pull.js";
+import { extractRbac } from "../rbac/policy-schema.js";
 import { identityId } from "../identity.js";
 import {
   resolveKeyStore,
@@ -86,6 +87,18 @@ function policyPull(root: string): boolean {
     console.log(
       `${c.green}✓${c.reset} ${r.detail}  ${c.dim}${r.fingerprint ?? ""} → ${getPolicyPath(root)}${c.reset}`,
     );
+    // Fleet-RBAC distributes IN the signed policy (§4.4). Surface what arrived so the operator sees
+    // the roles/bindings were distributed — best-effort; never changes the pull verdict.
+    try {
+      const rbac = extractRbac(loadPolicy(root));
+      if (rbac) {
+        console.log(
+          `${c.dim}distributed RBAC: ${Object.keys(rbac.roles).length} role(s), ${rbac.bindings.length} binding(s)${rbac.defaultRole ? `, default role ${rbac.defaultRole}` : ""}${c.reset}`,
+        );
+      }
+    } catch {
+      /* best-effort summary only */
+    }
     console.log(
       `${c.dim}verify anytime with ${c.reset}${c.bold}kit policy verify${c.reset}${c.dim}; commit the applied .kit-policy.toml + .kit-policy.sig${c.reset}`,
     );

--- a/src/policy-pull-rbac.test.ts
+++ b/src/policy-pull-rbac.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Pillar 2 §4.4 — fleet-RBAC distribution. RBAC is carried in the signed `.kit-policy.toml`
+ * (`[rbac]` table, extracted by rbac/resolve.loadVerifiedPolicy), so `kit policy pull` ALREADY
+ * distributes role→permission mappings "verified as policy, no new runtime". These tests LOCK that
+ * end-to-end guarantee: a pulled policy's bindings take effect, and a tampered `[rbac]` table is
+ * rejected (fail-closed) exactly like any other policy change.
+ */
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadOrCreateIdentity, identityId } from "./identity.js";
+import { resolveKeyStore } from "./keystore/index.js";
+import {
+  loadPolicy,
+  canonicalPolicyBytes,
+  policyFingerprint,
+  getPolicyPath,
+  getPolicySigPath,
+  type PolicySignature,
+} from "./policy-doc.js";
+import { addPolicySigner } from "./policy-trust.js";
+import { pullPolicy } from "./policy-pull.js";
+import { loadVerifiedPolicy, effectivePermissions, can } from "./rbac/resolve.js";
+
+let idDir: string;
+let source: string;
+let dest: string;
+let savedId: string | undefined;
+
+const SUBJECT = "kid_subject_example";
+
+const RBAC_POLICY = `version = 1
+
+[rbac.roles]
+deployer = ["deploy:prod"]
+reader = ["read:*"]
+
+[[rbac.bindings]]
+kid = "${SUBJECT}"
+role = "deployer"
+`;
+
+function signPolicyInDir(dir: string): string {
+  const doc = loadPolicy(dir)!;
+  const pub = resolveKeyStore().store.publicKeyPem()!;
+  const record: PolicySignature = {
+    kid: identityId(pub),
+    sig: resolveKeyStore().store.sign(canonicalPolicyBytes(doc)).toString("base64"),
+    ts: new Date().toISOString(),
+    fingerprint: policyFingerprint(doc),
+  };
+  writeFileSync(getPolicySigPath(dir), JSON.stringify(record, null, 2) + "\n", "utf-8");
+  return pub;
+}
+
+beforeEach(() => {
+  idDir = mkdtempSync(join(tmpdir(), "kit-id-"));
+  source = mkdtempSync(join(tmpdir(), "kit-rbac-src-"));
+  dest = mkdtempSync(join(tmpdir(), "kit-rbac-dest-"));
+  savedId = process.env.KIT_IDENTITY_DIR;
+  process.env.KIT_IDENTITY_DIR = idDir;
+  loadOrCreateIdentity();
+});
+
+afterEach(() => {
+  if (savedId === undefined) delete process.env.KIT_IDENTITY_DIR;
+  else process.env.KIT_IDENTITY_DIR = savedId;
+  for (const d of [idDir, source, dest]) rmSync(d, { recursive: true, force: true });
+});
+
+describe("fleet-RBAC distributes via kit policy pull (Pillar 2 §4.4)", () => {
+  it("a pulled policy's [rbac] bindings take effect", () => {
+    writeFileSync(getPolicyPath(source), RBAC_POLICY, "utf-8");
+    const pub = signPolicyInDir(source);
+    addPolicySigner(dest, pub, "org");
+
+    const r = pullPolicy(source, dest);
+    assert.equal(r.ok, true, r.detail);
+
+    const vp = loadVerifiedPolicy(dest);
+    assert.ok(vp, "pulled policy must load + verify at the destination");
+    assert.deepEqual(effectivePermissions(SUBJECT, vp), ["deploy:prod"]);
+    assert.equal(can(SUBJECT, "deploy:prod", vp), true);
+    assert.equal(can(SUBJECT, "deploy:staging", vp), false, "not granted → deny");
+    assert.equal(can("kid_stranger", "deploy:prod", vp), false, "unbound subject → deny");
+  });
+
+  it("a tampered [rbac] table is rejected — not applied (fail-closed)", () => {
+    writeFileSync(getPolicyPath(source), RBAC_POLICY, "utf-8");
+    const pub = signPolicyInDir(source);
+    addPolicySigner(dest, pub, "org");
+    // Escalate the grant AFTER signing → canonical bytes change → signature no longer matches.
+    writeFileSync(getPolicyPath(source), RBAC_POLICY.replace('["deploy:prod"]', '["*"]'), "utf-8");
+
+    const r = pullPolicy(source, dest);
+    assert.equal(r.ok, false);
+    assert.equal(r.status, "invalid");
+    assert.equal(existsSync(getPolicyPath(dest)), false, "must not apply a tampered RBAC policy");
+    assert.equal(loadVerifiedPolicy(dest), null);
+  });
+});


### PR DESCRIPTION
## Pillar 2 — step 4 (fleet-RBAC distribution)

RBAC role→permission mappings ride **inside** the signed `.kit-policy.toml` (`[rbac]` table, read by `rbac/resolve.loadVerifiedPolicy`) — so `kit policy pull` (step 1) **already distributes them** "verified as policy, no new runtime", exactly as `pillar2-control-plane-5.0.md` §4.4 intended. This increment **locks and surfaces** that guarantee rather than building a redundant channel.

### Changes
- **`kit policy pull` prints a one-line RBAC summary** on success — `N role(s), M binding(s)[, default role X]` — so the operator sees the fleet-RBAC that arrived. Best-effort; never changes the pull verdict.
- **New `src/policy-pull-rbac.test.ts`** proving end-to-end:
  - a pulled policy's `[rbac]` bindings take effect — `effectivePermissions` / `can` reflect the distributed roles; unbound subjects and ungranted permissions deny;
  - a **tampered `[rbac]` table is rejected fail-closed** (`invalid` → not applied), like any other policy change.

**No new runtime, no new trust** — distribution + verification reuse the existing signed-policy channel and `rbac/resolve`.

### Verification
- `tsc` clean · `eslint src` 0 errors · build clean
- Full suite **2731 pass / 0 fail** (2 new RBAC end-to-end tests).

### Next (per §4)
Approval routing (`requestApproval` → self-hosted, offline-verifiable), then `kit doctor` control-plane row + documented self-host protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_