### PR TITLE
chore(release): prepare 5.0.0 — CHANGELOG, README, version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,101 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.0.0] - 2026-07-11
+
+kit 5.0 is the **North Star** release: kit stops being only a *point-in-time*
+verifier and becomes a *continuous, portable, fail-closed governance layer* for
+the agent loop. Four pillars land, on top of a unified command surface. Nothing
+here breaks the 2.x/4.x CLI, config, or plugin contracts — every new capability
+is additive and every new gate is opt-in or degrades honestly.
+
+### Pillar 1 — Hardware-rooted identity (#289, #290)
+
+- **Honest keystore posture.** `kit doctor` surfaces WHICH backend signs kit's
+  identity (Secure Enclave / TPM / external command vs. the file-backed 0600
+  key) and NEVER silently downgrades: a file-backed key is a `warn`, and
+  `KIT_REQUIRE_HARDWARE` makes a missing hardware backend a fail-closed `fail`.
+- **`kit identity migrate`.** Move identity onto a hardware backend and revoke
+  the old file key in one attributable, audited step.
+
+### Pillar 2 — Control plane + keyless credentials (#317–#323)
+
+- **Offline-verified policy distribution.** `kit policy pull` fetches an
+  org-signed `.kit-policy.toml`, verifies it against the anchored signers
+  entirely offline, and `pull-revocations` propagates revocations monotonically
+  (never un-revokes). Fleet-RBAC rides the same signed channel.
+- **Offline signed approval tokens.** `kit policy approve` mints/consumes
+  identity-signed, offline-verifiable approval tokens for gated operations.
+- **Keyless credentials — sign, don't store.** A pure RFC 9421 HTTP Message
+  Signatures core (`src/keyless/http-sig.ts`) plus an identity bridge lets kit
+  sign egress requests for hosts declared in `[scope].sign` instead of holding a
+  long-lived secret. `kit doctor` reports the keyless posture, fail-closed.
+- **Control-plane posture row** in `kit doctor` + self-host protocol docs.
+
+### Pillar 3 — Exec-broker: one governance floor (#303–#316, #324–#326)
+
+- **Pure scope-decision core** (`checkEgress` / `checkFsWrite` / `scopeEnv`) with
+  fail-closed source resolution: no verified signed scope ⇒ grants nothing.
+- **PreToolUse enforcers** `kit gate-egress` / `kit gate-fs` block Bash network
+  targets and Write/Edit paths outside the signed `[scope]`, wired via
+  `kit agent-config --broker-gate`.
+- **Runtime mediation at the MCP surface**, staged safely: `off → observe
+  (dry-run, audits `wouldDeny`) → enforce`. A verified scope now **observes by
+  default** (`[scope].enforce_runtime` absent ⇒ observe) — mediation is on out of
+  the box without breaking anyone; enforce remains an explicit opt-in.
+- **Reconciliation (R1–R4).** The duplicate broker core was deleted and the whole
+  governance floor unified onto ONE exec-broker: CLI gates, the MCP runtime, and
+  the `kit doctor` posture all read the same signed decision — there is one
+  broker, not two.
+
+### Pillar 4 — Traveling profile + lifecycle insight (#291–#299, #325)
+
+- **Versioned, portable profile.** `kit profile` declares
+  `{skills, mcp, workflows, plugins, vault, gates, scope}` with canonical
+  serialization; `show|freeze|check` report declared-vs-discovered drift; `sign`
+  binds the scope/RoE; **`export`/`import`** move a signed bundle to a fresh host,
+  integrity-verified offline and fail-closed on tamper/revocation.
+- **Lifecycle insight.** A deterministic transcript tool-usage scanner powers
+  `kit insight unused` (loaded-but-never-called MCP servers), real
+  loaded-but-unused verdicts for skills, and a repeat→codify skill-draft scaffold.
+- **BYO-gap closers.** `kit triage plugin` (supply-chain + manifest-poisoning),
+  `kit triage vault-config` (backend-selection), and plugin discovery close the
+  last unaudited surfaces.
+
+### Triage delegate — deep skill scanning, borrowed authority (#327–#332)
+
+- **`kit triage skill --deep`** delegates to NVIDIA SkillSpector's STATIC Stage 1
+  (regex + AST + offline OSV) and normalizes its SARIF into kit's verdict,
+  attributed to the source. kit NEVER runs SkillSpector's LLM stage — enforced by
+  a scrubbed child env (every `SKILLSPECTOR_*` + provider key stripped) and a
+  static invocation. Fail-closed: an absent binary is a `skip`, never a silent
+  deep-clean.
+- **Commit-time enforcement.** `kit triage check-skills` blocks a staged skill
+  that lacks a fresh `--deep` triage; `kit setup --recommended` now wires both
+  triage gates (`check-deps` + `check-skills`) into the pre-commit hook; and
+  `kit doctor` reports whether the gates are actually wired.
+
+### Unified surface (#271–#288)
+
+- **One source of truth.** `cli.ts` was decomposed into cohesive `commands/*`
+  modules and a `COMMAND_REGISTRY` from which the CLI verbs, MCP exposure, help,
+  and stability tiers are all derived — a drift test proves CLI ≡ MCP.
+- **No false green.** Six fabricated-success MCP stubs were removed; a tool that
+  can't really run now says so.
+
+### Added — coverage + supply-chain gates (#255–#266, #270)
+
+- `kit coverage --standard` maps kit's deterministic checks to OWASP ASVS L2,
+  OWASP LLM Top 10 (2025), and NIST SSDF (800-218A) evidence maps.
+- Memory write-gate + verified-forget (G1), secret write-gate (G2), calibrated
+  slopsquat risk score (G4), `kit triage mcp` tool-poisoning/rug-pull (G3), and
+  the agent-toolchain SBOM over skills/MCP/plugins (G5).
+
+### Changed
+
+- Minimum Node.js is 22+. The public CLI/config/plugin contracts are unchanged;
+  5.0 is a major version for the scope of new capability, not for any break.
+
 ## [4.4.0] - 2026-07-07
 
 ### Added — `kit standards`: the third quality dimension (P1–P5, #255–#257)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 For AI agents and humans. Manages tools, auth, secrets, and project setup. Zero LLM calls, local-first, multi-vault.
 
