### PR TITLE
feat(map): kit map Python extractor — polyglot import graph (Pillar 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,9 @@ is additive and every new gate is opt-in or degrades honestly.
   (coupling imports miss — schema↔migration, code↔test), from one bounded
   `git log`; fail-closed when git is absent. Exposed to agents as the **`kit_map`
   MCP tool** (paths / depth / budget / co_change), sharing one core (`mapReport`)
-  with the CLI so the two surfaces can't disagree.
+  with the CLI so the two surfaces can't disagree. The import graph covers
+  **TS/JS and Python** (dotted/relative imports, `src/` layouts); an unresolved
+  import is external, never guessed.
 
 ### Triage delegate — deep skill scanning, borrowed authority (#327–#332)
 

--- a/src/commands/repomap.ts
+++ b/src/commands/repomap.ts
@@ -24,6 +24,7 @@ import {
   resolveImport,
   isRelativeSpecifier,
 } from "../repomap/extract-ts.js";
+import { parsePythonImports, resolvePythonImport } from "../repomap/extract-py.js";
 import {
   parseCodeowners,
   ownerFor,
@@ -39,7 +40,7 @@ import {
   type CoChange,
 } from "../repomap/cochange.js";
 
-const EXTS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
+const EXTS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".py"];
 
 /** Walk `root`, parse imports, and build the whole-repo import graph (repo-relative posix ids). */
 export function buildRepoGraph(root: string): RepoGraph {
@@ -56,20 +57,37 @@ export function buildRepoGraph(root: string): RepoGraph {
     } catch {
       /* unreadable — treat as no imports */
     }
-    const internal: string[] = [];
-    const external: string[] = [];
-    for (const spec of parseImportSpecifiers(source)) {
-      if (isRelativeSpecifier(spec)) {
-        const target = resolveImport(path, spec, fileSet);
-        if (target) internal.push(target);
-        // a relative spec that resolves to nothing is dropped (generated/missing) — never guessed
-      } else {
-        external.push(spec);
-      }
-    }
-    files.push({ path, internal, external });
+    files.push({ path, ...resolveImports(path, source, fileSet) });
   }
   return buildImportGraph(files);
+}
+
+/** Resolve one file's imports to in-repo targets + external specifiers, dispatched by language. */
+function resolveImports(
+  path: string,
+  source: string,
+  fileSet: Set<string>,
+): { internal: string[]; external: string[] } {
+  const internal: string[] = [];
+  const external: string[] = [];
+  if (path.endsWith(".py")) {
+    // Python: resolve dotted/relative imports to repo files; unresolved → external (never guessed).
+    for (const tok of parsePythonImports(source)) {
+      const target = resolvePythonImport(path, tok, fileSet);
+      if (target) internal.push(target);
+      else external.push(tok);
+    }
+  } else {
+    for (const spec of parseImportSpecifiers(source)) {
+      if (!isRelativeSpecifier(spec)) {
+        external.push(spec);
+        continue;
+      }
+      const target = resolveImport(path, spec, fileSet);
+      if (target) internal.push(target); // unresolved relative spec is dropped — never guessed
+    }
+  }
+  return { internal, external };
 }
 
 /** Load CODEOWNERS rules from the first standard location that exists (empty if none). */

