### PR TITLE
feat(skill): kit skill test --runtime — recorded-run adherence + negative controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`kit skill test --runtime` (experimental) — the recorded-run audit that closes two
+  of the checks P1 disclaimed.** kit never runs a skill (zero-LLM); it audits what the
+  agent already recorded. The memory transcript index (`tool_uses`) reconstructs each
+  skill run as a **span** — a `Skill` invocation opens it, following tool calls until the
+  next `Skill` call or session end are that skill's actions — and two checks now decide
+  from that evidence: **adherence** (an out-of-declared-scope tool that actually ran →
+  `fail`; all in-scope across N observed runs → `pass`; no recorded run → honest `skip`)
+  and **negative controls** (a forbidden action that succeeded → `fail`; none attempted →
+  `skip` "not exercised", never a false-green pass). Low-confidence attribution downgrades
+  a would-be fail to an inconclusive `skip` — kit never blames a skill for an action it
+  cannot attribute. Off by default; `--runtime` opts in. Honest coverage limit surfaced:
+  verdicts cover _observed_ runs, not all runs; denial-based "control held" evidence and
+  egress/fs target-scope adherence are later increments. `rubric` stays OUT forever (LLM —
+  delegated). Design: kit-research skill-test-p2-runtime-adherence note.
+
 ## [5.1.0] - 2026-07-16
 
 ### Added

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -849,7 +849,7 @@
     },
     "skill": {
       "kind": "command",
-      "summary": "Module-discipline linter for a SKILL.md: contract shape, trigger + sibling-collision, declared least-privilege scope, and CI regression drift (test <path> [--json] [--gate] [--update-snapshot]) — proves a skill is engineered like a module, NOT that its output is good (rubric grading is delegated) (experimental)",
+      "summary": "Module-discipline linter for a SKILL.md: contract shape, trigger + sibling-collision, declared least-privilege scope, and CI regression drift — plus --runtime to audit recorded runs for scope-adherence + negative controls (from the transcript index, zero-LLM) (test <path> [--runtime] [--json] [--gate] [--update-snapshot]) — proves a skill is engineered like a module, NOT that its output is good (rubric grading is delegated) (experimental)",
       "x-kit-args-modeled": false,
       "x-kit-mcp": false,
       "x-kit-stability": "experimental"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -660,7 +660,7 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
   skill: {
     handler: cmdSkill,
     stability: "experimental",
-    help: "Module-discipline linter for a SKILL.md: contract shape, trigger + sibling-collision, declared least-privilege scope, and CI regression drift (test <path> [--json] [--gate] [--update-snapshot]) — proves a skill is engineered like a module, NOT that its output is good (rubric grading is delegated) (experimental)",
+    help: "Module-discipline linter for a SKILL.md: contract shape, trigger + sibling-collision, declared least-privilege scope, and CI regression drift — plus --runtime to audit recorded runs for scope-adherence + negative controls (from the transcript index, zero-LLM) (test <path> [--runtime] [--json] [--gate] [--update-snapshot]) — proves a skill is engineered like a module, NOT that its output is good (rubric grading is delegated) (experimental)",
   },
   baseline: {
     handler: cmdBaseline,

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -26,7 +26,10 @@ import {
   type SiblingSkill,
   type SkillSnapshot,
   type CheckResult,
+  type DisclaimedItem,
 } from "../skill/test.js";
+import { auditRuntime, type RuntimeCheckResult, type RuntimeEvidence } from "../skill/adherence.js";
+import { readRunEvidence } from "../skill/attribute.js";
 
 /** Snapshot file written next to the SKILL.md it pins. */
 const SNAPSHOT_NAME = ".kit-skill.snapshot.json";
@@ -84,6 +87,90 @@ function mark(status: CheckResult["status"]): string {
   return `${c.yellow}−${c.reset}`; // skip
 }
 
+/**
+ * Gather the two runtime checks (adherence, negative controls) from the transcript index.
+ * Honest skips when the skill has no name to attribute by, or the index is unavailable —
+ * never a silent pass. The pure `auditRuntime` decides; this only sources the evidence.
+ */
+async function gatherRuntime(
+  skillName: string,
+  allowedTools: string[] | undefined,
+): Promise<RuntimeCheckResult[]> {
+  const skipBoth = (reason: string): RuntimeCheckResult[] => [
+    { id: "adherence", status: "skip", detail: reason },
+    { id: "negative", status: "skip", detail: reason },
+  ];
+  if (!skillName)
+    return skipBoth("no name in frontmatter — cannot attribute recorded runs to this skill");
+  let evidence: RuntimeEvidence;
+  try {
+    const { openMemoryDb } = await import("../memory/db.js");
+    const db = openMemoryDb();
+    evidence = readRunEvidence(db, skillName);
+  } catch {
+    return skipBoth("transcript index unavailable — runtime audit skipped");
+  }
+  return auditRuntime(allowedTools, evidence).checks;
+}
+
+interface SkillTestRender {
+  name: string;
+  checks: CheckResult[];
+  runtime: boolean;
+  runtimeChecks: RuntimeCheckResult[];
+  disclaimed: readonly DisclaimedItem[];
+  overallOk: boolean;
+  hasSkips: boolean;
+  json: boolean;
+}
+
+/** Render the folded static + (optional) runtime report as JSON or human output. */
+function renderResult(r: SkillTestRender): void {
+  if (r.json) {
+    console.log(
+      JSON.stringify(
+        {
+          skill: r.name,
+          checks: r.checks,
+          ...(r.runtime ? { runtime: r.runtimeChecks } : {}),
+          disclaimed: r.disclaimed,
+          ok: r.overallOk,
+          hasSkips: r.hasSkips,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+  console.log(
+    `${c.bold}kit skill test${c.reset} ${c.dim}${r.name} — module-discipline checks (deterministic)${c.reset}`,
+  );
+  for (const ch of r.checks) {
+    console.log(`  ${mark(ch.status)} ${ch.id.padEnd(11)} ${c.dim}${ch.detail}${c.reset}`);
+  }
+  if (r.runtime) {
+    console.log(`  ${c.dim}runtime (recorded-run audit):${c.reset}`);
+    for (const ch of r.runtimeChecks) {
+      console.log(`  ${mark(ch.status)} ${ch.id.padEnd(11)} ${c.dim}${ch.detail}${c.reset}`);
+    }
+  }
+  console.log(`\n  ${c.dim}not decided here (by design):${c.reset}`);
+  for (const d of r.disclaimed) {
+    console.log(`  ${c.dim}·${c.reset} ${c.dim}${d.id.padEnd(16)} ${d.reason}${c.reset}`);
+  }
+  if (r.overallOk) {
+    const note = r.hasSkips
+      ? "(some checks skipped — see above)"
+      : "(engineered like a module; not a judgement of quality)";
+    console.log(`\n${c.green}module discipline: ok${c.reset} ${c.dim}${note}${c.reset}`);
+  } else {
+    console.log(
+      `\n${c.red}module discipline: fail${c.reset} ${c.dim}(a check failed — see above)${c.reset}`,
+    );
+  }
+}
+
 export async function cmdSkill(): Promise<boolean> {
   const sub = process.argv[3];
   const args = process.argv.slice(4);
@@ -91,7 +178,7 @@ export async function cmdSkill(): Promise<boolean> {
 
   if (sub !== "test") {
     console.error(
-      `${c.red}usage: kit skill test <path-to-SKILL.md|skill-dir> [--json] [--gate] [--update-snapshot]${c.reset}`,
+      `${c.red}usage: kit skill test <path-to-SKILL.md|skill-dir> [--runtime] [--json] [--gate] [--update-snapshot]${c.reset}`,
     );
     return false;
   }
@@ -99,7 +186,7 @@ export async function cmdSkill(): Promise<boolean> {
   const target = args.find((a) => !a.startsWith("-")) ?? flagValue(process.argv, "--path");
   if (!target) {
     console.error(
-      `${c.red}usage: kit skill test <path-to-SKILL.md|skill-dir> [--json] [--gate] [--update-snapshot]${c.reset}`,
+      `${c.red}usage: kit skill test <path-to-SKILL.md|skill-dir> [--runtime] [--json] [--gate] [--update-snapshot]${c.reset}`,
     );
     return false;
   }
@@ -133,36 +220,30 @@ export async function cmdSkill(): Promise<boolean> {
     snapshot: loadSnapshot(skillPath),
   });
 
-  if (json) {
-    console.log(
-      JSON.stringify({ skill: manifest.name ?? basename(dirname(skillPath)), ...report }, null, 2),
-    );
-  } else {
-    console.log(
-      `${c.bold}kit skill test${c.reset} ${c.dim}${manifest.name ?? basename(dirname(skillPath))} — module-discipline checks (deterministic)${c.reset}`,
-    );
-    for (const ch of report.checks) {
-      console.log(`  ${mark(ch.status)} ${ch.id.padEnd(11)} ${c.dim}${ch.detail}${c.reset}`);
-    }
-    console.log(`\n  ${c.dim}not decided here (by design):${c.reset}`);
-    for (const d of report.disclaimed) {
-      console.log(`  ${c.dim}·${c.reset} ${c.dim}${d.id.padEnd(16)} ${d.reason}${c.reset}`);
-    }
-    if (report.ok && report.hasSkips) {
-      console.log(
-        `\n${c.green}module discipline: ok${c.reset} ${c.dim}(some checks skipped — see above)${c.reset}`,
-      );
-    } else if (report.ok) {
-      console.log(
-        `\n${c.green}module discipline: ok${c.reset} ${c.dim}(engineered like a module; not a judgement of quality)${c.reset}`,
-      );
-    } else {
-      console.log(
-        `\n${c.red}module discipline: fail${c.reset} ${c.dim}(a check failed — see above)${c.reset}`,
-      );
-    }
-  }
+  // --runtime opts into the recorded-run audit; it upgrades the adherence + negative-control
+  // rows from disclaimed-OUT to real verdicts. rubric stays OUT forever (LLM — delegated).
+  const runtime = hasFlag(process.argv, "--runtime");
+  const runtimeChecks = runtime
+    ? await gatherRuntime(manifest.name ?? "", manifest.allowedTools)
+    : [];
+  const disclaimed = runtime
+    ? report.disclaimed.filter((d) => d.id === "rubric")
+    : report.disclaimed;
+  const runtimeOk = runtimeChecks.every((r) => r.status !== "fail");
+  const overallOk = report.ok && runtimeOk;
+  const hasSkips = report.hasSkips || runtimeChecks.some((r) => r.status === "skip");
+
+  renderResult({
+    name: manifest.name ?? basename(dirname(skillPath)),
+    checks: report.checks,
+    runtime,
+    runtimeChecks,
+    disclaimed,
+    overallOk,
+    hasSkips,
+    json,
+  });
 
   // --gate makes any failure a non-zero exit for CI; without it, the report is advisory.
-  return hasFlag(process.argv, "--gate") ? report.ok : true;
+  return hasFlag(process.argv, "--gate") ? overallOk : true;
 }

--- a/src/skill/attribute.test.ts
+++ b/src/skill/attribute.test.ts
@@ -1,0 +1,103 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseSkillOpen, attributeRuns, type ToolCallRow } from "./attribute.js";
+
+describe("parseSkillOpen", () => {
+  it("returns the slug for a Skill call", () => {
+    assert.equal(parseSkillOpen("Skill", '{"skill":"triage"}'), "triage");
+  });
+  it("returns null for a non-Skill tool", () => {
+    assert.equal(parseSkillOpen("Bash", '{"skill":"triage"}'), null);
+  });
+  it("returns null for blank/unparseable/missing input", () => {
+    assert.equal(parseSkillOpen("Skill", null), null);
+    assert.equal(parseSkillOpen("Skill", "not json"), null);
+    assert.equal(parseSkillOpen("Skill", "{}"), null);
+    assert.equal(parseSkillOpen("Skill", '{"skill":"   "}'), null);
+  });
+});
+
+const row = (sessionId: string, tool: string, opensSkill: string | null = null): ToolCallRow => ({
+  sessionId,
+  tool,
+  opensSkill,
+});
+
+describe("attributeRuns", () => {
+  it("attributes the calls inside a target span, excluding the Skill row itself", () => {
+    const rows: ToolCallRow[] = [
+      row("s1", "Read"), // before any skill — ignored
+      row("s1", "Skill", "run-tests"), // opens span
+      row("s1", "Bash"),
+      row("s1", "Grep"),
+    ];
+    const ev = attributeRuns(rows, "run-tests");
+    assert.equal(ev.runs, 1);
+    assert.equal(ev.sessions, 1);
+    assert.deepEqual(
+      ev.actions.map((a) => a.tool),
+      ["Bash", "Grep"],
+    );
+    assert.equal(ev.confidence, "span");
+  });
+
+  it("closes the span when another skill opens", () => {
+    const rows: ToolCallRow[] = [
+      row("s1", "Skill", "run-tests"),
+      row("s1", "Bash"),
+      row("s1", "Skill", "deploy"), // closes run-tests span
+      row("s1", "WebFetch"), // belongs to deploy, not run-tests
+    ];
+    const ev = attributeRuns(rows, "run-tests");
+    assert.deepEqual(
+      ev.actions.map((a) => a.tool),
+      ["Bash"],
+    );
+    assert.equal(ev.runs, 1);
+  });
+
+  it("resets the active span at a session boundary", () => {
+    const rows: ToolCallRow[] = [
+      row("s1", "Skill", "run-tests"),
+      row("s1", "Bash"),
+      row("s2", "Grep"), // new session, no active span → not attributed
+    ];
+    const ev = attributeRuns(rows, "run-tests");
+    assert.deepEqual(
+      ev.actions.map((a) => a.tool),
+      ["Bash"],
+    );
+    assert.equal(ev.sessions, 1);
+  });
+
+  it("counts runs across sessions and multiple invocations", () => {
+    const rows: ToolCallRow[] = [
+      row("s1", "Skill", "run-tests"),
+      row("s1", "Bash"),
+      row("s1", "Skill", "run-tests"), // second run, same session
+      row("s1", "Read"),
+      row("s2", "Skill", "run-tests"), // third run, new session
+      row("s2", "Grep"),
+    ];
+    const ev = attributeRuns(rows, "run-tests");
+    assert.equal(ev.runs, 3);
+    assert.equal(ev.sessions, 2);
+    assert.deepEqual(
+      ev.actions.map((a) => a.tool),
+      ["Bash", "Read", "Grep"],
+    );
+  });
+
+  it("returns zero runs when the target skill never opened a span", () => {
+    const rows: ToolCallRow[] = [row("s1", "Skill", "other"), row("s1", "Bash")];
+    const ev = attributeRuns(rows, "run-tests");
+    assert.equal(ev.runs, 0);
+    assert.equal(ev.actions.length, 0);
+  });
+
+  it("marks every attributed action as not-denied (transcript records runs)", () => {
+    const rows: ToolCallRow[] = [row("s1", "Skill", "x"), row("s1", "Bash")];
+    const ev = attributeRuns(rows, "x");
+    assert.equal(ev.actions[0].denied, false);
+  });
+});

--- a/src/skill/attribute.ts
+++ b/src/skill/attribute.ts
@@ -1,0 +1,103 @@
+/**
+ * `kit skill test` P2b — attribute recorded tool calls to a skill's runs (transcript).
+ *
+ * Design: `kit-research/docs/research/skill-test-p2-runtime-adherence.md`.
+ *
+ * kit never runs a skill (zero-LLM). It reads what the agent already recorded: the memory
+ * index normalizes every transcript into `tool_uses` (one row per call, ordered by `id`).
+ * A skill run is a SPAN — a `Skill` tool call opens it (`tool_input` carries the slug), and
+ * the tool calls that follow, until the next `Skill` call or the session ends, are that
+ * skill's actions. Intersecting spans with tool usage yields per-skill runtime evidence,
+ * which `adherence.ts` turns into the scope-adherence + negative-control verdicts.
+ *
+ * The pure core (`parseSkillOpen`, `attributeRuns`) is deterministic and unit-tested; the
+ * thin `readRunEvidence` reads the ordered rows from the DB and delegates to it.
+ *
+ * SCOPE OF THIS INCREMENT (stated honestly, surfaced in the command output):
+ *   - Confidence is `span` — bounded by explicit `Skill` invocations. Skills that
+ *     auto-activate without a `Skill` call leave no span → no runs → honest skip.
+ *   - `denied` is always false here: the transcript records calls that RAN. A gate deny
+ *     blocks a call before it runs and lands in `.kit-audit.jsonl`, not `tool_uses` — so
+ *     denial-based "control held" evidence needs an audit-log join (a later increment).
+ *   - Only TOOL-scope adherence is judged (tool ∈ declared allowed-tools). Egress/fs
+ *     TARGET-scope adherence (broker verdict per target) is a later increment.
+ */
+import type { DatabaseSync } from "node:sqlite";
+import type { ObservedAction, RuntimeEvidence } from "./adherence.js";
+
+/** One ordered tool-call row from `tool_uses`, reduced to what attribution needs. */
+export interface ToolCallRow {
+  sessionId: string;
+  tool: string;
+  /** For a `Skill` row, the invoked skill slug (parsed from `tool_input`); else null. */
+  opensSkill: string | null;
+}
+
+/**
+ * Parse the skill slug a row opens: a `Skill` tool call whose `tool_input` JSON is
+ * `{ "skill": "<slug>", ... }`. Any other tool, or unparseable/blank input, opens no span.
+ * Pure — never throws.
+ */
+export function parseSkillOpen(tool: string, toolInput: string | null | undefined): string | null {
+  if (tool !== "Skill") return null;
+  if (toolInput == null) return null;
+  let slug: unknown;
+  try {
+    slug = (JSON.parse(toolInput) as { skill?: unknown }).skill;
+  } catch {
+    return null;
+  }
+  if (typeof slug !== "string") return null;
+  const s = slug.trim();
+  return s.length > 0 ? s : null;
+}
+
+/**
+ * Attribute ordered rows to the target skill's runs. Rows MUST be ordered by
+ * (session_id, id). Within a session, a `Skill` row opens a span; while the open span is
+ * the target skill, following non-`Skill` rows become its actions; a new `Skill` row (or a
+ * session change) closes the span. The `Skill` row itself is a boundary, never an action.
+ * Pure. Confidence is always `span` (we have explicit run boundaries).
+ */
+export function attributeRuns(rows: ToolCallRow[], target: string): RuntimeEvidence {
+  const actions: ObservedAction[] = [];
+  const sessionsWithSpan = new Set<string>();
+  let runs = 0;
+  let curSession: string | null = null;
+  let active = false;
+
+  for (const row of rows) {
+    if (row.sessionId !== curSession) {
+      curSession = row.sessionId;
+      active = false;
+    }
+    if (row.opensSkill !== null) {
+      active = row.opensSkill === target;
+      if (active) {
+        runs++;
+        sessionsWithSpan.add(row.sessionId);
+      }
+      continue; // the Skill row opens/closes a span; it is not itself an action
+    }
+    if (active) actions.push({ tool: row.tool, denied: false });
+  }
+
+  return { actions, runs, sessions: sessionsWithSpan.size, confidence: "span" };
+}
+
+/**
+ * Read ordered `tool_uses` rows from the memory DB and attribute them to `target`. The
+ * ORDER BY (session_id, id) reproduces per-session call order so spans reconstruct exactly.
+ * Deterministic given the DB. The pure `attributeRuns` does the decision.
+ */
+export function readRunEvidence(db: DatabaseSync, target: string): RuntimeEvidence {
+  const raw = db
+    .prepare("SELECT session_id, tool_name, tool_input FROM tool_uses ORDER BY session_id, id")
+    .all() as { session_id: string | null; tool_name: string | null; tool_input: string | null }[];
+  const rows: ToolCallRow[] = raw.map((r) => ({
+    sessionId: r.session_id ?? "",
+    tool: (r.tool_name ?? "").trim(),
+    opensSkill: parseSkillOpen(r.tool_name ?? "", r.tool_input),
+  }));
+  return attributeRuns(rows, target);
+}


### PR DESCRIPTION
## Description

P2b of `kit skill test` — wires the runtime pass whose pure core (`adherence.ts`) landed in #352. It moves the two checks P1 shipped disclaimed as OUT — **scope adherence** and **negative controls** — to real, deterministic verdicts, behind `--runtime`.

kit never runs a skill (zero-LLM); it **audits what the agent already recorded**. The memory transcript index (`tool_uses`) reconstructs each skill run as a **span** — a `Skill` invocation opens it, the tool calls that follow until the next `Skill` call or session end are that skill's actions. The verdicts are decided from that evidence, no model call.

## Type of Change

- [x] New feature (non-breaking) — new opt-in flag on an `experimental` command

## Changes Made

- **`src/skill/attribute.ts`** — pure span attribution (`parseSkillOpen`, `attributeRuns`) + a thin `readRunEvidence` DB reader (`ORDER BY session_id, id` reproduces per-session call order).
- **`src/commands/skill.ts`** — `--runtime` flag, `gatherRuntime` (honest skips when there's no name to attribute by or the index is unavailable), and the render path extracted to `renderResult` (keeps `cmdSkill` under the complexity budget).
- **`cli.ts`** help updated; `kit.opencli.json` regenerated. CHANGELOG entry.

## Honest verdict rules (no false green)

- **adherence** — an out-of-declared-scope tool that actually **ran** → `fail`; all in-scope across N observed runs → `pass`; no recorded run → honest `skip`.
- **negative controls** — a forbidden action that **succeeded** → `fail`; none attempted → `skip` "control not exercised", never a pass.
- **low-confidence attribution** downgrades a would-be `fail` to an inconclusive `skip` — kit never blames a skill for an action it cannot attribute.
- Off by default; `--runtime` opts in. `rubric` stays OUT forever (LLM — delegated).

## Stated coverage limits (surfaced, deferred to later increments)

- Verdicts cover **observed** runs, not all possible runs.
- `denied` is false here: the transcript records calls that **ran**; a gate deny lands in `.kit-audit.jsonl`, not `tool_uses`, so denial-based "control held" evidence needs an audit-log join (later).
- Only **tool-scope** adherence is judged; egress/fs **target-scope** adherence (broker verdict per target) is a later increment.

## Testing

- [x] Added 9 attribution unit tests (span boundaries, session reset, multi-run counting, non-target skills, no-span skip)
- [x] All tests pass (`npm test`) — full suite **2945/2945**; tsc, eslint (0 errors), format:check clean
- [x] Manual: live-verified `--runtime` against the real transcript index — emits the honest `skip` when no `Skill` spans are present; `--json` shape carries the `runtime` block and folds into `ok`/`hasSkips`

## Design

`kit-research/docs/research/skill-test-p2-runtime-adherence.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)