### PR TITLE
chore(release): 5.1.0 — ecosystem-aware lockfile fix (#354) + skill test + bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.1.0] - 2026-07-16
+
 ### Added
 
 - **`kit skill test <path>` (experimental) — module-discipline linter for a
@@ -41,6 +43,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   literal credential. Found by running the findings sweep against `curl/curl`
   (workflow files) and `simonw/llm` (contributing docs) — the only warns on both. The filter is now an exported pure function
   (`basicSecretScanFiles`) with unit tests; a template-_prefixed_ literal still flags.
+- **Lockfile handling is ecosystem-aware — no more false-RED on pnpm/bun/yarn/cargo/go/…
+  repos (#354).** Both signal layers were npm/pip-only: `npm audit` ran on any
+  `package.json` (erroring into a high-severity `audit check failed` on pnpm/bun/yarn),
+  and the committed-lockfile check only accepted `package-lock.json` / `requirements.txt`
+  (flagging a healthy repo that commits `pnpm-lock.yaml` / `bun.lock` / `Cargo.lock` /
+  `go.sum` / … as "no lockfile"). Now `npm audit` skips honestly (not-applicable; deps
+  still covered by osv-scanner) when there is no npm lockfile, and a new
+  `LOCKFILE_ECOSYSTEMS` map accepts any valid committed lockfile per present manifest.
+  Found by pointing kit's floor at the agent harnesses it integrates with; verified e2e
+  (cline/opencode/codex/create-t3-app: 2 false-red high-fails each → skip + pass).
 
 ## [5.0.0] - 2026-07-11
 

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -936,7 +936,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.0.0"
+    "version": "5.1.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
Minor bump — `[Unreleased]` carries new experimental features so it's 5.1.0, not a patch.

**In this release:**
- **fix(check) #354** — ecosystem-aware lockfile handling (no false-RED on pnpm/bun/yarn/cargo/go/…): `npm audit` skips honestly when there's no npm lockfile; committed-lockfile check accepts any valid lockfile per ecosystem. CHANGELOG entry added here (the code PR didn't include one).
- feat: `kit skill test` (experimental) + `kit bootstrap` (experimental) — from parallel work, already in main + Unreleased.
- fix: degraded secret-scan substitution filter.

After merge: signed tag `v5.1.0` → publish.yml → npm. Then a CI findings-sweep re-runs the 200 with 5.1.0 for corrected lockfile stats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)