--- a/src/repomap/extract-py.test.ts
+++ b/src/repomap/extract-py.test.ts
@@ -1,0 +1,77 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parsePythonImports, resolvePythonImport } from "./extract-py.js";
+
+describe("repomap extract-py — parsePythonImports", () => {
+  it("captures import / from-import forms, aliases, commas, relative dots", () => {
+    const src = `
+      import os
+      import a.b.c as abc
+      import x, y as why
+      from pkg.mod import thing
+      from . import sibling
+      from .local import f
+      from ..up import g
+      from pkg import (one, two)
+      # import commented.out
+    `;
+    assert.deepEqual(parsePythonImports(src), [
+      "os",
+      "a.b.c",
+      "x",
+      "y",
+      "pkg.mod",
+      ".sibling",
+      ".local",
+      "..up",
+      "pkg",
+    ]);
+  });
+
+  it("ignores commented lines and dedupes", () => {
+    assert.deepEqual(parsePythonImports("import os\nimport os\n# import re"), ["os"]);
+  });
+});
+
+describe("repomap extract-py — resolvePythonImport", () => {
+  const fileSet = new Set([
+    "pkg/__init__.py",
+    "pkg/mod.py",
+    "pkg/sub/__init__.py",
+    "pkg/sub/deep.py",
+    "app/main.py",
+    "app/util.py",
+    "src/lib/thing.py",
+  ]);
+
+  it("resolves a relative sibling import (from .local import x)", () => {
+    assert.equal(resolvePythonImport("app/main.py", ".util", fileSet), "app/util.py");
+  });
+
+  it("resolves `from . import sub` to the submodule/package", () => {
+    assert.equal(resolvePythonImport("pkg/mod.py", ".sub", fileSet), "pkg/sub/__init__.py");
+  });
+
+  it("resolves a parent-relative import (..up style) up the tree", () => {
+    // from pkg/sub/deep.py, `..mod` → pkg/mod.py
+    assert.equal(resolvePythonImport("pkg/sub/deep.py", "..mod", fileSet), "pkg/mod.py");
+  });
+
+  it("resolves an absolute dotted import from the repo root", () => {
+    assert.equal(resolvePythonImport("app/main.py", "pkg.mod", fileSet), "pkg/mod.py");
+    assert.equal(resolvePythonImport("app/main.py", "pkg.sub.deep", fileSet), "pkg/sub/deep.py");
+  });
+
+  it("resolves an absolute import by a UNIQUE path suffix (src/ layout)", () => {
+    assert.equal(resolvePythonImport("app/main.py", "lib.thing", fileSet), "src/lib/thing.py");
+  });
+
+  it("returns null for an unresolved (external / stdlib) import — never guessed", () => {
+    assert.equal(resolvePythonImport("app/main.py", "os", fileSet), null);
+    assert.equal(resolvePythonImport("app/main.py", "numpy.linalg", fileSet), null);
+  });
+
+  it("returns null when a parent-relative import walks above the repo root", () => {
+    assert.equal(resolvePythonImport("main.py", "..x", fileSet), null);
+  });
+});

