### PR TITLE
feat(exec-broker): observe (dry-run) runtime mode toward default-on (Pillar 3)

### DIFF
--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -196,6 +196,25 @@ describe("runDoctor", () => {
     }
   });
 
+  it("exec-broker runtime: warns in OBSERVE (dry-run) mode", async () => {
+    const tmpDir = join(tmpdir(), `kit-doctor-test-${process.pid}-rt-observe`);
+    await mkdir(tmpDir, { recursive: true });
+    await writeFile(
+      join(tmpDir, ".kit-profile.toml"),
+      `version = 1\n[scope]\negress = ["api.acme.com"]\nenforce_runtime = "observe"\n`,
+      "utf-8",
+    );
+    try {
+      const result = await runDoctor({}, tmpDir);
+      const rt = result.checks.find((c) => c.name === "exec-broker runtime");
+      assert.ok(rt, "exec-broker runtime check should be present");
+      assert.equal(rt.status, "warn");
+      assert.ok(rt.detail.includes("OBSERVE"), `detail should name the observe mode: ${rt.detail}`);
+    } finally {
+      await rm(tmpDir, { recursive: true });
+    }
+  });
+
   it("surfaces the identity keystore posture (Pelare 1 — never silent)", async () => {
     const tmpDir = join(tmpdir(), `kit-doctor-test-${process.pid}-9`);
     await mkdir(tmpDir, { recursive: true });

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -309,13 +309,25 @@ async function scopeDegradationStatus(cwd: string): Promise<"warn" | "fail"> {
 async function checkBrokerRuntime(cwd: string): Promise<DoctorCheck> {
   const name = "exec-broker runtime";
   const category = "security";
-  const { enforceRuntime, policy } = await profileBrokerPolicy(cwd);
-  if (!enforceRuntime) {
+  const { runtimeMode, policy } = await profileBrokerPolicy(cwd);
+  if (runtimeMode === "off") {
     return {
       name,
       status: "skip",
       detail:
-        "MCP-runtime mediation not opted in — set [scope].enforce_runtime = true and re-sign to mediate governed MCP ops against the scope",
+        'MCP-runtime mediation not opted in — set [scope].enforce_runtime = true (or "observe" for a dry-run) and re-sign to mediate governed MCP ops against the scope',
+      category,
+    };
+  }
+  if (runtimeMode === "observe") {
+    // Dry-run: never denies. warn (not pass) — mediation is not actually protecting yet; the point is
+    // to read the would-be denials in the audit trail, then graduate to enforce.
+    return {
+      name,
+      status: "warn",
+      detail: policy
+        ? "runtime mediation in OBSERVE mode — gates run but never deny; would-be denials are recorded to the audit trail. Review them, then set enforce_runtime = true"
+        : "runtime OBSERVE mode but the scope is unsigned/invalid — every declared op would be denied under enforce; run 'kit profile sign' before graduating",
       category,
     };
   }

--- a/src/exec-broker/broker.test.ts
+++ b/src/exec-broker/broker.test.ts
@@ -472,6 +472,73 @@ enforce_runtime = true
   });
 });
 
+describe("runBrokered OBSERVE mode (Pillar 3 default-on ladder — dry-run)", () => {
+  const OBSERVE = `version = 1\n[scope]\negress = ["api.acme.com"]\nenforce_runtime = "observe"\n`;
+
+  async function writeObserve(sign: boolean): Promise<void> {
+    loadOrCreateIdentity();
+    writeFileSync(join(sandbox, PROFILE_FILE), OBSERVE);
+    if (sign) await signProfile(sandbox);
+    delete process.env.KIT_EXEC_BROKER_POLICY;
+  }
+
+  const observeLine = () =>
+    auditLines().find((l) => (l.metadata as { phase?: string })?.phase === "observe");
+
+  it("OFF-scope egress → still RUNS (never denies) but records the would-be denial", async () => {
+    await writeObserve(true);
+    let ran = false;
+    const out = await runBrokered(
+      CTX({ egressTargets: ["https://evil.com"] }),
+      async () => {
+        ran = true;
+        return "ok";
+      },
+      { cwd: sandbox },
+    );
+    assert.equal(out.ok, true, "observe must never deny");
+    assert.equal(ran, true);
+    const obs = observeLine();
+    assert.ok(obs, "an observe audit entry must be written");
+    const wouldDeny = (obs!.metadata as { wouldDeny?: string[] }).wouldDeny ?? [];
+    assert.ok(
+      wouldDeny.some((d) => d.includes("evil.com")),
+      `would-be denial must be recorded: ${JSON.stringify(wouldDeny)}`,
+    );
+  });
+
+  it("IN-scope egress → runs with an empty would-deny (clean, ready to enforce)", async () => {
+    await writeObserve(true);
+    const out = await runBrokered(
+      CTX({ egressTargets: ["https://api.acme.com/v1"] }),
+      async () => "ok",
+      { cwd: sandbox },
+    );
+    assert.equal(out.ok, true);
+    assert.deepEqual((observeLine()!.metadata as { wouldDeny?: string[] }).wouldDeny, []);
+  });
+
+  it("UNSIGNED observe scope → runs, but records the default-deny that enforce would apply", async () => {
+    await writeObserve(false);
+    let ran = false;
+    const out = await runBrokered(
+      CTX({ egressTargets: ["https://api.acme.com/v1"] }),
+      async () => {
+        ran = true;
+        return "ok";
+      },
+      { cwd: sandbox },
+    );
+    assert.equal(out.ok, true, "observe never denies, even on an unsigned scope");
+    assert.equal(ran, true);
+    const wouldDeny = (observeLine()!.metadata as { wouldDeny?: string[] }).wouldDeny ?? [];
+    assert.ok(
+      wouldDeny.some((d) => d.includes("default-deny")),
+      `unsigned observe must record the default-deny: ${JSON.stringify(wouldDeny)}`,
+    );
+  });
+});
+
 describe("brokerExec infrastructure exemption", () => {
   it("runs an infrastructure op even when policy is null (RoE does not govern it)", async () => {
     let ran = false;

--- a/src/exec-broker/broker.ts
+++ b/src/exec-broker/broker.ts
@@ -187,6 +187,31 @@ export async function brokerExec<T>(
 }
 
 /**
+ * OBSERVE (dry-run) enforcement — Pillar 3 default-on ladder. Run the SAME gates as brokerExec over
+ * the declared effects, but NEVER deny: record the would-be denials to the audit trail
+ * (`phase: "observe"`, `wouldDeny`) and always execute with the FULL env (behavior-neutral — observe
+ * must not alter what the op sees). A null policy (unverified scope) is reported as the default-deny
+ * that enforce mode WOULD apply, so an operator sees "this op would be denied under enforce" without
+ * anything actually breaking. Never a false green: the op is audited as observed, not as mediated.
+ */
+async function brokerObserve<T>(
+  context: BrokerContext,
+  policy: BrokerPolicy | null | undefined,
+  run: (scopedEnv: Record<string, string>) => Promise<T>,
+): Promise<BrokerOutcome<T>> {
+  const wouldDeny = policy
+    ? collectDenials(context, policy)
+    : ["exec-broker: no policy (default-deny)"];
+  await audit(context, true, undefined, { phase: "observe", wouldDeny });
+  try {
+    const result = await run(scopeEnv(Object.keys(process.env), process.env));
+    return { ok: true, result };
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
  * Run all three resource gates over an operation's DECLARED effects and return one
  * denial line per violation (empty array = all gates passed). Extracted from
  * brokerExec so the enforcement wrapper stays simple. fs-write is checked twice:
@@ -253,11 +278,15 @@ export async function runBrokered<T>(
   // 1. Signed profile scope at the runtime — only when the scope explicitly opted in.
   const { profileBrokerPolicy } = await import("./profile-policy.js");
   const signed = await profileBrokerPolicy(opts.cwd ?? process.cwd());
-  if (signed.enforceRuntime) {
+  if (signed.runtimeMode !== "off") {
     if (hasDeclaredEffects(context)) {
-      return brokerExec(context, signed.policy, run);
+      // "observe" = dry-run: mediate the same gates but NEVER deny — record would-be denials so an
+      // operator can see what default-on would block before flipping to "enforce" (Pillar 3 ladder).
+      return signed.runtimeMode === "observe"
+        ? brokerObserve(context, signed.policy, run)
+        : brokerExec(context, signed.policy, run);
     }
-    // Undeclared op under runtime enforcement → migration passthrough (unchanged behavior).
+    // Undeclared op under runtime enforcement/observe → migration passthrough (unchanged behavior).
     try {
       return { ok: true, result: await run(scopeEnv(Object.keys(process.env), process.env)) };
     } catch (err) {

--- a/src/exec-broker/profile-policy.test.ts
+++ b/src/exec-broker/profile-policy.test.ts
@@ -121,4 +121,28 @@ describe("profileBrokerPolicy", () => {
     assert.deepEqual(r.signHostsDeclared, []);
     assert.deepEqual(r.signHosts, []);
   });
+
+  it("runtimeMode reflects the enforce_runtime declaration (off / observe / enforce)", async () => {
+    // off — no scope
+    assert.equal((await profileBrokerPolicy(proj)).runtimeMode, "off");
+    // observe
+    writeFileSync(join(proj, PROFILE_FILE), `version = 1\n[scope]\nenforce_runtime = "observe"\n`);
+    await signProfile(proj);
+    const obs = await profileBrokerPolicy(proj);
+    assert.equal(obs.runtimeMode, "observe");
+    assert.equal(obs.enforceRuntime, false, "observe is not enforce");
+    // enforce
+    writeFileSync(join(proj, PROFILE_FILE), `version = 1\n[scope]\nenforce_runtime = true\n`);
+    await signProfile(proj);
+    const enf = await profileBrokerPolicy(proj);
+    assert.equal(enf.runtimeMode, "enforce");
+    assert.equal(enf.enforceRuntime, true);
+  });
+
+  it("runtimeMode is read from the declaration even before signing", async () => {
+    writeFileSync(join(proj, PROFILE_FILE), `version = 1\n[scope]\nenforce_runtime = "observe"\n`);
+    const r = await profileBrokerPolicy(proj); // unsigned
+    assert.equal(r.runtimeMode, "observe");
+    assert.equal(r.policy, null, "unsigned → null policy (observe still reports would-denies)");
+  });
 });

--- a/src/exec-broker/profile-policy.ts
+++ b/src/exec-broker/profile-policy.ts
@@ -29,12 +29,18 @@ export interface ProfilePolicyResult {
   /** The governing policy — non-null ONLY when regime is "active" AND the signature verified. */
   policy: BrokerPolicy | null;
   /**
-   * Did the scope opt IN to enforcement at the MCP runtime (`[scope].enforce_runtime = true`)?
-   * Read from the DECLARATION regardless of signature status: opted-in + unsigned ⇒ this is true
-   * AND `policy` is null, so the runtime default-denies declared ops (fail-closed). False when no
-   * scope is declared or the profile is unreadable.
+   * Did the scope opt IN to ENFORCING runtime mediation (`[scope].enforce_runtime = true`)? Read
+   * from the DECLARATION regardless of signature status: opted-in + unsigned ⇒ this is true AND
+   * `policy` is null, so the runtime default-denies declared ops (fail-closed). False for observe /
+   * off / no scope / unreadable. Equivalent to `runtimeMode === "enforce"` (kept for back-compat).
    */
   enforceRuntime: boolean;
+  /**
+   * The declared runtime posture (Pillar 3 default-on ladder): `"off"` (absent/false — runtime
+   * unchanged), `"observe"` (dry-run: mediate but never deny, audit would-be denials), or
+   * `"enforce"` (mediate + deny). Read from the DECLARATION regardless of signature status.
+   */
+  runtimeMode: "off" | "observe" | "enforce";
   /**
    * Keyless "sign, don't store" hosts (Pillar 2 tail) declared in `[scope].sign`, read from the
    * DECLARATION regardless of signature status — so `kit doctor` can surface "declared but
@@ -55,7 +61,14 @@ interface ScopeShape {
   fs?: string[];
   secrets?: string[];
   sign?: string[];
-  enforce_runtime?: boolean;
+  enforce_runtime?: boolean | "observe";
+}
+
+/** Map the signed `enforce_runtime` declaration onto the runtime posture. */
+function runtimeModeOf(scope: ScopeShape): "off" | "observe" | "enforce" {
+  if (scope.enforce_runtime === "observe") return "observe";
+  if (scope.enforce_runtime === true) return "enforce";
+  return "off";
 }
 
 /** Map a verified profile `[scope]` onto a BrokerPolicy (fs paths resolved against `cwd`). */
@@ -81,6 +94,7 @@ export async function profileBrokerPolicy(cwd = process.cwd()): Promise<ProfileP
         regime: "none",
         policy: null,
         enforceRuntime: false,
+        runtimeMode: "off",
         signHostsDeclared: [],
         signHosts: [],
         detail: "no profile declared",
@@ -95,6 +109,7 @@ export async function profileBrokerPolicy(cwd = process.cwd()): Promise<ProfileP
       regime: "active",
       policy: null,
       enforceRuntime: false,
+      runtimeMode: "off",
       signHostsDeclared: [],
       signHosts: [],
       detail: `profile unreadable — ${err instanceof Error ? err.message : String(err)} (default-deny)`,
@@ -105,13 +120,15 @@ export async function profileBrokerPolicy(cwd = process.cwd()): Promise<ProfileP
       regime: "none",
       policy: null,
       enforceRuntime: false,
+      runtimeMode: "off",
       signHostsDeclared: [],
       signHosts: [],
       detail: "profile declares no [scope]/RoE",
     };
   }
 
-  const enforceRuntime = scope.enforce_runtime === true;
+  const runtimeMode = runtimeModeOf(scope);
+  const enforceRuntime = runtimeMode === "enforce";
   const signHostsDeclared = scope.sign ? [...scope.sign] : [];
   const v = await verifyProfileSignature(cwd);
   if (v.status === "valid") {
@@ -119,6 +136,7 @@ export async function profileBrokerPolicy(cwd = process.cwd()): Promise<ProfileP
       regime: "active",
       policy: scopeToPolicy(scope, cwd),
       enforceRuntime,
+      runtimeMode,
       signHostsDeclared,
       signHosts: signHostsDeclared,
       detail: `scope verified (${v.detail})`,
@@ -128,6 +146,7 @@ export async function profileBrokerPolicy(cwd = process.cwd()): Promise<ProfileP
     regime: "active",
     policy: null,
     enforceRuntime,
+    runtimeMode,
     signHostsDeclared,
     signHosts: [],
     detail: `scope declared but ${v.status} — ${v.detail}; grants nothing (fail-closed)`,

--- a/src/profile/schema.ts
+++ b/src/profile/schema.ts
@@ -80,12 +80,15 @@ export interface ProfileScope {
    */
   sign?: string[];
   /**
-   * Explicit opt-in to exec-broker enforcement AT THE MCP RUNTIME (not just the PreToolUse gates /
-   * governance floor). When true and the scope is verified, governed MCP ops that declare their
-   * effects are mediated against this scope; when false/absent, the runtime is unchanged. Being
-   * inside `[scope]`, this flag is covered by the signature — it cannot be flipped without re-signing.
+   * Exec-broker enforcement AT THE MCP RUNTIME (not just the PreToolUse gates / governance floor):
+   *   - `true`      → mediate governed MCP ops against the verified scope and DENY on a violation;
+   *   - `"observe"` → dry-run: mediate the SAME gates but NEVER deny — record would-be denials to the
+   *                   audit trail so an operator can see what default-on would block before it does;
+   *   - absent/false → the runtime is unchanged.
+   * Being inside `[scope]`, this flag is covered by the signature — it cannot be changed without
+   * re-signing. See `pillar3-runtime-default-on-5.0.md` for the off → observe → enforce ladder.
    */
-  enforce_runtime?: boolean;
+  enforce_runtime?: boolean | "observe";
 }
 
 export interface KitProfile {
@@ -155,7 +158,7 @@ const kitProfileSchema = z
         fs: z.array(z.string()).optional(),
         secrets: z.array(z.string()).optional(),
         sign: z.array(z.string()).optional(),
-        enforce_runtime: z.boolean().optional(),
+        enforce_runtime: z.union([z.boolean(), z.literal("observe")]).optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
Adds the field-validation mechanism that makes runtime-enforcement **default-on** safe (design note: kit-research #40). The blocker to flipping the default was never code — it was **evidence**: the broker only mediates *declared* effects, so a blind flip would turn every not-yet-declaring op under a verified scope into a fail-closed deny on upgrade. This PR builds the dry-run that produces that evidence.

## What
- **profile schema** — `[scope].enforce_runtime` now accepts `"observe"` (alongside `true` / absent). Signed, so the mode is cryptographically attributable.
- **`profile-policy`** — surfaces `runtimeMode: "off" | "observe" | "enforce"`; `enforceRuntime` kept as `runtimeMode === "enforce"` for back-compat.
- **`runBrokered` / `brokerObserve`** — in observe mode, run the **same gates** as enforcement but **never deny**: record would-be denials to the audit trail (`phase: "observe"`, `wouldDeny`) and execute with full env (behavior-neutral). A null policy (unsigned scope) records the default-deny that enforce *would* apply — so an operator sees what default-on would block before anything breaks.
- **`kit doctor`** — the `exec-broker runtime` row reports the observe posture (`warn` — mediating without denying; review the would-be denials, then graduate to `enforce`).

## Not in this PR (by design)
The default stays **off**; `enforce_runtime = true` is unchanged. Flipping the default is a *later* increment justified by the field evidence observe produces — the migration ladder is `off → observe → enforce → default-on`.

## No false green
Observe audits an op as *observed*, never as mediated-and-allowed; `wouldDeny` is recorded honestly (empty = clean, ready to enforce).

## Verification
- `npx tsc --noEmit` clean · `npx eslint src` 0 errors (124 pre-existing warnings)
- 6 new tests (runtimeMode off/observe/enforce; observe off-scope/in-scope/unsigned would-deny recording + never-deny; doctor observe warn)
- `node scripts/test.mjs` — **2776/2776 pass, 0 fail** · prettier applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_