### PR TITLE
fix(check): ecosystem-aware lockfile handling — no false-RED on pnpm/bun/yarn/cargo/go/… (#353)

### DIFF
--- a/src/check-security.test.ts
+++ b/src/check-security.test.ts
@@ -12,6 +12,7 @@ import {
   findJvmProject,
   checkMemoryHooksLiveness,
   checkDeviceIdOverride,
+  LOCKFILE_ECOSYSTEMS,
   type SecurityCheckResult,
 } from "./check-security.js";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
@@ -472,5 +473,41 @@ describe("basicSecretScanFiles — degraded-path false-positive filter", () => {
       "not-a-grep-line",
     ]);
     assert.deepStrictEqual(files, ["src/a.ts"]);
+  });
+});
+
+describe("lockfile ecosystem coverage (#353)", () => {
+  const byName = Object.fromEntries(LOCKFILE_ECOSYSTEMS.map((e) => [e.name, e]));
+
+  it("npm/node accepts any JS lockfile, not just package-lock.json", () => {
+    const npm = byName["package-lock.json"];
+    for (const lf of [
+      "package-lock.json",
+      "pnpm-lock.yaml",
+      "yarn.lock",
+      "bun.lockb",
+      "bun.lock",
+    ]) {
+      assert.ok(npm.lockfiles.includes(lf), `npm ecosystem should accept ${lf}`);
+    }
+  });
+
+  it("covers the non-npm/pip ecosystems that used to false-fail", () => {
+    for (const name of ["Cargo.lock", "go.sum", "Gemfile.lock", "composer.lock", "pubspec.lock"]) {
+      assert.ok(byName[name], `missing ecosystem: ${name}`);
+    }
+  });
+
+  it("python accepts poetry/pipenv/uv locks, not just requirements.txt", () => {
+    const py = byName["requirements.txt"];
+    for (const lf of ["requirements.txt", "poetry.lock", "Pipfile.lock", "uv.lock"]) {
+      assert.ok(py.lockfiles.includes(lf), `python ecosystem should accept ${lf}`);
+    }
+  });
+
+  it("every ecosystem lists at least one manifest and one lockfile", () => {
+    for (const e of LOCKFILE_ECOSYSTEMS) {
+      assert.ok(e.manifests.length > 0 && e.lockfiles.length > 0, `${e.name} malformed`);
+    }
   });
 });

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -295,6 +295,34 @@ async function checkNpmAudit(): Promise<SecurityCheckResult> {
     };
   }
 
