### PR TITLE
fix(memory): kit memory restore surfaces the real failure cause (not always "wrong passphrase")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [5.0.0] - 2026-07-11
 
-kit 5.0 is the **North Star** release: kit stops being only a *point-in-time*
-verifier and becomes a *continuous, portable, fail-closed governance layer* for
+kit 5.0 is the **North Star** release: kit stops being only a _point-in-time_
+verifier and becomes a _continuous, portable, fail-closed governance layer_ for
 the agent loop. Four pillars land, on top of a unified command surface. Nothing
 here breaks the 2.x/4.x CLI, config, or plugin contracts — every new capability
 is additive and every new gate is opt-in or degrades honestly.
@@ -45,7 +45,7 @@ is additive and every new gate is opt-in or degrades honestly.
   targets and Write/Edit paths outside the signed `[scope]`, wired via
   `kit agent-config --broker-gate`.
 - **Runtime mediation at the MCP surface**, staged safely: `off → observe
-  (dry-run, audits `wouldDeny`) → enforce`. A verified scope now **observes by
+(dry-run, audits `wouldDeny`) → enforce`. A verified scope now **observes by
   default** (`[scope].enforce_runtime` absent ⇒ observe) — mediation is on out of
   the box without breaking anyone; enforce remains an explicit opt-in.
 - **Reconciliation (R1–R4).** The duplicate broker core was deleted and the whole
@@ -95,6 +95,13 @@ is additive and every new gate is opt-in or degrades honestly.
 - Memory write-gate + verified-forget (G1), secret write-gate (G2), calibrated
   slopsquat risk score (G4), `kit triage mcp` tool-poisoning/rug-pull (G3), and
   the agent-toolchain SBOM over skills/MCP/plugins (G5).
+
+### Fixed
+
+- `kit memory restore` now surfaces the REAL failure cause (missing file, bad
+  format, permissions) instead of always reporting "wrong passphrase or corrupt
+  backup" — only a genuine AES-GCM auth failure blames the passphrase now
+  (`restoreFailureMessage`, unit-tested).
 
 ### Changed
 

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -27,6 +27,7 @@ import { sanitizeForPrompt } from "../memory/injection.js";
 import {
   backupEncrypted,
   restoreEncrypted,
+  restoreFailureMessage,
   generateMemoryKeypair,
   saveMemoryKey,
   loadMemoryKey,
@@ -1389,8 +1390,10 @@ async function memRestore(): Promise<boolean> {
   }
   try {
     restoreEncrypted(pass, inFile, dest);
-  } catch {
-    console.error(`${c.red}restore failed — wrong passphrase or corrupt backup${c.reset}`);
+  } catch (err) {
+    // Surface the REAL cause (missing file, permissions, bad format) instead of always
+    // blaming the passphrase — only a genuine AES-GCM auth failure means wrong-key/corrupt.
+    console.error(`${c.red}restore failed — ${restoreFailureMessage(err)}${c.reset}`);
     return false;
   }
   console.log(`${c.green}✓${c.reset} restored → ${dest}`);

--- a/src/memory/backup.test.ts
+++ b/src/memory/backup.test.ts
@@ -14,6 +14,7 @@ import {
   isEncryptedBackup,
   parseRecipient,
   maybeGunzip,
+  restoreFailureMessage,
 } from "./backup.js";
 import { gzipSync } from "node:zlib";
 
@@ -184,5 +185,41 @@ describe("memory backup — gzip compression (fits under host size caps)", () =>
     assert.equal(getStats(rdb).messages, 500);
     rdb.close();
     rmSync(tmp, { recursive: true, force: true });
+  });
+});
+
+describe("restoreFailureMessage — honest restore errors (not always 'wrong passphrase')", () => {
+  it("blames the passphrase ONLY for a genuine AES-GCM auth failure", () => {
+    assert.equal(
+      restoreFailureMessage(new Error("Unsupported state or unable to authenticate data")),
+      "wrong passphrase or corrupt backup",
+    );
+    assert.equal(
+      restoreFailureMessage(
+        new Error("error:1e000065:Cipher functions:OPENSSL_internal:BAD_DECRYPT"),
+      ),
+      "wrong passphrase or corrupt backup",
+    );
+  });
+
+  it("surfaces the REAL cause for non-crypto failures", () => {
+    assert.match(
+      restoreFailureMessage(
+        new Error("ENOENT: no such file or directory, open '/tmp/missing.enc'"),
+      ),
+      /ENOENT|no such file/,
+    );
+    assert.equal(
+      restoreFailureMessage(new Error("not a kit memory backup (bad magic)")),
+      "not a kit memory backup (bad magic)",
+    );
+    assert.match(
+      restoreFailureMessage(new Error("EACCES: permission denied")),
+      /EACCES|permission/,
+    );
+  });
+
+  it("never throws on a non-Error value", () => {
+    assert.equal(restoreFailureMessage("weird"), "weird");
   });
 });

--- a/src/memory/backup.ts
+++ b/src/memory/backup.ts
@@ -185,6 +185,18 @@ export function backupPlain(srcPath: string = getMemoryDbPath(), outPath?: strin
 }
 
 /** Decrypt a backup blob into `destPath`. Throws on a wrong passphrase or tampered blob (GCM auth). */
+/**
+ * Map a restore error to a user-facing message. Only a genuine AES-GCM auth failure (wrong key /
+ * tampered ciphertext) blames the passphrase; every other cause — missing file, bad magic,
+ * permissions — surfaces its real message instead of the misleading "wrong passphrase". Pure.
+ */
+export function restoreFailureMessage(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /unable to authenticate|bad[ _]decrypt|unsupported state|auth tag/i.test(msg)
+    ? "wrong passphrase or corrupt backup"
+    : msg;
+}
+
 export function restoreEncrypted(passphrase: string, inPath: string, destPath: string): void {
   const blob = readFileSync(inPath);
   const magic = blob.subarray(0, MAGIC_LEN);


### PR DESCRIPTION
## Description

Found while live-verifying the memory-move path for 5.0: `kit memory restore` reported **"wrong passphrase or corrupt backup"** for *every* failure — including a missing file, bad format, or permission error — because `memRestore`'s catch swallowed the real error. Misleading exactly when you're moving your brain to a new machine and something mundane (path/perms) is wrong.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`src/memory/backup.ts`** — new pure, exported `restoreFailureMessage(err)`: blames the passphrase **only** on a genuine AES-GCM auth failure (`unable to authenticate` / `BAD_DECRYPT` / `unsupported state` / `auth tag`); every other cause surfaces its real message.
- **`src/commands/memory.ts`** — `memRestore` uses it, so the CLI now prints the actual cause.
- **CHANGELOG.md** — `[5.0.0]` Fixed note.

## Testing

- Added `restoreFailureMessage` unit tests: auth-failure → friendly message; ENOENT / bad-magic / EACCES → real message; non-Error value never throws.
- `npx tsc --noEmit` clean · `npx eslint src` 0 errors · `npm run build` clean · `node scripts/test.mjs` **2813/2813**.
- Public surface unchanged (no new commands).

## Breaking Changes

None.

## Checklist

- [x] All new code has test coverage
- [x] All tests pass locally
- [x] No new warnings or errors introduced
- [x] Code has been self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_