### PR TITLE
docs: sync COMMANDS.md + README with the repo-map (pre-5.0.0 polish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,9 @@ is additive and every new gate is opt-in or degrades honestly.
 
 ## [4.4.0] - 2026-07-07
 
+> Note: 4.4.0 was prepared in-repo but never published to npm (the registry went
+> straight from 4.3.0 to 5.0.0). Everything below ships as part of 5.0.0.
+
 ### Added — `kit standards`: the third quality dimension (P1–P5, #255–#257)
 
 - **General gate (P1).** Language-agnostic code-quality metrics, measured the same

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ recall — with zero manual steps. See [docs/ENV_FUELING.md](docs/ENV_FUELING.md
 ## What's new in 5.0
 
 kit 5.0 is the **North Star** release: it takes kit from a point-in-time verifier
-to a *continuous, portable, fail-closed governance layer* for the agent loop.
+to a _continuous, portable, fail-closed governance layer_ for the agent loop.
 Four pillars, all additive over 4.x — no stable command removed. Highlights:
 
 - **Pillar 1 — hardware-rooted identity.** `kit doctor` surfaces which backend
@@ -86,7 +86,7 @@ Four pillars, all additive over 4.x — no stable command removed. Highlights:
 - **Pillar 3 — one exec-broker.** A single signed-scope governance floor drives
   the PreToolUse gates (`kit gate-egress` / `gate-fs`), the MCP runtime, and the
   `kit doctor` posture. Runtime mediation is **on by default in observe mode**
-  (audits what it *would* deny); enforce is an explicit opt-in.
+  (audits what it _would_ deny); enforce is an explicit opt-in.
 - **Pillar 4 — traveling profile.** `kit profile` declares your
   `{skills, mcp, workflows, plugins, vault, gates, scope}`, audits
   declared-vs-discovered drift, signs the scope/RoE, and **exports/imports** a
@@ -96,7 +96,7 @@ Four pillars, all additive over 4.x — no stable command removed. Highlights:
   SkillSpector's static Stage 1 (no LLM, no egress) and `kit setup --recommended`
   wires the triage gates into your pre-commit hook.
 - **Repo-map (`kit map` / MCP `kit_map`).** A deterministic, zero-LLM code map:
-  given a seed file, get the relevant *slice* of the repo — import neighbors
+  given a seed file, get the relevant _slice_ of the repo — import neighbors
   (TS/JS + Python), a `--budget` cap with a logged drop-list, owner attribution
   (CODEOWNERS or git-blame), and `--co-change` coupling from git history — so an
   agent loads part of a growing repo, not the whole tree.
@@ -328,17 +328,17 @@ The block is regenerated in place on re-run; edit outside its markers freely.
 kit is **agent-agnostic** — it's a CLI that any coding agent can run, plus opt-in
 adapters for the surfaces each agent exposes. Support today, per agent:
 
-| Agent            | Memory index¹ | "use kit" rules block² |         Agent/MCP config audit³         | Perm allowlist⁴ | Auto-capture hooks⁵ | Blocking gate⁶ |
-| :--------------- | :-----------: | :--------------------: | :-------------------------------------: | :-------------: | :-----------------: | :------------: |
-| **Claude Code**  |      ✅       |     ✅ `CLAUDE.md`     |   ✅ + commands/agents/skills/plugins   |       ✅        |         ✅          |    ✅ hook     |
-| **OpenAI Codex** |      ✅       |     ✅ `AGENTS.md`     |           ✅ `.codex/config`            |        —        |          —          |    ✅ hook     |
-| **OpenCode**     |      ✅       |     ✅ `AGENTS.md`     | ✅ `opencode.json` + `.opencode/plugin` |        —        |          —          |   ✅ plugin    |
-| **Cursor**       |      ✅       |   ✅ `.cursorrules`    |          ✅ `.cursor/mcp.json`          |        —        |          —          |    ✅ hook     |
-| **Cline**        |      ✅       |    ✅ `.clinerules`    |                    —                    |        —        |          —          |    ✅ hook     |
-| **Copilot**      |      —        | ✅ `copilot-instructions.md` |               —                   |        —        |          —          |      —⁸        |
-| **Gemini CLI**   |      ✅       |           —            |                    —                    |        —        |          —          |    ✅ hook     |
-| **Continue**     |      ✅       |           —            |                    —                    |        —        |          —          |      n/a⁷      |
-| **Amazon Q**     |      ✅       |           —            |                    —                    |        —        |          —          |    ✅ hook     |
+| Agent            | Memory index¹ |    "use kit" rules block²    |         Agent/MCP config audit³         | Perm allowlist⁴ | Auto-capture hooks⁵ | Blocking gate⁶ |
+| :--------------- | :-----------: | :--------------------------: | :-------------------------------------: | :-------------: | :-----------------: | :------------: |
+| **Claude Code**  |      ✅       |        ✅ `CLAUDE.md`        |   ✅ + commands/agents/skills/plugins   |       ✅        |         ✅          |    ✅ hook     |
+| **OpenAI Codex** |      ✅       |        ✅ `AGENTS.md`        |           ✅ `.codex/config`            |        —        |          —          |    ✅ hook     |
+| **OpenCode**     |      ✅       |        ✅ `AGENTS.md`        | ✅ `opencode.json` + `.opencode/plugin` |        —        |          —          |   ✅ plugin    |
+| **Cursor**       |      ✅       |      ✅ `.cursorrules`       |          ✅ `.cursor/mcp.json`          |        —        |          —          |    ✅ hook     |
+| **Cline**        |      ✅       |       ✅ `.clinerules`       |                    —                    |        —        |          —          |    ✅ hook     |
+| **Copilot**      |       —       | ✅ `copilot-instructions.md` |                    —                    |        —        |          —          |       —⁸       |
+| **Gemini CLI**   |      ✅       |              —               |                    —                    |        —        |          —          |    ✅ hook     |
+| **Continue**     |      ✅       |              —               |                    —                    |        —        |          —          |      n/a⁷      |
+| **Amazon Q**     |      ✅       |              —               |                    —                    |        —        |          —          |    ✅ hook     |
 
 ✅ supported · — not yet · n/a not applicable (no surface) ([#146](https://github.com/sandstream/kit/issues/146))
 
@@ -966,7 +966,7 @@ implementations here are kit's own (deterministic, zero-LLM). Thanks to:
 - **[cloudctx](https://github.com/chadptk1238/cloudctx)** (MIT) — the memory
   store's SQLite schema and two-hook capture design.
 - **[headroom](https://github.com/chopratejas/headroom)** — the idea behind
-  `kit memory learn`: mine transcripts for recurring instructions and *suggest*
+  `kit memory learn`: mine transcripts for recurring instructions and _suggest_
   memory rules (kit does it deterministically, bring-your-own-LLM, no model call).
 - **[guild](https://github.com/mathomhaus/guild)** (Apache-2.0) — atomic PAL
   ("blocked-on-you") claiming: claim/release with auto-release of abandoned

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ Four pillars, all additive over 4.x — no stable command removed. Highlights:
 - **Deep skill triage.** `kit triage skill --deep` delegates to NVIDIA
   SkillSpector's static Stage 1 (no LLM, no egress) and `kit setup --recommended`
   wires the triage gates into your pre-commit hook.
+- **Repo-map (`kit map` / MCP `kit_map`).** A deterministic, zero-LLM code map:
+  given a seed file, get the relevant *slice* of the repo — import neighbors
+  (TS/JS + Python), a `--budget` cap with a logged drop-list, owner attribution
+  (CODEOWNERS or git-blame), and `--co-change` coupling from git history — so an
+  agent loads part of a growing repo, not the whole tree.
 
 All of it holds the frozen CLI / config / plugin contracts. See
 [CHANGELOG.md](CHANGELOG.md) for the full list.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -191,13 +191,13 @@
 
 Deterministic, zero-LLM code map: load only the relevant slice of a growing repo. Also exposed to agents as the `kit_map` MCP tool (same core — CLI ≡ MCP).
 
-| Command                        | Purpose                                                                                                             |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| `kit map <path...>`            | The files connected to the seed(s) within `--depth` import hops (both directions) + external packages. TS/JS + Python. |
-| `kit map <path> --depth N`     | Widen the neighborhood (default 1).                                                                                  |
-| `kit map <path> --budget N`    | Keep only the N nearest-to-seed files; every drop is logged (never silent truncation).                               |
-| `kit map <path> --co-change`   | Add files that historically change WITH the seed (bounded `git log`; fail-closed without git).                       |
-| `kit map <path> --json`        | Emit the slice (+ owners, ownerSource, coChanged, dropped) for an agent/tool.                                        |
+| Command                      | Purpose                                                                                                                |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `kit map <path...>`          | The files connected to the seed(s) within `--depth` import hops (both directions) + external packages. TS/JS + Python. |
+| `kit map <path> --depth N`   | Widen the neighborhood (default 1).                                                                                    |
+| `kit map <path> --budget N`  | Keep only the N nearest-to-seed files; every drop is logged (never silent truncation).                                 |
+| `kit map <path> --co-change` | Add files that historically change WITH the seed (bounded `git log`; fail-closed without git).                         |
+| `kit map <path> --json`      | Emit the slice (+ owners, ownerSource, coChanged, dropped) for an agent/tool.                                          |
 
 Every slice file is attributed to its owner — CODEOWNERS (last-match-wins) or the git-blame top-author fallback; no CODEOWNERS and no git ⇒ no owner shown, never guessed.
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,6 +1,6 @@
 # kit commands
 
-> Complete reference for every `kit <subcommand>`. Last updated 2026-06-27 (kit 2.0.0).
+> Complete reference for every `kit <subcommand>`. Last updated 2026-07-11 (kit 5.0.0).
 > Pair this with `docs/THREAT_MODEL.md` (what data flows where) and
 > `docs/DATA_FLOW.md` (exact reads/writes per op).
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -187,6 +187,20 @@
 | `kit version`                       | Print kit version + exit.                                                                                                                                                                                                                                    |
 | `kit completions <bash\|zsh\|fish>` | Output shell completion script for the given shell.                                                                                                                                                                                                          |
 
+## Repo-map (experimental)
+
+Deterministic, zero-LLM code map: load only the relevant slice of a growing repo. Also exposed to agents as the `kit_map` MCP tool (same core — CLI ≡ MCP).
+
+| Command                        | Purpose                                                                                                             |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `kit map <path...>`            | The files connected to the seed(s) within `--depth` import hops (both directions) + external packages. TS/JS + Python. |
+| `kit map <path> --depth N`     | Widen the neighborhood (default 1).                                                                                  |
+| `kit map <path> --budget N`    | Keep only the N nearest-to-seed files; every drop is logged (never silent truncation).                               |
+| `kit map <path> --co-change`   | Add files that historically change WITH the seed (bounded `git log`; fail-closed without git).                       |
+| `kit map <path> --json`        | Emit the slice (+ owners, ownerSource, coChanged, dropped) for an agent/tool.                                        |
+
+Every slice file is attributed to its owner — CODEOWNERS (last-match-wins) or the git-blame top-author fallback; no CODEOWNERS and no git ⇒ no owner shown, never guessed.
+
 ## Memory
 
 Local-first second brain — SQLite + FTS5, deterministic, zero model calls. Full guide: `docs/MEMORY.md`.


### PR DESCRIPTION
## Description

Pre-release docs sync. The repo-map ladder (#335–#341) landed **after** the 5.0 release-prep docs (#333) were written, so `kit map` existed in the CHANGELOG but was missing from the user-facing docs.

## Type of Change

- [x] Documentation update

## Changes Made

- **`docs/COMMANDS.md`** — new **Repo-map (experimental)** section: `kit map` with all flags (`--depth`, `--budget`, `--co-change`, `--json`), ownership semantics (CODEOWNERS last-match-wins / git-blame fallback / never guessed), and the CLI ≡ MCP (`kit_map`) note.
- **`README.md`** — added the repo-map bullet to "What's new in 5.0" (written before the repo-map existed).
- Prettier-normalized both files (pre-existing style drift; separate commit).

## Testing

Docs only — no runtime changes. `npm run format:check` clean.

## Breaking Changes

None.

## Checklist

- [x] I've updated documentation as needed
- [x] Code has been self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_