### PR TITLE
feat(doctor): control-plane posture row + self-host protocol docs (Pillar 2 step 6)

### DIFF
--- a/docs/CONTROL_PLANE.md
+++ b/docs/CONTROL_PLANE.md
@@ -1,0 +1,56 @@
+# kit control plane (self-hostable, offline-verified)
+
+kit's control plane (North Star Pillar 2) is a **verifier and distributor of signed artifacts, not
+a runtime-dependent service.** It has **no server logic**: the "plane" is a folder of signed files
+behind any file server, object store, or git remote. Every machine verifies those files **offline**
+against a committed trust anchor. There is no telemetry and no egress by default; if the plane
+disappears, kit falls back to the local floor.
+
+## What it distributes
+
+| Artifact                               | Verb (produce)            | Verb (consume)                      | Effect                                                                    |
+| -------------------------------------- | ------------------------- | ----------------------------------- | ------------------------------------------------------------------------- |
+| `.kit-policy.toml` + `.kit-policy.sig` | `kit policy sign`         | `kit policy pull <src>`             | org policy-as-code, incl. the `[rbac]` role→permission table (fleet-RBAC) |
+| `revocations.jsonl`                    | `kit panic` / rotate      | `kit policy pull-revocations <src>` | identity-key revocations (monotone, add-only)                             |
+| `.kit-approvals.jsonl`                 | `kit policy approve <op>` | (honored by `requestApproval`)      | time-boxed, operation-scoped approvals                                    |
+
+## The trust anchor (`.kit-policy.signers`) — bootstrapped out of band
+
+The anchor lists the org's public keys and is the root of all verification. It is **never fetched
+over the network** — commit it to the repo (or provision it by hand) so a pull can only ever deliver
+artifacts your _existing_ trusted keys signed. Add keys with `kit policy trust add`.
+
+> Root trust from the network would make the whole chain only as strong as the fetch. A pulled
+> `.kit-policy.signers` is ignored; the local anchor is never overwritten by a pull.
+
+## Self-hosting the source
+
+1. On an authorized machine, produce the artifacts: `kit policy sign`, `kit policy approve …`,
+   emit revocations via `kit panic`/rotate.
+2. Publish the files to any source — a git remote, an S3/GCS bucket, an nginx dir, or a shared
+   folder. No server code; a static directory is enough.
+3. On each machine, commit the `.kit-policy.signers` anchor, then pull:
+   ```
+   kit policy pull            <source>   # fetch + verify the org policy (and its RBAC) offline
+   kit policy pull-revocations <source>   # merge authoritative revocations (add-only)
+   ```
+   A `source` is a local path or a `file://` dir holding the artifacts above.
+
+## Safety invariants (all enforced, fail-closed)
+
+- **Verify before apply.** A pulled policy is staged and run through `verifyPolicy` against the local
+  anchor; only a `valid` signature is written. Anything else keeps the existing policy.
+- **No root-trust-from-the-network.** The anchor is local-only; no anchor ⇒ pulls fail closed.
+- **Monotone revocations.** A pulled feed can only _add_ revocations (dedup by kid+ts+sig); it can
+  never un-revoke a key. Only records signed by an org authority are honored.
+- **Approvals are org-signed + time-boxed.** `requestApproval` honors a signed token only if it is
+  from an org authority, unexpired, matches the exact operation+environment, and the signer isn't
+  revoked — otherwise it falls back to interactive approval. Never auto-approves.
+- **Air-gap stays green.** Pull/approve are manual and offline; `kit airgap verify` never triggers a
+  fetch. `kit doctor` surfaces the control-plane posture (org policy present / verified / RBAC).
+
+## Posture
+
+`kit doctor` reports a **control plane (org policy)** row: `skip` (nothing distributed), `pass`
+(present + verified, with any RBAC counts), `warn` (present but unsigned/unverifiable), or `fail`
+(invalid/revoked/unparseable — not trusted).

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -1,9 +1,21 @@
-import { describe, it } from "node:test";
+import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { writeFile, unlink, mkdir, rmdir, rm } from "node:fs/promises";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { runDoctor } from "./doctor.js";
+import { loadOrCreateIdentity, identityId } from "./identity.js";
+import { resolveKeyStore } from "./keystore/index.js";
+import {
+  loadPolicy,
+  canonicalPolicyBytes,
+  policyFingerprint,
+  getPolicyPath,
+  getPolicySigPath,
+  type PolicySignature,
+} from "./policy-doc.js";
+import { addPolicySigner } from "./policy-trust.js";
 
 describe("runDoctor", () => {
   it("returns skip for Node.js check when no package.json exists", async () => {
@@ -198,5 +210,65 @@ describe("runDoctor", () => {
     } finally {
       await rmdir(tmpDir);
     }
+  });
+});
+
+describe("runDoctor — control plane (org policy) row (Pillar 2 §4.6)", () => {
+  let idDir: string;
+  let proj: string;
+  let savedId: string | undefined;
+
+  beforeEach(() => {
+    idDir = mkdtempSync(join(tmpdir(), "kit-id-"));
+    proj = mkdtempSync(join(tmpdir(), "kit-cp-"));
+    savedId = process.env.KIT_IDENTITY_DIR;
+    process.env.KIT_IDENTITY_DIR = idDir;
+    loadOrCreateIdentity();
+  });
+
+  afterEach(() => {
+    if (savedId === undefined) delete process.env.KIT_IDENTITY_DIR;
+    else process.env.KIT_IDENTITY_DIR = savedId;
+    rmSync(idDir, { recursive: true, force: true });
+    rmSync(proj, { recursive: true, force: true });
+  });
+
+  const cpRow = async () =>
+    (await runDoctor({}, proj)).checks.find((c) => c.name === "control plane (org policy)");
+
+  it("skips when no org policy is distributed here", async () => {
+    const row = await cpRow();
+    assert.ok(row);
+    assert.equal(row.status, "skip");
+  });
+
+  it("warns when an org policy is present but unsigned", async () => {
+    writeFileSync(getPolicyPath(proj), "version = 1\n", "utf-8");
+    const row = await cpRow();
+    assert.ok(row);
+    assert.equal(row.status, "warn");
+  });
+
+  it("passes for a present + verified org policy (and notes RBAC)", async () => {
+    writeFileSync(
+      getPolicyPath(proj),
+      `version = 1\n[rbac.roles]\ndeployer = ["deploy:prod"]\n\n[[rbac.bindings]]\nkid = "kid_x"\nrole = "deployer"\n`,
+      "utf-8",
+    );
+    const pub = resolveKeyStore().store.publicKeyPem()!;
+    const doc = loadPolicy(proj)!;
+    const record: PolicySignature = {
+      kid: identityId(pub),
+      sig: resolveKeyStore().store.sign(canonicalPolicyBytes(doc)).toString("base64"),
+      ts: new Date().toISOString(),
+      fingerprint: policyFingerprint(doc),
+    };
+    writeFileSync(getPolicySigPath(proj), JSON.stringify(record, null, 2) + "\n", "utf-8");
+    addPolicySigner(proj, pub, "org");
+
+    const row = await cpRow();
+    assert.ok(row);
+    assert.equal(row.status, "pass", row.detail);
+    assert.match(row.detail, /RBAC 1 role/);
   });
 });

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -5,8 +5,11 @@ import { promisify } from "node:util";
 import type { kitConfig } from "./config.js";
 import { resolveToolBin } from "./utils/resolveTool.js";
 import { activeKeyStoreStatus, hardwareRequired } from "./keystore/active.js";
+import { existsSync } from "node:fs";
 import { profileBrokerPolicy } from "./exec-broker/profile-policy.js";
 import { verifyProfileSignature } from "./profile/sign.js";
+import { verifyPolicy, loadPolicy, getPolicyPath } from "./policy-doc.js";
+import { extractRbac } from "./rbac/policy-schema.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -332,6 +335,63 @@ async function checkBrokerRuntime(cwd: string): Promise<DoctorCheck> {
   };
 }
 
