### PR TITLE
fix(security): basic secrets scan no longer flags substitution expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - **Secrets scan (degraded path): substitution expressions are no longer flagged.**
   The basic no-trufflehog scan flagged pure template references — `${{ secrets.X }}`
-  (GitHub Actions), `${VAR}` (shell/compose), `{{ .Values.x }}` (Helm/Jinja) — as
+  (GitHub Actions), `${VAR}` (shell/compose), `{{ .Values.x }}` (Helm/Jinja),
+  `$(cmd)` (command substitution) — as
   secret-shaped strings; these are the _correct_ way to reference a secret, never a
-  literal credential. Found by running the findings sweep against `curl/curl` (its
-  workflow files were the only warn). The filter is now an exported pure function
+  literal credential. Found by running the findings sweep against `curl/curl`
+  (workflow files) and `simonw/llm` (contributing docs) — the only warns on both. The filter is now an exported pure function
   (`basicSecretScanFiles`) with unit tests; a template-_prefixed_ literal still flags.
 
 ## [5.0.0] - 2026-07-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Secrets scan (degraded path): substitution expressions are no longer flagged.**
+  The basic no-trufflehog scan flagged pure template references — `${{ secrets.X }}`
+  (GitHub Actions), `${VAR}` (shell/compose), `{{ .Values.x }}` (Helm/Jinja) — as
+  secret-shaped strings; these are the _correct_ way to reference a secret, never a
+  literal credential. Found by running the findings sweep against `curl/curl` (its
+  workflow files were the only warn). The filter is now an exported pure function
+  (`basicSecretScanFiles`) with unit tests; a template-_prefixed_ literal still flags.
+
 ## [5.0.0] - 2026-07-11
 
 With 5.0, kit stops being only a _point-in-time_

--- a/src/check-security.test.ts
+++ b/src/check-security.test.ts
@@ -453,6 +453,7 @@ describe("basicSecretScanFiles — degraded-path false-positive filter", () => {
       hit(".github/workflows/ci.yml", `GH_TOKEN: '${"$"}{{ secrets.GITHUB_TOKEN }}'`),
       hit("docker-compose.yml", `password: '${"$"}{POSTGRES_PASSWORD_FROM_ENV}'`),
       hit("chart/values.yaml", `apiKey: '{{ .Values.global.apiKeySecretRef }}'`),
+      hit("docs/contributing.md", `PYTEST_OPENAI_API_KEY="$(llm keys get openai)"`),
     ]);
     assert.deepStrictEqual(files, []);
   });

