### PR TITLE
feat(triage): kit doctor deep-skill-scanner detection + record --deep in triage log (increment 2)

### DIFF
--- a/src/commands/triage.ts
+++ b/src/commands/triage.ts
@@ -151,7 +151,7 @@ export async function cmdTriage(): Promise<boolean> {
   // a failed triage means the user explicitly chose not to install, so it
   // shouldn't unblock the commit.
   if (overall && target) {
-    await recordTriageRun(type, target, sandbox);
+    await recordTriageRun(type, target, sandbox, deep);
   }
 
   return overall;
@@ -415,10 +415,17 @@ interface TriageLogEntry {
   type: string;
   target: string;
   sandbox: boolean;
+  /** Whether a deep delegate scan (SkillSpector Stage 1) ran — lets a gate require it for skills. */
+  deep?: boolean;
   granter: string;
 }
 
-async function recordTriageRun(type: string, target: string, sandbox: boolean): Promise<void> {
+async function recordTriageRun(
+  type: string,
+  target: string,
+  sandbox: boolean,
+  deep = false,
+): Promise<void> {
   const { appendFile } = await import("node:fs/promises");
   const { resolve } = await import("node:path");
   const entry: TriageLogEntry = {
@@ -426,6 +433,7 @@ async function recordTriageRun(type: string, target: string, sandbox: boolean): 
     type,
     target,
     sandbox,
+    deep,
     granter: process.env.USER ?? "unknown",
   };
   try {

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -215,6 +215,21 @@ describe("runDoctor", () => {
     }
   });
 
+  it("deep skill scanner: skips when SkillSpector is not installed (optional delegate)", async () => {
+    const tmpDir = join(tmpdir(), `kit-doctor-test-${process.pid}-deep`);
+    await mkdir(tmpDir, { recursive: true });
+    try {
+      const result = await runDoctor({}, tmpDir);
+      const deep = result.checks.find((c) => c.name === "deep skill scanner");
+      assert.ok(deep, "deep skill scanner check should always be present");
+      // Not installed in CI → skip (optional); if a future runner has it, pass is also honest.
+      assert.ok(["skip", "pass"].includes(deep.status), `unexpected status: ${deep.status}`);
+      assert.ok(deep.detail.length > 0);
+    } finally {
+      await rm(tmpDir, { recursive: true });
+    }
+  });
+
   it("surfaces the identity keystore posture (Pelare 1 — never silent)", async () => {
     const tmpDir = join(tmpdir(), `kit-doctor-test-${process.pid}-9`);
     await mkdir(tmpDir, { recursive: true });

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -353,6 +353,28 @@ async function checkBrokerRuntime(cwd: string): Promise<DoctorCheck> {
 }
 
 /**
+ * Deep skill-scanner delegate posture. The optional SkillSpector (NVIDIA) delegate deepens
+ * `kit triage skill --deep` (static Stage 1 only — kit never runs its LLM stage). Optional, so its
+ * absence is a `skip`, not a failure:
+ *   pass  installed — deep static skill triage is available
+ *   skip  not installed — --deep falls back to kit's built-in checks
+ */
+async function checkDeepSkillScanner(): Promise<DoctorCheck> {
+  const name = "deep skill scanner";
+  const category = "security";
+  const { skillspectorStatus } = await import("./skillspector-delegate.js");
+  const s = await skillspectorStatus();
+  return s.available
+    ? {
+        name,
+        status: "pass",
+        detail: `SkillSpector ${s.version ? `${s.version} ` : ""}— deep skill triage available (static Stage 1 only; kit never runs its LLM stage)`,
+        category,
+      }
+    : { name, status: "skip", detail: s.detail, category };
+}
+
+/**
  * Keyless-credential posture (Pelare 2 tail — "sign, don't store"). Reports whether any hosts are
  * declared keyless (`[scope].sign`) and whether kit can actually sign for them — never silent:
  *   skip  no keyless hosts declared
@@ -484,6 +506,7 @@ export async function runDoctor(config: kitConfig, cwd: string): Promise<DoctorR
   allChecks.push(await checkBrokerScope(cwd));
   allChecks.push(await checkBrokerRuntime(cwd));
   allChecks.push(await checkKeyless(cwd));
+  allChecks.push(await checkDeepSkillScanner());
   allChecks.push(checkControlPlane(cwd));
 
   const passed = allChecks.filter((c) => c.status === "pass").length;

--- a/src/skillspector-delegate.test.ts
+++ b/src/skillspector-delegate.test.ts
@@ -5,6 +5,7 @@ import {
   stage1Args,
   normalizeSkillspectorSarif,
   runSkillspectorStage1,
+  skillspectorStatus,
   LLM_ENV_VARS,
   SKILLSPECTOR_SOURCE,
   SKILLSPECTOR_BIN,
@@ -101,5 +102,11 @@ describe("skillspector delegate — fail-closed when the binary is absent", () =
     const r = await runSkillspectorStage1("./skill");
     assert.equal(r.status, "unavailable");
     if (r.status === "unavailable") assert.match(r.detail, new RegExp(SKILLSPECTOR_BIN));
+  });
+
+  it("skillspectorStatus reports not-available when the binary is absent", async () => {
+    const s = await skillspectorStatus();
+    assert.equal(s.available, false);
+    assert.match(s.detail, new RegExp(SKILLSPECTOR_BIN));
   });
 });

--- a/src/skillspector-delegate.ts
+++ b/src/skillspector-delegate.ts
@@ -78,6 +78,30 @@ export function normalizeSkillspectorSarif(sarifJson: string): SecurityCheckResu
   }));
 }
 
+export interface SkillspectorStatus {
+  available: boolean;
+  version?: string;
+  detail: string;
+}
+
+/**
+ * Detect whether the SkillSpector delegate is installed (mise-first, then PATH) and its version.
+ * Runs `--version` with the SAME scrubbed env as a scan, so probing can never touch a provider.
+ * Never throws.
+ */
+export async function skillspectorStatus(): Promise<SkillspectorStatus> {
+  const bin = await resolveToolBin(SKILLSPECTOR_BIN);
+  if (!bin) {
+    return {
+      available: false,
+      detail: `${SKILLSPECTOR_BIN} not installed — 'kit triage skill --deep' uses kit's built-in checks only`,
+    };
+  }
+  const res = await execFileNoThrow(bin, ["--version"], { timeout: 10_000, env: scrubbedEnv() });
+  const version = (res.stdout.trim() || res.stderr.trim()).split("\n")[0] || undefined;
+  return { available: true, version, detail: version ? `available (${version})` : "available" };
+}
+
 export type SkillspectorResult =
   | { status: "ok"; findings: SecurityCheckResult[]; worst: SecurityCheckResult["severity"] }
   | { status: "unavailable"; detail: string }


### PR DESCRIPTION
## Description

Increment 2 of the SkillSpector delegate (`kit triage skill --deep`, landed in #327). This wires the delegate into two places so its presence and use are *observable* — closing the loop between "the deep scanner exists" and "the operator can see whether it ran."

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

- Related to #327 (SkillSpector delegate, Stage-1 only — no LLM, no egress)

## Changes Made

- **`kit doctor` deep-skill-scanner row** (`src/doctor.ts`): `checkDeepSkillScanner()` reports `pass` when the `skillspector` binary is installed and `skip` when it's absent (it's an optional deep-scan delegate, not a required tool — never a `fail`). Wired into `allChecks` ahead of the control-plane row.
- **`skillspectorStatus()`** (`src/skillspector-delegate.ts`): probes the delegate (mise-first, then PATH) and its `--version` using the **same scrubbed env** as a scan, so detection itself can never touch a provider or activate Stage 2.
- **Triage log `deep` flag** (`src/commands/triage.ts`): `TriageLogEntry.deep?: boolean`; `recordTriageRun(type, target, sandbox, deep=false)` records whether a run used the deep delegate, so the audit trail distinguishes built-in-only triage from delegate-backed triage.

## Testing

Zero-LLM / no-egress invariant stays enforced and tested: `scrubbedEnv` strips every `SKILLSPECTOR_*` and provider-key var, `stage1Args` never carries an LLM/provider flag, and an absent binary yields a fail-closed `unavailable`/`skip` (never a silent deep-clean).

### Test Coverage
- [x] Added new tests (`skillspectorStatus` absent-binary case; doctor row)
- [x] All tests pass (`npm test`)

- `npx tsc --noEmit` — clean
- `npx eslint src` — 0 errors (pre-existing warnings only)
- `npm run build` — clean
- `node scripts/test.mjs` — **2796/2796 pass**
- Public surface unchanged (help-text only; no new subcommands) — no `public-surface.json` regen needed

### Manual Testing
1. `kit doctor` with `skillspector` absent → deep-skill-scanner row shows `skip` (optional).
2. Install `skillspector`, re-run → row shows `pass` with version.
3. `kit triage skill --deep <target>` → triage log entry carries `deep: true`.

## Breaking Changes

None / N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] All new code has test coverage
- [x] All tests pass locally (`npm test`)
- [x] No new warnings or errors introduced
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

## Performance Impact

- [x] No performance impact

## Reviewer Notes

Fail-closed throughout: the delegate is an *optional* deep pass. `kit doctor` degrades honestly (`skip`, not `fail`) when it's absent, and the triage log's `deep` flag makes it auditable whether any given run was delegate-backed or built-in-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_