### PR TITLE
feat(policy): offline signed approval tokens — control-plane approval routing (Pillar 2 step 5)

### DIFF
--- a/src/approval-tokens.test.ts
+++ b/src/approval-tokens.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadOrCreateIdentity, identityId, recordRevocation } from "./identity.js";
+import { resolveKeyStore } from "./keystore/index.js";
+import { addPolicySigner, getSignersPath } from "./policy-trust.js";
+import { mintApprovalToken, checkSignedApproval, APPROVAL_TOKENS_FILE } from "./approval-tokens.js";
+
+let idDir: string;
+let root: string;
+let savedId: string | undefined;
+let orgId: string;
+
+const OP = "secrets.rotate";
+const ENV = "prod";
+
+beforeEach(() => {
+  idDir = mkdtempSync(join(tmpdir(), "kit-id-"));
+  root = mkdtempSync(join(tmpdir(), "kit-appr-"));
+  savedId = process.env.KIT_IDENTITY_DIR;
+  process.env.KIT_IDENTITY_DIR = idDir;
+  loadOrCreateIdentity();
+  const pub = resolveKeyStore().store.publicKeyPem()!;
+  orgId = identityId(pub);
+  addPolicySigner(root, pub, "org"); // this identity is a trusted approval authority
+});
+
+afterEach(() => {
+  if (savedId === undefined) delete process.env.KIT_IDENTITY_DIR;
+  else process.env.KIT_IDENTITY_DIR = savedId;
+  for (const d of [idDir, root]) rmSync(d, { recursive: true, force: true });
+});
+
+describe("signed approval tokens", () => {
+  it("a valid org-signed token grants the matching operation", () => {
+    mintApprovalToken(OP, ENV, 3600, { root, dir: idDir });
+    const r = checkSignedApproval({ operation: OP, environment: ENV }, root, { dir: idDir });
+    assert.equal(r.approved, true, r.detail);
+  });
+
+  it("does not grant a different operation or environment", () => {
+    mintApprovalToken(OP, ENV, 3600, { root, dir: idDir });
+    assert.equal(
+      checkSignedApproval({ operation: "other.op", environment: ENV }, root, { dir: idDir })
+        .approved,
+      false,
+    );
+    assert.equal(
+      checkSignedApproval({ operation: OP, environment: "dev" }, root, { dir: idDir }).approved,
+      false,
+    );
+  });
+
+  it("does not grant an expired token", () => {
+    mintApprovalToken(OP, ENV, 3600, { root, dir: idDir, now: new Date(1000) });
+    // Evaluate far in the future → expired.
+    const r = checkSignedApproval({ operation: OP, environment: ENV }, root, {
+      dir: idDir,
+      now: new Date(1000 + 3600_000 + 1),
+    });
+    assert.equal(r.approved, false);
+  });
+
+  it("fail-closed: a token whose signer is not an org authority is ignored", () => {
+    mintApprovalToken(OP, ENV, 3600, { root, dir: idDir });
+    // Remove the anchor so the signer is no longer a trusted authority.
+    rmSync(getSignersPath(root), { force: true });
+    assert.equal(
+      checkSignedApproval({ operation: OP, environment: ENV }, root, { dir: idDir }).approved,
+      false,
+    );
+  });
+
+  it("fail-closed: a forged signature is rejected", () => {
+    mintApprovalToken(OP, ENV, 3600, { root, dir: idDir });
+    // Corrupt the stored token's signature.
+    const p = join(root, APPROVAL_TOKENS_FILE);
+    const tampered = {
+      operation: OP,
+      environment: ENV,
+      kid: orgId,
+      ts: new Date().toISOString(),
+      expires: new Date(Date.now() + 3600_000).toISOString(),
+      sig: "AA==",
+    };
+    writeFileSync(p, JSON.stringify(tampered) + "\n", "utf-8");
+    assert.equal(
+      checkSignedApproval({ operation: OP, environment: ENV }, root, { dir: idDir }).approved,
+      false,
+    );
+  });
+
+  it("fail-closed: a revoked approver's token is not honored", () => {
+    mintApprovalToken(OP, ENV, 3600, { root, dir: idDir });
+    // The approver self-revokes → the token must stop granting.
+    recordRevocation(orgId, "compromised", idDir);
+    assert.equal(
+      checkSignedApproval({ operation: OP, environment: ENV }, root, { dir: idDir }).approved,
+      false,
+    );
+  });
+
+  it("no token store ⇒ not approved (falls through to interactive)", () => {
+    const r = checkSignedApproval({ operation: OP, environment: ENV }, root, { dir: idDir });
+    assert.equal(r.approved, false);
+    assert.match(r.detail, /no approval tokens/);
+  });
+});