--- a/src/repomap/extract-py.ts
+++ b/src/repomap/extract-py.ts
@@ -1,0 +1,117 @@
+/**
+ * Repo-map — Python import extractor (deterministic, dependency-free, zero-LLM).
+ *
+ * Parses `import` / `from … import …` statements and resolves the in-repo ones to repo-relative file
+ * ids, so `kit map` covers Python alongside TS/JS. Relative (dotted) imports resolve precisely against
+ * the importer's package; absolute imports resolve from the repo root or a unique path suffix (src/
+ * layouts). Anything that doesn't resolve to a known file is reported external — never guessed.
+ */
+
+/**
+ * Extract module tokens from Python source: `import a.b`, `import a as x, c`, `from a.b import c`,
+ * `from . import x`, `from .mod import y`, `from ..pkg import z`. Relative tokens keep their leading
+ * dots. Deterministic, order-preserving, deduped. Pure.
+ */
+export function parsePythonImports(source: string): string[] {
+  const tokens: string[] = [];
+  const push = (t: string) => {
+    const v = t.trim();
+    if (v && !tokens.includes(v)) tokens.push(v);
+  };
+  for (const rawLine of source.split("\n")) {
+    const line = rawLine.replace(/#.*$/, "").trim();
+    if (!line) continue;
+
+    const fromM = /^from\s+(\.*[\w.]*)\s+import\s+(.+)$/.exec(line);
+    if (fromM) {
+      const mod = fromM[1];
+      if (/^\.+$/.test(mod)) {
+        // `from . import a, b` / `from .. import x` — each name is a submodule of the (relative) pkg.
+        for (const name of splitImportNames(fromM[2])) push(mod + name);
+      } else {
+        push(mod);
+      }
+      continue;
+    }
+
+    const importM = /^import\s+(.+)$/.exec(line);
+    if (importM) {
+      for (const part of importM[1].split(",")) {
+        const mod = part
+          .trim()
+          .split(/\s+as\s+/)[0]
+          .trim();
+        if (mod) push(mod);
+      }
+    }
+  }
+  return tokens;
+}
+
+/** Split the names after `import` (handles `(a, b)`, `as` aliases, trailing commas). */
+function splitImportNames(rest: string): string[] {
+  return rest
+    .replace(/[()]/g, "")
+    .split(",")
+    .map((n) =>
+      n
+        .trim()
+        .split(/\s+as\s+/)[0]
+        .trim(),
+    )
+    .filter(Boolean);
+}
+
+/** dirname on a posix repo-relative path ("" for a top-level file). */
+function dirOf(p: string): string {
+  const i = p.lastIndexOf("/");
+  return i < 0 ? "" : p.slice(0, i);
+}
+
+function upDirs(dir: string, n: number): string | null {
+  let d = dir;
+  for (let i = 0; i < n; i++) {
+    if (d === "") return null; // walked above the repo root — unresolvable
+    d = dirOf(d);
+  }
+  return d;
+}
+
+/** Candidate repo files for a slash path with no extension: `p.py` and `p/__init__.py`. */
+function candidatesFor(base: string): string[] {
+  const b = base.replace(/\/+$/, "");
+  return b ? [b + ".py", b + "/__init__.py"] : [];
+}
+
+/**
+ * Resolve a Python module `token` imported from repo-relative `fromRel` to a member of `fileSet`, or
+ * null (external / unresolved — never guessed). Relative tokens (leading dots) resolve against the
+ * importer's package; absolute tokens resolve from the repo root, then by a UNIQUE path-suffix match
+ * (src/ layouts). An ambiguous absolute match (multiple candidates) stays external. Pure.
+ */
+export function resolvePythonImport(
+  fromRel: string,
+  token: string,
+  fileSet: Set<string>,
+): string | null {
+  const dotMatch = /^(\.+)(.*)$/.exec(token);
+  if (dotMatch) {
+    const level = dotMatch[1].length;
+    const rest = dotMatch[2].replace(/^\./, ""); // remainder after the leading dots
+    const base = upDirs(dirOf(fromRel), level - 1); // 1 dot = current package (importer's dir)
+    if (base === null) return null;
+    const relPath = rest ? `${base}/${rest.split(".").join("/")}` : `${base}/__init__`;
+    for (const c of candidatesFor(relPath)) if (fileSet.has(c)) return c;
+    return null;
+  }
+
+  const segs = token.split(".").filter(Boolean);
+  if (segs.length === 0) return null;
+  const path = segs.join("/");
+  // 1) exact from repo root
+  for (const c of candidatesFor(path)) if (fileSet.has(c)) return c;
+  // 2) unique suffix match (e.g. src/pkg/mod.py for `import pkg.mod`)
+  const suffixes = candidatesFor(path).map((c) => "/" + c);
+  const hits = [...fileSet].filter((f) => suffixes.some((s) => f.endsWith(s)));
+  return hits.length === 1 ? hits[0] : null; // ambiguous → external (never guessed)
+}


### PR DESCRIPTION
## Description

Final repo-map ladder rung: extends the import graph to **Python**, so `kit map` / `kit_map` build a slice on polyglot and Python-first repos, not just TS/JS.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- **`src/repomap/extract-py.ts`** — pure, dependency-free:
  - `parsePythonImports` — `import a.b`, `import a as x, c`, `from a.b import c`, `from . import x`, `from .mod import y`, `from ..pkg import z` (comments/aliases/commas/parens handled; deduped).
  - `resolvePythonImport` — relative (dotted) imports resolve against the importer's package; absolute imports resolve from the repo root, then by a **unique path suffix** (`src/` layouts); `__init__.py` packages handled. Walk-above-root and ambiguous/stdlib imports → external, **never guessed**.
- **`src/commands/repomap.ts`** — `.py` added to the walk; `buildRepoGraph` dispatches per file via a small `resolveImports` helper (keeps nesting flat).
- **CHANGELOG.md** — extended the repo-map bullet.

## Testing

- 9 new unit tests (parse forms; relative/parent/absolute/suffix resolution; external/no-guess; walk-above-root).
- Live: a temp Python pkg — `kit map pkg/main.py` resolves `from .util` → `pkg/util.py`, `os` → external, excludes unrelated files.
- `npx tsc --noEmit` clean · `npx eslint src` 0 errors · `npm run format:check` clean · `node scripts/test.mjs` **2864/2864**.
- Public surface unchanged.

## Breaking Changes

None. Additive language coverage on the experimental `kit map` / `kit_map`.

## Checklist

- [x] All new code has test coverage
- [x] All tests pass locally
- [x] No new warnings or errors introduced
- [x] Code has been self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_