### PR TITLE
feat(map): kit map ownership — git-blame top-author fallback (Pillar 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,9 +73,10 @@ is additive and every new gate is opt-in or degrades honestly.
   repo, not the whole tree. `--budget` keeps the N nearest-to-seed files and
   **logs every drop** (never silent truncation). Pure graph core + a
   dependency-free TS/JS extractor; relative specifiers that resolve to no known
-  file are dropped, never guessed. Each slice file is annotated with its
-  **CODEOWNERS** owner(s) (deterministic, last-match-wins) so an agent knows who
-  to route to.
+  file are dropped, never guessed. Each slice file is annotated with its owner(s)
+  — from a committed **CODEOWNERS** (deterministic, last-match-wins), or the
+  **git-blame top-author** when no CODEOWNERS exists (fail-closed: git
+  absent/errored → no owner, never guessed) — so an agent knows who to route to.
 
 ### Triage delegate — deep skill scanning, borrowed authority (#327–#332)
 

--- a/src/commands/repomap.ts
+++ b/src/commands/repomap.ts
@@ -7,6 +7,7 @@
  * Design: `kit-research/docs/research/pillar4-repo-map-5.0.md`. Deterministic and offline.
  */
 import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { relative, resolve } from "node:path";
 import { c } from "../utils/colors.js";
 import { hasFlag, flagValue } from "../utils/flags.js";
@@ -26,6 +27,7 @@ import {
 import {
   parseCodeowners,
   ownerFor,
+  topAuthor,
   CODEOWNERS_PATHS,
   type CodeownersRule,
 } from "../repomap/ownership.js";
@@ -134,21 +136,22 @@ export async function cmdMap(): Promise<boolean> {
       : full;
   const droppedFiles = dropped.filter((n) => n.kind === "file").map((n) => n.id);
 
-  // Ownership (deterministic, from a committed CODEOWNERS): who to route each slice file to.
-  const rules = loadCodeowners(root);
-  const owners: Record<string, string[]> = {};
-  if (rules.length) {
-    for (const n of slice.nodes) {
-      if (n.kind !== "file") continue;
-      const who = ownerFor(n.id, rules);
-      if (who.length) owners[n.id] = who;
-    }
-  }
+  // Ownership: who to route each slice file to — CODEOWNERS if present, else git-blame top-author.
+  const { owners, source } = computeOwners(root, slice);
 
   if (json) {
     console.log(
       JSON.stringify(
-        { seeds, depth, budget: budget || null, slice, owners, dropped: droppedFiles, missing },
+        {
+          seeds,
+          depth,
+          budget: budget || null,
+          slice,
+          owners,
+          ownerSource: source,
+          dropped: droppedFiles,
+          missing,
+        },
         null,
         2,
       ),
@@ -156,8 +159,58 @@ export async function cmdMap(): Promise<boolean> {
     return true;
   }
 
-  printReadableSlice({ slice, seeds, depth, budget, droppedFiles, missing, owners });
+  printReadableSlice({ slice, seeds, depth, budget, droppedFiles, missing, owners, source });
   return true;
+}
+
+/** Max files to git-blame for the ownership fallback — bounds per-file git calls on a big slice. */
+const BLAME_CAP = 60;
+
+/**
+ * Owners for the slice's files. Prefers a committed CODEOWNERS (deterministic, no I/O beyond the
+ * file read). Without one, falls back to each file's git-blame top-author (bounded by BLAME_CAP,
+ * fail-closed: git absent/errored → no owner, never guessed). Returns the source so the UI can say so.
+ */
+function computeOwners(
+  root: string,
+  slice: RepoGraph,
+): { owners: Record<string, string[]>; source: "codeowners" | "git" | "none" } {
+  const files = slice.nodes.filter((n) => n.kind === "file");
+  const owners: Record<string, string[]> = {};
+
+  const rules = loadCodeowners(root);
+  if (rules.length) {
+    for (const n of files) {
+      const who = ownerFor(n.id, rules);
+      if (who.length) owners[n.id] = who;
+    }
+    return { owners, source: "codeowners" };
+  }
+
+  let blamed = false;
+  for (const n of files.slice(0, BLAME_CAP)) {
+    const author = gitTopAuthor(root, n.id);
+    if (author) {
+      owners[n.id] = [`${author} (git)`];
+      blamed = true;
+    }
+  }
+  return { owners, source: blamed ? "git" : "none" };
+}
+
+/** A file's git-blame top-author, or null if git is absent/errors (fail-closed — never guessed). */
+function gitTopAuthor(root: string, file: string): string | null {
+  try {
+    const out = execFileSync("git", ["-C", root, "log", "--format=%an", "--", file], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5_000,
+      maxBuffer: 4 * 1024 * 1024,
+    });
+    return topAuthor(out.split("\n"));
+  } catch {
+    return null;
+  }
 }
 
 /** Human-readable render of a slice (the non-`--json` path). Kept separate so `cmdMap` stays lean. */
@@ -169,11 +222,18 @@ function printReadableSlice(o: {
   droppedFiles: string[];
   missing: string[];
   owners: Record<string, string[]>;
+  source: "codeowners" | "git" | "none";
 }): void {
   const files = o.slice.nodes.filter((n) => n.kind === "file");
   const externals = o.slice.nodes.filter((n) => n.kind === "external");
+  const ownerNote =
+    o.source === "codeowners"
+      ? ` ${c.dim}· owners from CODEOWNERS${c.reset}`
+      : o.source === "git"
+        ? ` ${c.dim}· owners from git blame${c.reset}`
+        : "";
   console.log(
-    `${c.bold}Relevant slice${c.reset} ${c.dim}(depth ${o.depth}, from ${o.seeds.join(", ")})${c.reset}`,
+    `${c.bold}Relevant slice${c.reset} ${c.dim}(depth ${o.depth}, from ${o.seeds.join(", ")})${c.reset}${ownerNote}`,
   );
   console.log(`  ${c.bold}${files.length}${c.reset} files · ${externals.length} external packages`);
   for (const n of files) {

--- a/src/repomap/ownership.test.ts
+++ b/src/repomap/ownership.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parseCodeowners, ownerFor } from "./ownership.js";
+import { parseCodeowners, ownerFor, topAuthor } from "./ownership.js";
 
 describe("repomap ownership — parseCodeowners", () => {
   it("parses rules, skipping comments and blanks; keeps order + multiple owners", () => {
@@ -71,5 +71,20 @@ describe("repomap ownership — glob edge cases", () => {
       [],
       "leading / anchors to root",
     );
+  });
+});
+
+describe("repomap ownership — topAuthor (git-blame fallback)", () => {
+  it("returns the most frequent author", () => {
+    assert.equal(topAuthor(["Ada", "Bo", "Ada", "Ada", "Bo"]), "Ada");
+  });
+  it("breaks ties alphabetically for determinism", () => {
+    assert.equal(topAuthor(["Bo", "Ada"]), "Ada");
+    assert.equal(topAuthor(["Zed", "Ada", "Zed", "Ada"]), "Ada");
+  });
+  it("ignores blank lines and returns null for no history", () => {
+    assert.equal(topAuthor(["", "  ", "Ada", ""]), "Ada");
+    assert.equal(topAuthor([]), null);
+    assert.equal(topAuthor(["", "   "]), null);
   });
 });

--- a/src/repomap/ownership.ts
+++ b/src/repomap/ownership.ts
@@ -97,3 +97,26 @@ export function ownerFor(path: string, rules: CodeownersRule[]): string[] {
 
 /** The standard locations a CODEOWNERS file may live, in GitHub's precedence order. */
 export const CODEOWNERS_PATHS = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"];
+
+/**
+ * The most frequent author from a file's `git log --format=%an` lines — the de-facto owner when no
+ * CODEOWNERS exists. Ties break alphabetically for determinism; blank lines are ignored; null if the
+ * file has no history. Pure (the caller does the git I/O and feeds the lines here).
+ */
+export function topAuthor(authorLines: string[]): string | null {
+  const counts = new Map<string, number>();
+  for (const raw of authorLines) {
+    const name = raw.trim();
+    if (name) counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+  if (counts.size === 0) return null;
+  let best: string | null = null;
+  let bestN = -1;
+  for (const [name, n] of [...counts].sort((a, b) => (a[0] < b[0] ? -1 : 1))) {
+    if (n > bestN) {
+      best = name;
+      bestN = n;
+    }
+  }
+  return best;
+}


### PR DESCRIPTION
## Description

Fourth repo-map increment: completes ownership. When a repo has **no CODEOWNERS**, `kit map` now derives each slice file's owner from its **git-blame top-author**, so ownership works everywhere — not just repos with a CODEOWNERS file.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- **`src/repomap/ownership.ts`** — pure `topAuthor(authorLines)`: most frequent author, alphabetical tie-break, `null` for no history.
- **`src/commands/repomap.ts`** — `computeOwners(root, slice)`: CODEOWNERS first; else git-blame top-author per file via `git log --format=%an -- <file>`, **bounded by `BLAME_CAP` (60)** and **fail-closed** (git absent/errored/timeout → no owner, never guessed). Output notes the source (`owners from CODEOWNERS` vs `owners from git blame`); `--json` carries `ownerSource`. Extraction keeps `cmdMap` lean.
- **CHANGELOG.md** — extended the repo-map bullet.

## Testing

- New unit tests for `topAuthor` (frequency, deterministic tie-break, blank/empty handling).
- Live on kit (no CODEOWNERS): `kit map src/exec-broker/broker.ts` → "owners from git blame", files tagged `Peter Sandström (git)`.
- `npx tsc --noEmit` clean · `npx eslint src` 0 errors · `npm run format:check` clean · `node scripts/test.mjs` **2847/2847**.
- Public surface unchanged.

## Breaking Changes

None. Additive on the experimental `kit map`; bounded + fail-closed git usage.

## Checklist

- [x] All new code has test coverage
- [x] All tests pass locally
- [x] No new warnings or errors introduced
- [x] Code has been self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_