### PR TITLE
docs(claude): forbid claude.ai/code/session URLs in public issue/PR bodies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,3 +12,16 @@ This project uses [kit](https://github.com/sandstream/kit) to manage tools, secr
 - Destructive secret ops require `kit auth elevate` first (the CLI enforces this).
 
 <!-- END kit -->
+
+## Public artifacts — issue & PR hygiene
+
+`sandstream/kit` is a **public** repository. When opening issues or PRs here:
+
+- **Never put a `claude.ai/code/session_…` URL in an issue or PR body.** It is
+  internal session metadata, not useful to readers, and it clutters the public
+  record (it accumulated on ~160 existing artifacts). The only footer to use is
+  the generic `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+- No internal session IDs, private dashboard/console links, or paths under
+  another customer's project in public bodies.
+- Findings that could be a real security leak in a named third-party repo go to
+  the private `sandstream/kit-research` repo, never a public kit issue.


### PR DESCRIPTION
`sandstream/kit` is public. The `claude.ai/code/session_…` footer had accumulated on ~160 public issues/PRs — internal session metadata, not openable by others and carrying no secret, but clutter on the public record.

Adds an agent convention (outside the kit-managed CLAUDE.md block): use only the generic `🤖 Generated with [Claude Code](https://claude.com/claude-code)` footer; no session IDs, private dashboard links, or cross-customer paths in public bodies; route real-leak findings to the private kit-research repo.

Stops it going forward. The 160 existing artifacts are left untouched (bulk-editing public history was explicitly out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)