### PR TITLE
feat(map): kit map --co-change — historical coupling from git (Pillar 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ is additive and every new gate is opt-in or degrades honestly.
   — from a committed **CODEOWNERS** (deterministic, last-match-wins), or the
   **git-blame top-author** when no CODEOWNERS exists (fail-closed: git
   absent/errored → no owner, never guessed) — so an agent knows who to route to.
+  `--co-change` adds each seed's historically co-changing files from git history
+  (coupling imports miss — schema↔migration, code↔test), from one bounded
+  `git log`; fail-closed when git is absent.
 
 ### Triage delegate — deep skill scanning, borrowed authority (#327–#332)
 

--- a/src/commands/repomap.ts
+++ b/src/commands/repomap.ts
@@ -31,6 +31,13 @@ import {
   CODEOWNERS_PATHS,
   type CodeownersRule,
 } from "../repomap/ownership.js";
+import {
+  parseCoChangeLog,
+  coChangeCounts,
+  topCoChanged,
+  COCHANGE_SEP,
+  type CoChange,
+} from "../repomap/cochange.js";
 
 const EXTS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
 
@@ -91,13 +98,17 @@ export async function cmdMap(): Promise<boolean> {
     console.log(
       "  kit map <path> --budget 20   Keep only the 20 nearest files (drops are logged, never silent)",
     );
+    console.log(
+      "  kit map <path> --co-change   Add files that historically change WITH the seed (git history)",
+    );
     console.log("  kit map <path> --json        Emit the slice as JSON (for an agent/tool)");
     console.log("\nExample:");
-    console.log("  kit map src/exec-broker/broker.ts --depth 2 --budget 25");
+    console.log("  kit map src/exec-broker/broker.ts --depth 2 --budget 25 --co-change");
     return args.length !== 0;
   }
 
   const json = hasFlag(args, "--json");
+  const wantCoChange = hasFlag(args, "--co-change");
   const depthRaw = flagValue(process.argv, "--depth");
   const depth = depthRaw ? Math.max(0, Number.parseInt(depthRaw, 10) || 0) : 1;
   const budgetRaw = flagValue(process.argv, "--budget");
@@ -139,6 +150,10 @@ export async function cmdMap(): Promise<boolean> {
   // Ownership: who to route each slice file to — CODEOWNERS if present, else git-blame top-author.
   const { owners, source } = computeOwners(root, slice);
 
+  // Co-change (opt-in): files that historically changed WITH each seed, from git history. Coupling
+  // that imports miss (schema↔migration, code↔test). Fail-closed: git absent/errored → empty.
+  const coChanged: Record<string, CoChange[]> = wantCoChange ? computeCoChange(root, seeds) : {};
+
   if (json) {
     console.log(
       JSON.stringify(
@@ -149,6 +164,7 @@ export async function cmdMap(): Promise<boolean> {
           slice,
           owners,
           ownerSource: source,
+          coChanged: wantCoChange ? coChanged : undefined,
           dropped: droppedFiles,
           missing,
         },
@@ -159,8 +175,58 @@ export async function cmdMap(): Promise<boolean> {
     return true;
   }
 
-  printReadableSlice({ slice, seeds, depth, budget, droppedFiles, missing, owners, source });
+  printReadableSlice({
+    slice,
+    seeds,
+    depth,
+    budget,
+    droppedFiles,
+    missing,
+    owners,
+    source,
+    coChanged,
+  });
   return true;
+}
+
+/** Commits to scan for co-change coupling — bounds the single `git log` call on a deep history. */
+const COCHANGE_COMMITS = 1500;
+
+/**
+ * Top co-changed files per seed from git history. One bounded `git log --name-only` call; parsed and
+ * counted purely. Fail-closed: git absent/errored → `{}` (no coupling claimed, never guessed).
+ */
+function computeCoChange(root: string, seeds: string[]): Record<string, CoChange[]> {
+  let raw: string;
+  try {
+    raw = execFileSync(
+      "git",
+      [
+        "-C",
+        root,
+        "log",
+        `-n${COCHANGE_COMMITS}`,
+        "--no-merges",
+        "--name-only",
+        `--format=${COCHANGE_SEP}%H`,
+      ],
+      {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 15_000,
+        maxBuffer: 64 * 1024 * 1024,
+      },
+    );
+  } catch {
+    return {};
+  }
+  const counts = coChangeCounts(parseCoChangeLog(raw));
+  const out: Record<string, CoChange[]> = {};
+  for (const seed of seeds) {
+    const top = topCoChanged(counts, seed);
+    if (top.length) out[seed] = top;
+  }
+  return out;
 }
 
 /** Max files to git-blame for the ownership fallback — bounds per-file git calls on a big slice. */
@@ -223,6 +289,7 @@ function printReadableSlice(o: {
   missing: string[];
   owners: Record<string, string[]>;
   source: "codeowners" | "git" | "none";
+  coChanged: Record<string, CoChange[]>;
 }): void {
   const files = o.slice.nodes.filter((n) => n.kind === "file");
   const externals = o.slice.nodes.filter((n) => n.kind === "external");
@@ -252,6 +319,13 @@ function printReadableSlice(o: {
     console.log(
       `  ${c.yellow}${o.droppedFiles.length} file(s) dropped to fit --budget ${o.budget}:${c.reset} ${shown.join(", ")}${tail}`,
     );
+  }
+  for (const seed of o.seeds) {
+    const co = o.coChanged[seed];
+    if (co?.length) {
+      const list = co.map((x) => `${x.file} (${x.count})`).join(", ");
+      console.log(`  ${c.dim}co-changes with ${seed}:${c.reset} ${list}`);
+    }
   }
   if (o.missing.length) {
     console.log(`  ${c.yellow}unmatched seeds:${c.reset} ${o.missing.join(", ")}`);

--- a/src/repomap/cochange.test.ts
+++ b/src/repomap/cochange.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseCoChangeLog, coChangeCounts, topCoChanged, COCHANGE_SEP } from "./cochange.js";
+
+// Build a fake `git log --name-only --format=<SEP>%H` blob from commits (arrays of files).
+const log = (commits: string[][]) =>
+  commits.map((files) => `${COCHANGE_SEP}deadbeef\n${files.join("\n")}\n`).join("");
+
+describe("repomap cochange — parseCoChangeLog", () => {
+  it("parses one file-set per commit; skips single-file and empty commits", () => {
+    const raw = log([["a.ts", "b.ts"], ["solo.ts"], ["a.ts", "b.ts", "c.ts"]]);
+    assert.deepEqual(parseCoChangeLog(raw), [
+      ["a.ts", "b.ts"],
+      ["a.ts", "b.ts", "c.ts"],
+    ]);
+  });
+
+  it("skips mega-commits over the file cap (coupling noise)", () => {
+    const big = Array.from({ length: 10 }, (_, i) => `f${i}.ts`);
+    assert.deepEqual(parseCoChangeLog(log([big]), 5), [], "10-file commit dropped at cap 5");
+    assert.equal(parseCoChangeLog(log([big]), 20).length, 1, "kept under a higher cap");
+  });
+});
+
+describe("repomap cochange — counts + topCoChanged", () => {
+  const sets = [
+    ["a.ts", "b.ts"],
+    ["a.ts", "b.ts"],
+    ["a.ts", "c.ts"],
+    ["a.ts", "b.ts", "c.ts"],
+  ];
+  const counts = coChangeCounts(sets);
+
+  it("counts unordered pairs symmetrically", () => {
+    assert.equal(counts.get("a.ts")?.get("b.ts"), 3);
+    assert.equal(counts.get("b.ts")?.get("a.ts"), 3);
+    assert.equal(counts.get("a.ts")?.get("c.ts"), 2);
+  });
+
+  it("ranks a file's partners by count (path tie-break), min-count filtered", () => {
+    assert.deepEqual(topCoChanged(counts, "a.ts"), [
+      { file: "b.ts", count: 3 },
+      { file: "c.ts", count: 2 },
+    ]);
+  });
+
+  it("drops pairs seen only once (default minCount 2)", () => {
+    const once = coChangeCounts([["x.ts", "y.ts"]]);
+    assert.deepEqual(topCoChanged(once, "x.ts"), [], "a single shared commit is not a signal");
+    assert.deepEqual(topCoChanged(once, "x.ts", 5, 1), [{ file: "y.ts", count: 1 }]);
+  });
+
+  it("returns [] for a file with no history", () => {
+    assert.deepEqual(topCoChanged(counts, "unknown.ts"), []);
+  });
+
+  it("is deterministic", () => {
+    assert.deepEqual(coChangeCounts(sets), coChangeCounts(sets));
+  });
+});

--- a/src/repomap/cochange.ts
+++ b/src/repomap/cochange.ts
@@ -1,0 +1,83 @@
+/**
+ * Repo-map — co-change coupling (Pillar 4, deterministic / zero-LLM).
+ *
+ * Files that keep changing together are coupled even when nothing imports them across (a schema and
+ * its migration, a component and its test, a config and its consumer). This module turns git history
+ * into that signal: parse `git log --name-only`, count how often each file pair appears in the same
+ * commit, and surface a seed's top co-changed files. Pure (the command does the git I/O, feeds the
+ * text here); deterministic given the history window.
+ *
+ * Design: `kit-research/docs/research/pillar4-repo-map-5.0.md`.
+ */
+
+/** Unit-separator that precedes each commit's hash in our `git log --format` (robust block split). */
+export const COCHANGE_SEP = "\x1f";
+
+/**
+ * Parse `git log --name-only --format=<SEP>%H` output into one file-path list per commit. Commits
+ * touching more than `maxFilesPerCommit` files are skipped (mega-commits are coupling noise and blow
+ * up the pair count). Pure and order-preserving.
+ */
+export function parseCoChangeLog(raw: string, maxFilesPerCommit = 50): string[][] {
+  const sets: string[][] = [];
+  for (const block of raw.split(COCHANGE_SEP)) {
+    if (!block.trim()) continue;
+    const lines = block.split("\n");
+    const files = lines
+      .slice(1)
+      .map((l) => l.trim())
+      .filter(Boolean);
+    if (files.length >= 2 && files.length <= maxFilesPerCommit) sets.push(files);
+  }
+  return sets;
+}
+
+/**
+ * Count how often each unordered file pair co-occurs across the commit file-sets. Returned as an
+ * adjacency map: `file → (other → count)`. Pure and deterministic.
+ */
+export function coChangeCounts(commitFileSets: string[][]): Map<string, Map<string, number>> {
+  const counts = new Map<string, Map<string, number>>();
+  const bump = (a: string, b: string) => {
+    let row = counts.get(a);
+    if (!row) {
+      row = new Map();
+      counts.set(a, row);
+    }
+    row.set(b, (row.get(b) ?? 0) + 1);
+  };
+  for (const files of commitFileSets) {
+    const uniq = [...new Set(files)];
+    for (let i = 0; i < uniq.length; i++) {
+      for (let j = i + 1; j < uniq.length; j++) {
+        bump(uniq[i], uniq[j]);
+        bump(uniq[j], uniq[i]);
+      }
+    }
+  }
+  return counts;
+}
+
+export interface CoChange {
+  file: string;
+  count: number;
+}
+
+/**
+ * A file's top co-changed partners, most-frequent first (path tie-break), capped at `topN` and to
+ * pairs seen at least `minCount` times (default 2 — a single shared commit is not a signal). Pure.
+ */
+export function topCoChanged(
+  counts: Map<string, Map<string, number>>,
+  file: string,
+  topN = 5,
+  minCount = 2,
+): CoChange[] {
+  const row = counts.get(file);
+  if (!row) return [];
+  return [...row.entries()]
+    .filter(([, n]) => n >= minCount)
+    .map(([f, count]) => ({ file: f, count }))
+    .sort((a, b) => b.count - a.count || (a.file < b.file ? -1 : a.file > b.file ? 1 : 0))
+    .slice(0, topN);
+}


### PR DESCRIPTION
## Description

Fifth repo-map increment: **co-change coupling**. `kit map --co-change` surfaces the files that historically change *together* with a seed — coupling the import graph can't see (schema↔migration, code↔test, config↔consumer). This is often the most useful "what else do I need to touch?" signal in a growing repo.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- **`src/repomap/cochange.ts`** — pure: `parseCoChangeLog` (blocks from `git log --name-only --format=<SEP>%H`; skips single-file and mega-commits), `coChangeCounts` (symmetric unordered pair counts), `topCoChanged` (rank by count, path tie-break, `minCount` default 2 so a single shared commit isn't a signal).
- **`src/commands/repomap.ts`** — `--co-change` flag → one bounded `git log` (`COCHANGE_COMMITS=1500`, `--no-merges`), parsed+counted purely; each seed's top co-changed files shown inline and in `--json` `coChanged`. **Fail-closed**: git absent/errored → no coupling claimed.
- **CHANGELOG.md** — extended the repo-map bullet.

## Testing

- New unit tests: parse (per-commit sets, single-file/mega-commit skip), symmetric counts, ranking + `minCount` filter, empty/deterministic.
- Live on kit: `kit map src/commands/repomap.ts --co-change` → co-changes with `CHANGELOG.md (4)`, `graph.ts (2)`, `ownership.ts (2)` — exactly the coupling of these increments.
- `npx tsc --noEmit` clean · `npx eslint src` 0 errors · `npm run format:check` clean · `node scripts/test.mjs` **2854/2854**.
- Public surface unchanged (flag, not a subcommand).

## Breaking Changes

None. Opt-in flag on the experimental `kit map`; bounded + fail-closed git usage.

## Checklist

- [x] All new code has test coverage
- [x] All tests pass locally
- [x] No new warnings or errors introduced
- [x] Code has been self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_