--- a/src/approval-tokens.ts
+++ b/src/approval-tokens.ts
@@ -1,0 +1,149 @@
+/**
+ * kit control plane (Pelare 2) — offline-verifiable signed approval tokens (§4.5, approval-routing).
+ *
+ * `requestApproval` can already prompt interactively or call a webhook/remote API. This adds a
+ * THIRD, offline, no-egress path: an org authority mints a time-boxed, operation-scoped **signed
+ * approval token**; a machine honors a valid one BEFORE prompting, with interactive fallback when
+ * no token grants. This lets an org "route" approvals as signed artifacts (committed / distributed
+ * via the same pull channel) instead of a live service — verified offline against the same
+ * `.kit-policy.signers` trust anchor as policy and revocations.
+ *
+ * Safe by construction (mirrors the revocation trust model):
+ *   - **Fail-closed authority:** a token grants only if it is signed by an ORG trust-anchor signer
+ *     (the approval authority), the signature verifies, the token matches the exact operation +
+ *     environment, it has not expired, and the signer is not revoked. Anything else → no grant
+ *     (falls through to the existing interactive/remote path — never auto-approves).
+ *   - **No root-trust-from-the-network:** authority is the LOCAL anchor; no anchor ⇒ no grant.
+ *   - **Time-boxed:** a token authorizes op+env only until `expires` (documented replay window).
+ *   - Local file, offline, no telemetry.
+ */
+import { existsSync, readFileSync, appendFileSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import {
+  signWithIdentity,
+  tryLoadIdentity,
+  localPublicKeys,
+  isRevokedWith,
+  verifySignature,
+} from "./identity.js";
+import { policySignersMap, getSignersPath } from "./policy-trust.js";
+
+/** Append-only store of signed approval tokens at the project root. */
+export const APPROVAL_TOKENS_FILE = ".kit-approvals.jsonl";
+
+export interface ApprovalToken {
+  operation: string;
+  environment: string;
+  /** The approver identity id (must be an org trust-anchor signer to be honored). */
+  kid: string;
+  /** ISO timestamp the token was minted. */
+  ts: string;
+  /** ISO timestamp after which the token no longer grants. */
+  expires: string;
+  /** base64 Ed25519 signature over `approvalStatement(...)`. */
+  sig: string;
+}
+
+/** Canonical bytes signed for an approval token — stable across machines for offline verify. */
+export function approvalStatement(
+  operation: string,
+  environment: string,
+  ts: string,
+  expires: string,
+): string {
+  return `kit-approve\nop=${operation}\nenv=${environment}\nts=${ts}\nexp=${expires}`;
+}
+
+function tokensPath(root: string): string {
+  return join(root, APPROVAL_TOKENS_FILE);
+}
+
+/**
+ * Mint a signed approval token for `operation`+`environment`, valid for `ttlSeconds`, signed by the
+ * CURRENT identity, and append it to `<root>/.kit-approvals.jsonl`. The verifier only honors it if
+ * that identity is in the org trust anchor. Throws if there is no identity to sign with.
+ */
+export function mintApprovalToken(
+  operation: string,
+  environment: string,
+  ttlSeconds: number,
+  opts: { root?: string; dir?: string; now?: Date } = {},
+): ApprovalToken {
+  const root = opts.root ?? process.cwd();
+  const signer = tryLoadIdentity(opts.dir);
+  if (!signer) throw new Error("no current identity to sign the approval token");
+  const now = opts.now ?? new Date();
+  const ts = now.toISOString();
+  const expires = new Date(now.getTime() + ttlSeconds * 1000).toISOString();
+  const sig = signWithIdentity(
+    approvalStatement(operation, environment, ts, expires),
+    opts.dir,
+  ).toString("base64");
+  const token: ApprovalToken = { operation, environment, kid: signer.id, ts, expires, sig };
+  const path = tokensPath(root);
+  mkdirSync(dirname(path), { recursive: true });
+  appendFileSync(path, JSON.stringify(token) + "\n", { encoding: "utf-8", mode: 0o600 });
+  return token;
+}
+
+export interface ApprovalCheck {
+  approved: boolean;
+  detail: string;
+}
+
+/** Parse the token store; skip malformed lines (fail-closed, never throw). */
+function loadTokens(root: string): ApprovalToken[] {
+  const path = tokensPath(root);
+  if (!existsSync(path)) return [];
+  const out: ApprovalToken[] = [];
+  for (const line of readFileSync(path, "utf-8").split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      out.push(JSON.parse(t) as ApprovalToken);
+    } catch {
+      /* skip a malformed token line */
+    }
+  }
+  return out;
+}
+
+/**
+ * Is there a valid signed approval token granting `operation`+`environment`? Fail-closed: requires
+ * a local trust anchor, an org-authority signer, a verifying signature, an unexpired token, and a
+ * non-revoked signer. Returns the grant + a human detail (never throws).
+ */
+export function checkSignedApproval(
+  request: { operation: string; environment: string },
+  root: string,
+  opts: { dir?: string; now?: Date } = {},
+): ApprovalCheck {
+  const tokens = loadTokens(root);
+  if (tokens.length === 0) return { approved: false, detail: "no approval tokens" };
+  // Authority comes from the LOCAL anchor; without it we cannot trust any token.
+  if (!existsSync(getSignersPath(root))) {
+    return { approved: false, detail: "no local .kit-policy.signers trust anchor" };
+  }
+  const orgSigners = policySignersMap(root);
+  const trustedKeys = new Map<string, string>([...localPublicKeys(opts.dir), ...orgSigners]);
+  const authorities = new Set<string>(orgSigners.keys());
+  const nowMs = (opts.now ?? new Date()).getTime();
+
+  for (const tk of tokens) {
+    if (tk.operation !== request.operation || tk.environment !== request.environment) continue;
+    if (!authorities.has(tk.kid)) continue; // approver is not an org authority
+    const expMs = Date.parse(tk.expires);
+    if (!Number.isFinite(expMs) || expMs <= nowMs) continue; // expired / unparseable
+    const pub = trustedKeys.get(tk.kid);
+    if (!pub) continue;
+    const ok = verifySignature(
+      approvalStatement(tk.operation, tk.environment, tk.ts, tk.expires),
+      Buffer.from(tk.sig, "base64"),
+      pub,
+    );
+    if (!ok) continue; // forged / tampered
+    if (isRevokedWith(tk.kid, trustedKeys, authorities, opts.dir)) continue; // revoked approver
+    return { approved: true, detail: `signed by ${tk.kid}, expires ${tk.expires}` };
+  }
+  return { approved: false, detail: "no valid approval token for this operation" };
+}

