### PR TITLE
feat(map): kit_map MCP tool — repo-map for agents, one core with the CLI (Pillar 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,9 @@ is additive and every new gate is opt-in or degrades honestly.
   absent/errored → no owner, never guessed) — so an agent knows who to route to.
   `--co-change` adds each seed's historically co-changing files from git history
   (coupling imports miss — schema↔migration, code↔test), from one bounded
-  `git log`; fail-closed when git is absent.
+  `git log`; fail-closed when git is absent. Exposed to agents as the **`kit_map`
+  MCP tool** (paths / depth / budget / co_change), sharing one core (`mapReport`)
+  with the CLI so the two surfaces can't disagree.
 
 ### Triage delegate — deep skill scanning, borrowed authority (#327–#332)
 

--- a/contracts/public-surface.json
+++ b/contracts/public-surface.json
@@ -246,6 +246,7 @@
     "kit_init",
     "kit_install",
     "kit_login",
+    "kit_map",
     "kit_run",
     "kit_secrets",
     "kit_standards"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -679,7 +679,8 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
   map: {
     handler: cmdMap,
     stability: "experimental",
-    help: "Deterministic repo-map: the relevant slice of files around a seed (import graph, --depth, --json) — load part of a growing repo, not all of it (experimental)",
+    help: "Deterministic repo-map: the relevant slice of files around a seed (import graph, --depth, --budget, --co-change, --json) — load part of a growing repo, not all of it (experimental)",
+    mcp: true,
   },
   profile: {
     handler: cmdProfile,

--- a/src/commands/repomap.ts
+++ b/src/commands/repomap.ts
@@ -127,66 +127,82 @@ export async function cmdMap(): Promise<boolean> {
   }
   const seeds = positional.map((s) => relative(root, resolve(root, s)).split("\\").join("/"));
 
-  const graph = buildRepoGraph(root);
-  const known = new Set(graph.nodes.map((n) => n.id));
-  const missing = seeds.filter((s) => !known.has(s));
-  if (missing.length === seeds.length) {
+  const report = mapReport(root, seeds, { depth, budget, coChange: wantCoChange });
+  if (report.missing.length === seeds.length) {
     console.error(
-      `${c.red}no seed matched a source file — check the path(s):${c.reset} ${missing.join(", ")}`,
+      `${c.red}no seed matched a source file — check the path(s):${c.reset} ${report.missing.join(", ")}`,
     );
     return false;
   }
 
-  const full = relevantSlice(graph, seeds, depth);
-  // Apply a file-count budget: keep the nearest-to-seed files, log the rest (never silent).
-  const { kept, dropped } = budgetSlice(full, seeds, budget);
-  const keptIds = new Set(kept.map((n) => n.id));
-  const slice: RepoGraph =
-    budget > 0
-      ? { nodes: kept, edges: full.edges.filter((e) => keptIds.has(e.from) && keptIds.has(e.to)) }
-      : full;
-  const droppedFiles = dropped.filter((n) => n.kind === "file").map((n) => n.id);
-
-  // Ownership: who to route each slice file to — CODEOWNERS if present, else git-blame top-author.
-  const { owners, source } = computeOwners(root, slice);
-
-  // Co-change (opt-in): files that historically changed WITH each seed, from git history. Coupling
-  // that imports miss (schema↔migration, code↔test). Fail-closed: git absent/errored → empty.
-  const coChanged: Record<string, CoChange[]> = wantCoChange ? computeCoChange(root, seeds) : {};
-
   if (json) {
-    console.log(
-      JSON.stringify(
-        {
-          seeds,
-          depth,
-          budget: budget || null,
-          slice,
-          owners,
-          ownerSource: source,
-          coChanged: wantCoChange ? coChanged : undefined,
-          dropped: droppedFiles,
-          missing,
-        },
-        null,
-        2,
-      ),
-    );
+    console.log(JSON.stringify(report, null, 2));
     return true;
   }
 
   printReadableSlice({
-    slice,
+    slice: report.slice,
     seeds,
     depth,
     budget,
-    droppedFiles,
-    missing,
-    owners,
-    source,
-    coChanged,
+    droppedFiles: report.dropped,
+    missing: report.missing,
+    owners: report.owners,
+    source: report.ownerSource,
+    coChanged: report.coChanged ?? {},
   });
   return true;
+}
+
+export interface MapReport {
+  seeds: string[];
+  depth: number;
+  budget: number | null;
+  slice: RepoGraph;
+  owners: Record<string, string[]>;
+  ownerSource: "codeowners" | "git" | "none";
+  coChanged?: Record<string, CoChange[]>;
+  dropped: string[];
+  missing: string[];
+}
+
+/**
+ * The shared repo-map core behind BOTH `kit map` (CLI) and the `kit_map` MCP tool — one function so
+ * the two surfaces can never disagree (surface-unification doctrine). Deterministic; git usage in
+ * ownership/co-change is bounded and fail-closed. `seeds` are repo-relative posix paths.
+ */
+export function mapReport(
+  root: string,
+  seeds: string[],
+  opts: { depth: number; budget: number; coChange: boolean },
+): MapReport {
+  const graph = buildRepoGraph(root);
+  const known = new Set(graph.nodes.map((n) => n.id));
+  const missing = seeds.filter((s) => !known.has(s));
+
+  const full = relevantSlice(graph, seeds, opts.depth);
+  const { kept, dropped } = budgetSlice(full, seeds, opts.budget);
+  const keptIds = new Set(kept.map((n) => n.id));
+  const slice: RepoGraph =
+    opts.budget > 0
+      ? { nodes: kept, edges: full.edges.filter((e) => keptIds.has(e.from) && keptIds.has(e.to)) }
+      : full;
+  const droppedFiles = dropped.filter((n) => n.kind === "file").map((n) => n.id);
+
+  const { owners, source } = computeOwners(root, slice);
+  const coChanged = opts.coChange ? computeCoChange(root, seeds) : undefined;
+
+  return {
+    seeds,
+    depth: opts.depth,
+    budget: opts.budget || null,
+    slice,
+    owners,
+    ownerSource: source,
+    coChanged,
+    dropped: droppedFiles,
+    missing,
+  };
 }
 
 /** Commits to scan for co-change coupling — bounds the single `git log` call on a deep history. */

--- a/src/mcp-server.test.ts
+++ b/src/mcp-server.test.ts
@@ -80,7 +80,8 @@ describe("MCP server tool registration", () => {
       assert.ok(names.includes("kit_ci"), "kit_ci missing");
       assert.ok(names.includes("kit_run"), "kit_run missing");
       assert.ok(names.includes("kit_context"), "kit_context missing");
-      assert.equal(tools.length, 12);
+      assert.ok(names.includes("kit_map"), "kit_map missing");
+      assert.equal(tools.length, 13);
     } finally {
       await cleanup();
     }
@@ -780,6 +781,46 @@ describe("kit_init", () => {
       const content = await readFile(join(projectDir, ".kit.toml"), "utf-8");
       assert.equal(content, original, "original content should be unchanged");
     } finally {
+      await cleanup();
+    }
+  });
+});
+
+// ─── kit_map ───────────────────────────────────────────────────────────────
+describe("kit_map", () => {
+  it("returns the relevant import-slice around a seed (deterministic, read-only)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kit-mcp-map-"));
+    await mkdir(join(dir, "src"), { recursive: true });
+    await writeFile(
+      join(dir, "src", "a.ts"),
+      `import { b } from "./b.js";\nexport const a = b;\n`,
+      "utf-8",
+    );
+    await writeFile(join(dir, "src", "b.ts"), `export const b = 1;\n`, "utf-8");
+    await writeFile(join(dir, "src", "unrelated.ts"), `export const z = 0;\n`, "utf-8");
+
+    const { client, cleanup } = await createTestClient();
+    try {
+      const result = await client.callTool({
+        name: "kit_map",
+        arguments: { paths: ["src/a.ts"], cwd: dir },
+      });
+      const data = parseResult(result) as {
+        slice: { nodes: { id: string; kind: string }[] };
+        ownerSource: string;
+      };
+      const files = data.slice.nodes
+        .filter((n) => n.kind === "file")
+        .map((n) => n.id)
+        .sort();
+      assert.deepEqual(
+        files,
+        ["src/a.ts", "src/b.ts"],
+        "a's import-neighborhood, not unrelated.ts",
+      );
+      assert.ok(["codeowners", "git", "none"].includes(data.ownerSource));
+    } finally {
+      await rm(dir, { recursive: true, force: true });
       await cleanup();
     }
   });

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { resolve, join } from "node:path";
+import { resolve, join, relative } from "node:path";
 import { loadConfig } from "./config.js";
 import { checkTools } from "./check-tools.js";
 import { checkServices } from "./check-services.js";
