### PR TITLE
feat(map): kit map --budget — relevant-slice truncation with drop-log (Pillar 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,11 +67,13 @@ is additive and every new gate is opt-in or degrades honestly.
   `kit triage vault-config` (backend-selection), and plugin discovery close the
   last unaudited surfaces.
 - **Repo-map (`kit map`).** A deterministic, zero-LLM import graph of the repo:
-  `kit map <path> [--depth N] [--json]` returns the minimal relevant SLICE around a
-  seed file (the files connected within N import hops, both directions, plus the
-  external packages) — so an agent loads part of a growing repo, not the whole
-  tree. Pure graph core + a dependency-free TS/JS extractor; relative specifiers
-  that resolve to no known file are dropped, never guessed.
+  `kit map <path> [--depth N] [--budget N] [--json]` returns the minimal relevant
+  SLICE around a seed file (the files connected within N import hops, both
+  directions, plus the external packages) — so an agent loads part of a growing
+  repo, not the whole tree. `--budget` keeps the N nearest-to-seed files and
+  **logs every drop** (never silent truncation). Pure graph core + a
+  dependency-free TS/JS extractor; relative specifiers that resolve to no known
+  file are dropped, never guessed.
 
 ### Triage delegate — deep skill scanning, borrowed authority (#327–#332)
 

--- a/src/commands/repomap.ts
+++ b/src/commands/repomap.ts
@@ -14,6 +14,7 @@ import { walkSourceFiles } from "../source-walk.js";
 import {
   buildImportGraph,
   relevantSlice,
+  budgetSlice,
   type FileImports,
   type RepoGraph,
 } from "../repomap/graph.js";
@@ -67,21 +68,26 @@ export async function cmdMap(): Promise<boolean> {
       "  kit map <path...>            Files connected to <path> within --depth import hops",
     );
     console.log("  kit map <path> --depth 2     Widen the neighborhood (default 1)");
+    console.log(
+      "  kit map <path> --budget 20   Keep only the 20 nearest files (drops are logged, never silent)",
+    );
     console.log("  kit map <path> --json        Emit the slice as JSON (for an agent/tool)");
     console.log("\nExample:");
-    console.log("  kit map src/exec-broker/broker.ts --depth 2");
+    console.log("  kit map src/exec-broker/broker.ts --depth 2 --budget 25");
     return args.length !== 0;
   }
 
   const json = hasFlag(args, "--json");
   const depthRaw = flagValue(process.argv, "--depth");
   const depth = depthRaw ? Math.max(0, Number.parseInt(depthRaw, 10) || 0) : 1;
+  const budgetRaw = flagValue(process.argv, "--budget");
+  const budget = budgetRaw ? Math.max(0, Number.parseInt(budgetRaw, 10) || 0) : 0;
   const root = process.cwd();