--- a/src/approval.ts
+++ b/src/approval.ts
@@ -3,6 +3,7 @@ import { isNonInteractive } from "./environment.js";
 import type { GovernanceConfig } from "./config.js";
 import { mergeGovernanceConfig, isDestructiveOperation } from "./governance.js";
 import { IdGenerators } from "./id-generator.js";
+import { checkSignedApproval } from "./approval-tokens.js";
 
 export interface ApprovalRequest {
   operation: string;
@@ -107,6 +108,18 @@ export async function requestApproval(
     (request.environment === "prod" && fullConfig.approval.production_writes);
 
   if (!requiresApproval) {
+    return true;
+  }
+
+  // Control-plane approval routing (Pillar 2 §4.5): honor a valid, offline-verifiable SIGNED
+  // approval token before prompting. Opt-in (no token store ⇒ falls through), fail-closed (only an
+  // org-authority-signed, unexpired, op+env-matching, non-revoked token grants) — never auto-approves.
+  const routed = checkSignedApproval(
+    { operation: request.operation, environment: request.environment },
+    process.cwd(),
+  );
+  if (routed.approved) {
+    console.log(`✓ approved via signed approval token (${routed.detail})`);
     return true;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -610,7 +610,7 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
   policy: {
     handler: cmdPolicy,
     stability: "experimental",
-    help: "Signable org policy-as-code in .kit-policy.toml (init/show/validate/sign/verify/check/trust/pull/pull-revocations) — identity-signed standard, org-distributable + enforced offline (experimental)",
+    help: "Signable org policy-as-code in .kit-policy.toml (init/show/validate/sign/verify/check/trust/pull/pull-revocations/approve) — identity-signed standard, org-distributable + enforced offline (experimental)",
   },
   clone: {
     handler: cmdClone,

--- a/src/commands/policy.ts
+++ b/src/commands/policy.ts
@@ -5,6 +5,7 @@
 // and offline-verifiable. Distinct from `.kit.toml [policy.agent_writes]` (the 2.x
 // per-repo agent-write pre-approval) — this is the org-level standard.
 import { existsSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { c } from "../utils/colors.js";
 import { hasFlag, flagValue } from "../utils/flags.js";
 import { getCurrentProjectRoot } from "../memory/project.js";
@@ -30,6 +31,7 @@ import { evaluatePolicy, formatPolicyEval } from "../policy-check.js";
 import { pullPolicy } from "../policy-pull.js";
 import { pullRevocations } from "../revocation-pull.js";
 import { extractRbac } from "../rbac/policy-schema.js";
+import { mintApprovalToken, APPROVAL_TOKENS_FILE } from "../approval-tokens.js";
 import { identityId } from "../identity.js";
 import {
   resolveKeyStore,
@@ -60,11 +62,48 @@ export async function cmdPolicy(): Promise<boolean> {
       return policyPull(root);
     case "pull-revocations":
       return policyPullRevocations(root);
+    case "approve":
+      return policyApprove(root);
     default:
       console.error(
-        `${c.red}usage: kit policy <init|show|validate|sign|verify|check|trust|pull|pull-revocations>${c.reset}`,
+        `${c.red}usage: kit policy <init|show|validate|sign|verify|check|trust|pull|pull-revocations|approve>${c.reset}`,
       );
       return false;
+  }
+}
+
+/**
+ * `kit policy approve <operation> [--env <env>] [--ttl <seconds>]` — mint a signed, time-boxed
+ * approval token for an operation, signed by this identity. Honored offline by `requestApproval`
+ * ONLY if this identity is in the verifier's `.kit-policy.signers` org trust anchor (fail-closed).
+ * Distribute the token like any other signed artifact (commit / pull channel).
+ */
+function policyApprove(root: string): boolean {
+  const operation = process.argv[4];
+  if (!operation || operation.startsWith("-")) {
+    console.error(
+      `${c.red}usage: kit policy approve <operation> [--env <env>] [--ttl <seconds>]${c.reset}`,
+    );
+    return false;
+  }
+  const environment = flagValue(process.argv, "--env") ?? "prod";
+  const ttl = Number(flagValue(process.argv, "--ttl") ?? "3600");
+  if (!Number.isFinite(ttl) || ttl <= 0) {
+    console.error(`${c.red}--ttl must be a positive number of seconds${c.reset}`);
+    return false;
+  }
+  try {
+    const tk = mintApprovalToken(operation, environment, ttl, { root });
+    console.log(
+      `${c.green}✓${c.reset} minted approval for ${c.bold}${operation}${c.reset} ${c.dim}(env ${environment}, expires ${tk.expires}) as ${tk.kid} → ${join(root, APPROVAL_TOKENS_FILE)}${c.reset}`,
+    );
+    console.log(
+      `${c.dim}honored offline only if ${tk.kid} is in the verifier's .kit-policy.signers anchor; distribute/commit ${APPROVAL_TOKENS_FILE}${c.reset}`,
+    );
+    return true;
+  } catch (e) {
+    console.error(`${c.red}✗ approve failed: ${(e as Error).message}${c.reset}`);
+    return false;
   }
 }
 


### PR DESCRIPTION
## Pillar 2 — step 5 (approval routing)

Adds a **third, offline, no-egress** approval path to `requestApproval` (`pillar2-control-plane-5.0.md` §4.5). An org authority mints a time-boxed, operation-scoped **signed approval token**; a machine honors a valid one **before** prompting, with the existing interactive/webhook/remote path as fallback. This lets an org "route" approvals as **signed artifacts** (committed / distributed via the pull channel) instead of a live service — verified offline against the same `.kit-policy.signers` anchor as policy and revocations.

### Changes
- **`src/approval-tokens.ts`** — `approvalStatement`, `mintApprovalToken`, `checkSignedApproval` (`.kit-approvals.jsonl`). Same trust model as revocations: a token grants **only** if signed by an org trust-anchor authority, the signature verifies, op+env match exactly, it hasn't expired, and the signer isn't revoked. Anything else → no grant.
- **`approval.ts`** — `requestApproval` consults a signed token before prompting. **Opt-in** (no token store ⇒ unchanged), **fail-closed** (never auto-approves), no egress.
- **`kit policy approve <operation> [--env <env>] [--ttl <seconds>]`** — mints a token.

### Verification
- `tsc` clean · `eslint src` 0 errors · build clean
- Full suite **2738 pass / 0 fail** — 7 new tests: valid grant; wrong op/env; expired; non-authority signer; forged signature; revoked approver; no-store falls through.

### Next
Final Pillar 2 step: `kit doctor` control-plane row + documented self-host protocol (§4.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_