@@ -31,6 +31,7 @@ import { generateToml } from "./toml-generator.js";
 import { writeFile, access } from "node:fs/promises";
 import { executeCommand } from "./run.js";
 import { gatherProjectContext } from "./context.js";
+import { mapReport } from "./commands/repomap.js";
 import { isReadOnlyMode } from "./read-only-mode.js";
 import { escapeWorkflowCmd } from "./utils/ci-escape.js";
 import { runGovernedBrokered } from "./governance-middleware.js";
@@ -56,6 +57,7 @@ export const KIT_MCP_TOOLS: readonly string[] = [
   "kit_ci",
   "kit_run",
   "kit_context",
+  "kit_map",
 ];
 
 function configPath(cwd?: string): string {
@@ -122,6 +124,7 @@ export function createMcpServer(): McpServer {
   register_kit_ci(server);
   register_kit_run(server);
   register_kit_context(server);
+  register_kit_map(server);
 
   return server;
 }
@@ -959,6 +962,50 @@ function register_kit_context(server: McpServer): void {
             },
           ],
         };
+      } catch (err) {
+        return {
+          content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function register_kit_map(server: McpServer): void {
+  // kit_map — deterministic repo-map: the relevant slice around a seed file (read-only). Shares the
+  // exact core (mapReport) with the `kit map` CLI, so the two surfaces can't disagree.
+  server.tool(
+    "kit_map",
+    "Deterministic, zero-LLM repo-map: given seed file path(s), return the relevant SLICE of the codebase — files connected within N import hops (both directions) + external packages, each attributed to its owner (CODEOWNERS or git-blame). Optionally budget the slice to the N nearest files and add historical co-change coupling. Use it to load only the part of a growing repo that matters to a task, instead of the whole tree.",
+    {
+      paths: z
+        .array(z.string())
+        .min(1)
+        .describe("Seed file path(s) to map around (repo-relative or absolute)"),
+      depth: z.number().int().min(0).optional().describe("Import hops from the seed (default 1)"),
+      budget: z
+        .number()
+        .int()
+        .min(0)
+        .optional()
+        .describe("Keep only the N nearest-to-seed files (0 = unbounded); drops are reported"),
+      co_change: z
+        .boolean()
+        .optional()
+        .describe("Add files that historically change WITH each seed (git history)"),
+      cwd: z.string().optional().describe("Working directory (defaults to process.cwd())"),
+    },
+    async ({ paths, depth, budget, co_change, cwd }) => {
+      try {
+        const root = cwd ?? process.cwd();
+        const seeds = paths.map((s) => relative(root, resolve(root, s)).split("\\").join("/"));
+        const report = mapReport(root, seeds, {
+          depth: depth ?? 1,
+          budget: budget ?? 0,
+          coChange: co_change ?? false,
+        });
+        return { content: [{ type: "text" as const, text: JSON.stringify(report, null, 2) }] };
       } catch (err) {
         return {
           content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],


### PR DESCRIPTION
## Description

Sixth repo-map increment: exposes the repo-map to agents over **MCP** as `kit_map`. Since agents mostly reach kit through MCP, this is the increment that makes the whole `kit map` ladder actually usable in the loop.

Follows the surface-unification doctrine: the CLI and the MCP tool share **one core** (`mapReport`), so they can't drift — enforced by the existing CLI≡MCP drift test.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- **`src/commands/repomap.ts`** — extracted `mapReport(root, seeds, {depth, budget, coChange})` returning the structured slice (graph → slice → budget → owners → co-change). `cmdMap` now calls it (both `--json` and human paths).
- **`src/mcp-server.ts`** — new read-only `kit_map` tool (`paths`, `depth?`, `budget?`, `co_change?`, `cwd?`) calling `mapReport`; added to `KIT_MCP_TOOLS`.
- **`src/cli.ts`** — `map` registry entry gains `mcp: true` (single source of truth for MCP exposure).
- **`contracts/public-surface.json`** — regenerated (13 MCP tools; `map` mcp-exposed).
- **Tests** — registration guard bumped (12→13, `kit_map` asserted); CLI≡MCP drift holds; new functional `kit_map` test (import-neighborhood slice from a temp repo).
- **CHANGELOG.md** — extended the repo-map bullet.

## Testing

- `node --test dist/mcp-server.test.js` — 30/30 (guard + drift + functional `kit_map`); `command-surface.test.js` 7/7.
- `npx tsc --noEmit` clean · `npx eslint src` 0 errors · `npm run format:check` clean · `node scripts/test.mjs` **2855/2855**.

## Breaking Changes

None. New read-only MCP tool + additive registry marker; all existing contracts unchanged.

## Checklist

- [x] All new code has test coverage
- [x] All tests pass locally
- [x] No new warnings or errors introduced
- [x] Code has been self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_