-  // Positional seeds = args minus flags AND minus the value consumed by `--depth`.
+  // Positional seeds = args minus flags AND minus the values consumed by `--depth` / `--budget`.
   const positional: string[] = [];
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
-    if (a === "--depth") {
+    if (a === "--depth" || a === "--budget") {
       i++; // skip its value
       continue;
     }
@@ -100,28 +106,62 @@ export async function cmdMap(): Promise<boolean> {
     return false;
   }
 
-  const slice = relevantSlice(graph, seeds, depth);
-  const files = slice.nodes.filter((n) => n.kind === "file");
-  const externals = slice.nodes.filter((n) => n.kind === "external");
+  const full = relevantSlice(graph, seeds, depth);
+  // Apply a file-count budget: keep the nearest-to-seed files, log the rest (never silent).
+  const { kept, dropped } = budgetSlice(full, seeds, budget);
+  const keptIds = new Set(kept.map((n) => n.id));
+  const slice: RepoGraph =
+    budget > 0
+      ? { nodes: kept, edges: full.edges.filter((e) => keptIds.has(e.from) && keptIds.has(e.to)) }
+      : full;
+  const droppedFiles = dropped.filter((n) => n.kind === "file").map((n) => n.id);
 
   if (json) {
-    console.log(JSON.stringify({ seeds, depth, slice, missing }, null, 2));
+    console.log(
+      JSON.stringify(
+        { seeds, depth, budget: budget || null, slice, dropped: droppedFiles, missing },
+        null,
+        2,
+      ),
+    );
     return true;
   }
 
+  printReadableSlice({ slice, seeds, depth, budget, droppedFiles, missing });
+  return true;
+}
+
+/** Human-readable render of a slice (the non-`--json` path). Kept separate so `cmdMap` stays lean. */
+function printReadableSlice(o: {
+  slice: RepoGraph;
+  seeds: string[];
+  depth: number;
+  budget: number;
+  droppedFiles: string[];
+  missing: string[];
+}): void {
+  const files = o.slice.nodes.filter((n) => n.kind === "file");
+  const externals = o.slice.nodes.filter((n) => n.kind === "external");
   console.log(
-    `${c.bold}Relevant slice${c.reset} ${c.dim}(depth ${depth}, from ${seeds.join(", ")})${c.reset}`,
+    `${c.bold}Relevant slice${c.reset} ${c.dim}(depth ${o.depth}, from ${o.seeds.join(", ")})${c.reset}`,
   );
   console.log(`  ${c.bold}${files.length}${c.reset} files · ${externals.length} external packages`);
   for (const n of files) {
-    const isSeed = seeds.includes(n.id);
+    const isSeed = o.seeds.includes(n.id);
     console.log(`  ${isSeed ? `${c.green}◆${c.reset}` : "·"} ${n.id}`);
   }
   if (externals.length) {
     console.log(`  ${c.dim}external:${c.reset} ${externals.map((n) => n.id).join(", ")}`);
   }
-  if (missing.length) {
-    console.log(`  ${c.yellow}unmatched seeds:${c.reset} ${missing.join(", ")}`);
+  if (o.droppedFiles.length) {
+    const shown = o.droppedFiles.slice(0, 15);
+    const more = o.droppedFiles.length - shown.length;
+    const tail = more > 0 ? `, …and ${more} more (use --json for the full list)` : "";
+    console.log(
+      `  ${c.yellow}${o.droppedFiles.length} file(s) dropped to fit --budget ${o.budget}:${c.reset} ${shown.join(", ")}${tail}`,
+    );
   }
-  return true;
+  if (o.missing.length) {
+    console.log(`  ${c.yellow}unmatched seeds:${c.reset} ${o.missing.join(", ")}`);
+  }
 }

--- a/src/repomap/graph.test.ts
+++ b/src/repomap/graph.test.ts
@@ -1,6 +1,12 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { buildImportGraph, relevantSlice, type FileImports } from "./graph.js";
+import {
+  buildImportGraph,
+  relevantSlice,
+  distancesFromSeeds,
+  budgetSlice,
+  type FileImports,
+} from "./graph.js";
 
 const files: FileImports[] = [
   { path: "src/a.ts", internal: ["src/b.ts"], external: ["node:fs"] },
@@ -67,5 +73,51 @@ describe("repomap graph — relevantSlice", () => {
 
   it("an unknown seed yields an empty slice (never throws)", () => {
     assert.deepEqual(relevantSlice(g, ["nope.ts"], 3).nodes, []);
+  });
+});
+
+describe("repomap graph — distancesFromSeeds", () => {
+  const g = buildImportGraph(files);
+  it("gives seed distance 0 and BFS hop counts outward", () => {
+    const d = distancesFromSeeds(g, ["src/a.ts"]);
+    assert.equal(d.get("src/a.ts"), 0);
+    assert.equal(d.get("src/b.ts"), 1);
+    assert.equal(d.get("node:fs"), 1);
+    assert.equal(d.get("src/c.ts"), 2);
+    assert.equal(d.has("src/unrelated.ts"), false, "unreachable node absent");
+  });
+});
+
+describe("repomap graph — budgetSlice (deterministic truncation, no silent drop)", () => {
+  const g = buildImportGraph(files);
+
+  it("keeps everything when the budget is >= file count or <= 0", () => {
+    const full = relevantSlice(g, ["src/a.ts"], 5);
+    assert.deepEqual(budgetSlice(full, ["src/a.ts"], 0).dropped, []);
+    assert.deepEqual(budgetSlice(full, ["src/a.ts"], 99).dropped, []);
+  });
+
+  it("keeps the nearest-to-seed files and reports the rest as dropped", () => {
+    const full = relevantSlice(g, ["src/a.ts"], 5); // a,b,c + externals
+    const r = budgetSlice(full, ["src/a.ts"], 2); // keep 2 nearest files: a(0), b(1)
+    const keptFiles = r.kept.filter((n) => n.kind === "file").map((n) => n.id);
+    assert.deepEqual(keptFiles, ["src/a.ts", "src/b.ts"]);
+    assert.deepEqual(
+      r.dropped.map((n) => n.id),
+      ["src/c.ts"],
+    );
+  });
+
+  it("keeps only externals incident to a kept file", () => {
+    const full = relevantSlice(g, ["src/a.ts"], 5);
+    // budget 1 keeps only a.ts → its external node:fs stays; zod (on b.ts) is not kept
+    const r = budgetSlice(full, ["src/a.ts"], 1);
+    const keptExt = r.kept.filter((n) => n.kind === "external").map((n) => n.id);
+    assert.deepEqual(keptExt, ["node:fs"]);
+  });
+
+  it("is deterministic", () => {
+    const full = relevantSlice(g, ["src/a.ts"], 5);
+    assert.deepEqual(budgetSlice(full, ["src/a.ts"], 2), budgetSlice(full, ["src/a.ts"], 2));
   });
 });

--- a/src/repomap/graph.ts
+++ b/src/repomap/graph.ts
@@ -109,3 +109,76 @@ export function relevantSlice(graph: RepoGraph, seeds: string[], depth: number):
   const edges = graph.edges.filter((e) => keep.has(e.from) && keep.has(e.to));
   return { nodes, edges };
 }
+
+/**
+ * BFS distance (undirected import hops) from the nearest seed to every reachable node in `graph`.
+ * Seeds are distance 0; unreachable nodes are absent from the map. Pure and deterministic.
+ */
+export function distancesFromSeeds(graph: RepoGraph, seeds: string[]): Map<string, number> {
+  const known = new Set(graph.nodes.map((n) => n.id));
+  const adj = new Map<string, Set<string>>();
+  for (const n of graph.nodes) adj.set(n.id, new Set());
+  for (const e of graph.edges) {
+    adj.get(e.from)?.add(e.to);
+    adj.get(e.to)?.add(e.from);
+  }
+  const dist = new Map<string, number>();
+  let frontier: string[] = [];
+  for (const s of seeds) {
+    if (known.has(s) && !dist.has(s)) {
+      dist.set(s, 0);
+      frontier.push(s);
+    }
+  }
+  let d = 0;
+  while (frontier.length) {
+    const next: string[] = [];
+    for (const id of frontier) {
+      for (const nb of adj.get(id) ?? []) {
+        if (!dist.has(nb)) {
+          dist.set(nb, d + 1);
+          next.push(nb);
+        }
+      }
+    }
+    d++;
+    frontier = next;
+  }
+  return dist;
+}
+
+export interface BudgetResult {
+  kept: RepoNode[];
+  dropped: RepoNode[];
+}
+
+/**
+ * Rank a slice's FILE nodes by relevance — nearest-to-a-seed first (BFS distance), then path for a
+ * stable tie-break — and keep at most `maxFiles`, returning the rest as `dropped` (never silently
+ * truncated: the caller logs the drop). `external` nodes are metadata, not budgeted: every external
+ * incident to a kept file is kept. `maxFiles <= 0` keeps everything. Pure and deterministic.
+ */
+export function budgetSlice(slice: RepoGraph, seeds: string[], maxFiles: number): BudgetResult {
+  const files = slice.nodes.filter((n) => n.kind === "file");
+  const externals = slice.nodes.filter((n) => n.kind === "external");
+  if (maxFiles <= 0 || files.length <= maxFiles) {
+    return { kept: slice.nodes, dropped: [] };
+  }
+
+  const dist = distancesFromSeeds(slice, seeds);
+  const rank = (n: RepoNode) => dist.get(n.id) ?? Number.MAX_SAFE_INTEGER;
+  const ranked = [...files].sort((a, b) => rank(a) - rank(b) || (a.id < b.id ? -1 : 1));
+  const keptFiles = ranked.slice(0, maxFiles);
+  const droppedFiles = ranked.slice(maxFiles);
+
+  const keptIds = new Set(keptFiles.map((n) => n.id));
+  const keptExternals = externals.filter((ext) =>
+    slice.edges.some((e) => e.to === ext.id && keptIds.has(e.from)),
+  );
+
+  const byId = (a: RepoNode, b: RepoNode) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0);
+  return {
+    kept: [...keptFiles, ...keptExternals].sort(byId),
+    dropped: droppedFiles.sort(byId),
+  };
+}