--- a/src/check-security.test.ts
+++ b/src/check-security.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
 import {
+  basicSecretScanFiles,
   checkSecurity,
   gateStatus,
   parseTrivyMisconfigCount,
@@ -418,5 +419,57 @@ describe("checkSecurity", () => {
       cached.find((r) => r.name === "secrets scan"),
       "should include secrets scan check",
     );
+  });
+});
+
+describe("basicSecretScanFiles — degraded-path false-positive filter", () => {
+  const hit = (file: string, content: string) => `${file}:12:${content}`;
+
+  it("flags a literal secret-shaped value outside tests", () => {
+    const files = basicSecretScanFiles([
+      hit("src/config.ts", `const apiKey = "literal-looking-value-0123456789abcdef"`),
+    ]);
+    assert.deepStrictEqual(files, ["src/config.ts"]);
+  });
+
+  it("skips test/fixture/mock paths", () => {
+    const files = basicSecretScanFiles([
+      hit("src/auth.test.ts", `password = "hunter2hunter2hunter2hunter2"`),
+      hit("src/__mocks__/api.ts", `token = "aaaaaaaaaaaaaaaaaaaaaaaaaaaa"`),
+      hit("test/fixtures/creds.json", `"api_key": "bbbbbbbbbbbbbbbbbbbbbbbb"`),
+    ]);
+    assert.deepStrictEqual(files, []);
+  });
+
+  it("skips all-caps env-var NAMES used as values", () => {
+    const files = basicSecretScanFiles([
+      hit("src/env.ts", `token = "SOCKET_SECURITY_API_TOKEN_LONG"`),
+    ]);
+    assert.deepStrictEqual(files, []);
+  });
+
+  it("skips pure substitution expressions (Actions / shell / Helm) — the curl case", () => {
+    const files = basicSecretScanFiles([
+      hit(".github/workflows/ci.yml", `GH_TOKEN: '${"$"}{{ secrets.GITHUB_TOKEN }}'`),
+      hit("docker-compose.yml", `password: '${"$"}{POSTGRES_PASSWORD_FROM_ENV}'`),
+      hit("chart/values.yaml", `apiKey: '{{ .Values.global.apiKeySecretRef }}'`),
+    ]);
+    assert.deepStrictEqual(files, []);
+  });
+
+  it("still flags a template-PREFIXED literal (not a pure expression)", () => {
+    const files = basicSecretScanFiles([
+      hit("src/leak.ts", `token = "${"$"}{{ secrets.X }}-plus-a-literal-suffix"`),
+    ]);
+    assert.deepStrictEqual(files, ["src/leak.ts"]);
+  });
+
+  it("dedupes multiple hits in one file and ignores malformed grep lines", () => {
+    const files = basicSecretScanFiles([
+      hit("src/a.ts", `password = "cccccccccccccccccccccccc"`),
+      hit("src/a.ts", `api_key = "dddddddddddddddddddddddd"`),
+      "not-a-grep-line",
+    ]);
+    assert.deepStrictEqual(files, ["src/a.ts"]);
   });
 });

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -826,6 +826,42 @@ export function classifyTrufflehogFindings(
 /**
  * Scan for secrets in code using trufflehog or basic pattern matching
  */
+/**
+ * Filter git-grep hits from the DEGRADED secrets path (no trufflehog) down to the files
+ * worth a warn. It's an UNVERIFIED grep, so it drops the three dominant false-positive
+ * classes to not drown real signal:
+ *   1. test / fixture / mock files — fake credentials live here by design
+ *      (`sk_test_invalid_for_test...`, sample JWTs). The AUTHORITATIVE scanners
+ *      (trufflehog + the CI gitleaks job) still scan these and verify live, so
+ *      suppressing them HERE only de-noises the local stopgap, it does not weaken
+ *      the real gate.
+ *   2. all-caps identifier VALUES — an env-var NAME like `SOCKET_SECURITY_API_TOKEN`
+ *      is a config key, never a secret.
+ *   3. pure substitution EXPRESSIONS — `${{ secrets.X }}` (GitHub Actions), `${VAR}`
+ *      (shell/compose), `{{ .Values.x }}` (Helm/Jinja). These are the CORRECT way to
+ *      reference a secret, never a literal credential (found flagging curl's workflow
+ *      files in the findings sweep).
+ * Input: `git grep -n` output lines (`file:line:content`). Pure and deterministic.
+ */
+export function basicSecretScanFiles(lines: string[]): string[] {
+  const TEST_PATH = /(\.test\.|\.spec\.|__tests__|\/__mocks__\/|\/fixtures?\/|\.fixture\.)/;
+  const VALUE_RE =
+    /(?:api[_-]?key|secret[_-]?key|password|token|credential)["']?\s*[:=]\s*["']([^"']{20,})/i;
+  const TEMPLATE_VALUE = /^\s*(\$\{\{[^}]*\}\}|\$\{[A-Za-z_][A-Za-z0-9_:.-]*\}|\{\{[^}]*\}\})\s*$/;
+  const files = new Set<string>();
+  for (const line of lines) {
+    const m = line.match(/^([^:]+):\d+:(.*)$/);
+    if (!m) continue;
+    const [, file, content] = m;
+    if (TEST_PATH.test(file)) continue;
+    const value = content.match(VALUE_RE)?.[1] ?? "";
+    if (/^[A-Z][A-Z0-9_]+$/.test(value)) continue; // env-var name, not a secret
+    if (TEMPLATE_VALUE.test(value)) continue; // substitution syntax, not a literal
+    files.add(file);
+  }
+  return [...files];
+}
+
 async function checkSecretsInCode(): Promise<SecurityCheckResult> {
   try {
     // Check if we're in a git repo
@@ -929,41 +965,16 @@ async function checkSecretsInCode(): Promise<SecurityCheckResult> {
       );
 
       if (stdout.trim()) {
-        const lines = stdout.trim().split("\n");
+        const files = basicSecretScanFiles(stdout.trim().split("\n"));
 
-        // This is the DEGRADED path (no trufflehog). It's an UNVERIFIED grep, so
-        // — like the trufflehog `unverified` branch above — it's a medium warn,
-        // not a high one, and it filters its two dominant false-positive classes
-        // so it doesn't drown real signal:
-        //   1. test / fixture / mock files — fake credentials live here by design
-        //      (`sk_test_invalid_for_test...`, sample JWTs). The AUTHORITATIVE
-        //      scanners (trufflehog + the CI gitleaks job) still scan these and
-        //      verify live, so suppressing them HERE only de-noises the local
-        //      stopgap, it does not weaken the real gate.
-        //   2. all-caps identifier VALUES — an env-var NAME like
-        //      `SOCKET_SECURITY_API_TOKEN` is a config key, never a secret.
-        const TEST_PATH = /(\.test\.|\.spec\.|__tests__|\/__mocks__\/|\/fixtures?\/|\.fixture\.)/;
-        const VALUE_RE =
-          /(?:api[_-]?key|secret[_-]?key|password|token|credential)["']?\s*[:=]\s*["']([^"']{20,})/i;
-        const files = new Set<string>();
-        for (const line of lines) {
-          const m = line.match(/^([^:]+):\d+:(.*)$/);
-          if (!m) continue;
-          const [, file, content] = m;
-          if (TEST_PATH.test(file)) continue;
-          const value = content.match(VALUE_RE)?.[1] ?? "";
-          if (/^[A-Z][A-Z0-9_]+$/.test(value)) continue; // env-var name, not a secret
-          files.add(file);
-        }
-
-        if (files.size > 0) {
+        if (files.length > 0) {
           return {
             category: "secrets",
             name: "secrets scan",
             status: "warn",
-            detail: `${files.size} file(s) with unverified secret-shaped strings (basic scan, trufflehog absent — HEAD/working-tree only, does NOT scan git history) — review for real credentials`,
+            detail: `${files.length} file(s) with unverified secret-shaped strings (basic scan, trufflehog absent — HEAD/working-tree only, does NOT scan git history) — review for real credentials`,
             severity: "medium",
-            files: Array.from(files),
+            files,
             suggestion:
               "Install trufflehog for verified detection (it confirms live secrets, skipping test/example data):\n  • kit install (provisions the declared aqua:trufflesecurity/trufflehog)\n  • macOS/Linux: brew install trufflehog\n  • Go: go install github.com/trufflesecurity/trufflehog/v3@latest",
           };

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -838,16 +838,18 @@ export function classifyTrufflehogFindings(
  *   2. all-caps identifier VALUES — an env-var NAME like `SOCKET_SECURITY_API_TOKEN`
  *      is a config key, never a secret.
  *   3. pure substitution EXPRESSIONS — `${{ secrets.X }}` (GitHub Actions), `${VAR}`
- *      (shell/compose), `{{ .Values.x }}` (Helm/Jinja). These are the CORRECT way to
- *      reference a secret, never a literal credential (found flagging curl's workflow
- *      files in the findings sweep).
+ *      (shell/compose), `{{ .Values.x }}` (Helm/Jinja), `$(cmd)` (shell command
+ *      substitution). These are the CORRECT way to reference a secret, never a literal
+ *      credential (found flagging curl's workflows and llm's contributing docs in the
+ *      findings sweep).
  * Input: `git grep -n` output lines (`file:line:content`). Pure and deterministic.
  */
 export function basicSecretScanFiles(lines: string[]): string[] {
   const TEST_PATH = /(\.test\.|\.spec\.|__tests__|\/__mocks__\/|\/fixtures?\/|\.fixture\.)/;
   const VALUE_RE =
     /(?:api[_-]?key|secret[_-]?key|password|token|credential)["']?\s*[:=]\s*["']([^"']{20,})/i;
-  const TEMPLATE_VALUE = /^\s*(\$\{\{[^}]*\}\}|\$\{[A-Za-z_][A-Za-z0-9_:.-]*\}|\{\{[^}]*\}\})\s*$/;
+  const TEMPLATE_VALUE =
+    /^\s*(\$\{\{[^}]*\}\}|\$\{[A-Za-z_][A-Za-z0-9_:.-]*\}|\{\{[^}]*\}\}|\$\([^)]*\))\s*$/;
   const files = new Set<string>();
   for (const line of lines) {
     const m = line.match(/^([^:]+):\d+:(.*)$/);


### PR DESCRIPTION
## Description

The degraded no-trufflehog secrets scan flagged pure template references as secret-shaped strings: `${{ secrets.X }}` (GitHub Actions), `${VAR}` (shell/compose), `{{ .Values.x }}` (Helm/Jinja). These are the *correct* way to reference a secret — never a literal credential. Found by running the findings sweep against `curl/curl`, where the only content warn was two workflow YAMLs using `${{ secrets.GITHUB_TOKEN }}`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

- Related to the episode-10 findings sweep (kit-research)

## Changes Made

- Extracted the degraded-path filter into an exported pure function `basicSecretScanFiles()` (test-path, env-var-name, and the new template-expression false-positive classes documented in one place).
- Added the third filter class: pure substitution expressions are skipped; a template-*prefixed* literal (`"${{ secrets.X }}-suffix"`) still flags.
- CHANGELOG entry under [Unreleased].

## Testing

### Test Coverage
- [x] Added new tests — 6 unit tests for `basicSecretScanFiles` (flag literal, skip tests/mocks/fixtures, skip env-var names, skip Actions/shell/Helm expressions, still flag template-prefixed literal, dedupe + malformed lines)
- [ ] Updated existing tests
- [x] All tests pass (`npm test`) — full suite 2870/2870; tsc, eslint (0 errors), format:check clean

### Manual Testing
1. Cloned `curl/curl`, ran the built CLI: `kit check --category security` — secrets scan now **pass** (was warn on 2 workflow files).
2. Verified the negative case: a template-prefixed literal value still flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_