### PR TITLE
docs+comments: scrub internal roadmap language (North Star / Pelare) from public surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [5.0.0] - 2026-07-11
 
-kit 5.0 is the **North Star** release: kit stops being only a _point-in-time_
+With 5.0, kit stops being only a _point-in-time_
 verifier and becomes a _continuous, portable, fail-closed governance layer_ for
 the agent loop. Four pillars land, on top of a unified command surface. Nothing
 here breaks the 2.x/4.x CLI, config, or plugin contracts — every new capability
@@ -508,10 +508,10 @@ false-greens; all three are now closed:
 ## [4.1.0] - 2026-07-04
 
 A wholly **additive**, backward-compatible release along two axes — broader agent
-coverage and the first **v1 foundations of the 5.0 north-star pillars**. Semver
+coverage and the first **v1 foundations of the 5.0 pillars**. Semver
 note: nothing here breaks an existing contract (all-new modules, no default
 flipped), so this is a MINOR, not a major. The pillar work lands behind the
-interfaces the north-star design calls for, but the _breaking_ capabilities that
+interfaces the 5.0 design calls for, but the _breaking_ capabilities that
 will justify **5.0.0** — hardware-key migration, enforcement-on-by-default, a
 required control plane — deliberately do NOT ship here; `5.0.0` is reserved for
 when the first of those lands. Built via a multi-agent workflow (design →

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ recall — with zero manual steps. See [docs/ENV_FUELING.md](docs/ENV_FUELING.md
 
 ## What's new in 5.0
 
-kit 5.0 is the **North Star** release: it takes kit from a point-in-time verifier
+kit 5.0 takes kit from a point-in-time verifier
 to a _continuous, portable, fail-closed governance layer_ for the agent loop.
 Four pillars, all additive over 4.x — no stable command removed. Highlights:
 

--- a/docs/CONTROL_PLANE.md
+++ b/docs/CONTROL_PLANE.md
@@ -1,6 +1,6 @@
 # kit control plane (self-hostable, offline-verified)
 
-kit's control plane (North Star Pillar 2) is a **verifier and distributor of signed artifacts, not
+kit's control plane (5.0 Pillar 2) is a **verifier and distributor of signed artifacts, not
 a runtime-dependent service.** It has **no server logic**: the "plane" is a folder of signed files
 behind any file server, object store, or git remote. Every machine verifies those files **offline**
 against a committed trust anchor. There is no telemetry and no egress by default; if the plane

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -44,7 +44,7 @@ output. Grouped by area; kit-specific meaning noted where it matters.
 | **AES-256-GCM** | Advanced Encryption Standard / Galois-Counter Mode | Authenticated encryption used for encrypted sync blobs. |
 | **JWT** | JSON Web Token | A signed token format kit's secret detector recognizes (and skips known public demo keys). |
 | **TOTP** | Time-based One-Time Password | 2FA codes; kit treats them as secrets. |
-| **TPM / HSM** | Trusted Platform Module / Hardware Security Module | Hardware key stores; the "regulated tier" for non-exportable keys (kit 5.0 north star). |
+| **TPM / HSM** | Trusted Platform Module / Hardware Security Module | Hardware key stores; the "regulated tier" for non-exportable keys (kit 5.0 design). |
 | **TOFU** | Trust On First Use | Pin-on-first-sight trust model (same shape as the MCP drift pin). |
 | **TSA** | Time-Stamping Authority | Trusted timestamp source for attestations. |
 | **GPG** | GNU Privacy Guard | OpenPGP signing kit can verify. |

--- a/src/approval-tokens.ts
+++ b/src/approval-tokens.ts
@@ -1,5 +1,5 @@
 /**
- * kit control plane (Pelare 2) — offline-verifiable signed approval tokens (§4.5, approval-routing).
+ * kit control plane (Pillar 2) — offline-verifiable signed approval tokens (§4.5, approval-routing).
  *
  * `requestApproval` can already prompt interactively or call a webhook/remote API. This adds a
  * THIRD, offline, no-egress path: an org authority mints a time-boxed, operation-scoped **signed

--- a/src/commands/insight.ts
+++ b/src/commands/insight.ts
@@ -1,5 +1,5 @@
 /**
- * `kit insight` — Pelare 4's deterministic lifecycle-insight surface. First
+ * `kit insight` — Pillar 4's deterministic lifecycle-insight surface. First
  * subcommand: `unused` — which loaded MCP servers / skills were never actually
  * called, correlating the loaded toolchain (agent-sbom) against recorded usage
  * (the memory index's tool_uses table: MCP tools by `mcp__<server>__<tool>`,

--- a/src/control-plane/distribute.ts
+++ b/src/control-plane/distribute.ts
@@ -1,8 +1,8 @@
 /**
- * kit control plane — Pelare 2: signed-policy distribution + revocation propagation.
+ * kit control plane — Pillar 2: signed-policy distribution + revocation propagation.
  *
  * The control plane is a VERIFIER and DISTRIBUTOR of signed artifacts, NOT a
- * runtime-dependent service. Everything here holds the north-star invariants:
+ * runtime-dependent service. Everything here holds the 5.0-design invariants:
  *   - local-first / air-gap: a bundle can be a plain FILE; the only network is the
  *     opt-in `https:` fetch, behind an injectable `fetchImpl` (so tests + air-gap
  *     runs touch zero network). No egress by default, no telemetry.

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -245,7 +245,7 @@ describe("runDoctor", () => {
     }
   });
 
-  it("surfaces the identity keystore posture (Pelare 1 — never silent)", async () => {
+  it("surfaces the identity keystore posture (Pillar 1 — never silent)", async () => {
     const tmpDir = join(tmpdir(), `kit-doctor-test-${process.pid}-9`);
     await mkdir(tmpDir, { recursive: true });
     try {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -214,8 +214,8 @@ async function checkGitHooks(config: kitConfig): Promise<DoctorCheck[]> {
 }
 
 /**
- * Identity KeyStore posture (Pelare 1). Surfaces WHICH backend signs kit's
- * identity and — per the North Star design principle — makes any degradation to
+ * Identity KeyStore posture (Pillar 1). Surfaces WHICH backend signs kit's
+ * identity and — per the 5.0 design principle — makes any degradation to
  * the file-backed 0600 key HONEST rather than silent:
  *   pass  hardware-rooted (Secure Enclave / TPM / external command)
  *   warn  file-backed 0600 key (the working default; no hardware backend active)
@@ -254,7 +254,7 @@ function checkIdentityKeystore(): DoctorCheck {
 }
 
 /**
- * Exec-broker scope posture (Pelare 3). Surfaces the state of the signed [scope]/RoE the
+ * Exec-broker scope posture (Pillar 3). Surfaces the state of the signed [scope]/RoE the
  * broker enforces against — per the design principle, "enforced" must never silently mean
  * "no-op" and a degradation is surfaced, never swallowed:
  *   pass  scope declared + signature verified (this scope governs)
@@ -428,7 +428,7 @@ async function checkTriageGates(cwd: string): Promise<DoctorCheck> {
 }
 
 /**
- * Keyless-credential posture (Pelare 2 tail — "sign, don't store"). Reports whether any hosts are
+ * Keyless-credential posture (Pillar 2 tail — "sign, don't store"). Reports whether any hosts are
  * declared keyless (`[scope].sign`) and whether kit can actually sign for them — never silent:
  *   skip  no keyless hosts declared
  *   pass  keyless hosts declared, scope VERIFIED, and a usable identity can sign
@@ -474,7 +474,7 @@ async function checkKeyless(cwd: string): Promise<DoctorCheck> {
 }
 
 /**
- * Control-plane posture (Pelare 2): is a DISTRIBUTED org policy present at this project, and is it
+ * Control-plane posture (Pillar 2): is a DISTRIBUTED org policy present at this project, and is it
  * trustworthy? Honest — "distributed" must never silently mean "unverified":
  *   skip  no .kit-policy.toml here (nothing distributed yet)
  *   pass  policy present + signature verified (org standard + any RBAC it carries govern)

--- a/src/exec-broker/broker.ts
+++ b/src/exec-broker/broker.ts
@@ -1,4 +1,4 @@
-// Pelare 3 — exec-broker: the enforcement wrapper.
+// Pillar 3 — exec-broker: the enforcement wrapper.
 //
 // brokerExec moves governance from advisory-at-chokepoint to ENFORCED-AT-EXEC:
 // it runs the three pure decision gates on an operation's DECLARED effects

--- a/src/exec-broker/decisions.ts
+++ b/src/exec-broker/decisions.ts
@@ -1,4 +1,4 @@
-// Pelare 3 — exec-broker: the three pure, fail-closed decision functions.
+// Pillar 3 — exec-broker: the three pure, fail-closed decision functions.
 //
 // These gate the CONCRETE effects of an agent's tool-call (network egress,
 // filesystem write, environment exposure) at the moment before `run()` touches a

--- a/src/exec-broker/index.ts
+++ b/src/exec-broker/index.ts
@@ -1,4 +1,4 @@
-// Pelare 3 — exec-broker: public barrel. Callers import from
+// Pillar 3 — exec-broker: public barrel. Callers import from
 // "exec-broker/index.js".
 
 export { checkEgress, checkFsWrite, scopeEnv, type BrokerDecision } from "./decisions.js";

--- a/src/exec-broker/policy.ts
+++ b/src/exec-broker/policy.ts
@@ -1,4 +1,4 @@
-// Pelare 3 — exec-broker: policy shape + fail-closed loader.
+// Pillar 3 — exec-broker: policy shape + fail-closed loader.
 //
 // The BrokerPolicy declares what an operation is ALLOWED to touch: an egress
 // hostname allowlist, a filesystem write root, and the environment keys it may

--- a/src/governance-middleware.ts
+++ b/src/governance-middleware.ts
@@ -319,7 +319,7 @@ export async function runGoverned<T>(
 }
 
 /**
- * {@link runGoverned} with the Pelare 3 exec-broker composed ON TOP. The broker
+ * {@link runGoverned} with the Pillar 3 exec-broker composed ON TOP. The broker
  * gates an operation's declared RESOURCE effects (egress / fs-write / env)
  * BEFORE governance (identity / budget / permission) runs; the two are separate
  * concerns that stack.

--- a/src/insight/scaffold.ts
+++ b/src/insight/scaffold.ts
@@ -1,5 +1,5 @@
 /**
- * Repeat→codify scaffold for Pelare 4's insight loop
+ * Repeat→codify scaffold for Pillar 4's insight loop
  * (`pillar4-insight-loop-5.0.md`, step 4). `memory learn` already FINDS recurring
  * instructions deterministically (learnRecurring — pure counting, no ML); this
  * turns a found LearnCandidate into a skill-DRAFT skeleton the operator reviews.

--- a/src/insight/unused.ts
+++ b/src/insight/unused.ts
@@ -1,5 +1,5 @@
 /**
- * Loaded-vs-used correlation for Pelare 4's insight loop
+ * Loaded-vs-used correlation for Pillar 4's insight loop
  * (`pillar4-insight-loop-5.0.md`). Pure + deterministic: given the loaded
  * toolchain (agent-sbom.discoverAgentToolchain) and the used signal
  * (usage-scan.scanToolUsage), decide which loaded MCP servers were never called.

--- a/src/insight/usage-scan.ts
+++ b/src/insight/usage-scan.ts
@@ -1,5 +1,5 @@
 /**
- * Deterministic tool-usage scanner — the "used" signal for Pelare 4's
+ * Deterministic tool-usage scanner — the "used" signal for Pillar 4's
  * loaded-but-unused insight (`pillar4-insight-loop-5.0.md`).
  *
  * Zero-LLM, pure counting: kit's memory index already normalizes every agent's

--- a/src/keystore/file-store.ts
+++ b/src/keystore/file-store.ts
@@ -6,7 +6,7 @@
  * loadOrCreateIdentity / rotateIdentity / tryLoadIdentity and threads the
  * existing KIT_IDENTITY_DIR override (via the optional constructor `dir`)
  * straight through. Rewriting any of that here would fork the trust code; the
- * whole point of Pelare 1 is that this backend is a thin adapter over the
+ * whole point of Pillar 1 is that this backend is a thin adapter over the
  * primitive kit already ships.
  *
  * HONEST THREAT BOUNDARY: this backend stores the private key as a 0600 file

--- a/src/keystore/index.ts
+++ b/src/keystore/index.ts
@@ -1,5 +1,5 @@
 /**
- * Barrel for the KeyStore port (Pelare 1). Callers import from
+ * Barrel for the KeyStore port (Pillar 1). Callers import from
  * "./keystore/index.js" — one public path for the whole pillar.
  */
 export type { KeyStore, KeyStoreKind, KeyStoreAvailability, KeyStoreResolution } from "./types.js";

--- a/src/keystore/types.ts
+++ b/src/keystore/types.ts
@@ -1,5 +1,5 @@
 /**
- * KeyStore port — Pelare 1: hardware-rooted identity behind an interface.
+ * KeyStore port — Pillar 1: hardware-rooted identity behind an interface.
  *
  * This is the abstraction seam that lets kit's Ed25519 private key migrate from
  * the current 0600 PKCS8 PEM file under ~/.kit to NON-EXPORTABLE hardware

--- a/src/policy-pull.ts
+++ b/src/policy-pull.ts
@@ -1,5 +1,5 @@
 /**
- * kit control plane (Pelare 2) — `kit policy pull`: fetch an org-signed policy from a self-hostable
+ * kit control plane (Pillar 2) — `kit policy pull`: fetch an org-signed policy from a self-hostable
  * source and APPLY it only if it verifies OFFLINE against the LOCAL trust anchor.
  *
  * Design: `kit-research/docs/research/pillar2-control-plane-5.0.md` (MVP, §4.1). This is a

--- a/src/rbac/identity-provider.ts
+++ b/src/rbac/identity-provider.ts
@@ -1,5 +1,5 @@
 /**
- * kit RBAC identity providers — the ENROLLMENT-ONLY IdP layer for Pelare 2.
+ * kit RBAC identity providers — the ENROLLMENT-ONLY IdP layer for Pillar 2.
  *
  * An IdP (GitHub today; Azure/Entra and Google are documented future backends of
  * the SAME interface) is consulted ONLY at enrollment time to compile role

--- a/src/rbac/policy-schema.ts
+++ b/src/rbac/policy-schema.ts
@@ -1,5 +1,5 @@
 /**
- * kit RBAC schema — Pelare 2 (role-based access control bound to an IdP at
+ * kit RBAC schema — Pillar 2 (role-based access control bound to an IdP at
  * ENROLLMENT time, enforced fully OFFLINE from the org-signed `.kit-policy.toml`).
  *
  * This module is the PURE, zero-dependency schema shared by the enforcement path

--- a/src/rbac/providers-cloud.ts
+++ b/src/rbac/providers-cloud.ts
@@ -1,5 +1,5 @@
 /**
- * kit RBAC — cloud identity-provider backends for Pelare 2 (Microsoft Entra ID
+ * kit RBAC — cloud identity-provider backends for Pillar 2 (Microsoft Entra ID
  * and Google Cloud Identity), siblings of the GitHub backend in
  * identity-provider.ts. Like GitHub, these are consulted ONLY at ENROLLMENT time
  * to compile role bindings; they are NEVER imported by the enforcement path

--- a/src/rbac/resolve.ts
+++ b/src/rbac/resolve.ts
@@ -1,6 +1,6 @@
 /**
  * kit RBAC resolver — the OFFLINE, deterministic, fail-CLOSED decision engine
- * for Pelare 2.
+ * for Pillar 2.
  *
  * `can(subjectKid, permission, verifiedPolicy)` and
  * `effectivePermissions(subjectKid, verifiedPolicy)` are PURE functions over a

--- a/src/revocation-pull.ts
+++ b/src/revocation-pull.ts
@@ -1,5 +1,5 @@
 /**
- * kit control plane (Pelare 2) — `kit policy pull-revocations`: fetch signed identity-key
+ * kit control plane (Pillar 2) — `kit policy pull-revocations`: fetch signed identity-key
  * revocations from a self-hostable source and MONOTONE-merge the authoritative ones into the local
  * append-only log (`revocations.jsonl`). Design: `pillar2-control-plane-5.0.md` §4.3.
  *


### PR DESCRIPTION
## Description

Pre-release language audit of the public repo. Two kinds of internal language had leaked:

- **"North Star"** — our internal roadmap codename, unexplained jargon for outside readers (README's 5.0 section, CHANGELOG, `docs/CONTROL_PLANE.md`, `docs/GLOSSARY.md`, and several source comments).
- **"Pelare"** — Swedish for "Pillar", in CHANGELOG 4.x sections and ~18 source-comment sites (`doctor.ts`, `exec-broker/*`, `keystore/*`, `rbac/*`, `insight/*`, …).

Both reworded to plain English ("Pillar N", "the 5.0 design"). Matches the same scrub already applied to the website (PR sandstream.github.io#7).

## Type of Change

- [x] Documentation update (prose + code comments only)

## Deliberately kept

- **G1–G6 / P0.x ids in docs** — defined publicly in `docs/GLOSSARY.md`, so they're documented terminology, not leaked jargon.
- **Bumblebee** — shipped, documented scanner name.

## Testing

No behavior change — comments and prose only. Still ran the full gate: `npx tsc --noEmit` clean · `npx eslint src` 0 errors · `npm run build` clean · `npm run format:check` clean · `node scripts/test.mjs` **2864/2864**.

## Breaking Changes

None.

## Checklist

- [x] I've updated documentation as needed
- [x] All tests pass locally
- [x] Code has been self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_