### PR DESCRIPTION
## Description

Second repo-map increment. `kit map --budget N` makes `kit map` a **context-budget tool**: rank the slice's files by nearest-to-seed (BFS distance, path tie-break), keep the N most relevant, and **log every dropped file** — never silent truncation (the "no false green" doctrine applied to context selection).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- **`src/repomap/graph.ts`** — two pure helpers: `distancesFromSeeds` (BFS hop-count from nearest seed) and `budgetSlice` (rank + keep N files + return the rest as `dropped`; externals incident to a kept file are kept; `<=0` keeps everything).
- **`src/commands/repomap.ts`** — `--budget N` flag; human output caps the drop-list (with "…and M more"), `--json` carries the full `dropped` list. Print path extracted to `printReadableSlice` so `cmdMap` stays under the complexity budget.
- **CHANGELOG.md** — extended the repo-map bullet.

## Testing

- New unit tests: `distancesFromSeeds` hop counts; `budgetSlice` keeps nearest-N, reports dropped, keeps only incident externals, is deterministic, and no-ops at budget ≤0 / ≥count.
- Live: `kit map src/exec-broker/broker.ts --depth 2 --budget 5` → 5 nearest files kept, 301 dropped (logged).
- `npx tsc --noEmit` clean · `npx eslint src` 0 errors · `npm run format:check` clean · `node scripts/test.mjs` **2836/2836**.
- Public surface unchanged (`--budget` is a flag, not a subcommand).

## Breaking Changes

None. Additive flag on the experimental `kit map`.

## Checklist

- [x] All new code has test coverage
- [x] All tests pass locally
- [x] No new warnings or errors introduced
- [x] Code has been self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_