+/**
+ * Control-plane posture (Pelare 2): is a DISTRIBUTED org policy present at this project, and is it
+ * trustworthy? Honest — "distributed" must never silently mean "unverified":
+ *   skip  no .kit-policy.toml here (nothing distributed yet)
+ *   pass  policy present + signature verified (org standard + any RBAC it carries govern)
+ *   warn  present but unsigned/unverifiable — run kit policy verify
+ *   fail  present but signature invalid/revoked, or unparseable — not trusted
+ */
+function checkControlPlane(cwd: string): DoctorCheck {
+  const name = "control plane (org policy)";
+  const category = "security";
+  if (!existsSync(getPolicyPath(cwd))) {
+    return {
+      name,
+      status: "skip",
+      detail: "no .kit-policy.toml here — `kit policy pull <source>` to fetch a signed org policy",
+      category,
+    };
+  }
+  const doc = loadPolicy(cwd);
+  if (!doc) {
+    return {
+      name,
+      status: "fail",
+      detail: "org policy present but unparseable — not trusted",
+      category,
+    };
+  }
+  const v = verifyPolicy(cwd);
+  const rbac = extractRbac(doc);
+  const rbacNote = rbac
+    ? ` · RBAC ${Object.keys(rbac.roles).length} role(s), ${rbac.bindings.length} binding(s)`
+    : "";
+  if (v.status === "valid") {
+    return {
+      name,
+      status: "pass",
+      detail: `org policy verified${v.fingerprint ? ` (${v.fingerprint})` : ""}${rbacNote}`,
+      category,
+    };
+  }
+  if (v.status === "unsigned" || v.status === "unverifiable") {
+    return {
+      name,
+      status: "warn",
+      detail: `org policy present but ${v.status} — ${v.detail}`,
+      category,
+    };
+  }
+  return {
+    name,
+    status: "fail",
+    detail: `org policy ${v.status} — ${v.detail}; not trusted`,
+    category,
+  };
+}
+
 export async function runDoctor(config: kitConfig, cwd: string): Promise<DoctorResult> {
   const allChecks: DoctorCheck[] = [];
 
@@ -360,6 +420,7 @@ export async function runDoctor(config: kitConfig, cwd: string): Promise<DoctorR
 
   allChecks.push(await checkBrokerScope(cwd));
   allChecks.push(await checkBrokerRuntime(cwd));
+  allChecks.push(checkControlPlane(cwd));
 
   const passed = allChecks.filter((c) => c.status === "pass").length;
   const warnings = allChecks.filter((c) => c.status === "warn").length;


### PR DESCRIPTION
Closes out **Pillar 2 (self-hostable, offline-verified control plane)** with the observability + documentation layer over the distribution primitives shipped in #317–#320.

## What

- **`kit doctor` — new "control plane (org policy)" security row** (`checkControlPlane`):
  - `skip` — nothing distributed here (`kit policy pull <source>` to adopt)
  - `pass` — org policy present + verified against the local `.kit-policy.signers` anchor, with any RBAC role/binding counts
  - `warn` — present but unsigned/unverifiable
  - `fail` — invalid / revoked / unparseable → not trusted

  Verified fully offline, no egress. Never silent — every posture is an honest verdict.

- **`docs/CONTROL_PLANE.md` — the self-host protocol**: artifact table (`.kit-policy.toml`+`.sig`, `revocations.jsonl`, `.kit-approvals.jsonl`), out-of-band anchor bootstrap, publish/pull steps, and the fail-closed safety invariants (verify-before-apply, no root-trust-from-the-network, monotone revocations, org-signed time-boxed approvals, air-gap stays green).

- **`doctor.test.ts`** — skip/warn/pass coverage for the new row; the pass case asserts the RBAC note derived from a complete, org-signed `[rbac]` table.

## Verification

- `npx tsc --noEmit` clean
- `npx eslint src` — 0 errors (124 pre-existing warnings)
- `node scripts/test.mjs` — **2741/2741 pass, 0 fail**
- `npx prettier --write` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_