### PR TITLE
feat(exec-broker): default-on runtime mediation — verified scope observes by default (Pillar 3)

### DIFF
--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -159,7 +159,7 @@ describe("runDoctor", () => {
     }
   });
 
-  it("exec-broker runtime: skips when enforce_runtime is not opted in", async () => {
+  it("exec-broker runtime: skips when no [scope] is declared (nothing to mediate)", async () => {
     const tmpDir = join(tmpdir(), `kit-doctor-test-${process.pid}-rt-skip`);
     await mkdir(tmpDir, { recursive: true });
     try {
@@ -167,7 +167,7 @@ describe("runDoctor", () => {
       const rt = result.checks.find((c) => c.name === "exec-broker runtime");
       assert.ok(rt, "exec-broker runtime check should always be present");
       assert.equal(rt.status, "skip");
-      assert.ok(rt.detail.includes("enforce_runtime"), `unexpected detail: ${rt.detail}`);
+      assert.ok(rt.detail.includes("no [scope]"), `unexpected detail: ${rt.detail}`);
     } finally {
       await rm(tmpDir, { recursive: true });
     }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -309,13 +309,17 @@ async function scopeDegradationStatus(cwd: string): Promise<"warn" | "fail"> {
 async function checkBrokerRuntime(cwd: string): Promise<DoctorCheck> {
   const name = "exec-broker runtime";
   const category = "security";
-  const { runtimeMode, policy } = await profileBrokerPolicy(cwd);
+  const { runtimeMode, policy, regime } = await profileBrokerPolicy(cwd);
   if (runtimeMode === "off") {
+    // Default-on: a declared scope mediates in observe by default, so "off" means either no scope is
+    // declared here, or the scope explicitly opted OUT with enforce_runtime = false.
     return {
       name,
       status: "skip",
       detail:
-        'MCP-runtime mediation not opted in — set [scope].enforce_runtime = true (or "observe" for a dry-run) and re-sign to mediate governed MCP ops against the scope',
+        regime === "none"
+          ? "no [scope] declared — nothing to mediate at the MCP runtime"
+          : "MCP-runtime mediation explicitly OFF ([scope].enforce_runtime = false); remove it to get observe-by-default, or set true to enforce",
       category,
     };
   }

--- a/src/exec-broker/broker.test.ts
+++ b/src/exec-broker/broker.test.ts
@@ -433,19 +433,48 @@ enforce_runtime = true
     assert.equal(ran, false);
   });
 
-  it("signed scope WITHOUT enforce_runtime → runtime unchanged (falls through to passthrough)", async () => {
+  it("DEFAULT-ON: a signed scope WITHOUT enforce_runtime observes by default (audits would-deny, never denies)", async () => {
     await writeSignedProfile(`version = 1\n[scope]\negress = ["api.acme.com"]\n`, true);
     let ran = false;
     const out = await runBrokered(
-      CTX({ egressTargets: ["https://evil.com"] }), // off-scope, but no runtime opt-in → not gated
+      CTX({ egressTargets: ["https://evil.com"] }), // off-scope: enforce WOULD deny; observe records it
       async () => {
         ran = true;
         return "ok";
       },
       { cwd: sandbox },
     );
-    assert.equal(out.ok, true, "a signed scope alone does not gate the MCP runtime");
+    assert.equal(out.ok, true, "observe-by-default never denies");
     assert.equal(ran, true);
+    const obs = auditLines().find((l) => (l.metadata as { phase?: string })?.phase === "observe");
+    assert.ok(obs, "default-on mediates in observe → an observe audit entry is written");
+    const wouldDeny = (obs!.metadata as { wouldDeny?: string[] }).wouldDeny ?? [];
+    assert.ok(
+      wouldDeny.some((d) => d.includes("evil.com")),
+      `the would-be denial is recorded: ${JSON.stringify(wouldDeny)}`,
+    );
+  });
+
+  it("explicit enforce_runtime = false → runtime OFF (opt out of mediation entirely)", async () => {
+    await writeSignedProfile(
+      `version = 1\n[scope]\negress = ["api.acme.com"]\nenforce_runtime = false\n`,
+      true,
+    );
+    let ran = false;
+    const out = await runBrokered(
+      CTX({ egressTargets: ["https://evil.com"] }),
+      async () => {
+        ran = true;
+        return "ok";
+      },
+      { cwd: sandbox },
+    );
+    assert.equal(out.ok, true);
+    assert.equal(ran, true);
+    assert.ok(
+      !auditLines().some((l) => (l.metadata as { phase?: string })?.phase === "observe"),
+      "explicit off writes no observe audit entry",
+    );
   });
 
   it("infrastructure op under a restrictive enforce_runtime scope → allowed + audited exemption", async () => {

--- a/src/exec-broker/profile-policy.test.ts
+++ b/src/exec-broker/profile-policy.test.ts
@@ -145,4 +145,22 @@ describe("profileBrokerPolicy", () => {
     assert.equal(r.runtimeMode, "observe");
     assert.equal(r.policy, null, "unsigned → null policy (observe still reports would-denies)");
   });
+
+  it("DEFAULT-ON: a declared scope with no enforce_runtime defaults to observe", async () => {
+    writeFileSync(join(proj, PROFILE_FILE), `version = 1\n[scope]\negress = ["h.io"]\n`);
+    await signProfile(proj);
+    const r = await profileBrokerPolicy(proj);
+    assert.equal(
+      r.runtimeMode,
+      "observe",
+      "mediation is on (dry-run) by default for a declared scope",
+    );
+    assert.equal(r.enforceRuntime, false, "default-on is observe, not enforce");
+  });
+
+  it("enforce_runtime = false is an explicit opt-out (runtimeMode off)", async () => {
+    writeFileSync(join(proj, PROFILE_FILE), `version = 1\n[scope]\nenforce_runtime = false\n`);
+    await signProfile(proj);
+    assert.equal((await profileBrokerPolicy(proj)).runtimeMode, "off");
+  });
 });

--- a/src/exec-broker/profile-policy.ts
+++ b/src/exec-broker/profile-policy.ts
@@ -64,11 +64,21 @@ interface ScopeShape {
   enforce_runtime?: boolean | "observe";
 }
 
-/** Map the signed `enforce_runtime` declaration onto the runtime posture. */
+/**
+ * Map the signed `enforce_runtime` declaration onto the runtime posture (Pillar 3 default-on).
+ *   - `"observe"` → dry-run (mediate, audit would-be denials, never deny);
+ *   - `true`      → enforce (mediate + deny);
+ *   - `false`     → explicit OFF (opt out of runtime mediation entirely);
+ *   - ABSENT      → DEFAULT-ON: a declared scope mediates in `observe` by default. Turning mediation
+ *     on by default is safe because observe never denies — nothing an upgrade could break; it only
+ *     starts recording what enforce WOULD block. Enforce-by-default stays an explicit `true` until
+ *     field evidence from observe justifies flipping it.
+ */
 function runtimeModeOf(scope: ScopeShape): "off" | "observe" | "enforce" {
   if (scope.enforce_runtime === "observe") return "observe";
   if (scope.enforce_runtime === true) return "enforce";
-  return "off";
+  if (scope.enforce_runtime === false) return "off";
+  return "observe";
 }
 
 /** Map a verified profile `[scope]` onto a BrokerPolicy (fs paths resolved against `cwd`). */

--- a/src/mcp-server.test.ts
+++ b/src/mcp-server.test.ts
@@ -426,8 +426,9 @@ describe("kit_secrets + signed-scope runtime enforcement (MCP-runtime adoption s
     }
   });
 
-  it("without enforce_runtime the runtime is unchanged (write proceeds)", async () => {
-    // A signed scope that does NOT opt in ⇒ migration passthrough ⇒ secrets still written.
+  it("default-on (no enforce_runtime) OBSERVES but never denies (write proceeds)", async () => {
+    // A signed scope that does NOT set the flag ⇒ default-on observe ⇒ would-be denials are audited
+    // but the write still proceeds (observe never denies), even though .env.local is off the fs scope.
     await writeFile(join(tempDir, PROFILE_FILE), `version = 1\n[scope]\nfs = ["src"]\n`);
     await signProfile(tempDir);
     const { client, cleanup } = await createTestClient();
@@ -437,7 +438,7 @@ describe("kit_secrets + signed-scope runtime enforcement (MCP-runtime adoption s
       assert.equal(
         data.ok,
         true,
-        "no enforce_runtime ⇒ not gated even though .env.local is off the fs scope",
+        "observe-by-default never denies even though .env.local is off the fs scope",
       );
       assert.ok(data.writtenKeys.includes("APP_KEY"));
     } finally {


### PR DESCRIPTION
Turns runtime mediation **on by default** — the safe half of the default-on ladder (design note: kit-research `pillar3-runtime-default-on-5.0.md`).

## What
- **`profile-policy` `runtimeModeOf`:** a declared `[scope]` with **no** `enforce_runtime` now defaults to **`observe`** (was `off`). `enforce_runtime = false` is the explicit opt-out; `= true` stays explicit enforce; `= "observe"` unchanged.
- **`kit doctor`:** the `off` (skip) row now honestly means *no `[scope]` declared* or an explicit `enforce_runtime = false` opt-out.

## Why this is safe to flip now
Non-breaking **by construction**: observe mediates and audits would-be denials but **never denies**, so no existing flow can break on upgrade — it only starts *recording* what enforce would block, on the projects that already declare + sign a `[scope]`. Projects with no profile are wholly unaffected (regime `none` → off).

## Not in this PR (still deferred)
**enforce-by-default** (deny by default) — the final rung — stays gated on the field evidence observe now produces. This PR does not make anything deny that didn't before.

## Verification
- `npx tsc --noEmit` clean · `npx eslint src` 0 errors · **public surface unchanged**
- Tests: default-on observe for a signed scope without the flag (records would-deny, still runs); explicit `= false` → off (no observe audit); profile-policy runtimeMode default + opt-out; updated the now-stale "runtime unchanged" broker + mcp-server tests to assert observe-by-default.
- `node scripts/test.mjs` — **2788/2788 pass, 0 fail** · prettier applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_