### PR TITLE
feat(setup): recommended hardening wires the triage pre-commit gates (increment 2c)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -144,6 +144,7 @@
 | `kit triage all <target>`        | Auto-detect + run all checks.                                        |
 | `kit triage tools`               | List installed security tools.                                       |
 | `kit triage check-deps`          | Pre-commit gate: fail if staged deps lack triage entries.            |
+| `kit triage check-skills`        | Pre-commit gate: fail if staged skills lack a `--deep` triage entry. |
 
 ## Packages + plugins
 

--- a/docs/ENFORCEMENT_AND_AUDIT.md
+++ b/docs/ENFORCEMENT_AND_AUDIT.md
@@ -15,7 +15,8 @@ Deterministic, fail-closed, zero-LLM:
 - **PreToolUse gates** — `gate-bash`, `gate-env` block un-triaged installs and plaintext-secret
   writes *before* they land.
 - **Capture-time gates** — the memory write-gate (G1), install-gate, slopsquat scoring (G4).
-- **Commit/CI chokepoints** — `kit triage check-deps` (pre-commit), branch-protected checks.
+- **Commit/CI chokepoints** — `kit triage check-deps` + `kit triage check-skills` (pre-commit,
+  wired by `kit setup --recommended`), branch-protected checks.
 - **`warn → enforce` ramp** — a new gate warns first, then fails once enforced.
 
 This is the "gravitation": you *can't* do X. It shapes **how** software gets built.

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -233,7 +233,7 @@ export async function cmdSetup(): Promise<boolean> {
     recommended = profile.recommended;
   } else {
     recommended = await promptConfirm(
-      `Use the recommended profile? Wires cross-harness memory hooks (in ~/.claude) + git secret-scan${config.context ? " + context-check" : ""} gates after the core steps. [Y/n] `,
+      `Use the recommended profile? Wires cross-harness memory hooks (in ~/.claude) + git secret-scan + triage${config.context ? " + context-check" : ""} gates after the core steps. [Y/n] `,
       10000,
       profile.recommended,
     );

--- a/src/recommended.test.ts
+++ b/src/recommended.test.ts
@@ -28,16 +28,18 @@ describe("applyRecommendedHardening", () => {
     return mkdtempSync(join(tmp, "git-")) + "/.git";
   }
 
-  it("wires memory hooks + a pre-commit secret-scan, and a pre-push when context is declared", async () => {
+  it("wires memory hooks + a pre-commit secret-scan + triage gates, and a pre-push when context is declared", async () => {
     const g = gitDir();
     const r = await applyRecommendedHardening({ context: { git: { email: "x@y.z" } } }, g);
 
     // 3 memory hooks (UserPromptSubmit/SessionEnd/SessionStart).
     assert.equal(r.memory.added.length, 3);
 
-    // pre-commit secret-scan gate.
+    // pre-commit secret-scan + triage gates (deps + skills).
     const pc = readFileSync(join(g, "hooks", "pre-commit"), "utf-8");
     assert.ok(pc.includes("security scan-staged"), "pre-commit runs security scan-staged");
+    assert.ok(pc.includes("triage check-deps"), "pre-commit runs the dep triage gate");
+    assert.ok(pc.includes("triage check-skills"), "pre-commit runs the skill triage gate");
 
     // pre-push context-check gate (context was declared).
     assert.ok(existsSync(join(g, "hooks", "pre-push")), "pre-push installed when context declared");

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -22,8 +22,13 @@ function kitInvocation(): string {
 /**
  * The opinionated "recommended" hardening layered on top of `kit setup`:
  *   - cross-harness memory capture (the Claude Code hooks)
- *   - a pre-commit secret-scan gate
+ *   - a pre-commit gate: secret-scan + triage gates for newly-added deps and staged skills
  *   - a pre-push context-check gate (only when `[context]` is declared)
+ *
+ * The triage gates (`kit triage check-deps` / `check-skills`) were always meant to run at
+ * commit time — they're the fail-closed chokepoint that refuses staged deps/skills lacking a
+ * recent triage. Wiring them into the recommended pre-commit turns the documented gates into
+ * enforced ones. Both are cheap no-ops when nothing relevant is staged.
  *
  * Each piece is idempotent and uses the already-hardened installers
  * (absolute-path memory hooks; hooksPath-aware, no-clobber git hooks). It
@@ -37,7 +42,13 @@ export async function applyRecommendedHardening(
   const memory = installMemoryHooks();
 
   const kit = kitInvocation();
-  const hookConfig: HooksConfig = { "pre-commit": [`${kit} security scan-staged`] };
+  const hookConfig: HooksConfig = {
+    "pre-commit": [
+      `${kit} security scan-staged`,
+      `${kit} triage check-deps`,
+      `${kit} triage check-skills`,
+    ],
+  };
   // The context-check gate only makes sense once a context is declared.
   if (config.context) {
     hookConfig["pre-push"] = [`${kit} context check`];


### PR DESCRIPTION
## Description

Adoption step for the triage delegate line. The gates `kit triage check-deps` (existing) and `kit triage check-skills` (increment 2b) were documented as pre-commit steps — but nothing installed them. `kit setup --recommended` wired only `kit security scan-staged` into the pre-commit hook, so the triage chokepoint existed on paper only.

This adds both triage gates to `applyRecommendedHardening`, turning the documented fail-closed gates into enforced ones: a commit that adds an untriaged dependency, or stages a skill without a fresh `--deep` triage, is now blocked at commit time.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

- Related to #330 (`check-skills`), #329/#328 (the `deep` flag), #327 (the delegate)

## Changes Made

- **`src/recommended.ts`**: the recommended `pre-commit` hook now runs `security scan-staged` **+** `triage check-deps` **+** `triage check-skills`. Doc comment updated to explain the enforcement rationale.
- **`src/commands/setup.ts`**: the `--recommended` confirmation prompt now names the triage gates it wires.
- **Docs**: `COMMANDS.md` lists `kit triage check-skills`; `ENFORCEMENT_AND_AUDIT.md` notes both triage gates are wired by `kit setup --recommended`.

## Testing

Both gates are cheap no-ops when nothing relevant is staged, so the addition doesn't disturb ordinary commits — it only fires on newly-added deps or staged skills.

### Test Coverage
- [x] Updated existing tests (`recommended.test.ts` now asserts both triage gates land in the generated pre-commit hook)
- [x] All tests pass (`npm test`)

- `npx tsc --noEmit` — clean
- `npx eslint src` — 0 errors (pre-existing warnings only)
- `npm run build` — clean
- `node scripts/test.mjs` — **2805/2805 pass**
- Public surface unchanged — no `public-surface.json` regen needed

### Manual Testing
1. `kit setup --recommended` in a repo → `.git/hooks/pre-commit` contains all three gate commands.
2. Stage a new untriaged dep in `package.json` and commit → blocked by `check-deps`.
3. Stage a skill file with no `--deep` triage and commit → blocked by `check-skills`.

## Breaking Changes

None / N/A. Only affects users who opt into `--recommended`, and the gates no-op unless a dep/skill is actually staged. `--no-verify` remains the audited escape hatch (logged to `.kit-skipped-commits.jsonl`).

## Checklist

- [x] My code follows the project's style guidelines
- [x] All new code has test coverage
- [x] All tests pass locally (`npm test`)
- [x] No new warnings or errors introduced
- [x] I've updated documentation as needed
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

## Performance Impact

- [x] No performance impact

## Reviewer Notes

This closes the same "exists but nothing installs it" gap that `--broker-gate` closed for the runtime egress/fs gates (#71). The gates were always designed to run at commit time; this just makes the recommended profile actually wire them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_