### PR TITLE
feat(check): add Swift/Elixir/Nix to lockfile ecosystems (#353 follow-up)

### DIFF
--- a/src/check-security.test.ts
+++ b/src/check-security.test.ts
@@ -493,8 +493,28 @@ describe("lockfile ecosystem coverage (#353)", () => {
   });
 
   it("covers the non-npm/pip ecosystems that used to false-fail", () => {
-    for (const name of ["Cargo.lock", "go.sum", "Gemfile.lock", "composer.lock", "pubspec.lock"]) {
+    for (const name of [
+      "Cargo.lock",
+      "go.sum",
+      "Gemfile.lock",
+      "composer.lock",
+      "pubspec.lock",
+      "Package.resolved",
+      "mix.lock",
+      "flake.lock",
+    ]) {
       assert.ok(byName[name], `missing ecosystem: ${name}`);
+    }
+  });
+
+  it("does NOT flag opt-in-lockfile ecosystems (Gradle/Maven/.NET) — no new false-red", () => {
+    // Their lockfiles are opt-in; a missing one is not a finding. Absence from the
+    // map is intentional (JVM/.NET vulns are covered by trivy/osv instead).
+    for (const m of ["pom.xml", "build.gradle", "packages.lock.json"]) {
+      assert.ok(
+        !LOCKFILE_ECOSYSTEMS.some((e) => e.manifests.includes(m)),
+        `${m} should not gate the committed-lockfile check`,
+      );
     }
   });
 

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -525,6 +525,13 @@ export const LOCKFILE_ECOSYSTEMS: { name: string; manifests: string[]; lockfiles
   { name: "Gemfile.lock", manifests: ["Gemfile"], lockfiles: ["Gemfile.lock"] },
   { name: "composer.lock", manifests: ["composer.json"], lockfiles: ["composer.lock"] },
   { name: "pubspec.lock", manifests: ["pubspec.yaml"], lockfiles: ["pubspec.lock"] },
+  // Ecosystems where a committed lockfile is the NORM (so a missing one is a real
+  // finding). Deliberately NOT here: Gradle/Maven/.NET — their lockfiles are opt-in,
+  // so flagging their absence would re-introduce the #354 false-red (JVM/.NET
+  // dependency vulns are covered by trivy/osv-scanner instead).
+  { name: "Package.resolved", manifests: ["Package.swift"], lockfiles: ["Package.resolved"] },
+  { name: "mix.lock", manifests: ["mix.exs"], lockfiles: ["mix.lock"] },
+  { name: "flake.lock", manifests: ["flake.nix"], lockfiles: ["flake.lock"] },
 ];
 
 async function checkLockfilesCommitted(): Promise<SecurityCheckResult[]> {


### PR DESCRIPTION
Extends `LOCKFILE_ECOSYSTEMS` (from #354) with ecosystems where a committed lockfile is the **norm**: Swift (`Package.resolved`), Elixir (`mix.lock`), Nix (`flake.lock`).

Deliberately **not** Gradle/Maven/.NET — their lockfiles are opt-in, so flagging absence would re-introduce the #354 false-red (their dep vulns are covered by trivy/osv). Test asserts both the new coverage and that the opt-in ecosystems stay out. 46/46 check-security tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)