+  // npm audit REQUIRES an npm lockfile. On a pnpm/yarn/bun repo it errors out,
+  // which previously surfaced as a high-severity FAIL on a perfectly healthy repo
+  // (#353). Skip honestly instead — it is not-applicable, not a failure, and those
+  // repos' dependency vulnerabilities are still covered by osv-scanner. (No
+  // false-green risk: OSV runs regardless.)
+  const hasNpmLock = await access(resolve(process.cwd(), "package-lock.json"))
+    .then(() => true)
+    .catch(() => false);
+  if (!hasNpmLock) {
+    const other = (
+      await Promise.all(
+        (["pnpm-lock.yaml", "yarn.lock", "bun.lockb", "bun.lock"] as const).map((f) =>
+          access(resolve(process.cwd(), f))
+            .then(() => f)
+            .catch(() => null),
+        ),
+      )
+    ).find(Boolean);
+    return {
+      category: "dependency",
+      name: "npm audit",
+      status: "skip",
+      detail: other
+        ? `no package-lock.json — repo uses ${other}; npm audit not applicable (deps covered by osv-scanner)`
+        : "no package-lock.json — npm audit not applicable (deps covered by osv-scanner)",
+    };
+  }
+
   try {
     const { stdout } = await exec("npm", ["audit", "--audit-level=high", "--json"], {
       timeout: 30_000,
@@ -465,83 +493,97 @@ async function checkEnvGitignored(): Promise<SecurityCheckResult> {
 /**
  * Check if package-lock.json or requirements.txt are committed
  */
+/**
+ * Per-ecosystem lockfile map (#353): for each ecosystem whose MANIFEST is present,
+ * a committed lockfile of ANY kind for that ecosystem satisfies the reproducibility
+ * check. Previously only package-lock.json + requirements.txt counted, so a healthy
+ * pnpm/yarn/bun/cargo/go/ruby/php/dart repo that committed its own lockfile was
+ * false-flagged "not committed [high]". The result `name` keeps the canonical
+ * lockfile of the ecosystem (stable for coverage/citation mapping); the detail names
+ * whichever lockfile actually satisfied it.
+ */
+export const LOCKFILE_ECOSYSTEMS: { name: string; manifests: string[]; lockfiles: string[] }[] = [
+  {
+    name: "package-lock.json",
+    manifests: ["package.json"],
+    lockfiles: [
+      "package-lock.json",
+      "npm-shrinkwrap.json",
+      "pnpm-lock.yaml",
+      "yarn.lock",
+      "bun.lockb",
+      "bun.lock",
+    ],
+  },
+  {
+    name: "requirements.txt",
+    manifests: ["requirements.txt", "pyproject.toml", "Pipfile"],
+    lockfiles: ["requirements.txt", "poetry.lock", "Pipfile.lock", "uv.lock", "pdm.lock"],
+  },
+  { name: "Cargo.lock", manifests: ["Cargo.toml"], lockfiles: ["Cargo.lock"] },
+  { name: "go.sum", manifests: ["go.mod"], lockfiles: ["go.sum"] },
+  { name: "Gemfile.lock", manifests: ["Gemfile"], lockfiles: ["Gemfile.lock"] },
+  { name: "composer.lock", manifests: ["composer.json"], lockfiles: ["composer.lock"] },
+  { name: "pubspec.lock", manifests: ["pubspec.yaml"], lockfiles: ["pubspec.lock"] },
+];
+
 async function checkLockfilesCommitted(): Promise<SecurityCheckResult[]> {
   const results: SecurityCheckResult[] = [];
+  const present = (f: string): Promise<boolean> =>
+    access(resolve(process.cwd(), f))
+      .then(() => true)
+      .catch(() => false);
 
-  // Check package-lock.json
+  // Resolve git-tracked state once — a non-git tree is a single honest warn, not a
+  // per-ecosystem repeat.
+  let gitOk = true;
   try {
-    await access(resolve(process.cwd(), "package.json"));
-
-    try {
-      const { stdout } = await exec("git", ["ls-files", "package-lock.json"], {
-        timeout: 5_000,
-      });
-
-      if (stdout.trim()) {
-        results.push({
-          category: "supply-chain",
-          name: "package-lock.json",
-          status: "pass",
-          detail: "committed to git",
-        });
-      } else {
-        results.push({
-          category: "supply-chain",
-          name: "package-lock.json",
-          status: "fail",
-          detail: "not committed to git",
-          severity: "high",
-        });
-      }
-    } catch {
-      results.push({
-        category: "supply-chain",
-        name: "package-lock.json",
-        status: "warn",
-        detail: "git check failed (not in a git repo?)",
-        severity: "low",
-      });
-    }
+    await exec("git", ["rev-parse", "--git-dir"], { timeout: 5_000 });
   } catch {
-    // No package.json, skip
+    gitOk = false;
   }
 
-  // Check requirements.txt
-  try {
-    await access(resolve(process.cwd(), "requirements.txt"));
+  for (const eco of LOCKFILE_ECOSYSTEMS) {
+    const hasManifest = (await Promise.all(eco.manifests.map(present))).some(Boolean);
+    if (!hasManifest) continue;
 
-    try {
-      const { stdout } = await exec("git", ["ls-files", "requirements.txt"], {
-        timeout: 5_000,
-      });
-
-      if (stdout.trim()) {
-        results.push({
-          category: "supply-chain",
-          name: "requirements.txt",
-          status: "pass",
-          detail: "committed to git",
-        });
-      } else {
-        results.push({
-          category: "supply-chain",
-          name: "requirements.txt",
-          status: "fail",
-          detail: "not committed to git",
-          severity: "high",
-        });
-      }
-    } catch {
+    if (!gitOk) {
       results.push({
         category: "supply-chain",
-        name: "requirements.txt",
+        name: eco.name,
         status: "warn",
         detail: "git check failed (not in a git repo?)",
         severity: "low",
       });
+      continue;
     }
-  } catch {
-    // No requirements.txt, skip
+
+    // A committed lockfile of ANY kind for this ecosystem satisfies the check.
+    let committed: string | null = null;
+    for (const lf of eco.lockfiles) {
+      const { stdout } = await exec("git", ["ls-files", lf], { timeout: 5_000 });
+      if (stdout.trim()) {
+        committed = lf;
+        break;
+      }
+    }
+
+    if (committed) {
+      results.push({
+        category: "supply-chain",
+        name: eco.name,
+        status: "pass",
+        detail: `committed to git (${committed})`,
+      });
+    } else {
+      results.push({
+        category: "supply-chain",
+        name: eco.name,
+        status: "fail",
+        detail: `no committed lockfile for the detected ecosystem (${eco.lockfiles.slice(0, 3).join(" / ")}…)`,
+        severity: "high",
+      });
+    }
   }
 
   return results;


### PR DESCRIPTION
Both lockfile signal layers were npm/pip-only → high-severity **false reds** on any other package manager (surfaced by the harness dogfood: opencode/cline/codex/create-t3-app all hit it).

- **`checkNpmAudit`**: ran `npm audit` on any `package.json`; pnpm/bun/yarn (no `package-lock.json`) → errored → `audit check failed [high]`. Now **skips honestly** ("not applicable; deps covered by osv-scanner") when there's no npm lockfile. No false-green — OSV covers those deps.
- **`checkLockfilesCommitted`**: only `package-lock.json` + `requirements.txt` counted. New `LOCKFILE_ECOSYSTEMS` map accepts ANY valid committed lockfile per present manifest — npm (package-lock/pnpm/yarn/bun), python (requirements/poetry/pipenv/uv), + Cargo.lock, go.sum, Gemfile.lock, composer.lock, pubspec.lock. Only a manifest with **no** lockfile fails.

Result names kept stable (`package-lock.json`/`requirements.txt`) for coverage/citation mapping; the detail names whichever lockfile satisfied it.

**Verified e2e** on a pnpm repo: `npm audit → skip`, `package-lock.json → pass ("committed to git (pnpm-lock.yaml)")`. 45/45 check-security tests pass incl. new ecosystem-coverage tests.

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)