### PR TITLE
feat(doctor): kit doctor row — is the triage pre-commit gate actually wired? (increment 2d)

### DIFF
--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -4,7 +4,7 @@ import { writeFile, unlink, mkdir, rmdir, rm } from "node:fs/promises";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { runDoctor } from "./doctor.js";
+import { runDoctor, triageGateStatus } from "./doctor.js";
 import { loadOrCreateIdentity, identityId } from "./identity.js";
 import { resolveKeyStore } from "./keystore/index.js";
 import {
@@ -230,6 +230,21 @@ describe("runDoctor", () => {
     }
   });
 
+  it("triage pre-commit gates: check is always present (skip when not wired)", async () => {
+    const tmpDir = join(tmpdir(), `kit-doctor-test-${process.pid}-triage-gates`);
+    await mkdir(tmpDir, { recursive: true });
+    try {
+      const result = await runDoctor({}, tmpDir);
+      const g = result.checks.find((c) => c.name === "triage pre-commit gates");
+      assert.ok(g, "triage pre-commit gates check should always be present");
+      // tmpDir is not a git repo → skip; a wired repo would be pass — both honest.
+      assert.ok(["skip", "pass", "warn"].includes(g.status), `unexpected status: ${g.status}`);
+      assert.ok(g.detail.length > 0);
+    } finally {
+      await rm(tmpDir, { recursive: true });
+    }
+  });
+
   it("surfaces the identity keystore posture (Pelare 1 — never silent)", async () => {
     const tmpDir = join(tmpdir(), `kit-doctor-test-${process.pid}-9`);
     await mkdir(tmpDir, { recursive: true });
@@ -361,5 +376,33 @@ describe("runDoctor — keyless credentials row (Pillar 2 tail)", () => {
     assert.ok(row);
     assert.equal(row.status, "pass", row.detail);
     assert.match(row.detail, /require signed requests/);
+  });
+});
+
+describe("triageGateStatus (pure — pre-commit gate posture)", () => {
+  it("pass when both triage gates are wired into the pre-commit hook", () => {
+    const hook =
+      "#!/bin/sh\nkit security scan-staged\nkit triage check-deps\nkit triage check-skills\n";
+    const r = triageGateStatus(hook);
+    assert.equal(r.status, "pass");
+    assert.match(r.detail, /check-deps \+ check-skills/);
+  });
+
+  it("warn (partial drift) when only check-deps is wired — names the missing gate", () => {
+    const r = triageGateStatus("#!/bin/sh\nkit triage check-deps\n");
+    assert.equal(r.status, "warn");
+    assert.match(r.detail, /missing check-skills/);
+  });
+
+  it("warn (partial drift) when only check-skills is wired", () => {
+    const r = triageGateStatus("#!/bin/sh\nkit triage check-skills\n");
+    assert.equal(r.status, "warn");
+    assert.match(r.detail, /missing check-deps/);
+  });
+
+  it("skip when neither gate is present or there is no hook (never silent — suggests setup)", () => {
+    assert.equal(triageGateStatus("#!/bin/sh\nkit security scan-staged\n").status, "skip");
+    assert.equal(triageGateStatus(null).status, "skip");
+    assert.match(triageGateStatus(null).detail, /kit setup --recommended/);
   });
 });

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -375,6 +375,59 @@ async function checkDeepSkillScanner(): Promise<DoctorCheck> {
 }
 
 /**
+ * Triage pre-commit gate posture (increment 2d). Reports whether the commit-time triage chokepoint
+ * (`kit triage check-deps` + `kit triage check-skills`) is actually wired into the repo's pre-commit
+ * hook — the honest counterpart to `kit setup --recommended` installing it. Never silent:
+ *   pass  both triage gates present in the pre-commit hook
+ *   warn  the hook exists but is missing one gate (partial — e.g. wired before check-skills shipped)
+ *   skip  not a git repo, or the gates aren't wired (optional; run `kit setup --recommended`)
+ * Pure decision split out for testing.
+ */
+export function triageGateStatus(hookContent: string | null): {
+  status: DoctorCheckStatus;
+  detail: string;
+} {
+  const has = (needle: string) => !!hookContent && hookContent.includes(needle);
+  const deps = has("triage check-deps");
+  const skills = has("triage check-skills");
+  if (deps && skills) {
+    return { status: "pass", detail: "pre-commit runs triage check-deps + check-skills" };
+  }
+  if (deps || skills) {
+    return {
+      status: "warn",
+      detail: `pre-commit wires only triage ${deps ? "check-deps" : "check-skills"} — missing ${
+        deps ? "check-skills" : "check-deps"
+      }; re-run 'kit setup --recommended'`,
+    };
+  }
+  return {
+    status: "skip",
+    detail:
+      "triage pre-commit gates not wired — run 'kit setup --recommended' to enforce dep/skill triage at commit time",
+  };
+}
+
+async function checkTriageGates(cwd: string): Promise<DoctorCheck> {
+  const name = "triage pre-commit gates";
+  const category = "security";
+  const { isGitRepository } = await import("./check-hooks.js");
+  if (!isGitRepository()) {
+    return { name, status: "skip", detail: "not a git repository", category };
+  }
+  const { resolveHooksDir } = await import("./hooks.js");
+  const hookPath = join(resolveHooksDir(join(cwd, ".git")), "pre-commit");
+  let content: string | null = null;
+  try {
+    content = await readFile(hookPath, "utf-8");
+  } catch {
+    content = null; // no pre-commit hook → gates not wired
+  }
+  const { status, detail } = triageGateStatus(content);
+  return { name, status, detail, category };
+}
+
+/**
  * Keyless-credential posture (Pelare 2 tail — "sign, don't store"). Reports whether any hosts are
  * declared keyless (`[scope].sign`) and whether kit can actually sign for them — never silent:
  *   skip  no keyless hosts declared
@@ -507,6 +560,7 @@ export async function runDoctor(config: kitConfig, cwd: string): Promise<DoctorR
   allChecks.push(await checkBrokerRuntime(cwd));
   allChecks.push(await checkKeyless(cwd));
   allChecks.push(await checkDeepSkillScanner());
+  allChecks.push(await checkTriageGates(cwd));
   allChecks.push(checkControlPlane(cwd));
 
   const passed = allChecks.filter((c) => c.status === "pass").length;


### PR DESCRIPTION
## Description

Closes the loop on the triage delegate line. Increment 2c installs the triage pre-commit gates via `kit setup --recommended`; 2d makes their presence **auditable**. `kit doctor` now reads the repo's actual `.git/hooks/pre-commit` and reports — never silently — whether the commit-time triage chokepoint is live.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

- Related to #331 (2c — installs the gates), #330 (`check-skills`), #329/#328 (the `deep` flag)

## Changes Made

- **`src/doctor.ts`**: new `"triage pre-commit gates"` posture row (`checkTriageGates`), wired after the deep-skill-scanner row. Verdicts:
  - `pass` — both `kit triage check-deps` + `check-skills` present in the pre-commit hook
  - `warn` — the hook exists but wires only one gate (partial drift, e.g. installed before `check-skills` shipped); names the missing gate
  - `skip` — not a git repo, or the gates aren't wired (optional; suggests `kit setup --recommended`)
- **Pure decision** `triageGateStatus(hookContent)` split out and exported for deterministic unit testing (no git required).

## Testing

Honest posture is the point: the row is always present, degrades to `skip` rather than a false `pass`, and a partial wiring surfaces as `warn` instead of being swallowed.

### Test Coverage
- [x] Added new tests (4 pure `triageGateStatus` cases + 1 `runDoctor` integration assertion)
- [x] All tests pass (`npm test`)

- `npx tsc --noEmit` — clean
- `npx eslint src` — 0 errors (pre-existing warnings only)
- `npm run build` — clean
- `node scripts/test.mjs` — **2810/2810 pass**
- Public surface unchanged — no `public-surface.json` regen needed

### Manual Testing
1. `kit doctor` in a repo without the gates → row shows `skip` with the `kit setup --recommended` hint.
2. After `kit setup --recommended` → row shows `pass` (both gates present).
3. A pre-commit hook with only `check-deps` → row shows `warn`, naming `check-skills` as missing.

## Breaking Changes

None / N/A.

## Checklist

- [x] My code follows the project's style guidelines
- [x] All new code has test coverage
- [x] All tests pass locally (`npm test`)
- [x] No new warnings or errors introduced
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

## Performance Impact

- [x] No performance impact

## Reviewer Notes

Same "never silent" doctrine as the other posture rows (identity keystore, exec-broker scope/runtime): an inactive or partially-wired gate is surfaced, not hidden behind a green check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_