-**kit 2.0** makes its two promises concrete: `green = honest` is now externally _provable_ (kit can emit a signed receipt, anchored to a key its own process cannot recompute, proving which scanners actually ran and that none failed open, verifiable offline), and kit's CLI, config schema, and plugin SDK are frozen, versioned contracts that will not break across any 2.x release. See [Stability & contracts](#stability--contracts).
+**kit** makes two promises concrete and keeps them across every major since 2.0: `green = honest` is externally _provable_ (kit can emit a signed receipt, anchored to a key its own process cannot recompute, proving which scanners actually ran and that none failed open, verifiable offline), and kit's CLI, config schema, and plugin SDK are frozen, versioned contracts that do not break across a major line. **kit 5.0** turns the provable local floor into a continuous, portable, fail-closed **governance layer for the agent loop** — hardware-rooted identity, an offline-verified control plane, one exec-broker enforcing a signed scope, and a traveling profile you can carry to a fresh host. See [What's new in 5.0](#whats-new-in-50) and [Stability & contracts](#stability--contracts).
 
 🌐 [sandstre.am/kit](https://sandstre.am/kit)
 
@@ -66,6 +66,38 @@ Fresh or ephemeral environment (cloud container, Claude Code on the web, CI, new
 laptop)? Wire `kit setup` + `kit memory sync` into the environment's setup script
 so it fuels itself — config, secrets (vault-backed), agent gates, identity, and
 recall — with zero manual steps. See [docs/ENV_FUELING.md](docs/ENV_FUELING.md).
+
+## What's new in 5.0
+
+kit 5.0 is the **North Star** release: it takes kit from a point-in-time verifier
+to a *continuous, portable, fail-closed governance layer* for the agent loop.
+Four pillars, all additive over 4.x — no stable command removed. Highlights:
+
+- **Pillar 1 — hardware-rooted identity.** `kit doctor` surfaces which backend
+  signs kit's identity (Secure Enclave / TPM / external command vs. a file-backed
+  0600 key) and never silently downgrades; `KIT_REQUIRE_HARDWARE` makes a missing
+  hardware backend fail-closed. `kit identity migrate` moves onto hardware and
+  revokes the old key in one audited step.
+- **Pillar 2 — control plane + keyless credentials.** `kit policy pull` /
+  `pull-revocations` distribute an org-signed policy, verified and enforced fully
+  offline; `kit policy approve` mints offline signed approval tokens. Keyless
+  egress signs requests with RFC 9421 HTTP Message Signatures for hosts in
+  `[scope].sign` — sign, don't store.
+- **Pillar 3 — one exec-broker.** A single signed-scope governance floor drives
+  the PreToolUse gates (`kit gate-egress` / `gate-fs`), the MCP runtime, and the
+  `kit doctor` posture. Runtime mediation is **on by default in observe mode**
+  (audits what it *would* deny); enforce is an explicit opt-in.
+- **Pillar 4 — traveling profile.** `kit profile` declares your
+  `{skills, mcp, workflows, plugins, vault, gates, scope}`, audits
+  declared-vs-discovered drift, signs the scope/RoE, and **exports/imports** a
+  portable signed bundle to a fresh host — integrity-verified offline,
+  fail-closed on tamper.
+- **Deep skill triage.** `kit triage skill --deep` delegates to NVIDIA
+  SkillSpector's static Stage 1 (no LLM, no egress) and `kit setup --recommended`
+  wires the triage gates into your pre-commit hook.
+
+All of it holds the frozen CLI / config / plugin contracts. See
+[CHANGELOG.md](CHANGELOG.md) for the full list.
 
 ## What's new in 3.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "4.4.0",
+      "version": "5.0.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
## Description

Release-prep for **kit 5.0.0** (the North Star release). Docs + version only — no source-logic changes. Cut the tag/publish from your machine after this merges.

## Type of Change

- [x] Documentation update
- [x] Release chore (version bump)

## Changes Made

- **CHANGELOG.md** — new `[5.0.0] - 2026-07-11` section grouping:
  - Pillar 1 — hardware-rooted identity (honest keystore posture, `kit identity migrate`)
  - Pillar 2 — control plane (`kit policy pull` / `pull-revocations` / `approve`) + keyless credentials (RFC 9421 sign-don't-store)
  - Pillar 3 — one exec-broker (pure scope core, `gate-egress`/`gate-fs`, MCP-runtime observe-by-default, reconciliation R1–R4)
  - Pillar 4 — traveling profile (`kit profile` show/freeze/check/sign/export/import) + lifecycle insight
  - Triage delegate (`kit triage skill --deep`, `check-skills` gate, recommended wiring, doctor row)
  - Unified command surface (`COMMAND_REGISTRY` SoT, CLI≡MCP drift test, no false green)
  - G1–G5 gates + OWASP/NIST coverage maps
- **README.md** — refreshed the headline (2.0 → held-across-majors framing) and added a **What's new in 5.0** section with the four pillars.
- **package.json / package-lock.json** — `4.4.0 → 5.0.0`. `kit --version` prints `5.0.0`.

## Note on `kit --help`

No help edits were needed: `COMMAND_REGISTRY` in `cli.ts` is the single source of truth and every 5.0 command (`policy`, `profile`, `insight`, `identity`, `gate-egress`, `gate-fs`, and the `triage` subcommands) is already registered with help text. Help is derived, so it's already current.

## Testing

- `npm run build` — clean
- `node dist/cli.js --version` → `5.0.0`
- Full suite last ran green at the branch base (`f6f56bc`): **2810/2810**. These changes are docs + version metadata only (no runtime logic), so behavior is unchanged.

## Website

The `sandstre.am/kit` landing page (repo `sandstream/sandstream.github.io`) is updated for 5.0 in a **separate PR** against that repo.

## Breaking Changes

None. 5.0 is a major version for the *scope of new capability*, not for any contract break — the CLI, config schema, and plugin SDK are unchanged.

## Checklist

- [x] I've updated documentation as needed
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_