### PR TITLE
feat(skill): kit skill test --runtime — egress/fs target-scope adherence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`kit skill test --runtime` now checks egress/fs target-scope, not just tool-scope.**
+  When a signed broker scope is present, each span-attributed action is enriched with a
+  broker verdict via the SAME decisions the gate-egress / gate-fs enforcers apply
+  (`checkEgress`/`checkFsWrite`): a `Bash` command's hosts, a `WebFetch` URL, and a
+  `Write`/`Edit` `file_path` are checked against the signed `[scope]`. This catches a skill
+  that stays within its declared _tools_ but uses an allowed tool (Bash/WebFetch) to reach
+  an _off-scope host_ or write outside the allowed roots — the exfil-via-allowed-tool vector
+  — folding it into the existing `adherence`/`negative` verdicts. Without a verified scope,
+  tool-scope adherence still applies (verdicts stay undefined). Deterministic, zero-LLM.
+
 - **`kit skill test --runtime` (experimental) — the recorded-run audit that closes two
   of the checks P1 disclaimed.** kit never runs a skill (zero-LLM); it audits what the
   agent already recorded. The memory transcript index (`tool_uses`) reconstructs each

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -106,7 +106,16 @@ async function gatherRuntime(
   try {
     const { openMemoryDb } = await import("../memory/db.js");
     const db = openMemoryDb();
-    evidence = readRunEvidence(db, skillName);
+    // A signed broker scope enriches actions with egress/fs target-scope verdicts; absent one,
+    // tool-scope adherence still applies. A missing/invalid policy must never break the audit.
+    let policy = null;
+    try {
+      const { profileBrokerPolicy } = await import("../exec-broker/profile-policy.js");
+      policy = (await profileBrokerPolicy(process.cwd())).policy;
+    } catch {
+      /* no verified scope — tool-scope adherence only */
+    }
+    evidence = readRunEvidence(db, skillName, policy);
   } catch {
     return skipBoth("transcript index unavailable — runtime audit skipped");
   }

--- a/src/skill/attribute.test.ts
+++ b/src/skill/attribute.test.ts
@@ -1,6 +1,12 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parseSkillOpen, attributeRuns, type ToolCallRow } from "./attribute.js";
+import {
+  parseSkillOpen,
+  attributeRuns,
+  brokerVerdictForRow,
+  type ToolCallRow,
+} from "./attribute.js";
+import type { BrokerPolicy } from "../exec-broker/policy.js";
 
 describe("parseSkillOpen", () => {
   it("returns the slug for a Skill call", () => {
@@ -20,6 +26,7 @@ describe("parseSkillOpen", () => {
 const row = (sessionId: string, tool: string, opensSkill: string | null = null): ToolCallRow => ({
   sessionId,
   tool,
+  input: null,
   opensSkill,
 });
 
@@ -99,5 +106,78 @@ describe("attributeRuns", () => {
     const rows: ToolCallRow[] = [row("s1", "Skill", "x"), row("s1", "Bash")];
     const ev = attributeRuns(rows, "x");
     assert.equal(ev.actions[0].denied, false);
+  });
+
+  it("threads a broker verdict onto attributed actions via verdictOf", () => {
+    const rows: ToolCallRow[] = [row("s1", "Skill", "x"), row("s1", "WebFetch")];
+    const ev = attributeRuns(rows, "x", (r) =>
+      r.tool === "WebFetch" ? "out-of-scope" : undefined,
+    );
+    assert.equal(ev.actions[0].brokerVerdict, "out-of-scope");
+  });
+});
+
+const policy: BrokerPolicy = {
+  egress: { allow: ["api.example.com", ".trusted.dev"] },
+  fs: { root: "/repo", roots: ["/repo/extra"] },
+  env: { declared: [] },
+};
+
+describe("brokerVerdictForRow", () => {
+  it("Bash: in-scope when every extracted host is allowed, out-of-scope otherwise", () => {
+    assert.equal(
+      brokerVerdictForRow(
+        "Bash",
+        JSON.stringify({ command: "curl https://api.example.com/x" }),
+        policy,
+      ),
+      "in-scope",
+    );
+    assert.equal(
+      brokerVerdictForRow("Bash", JSON.stringify({ command: "curl https://evil.com/x" }), policy),
+      "out-of-scope",
+    );
+  });
+
+  it("Bash: no extractable host → undefined (tool-scope still applies)", () => {
+    assert.equal(
+      brokerVerdictForRow("Bash", JSON.stringify({ command: "ls -la" }), policy),
+      undefined,
+    );
+  });
+
+  it("WebFetch: url checked against the egress allowlist (suffix match honored)", () => {
+    assert.equal(
+      brokerVerdictForRow("WebFetch", JSON.stringify({ url: "https://sub.trusted.dev/a" }), policy),
+      "in-scope",
+    );
+    assert.equal(
+      brokerVerdictForRow("WebFetch", JSON.stringify({ url: "https://elsewhere.net" }), policy),
+      "out-of-scope",
+    );
+  });
+
+  it("Write/Edit: file_path must land under an allowed fs root", () => {
+    assert.equal(
+      brokerVerdictForRow("Write", JSON.stringify({ file_path: "/repo/src/a.ts" }), policy),
+      "in-scope",
+    );
+    assert.equal(
+      brokerVerdictForRow("Edit", JSON.stringify({ file_path: "/repo/extra/b.ts" }), policy),
+      "in-scope",
+    );
+    assert.equal(
+      brokerVerdictForRow("Write", JSON.stringify({ file_path: "/etc/passwd" }), policy),
+      "out-of-scope",
+    );
+  });
+
+  it("non-egress/fs tools and unparseable/absent input → undefined", () => {
+    assert.equal(
+      brokerVerdictForRow("Read", JSON.stringify({ file_path: "/x" }), policy),
+      undefined,
+    );
+    assert.equal(brokerVerdictForRow("Bash", null, policy), undefined);
+    assert.equal(brokerVerdictForRow("Bash", "not json", policy), undefined);
   });
 });

--- a/src/skill/attribute.ts
+++ b/src/skill/attribute.ts
@@ -24,13 +24,70 @@
  */
 import type { DatabaseSync } from "node:sqlite";
 import type { ObservedAction, RuntimeEvidence } from "./adherence.js";
+import { checkEgress, checkFsWrite } from "../exec-broker/decisions.js";
+import { policyFsRoots, type BrokerPolicy } from "../exec-broker/policy.js";
+import { extractHostsFromCommand } from "../broker/extract.js";
 
 /** One ordered tool-call row from `tool_uses`, reduced to what attribution needs. */
 export interface ToolCallRow {
   sessionId: string;
   tool: string;
+  /** Raw `tool_input` JSON (for egress/fs target-scope verdicts); null when absent. */
+  input: string | null;
   /** For a `Skill` row, the invoked skill slug (parsed from `tool_input`); else null. */
   opensSkill: string | null;
+}
+
+/** Per-action broker verdict from a signed scope, or undefined when the action carries no target. */
+export type BrokerVerdict = "in-scope" | "out-of-scope" | undefined;
+
+/** Pull a string field from a row's `tool_input` JSON; null on absent/unparseable/non-string. */
+function inputField(input: string | null, key: string): string | null {
+  if (input == null) return null;
+  try {
+    const v = (JSON.parse(input) as Record<string, unknown>)[key];
+    return typeof v === "string" ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Egress/fs target-scope verdict for a recorded action against a signed broker policy — the
+ * SAME decisions the gate-egress / gate-fs enforcers apply, pointed at a transcript row.
+ *   - Bash: extract hosts from the command; any host outside `policy.egress.allow` → out-of-scope.
+ *   - WebFetch: its `url` checked against the egress allowlist.
+ *   - Write/Edit: its `file_path` must land under some allowed fs root.
+ *   - Any other tool, or a tool with no extractable target → undefined (tool-scope still applies).
+ * Pure. Deterministic given (row, policy).
+ */
+export function brokerVerdictForRow(
+  tool: string,
+  input: string | null,
+  policy: BrokerPolicy,
+): BrokerVerdict {
+  if (tool === "Bash") {
+    const command = inputField(input, "command");
+    if (command === null) return undefined;
+    const hosts = extractHostsFromCommand(command);
+    if (hosts.length === 0) return undefined;
+    return hosts.every((h) => checkEgress(h, { allow: policy.egress.allow }).ok)
+      ? "in-scope"
+      : "out-of-scope";
+  }
+  if (tool === "WebFetch") {
+    const url = inputField(input, "url");
+    if (url === null) return undefined;
+    return checkEgress(url, { allow: policy.egress.allow }).ok ? "in-scope" : "out-of-scope";
+  }
+  if (tool === "Write" || tool === "Edit") {
+    const path = inputField(input, "file_path");
+    if (path === null) return undefined;
+    return policyFsRoots(policy).some((root) => checkFsWrite(path, root).ok)
+      ? "in-scope"
+      : "out-of-scope";
+  }
+  return undefined;
 }
 
 /**
@@ -59,7 +116,11 @@ export function parseSkillOpen(tool: string, toolInput: string | null | undefine
  * session change) closes the span. The `Skill` row itself is a boundary, never an action.
  * Pure. Confidence is always `span` (we have explicit run boundaries).
  */
-export function attributeRuns(rows: ToolCallRow[], target: string): RuntimeEvidence {
+export function attributeRuns(
+  rows: ToolCallRow[],
+  target: string,
+  verdictOf?: (row: ToolCallRow) => BrokerVerdict,
+): RuntimeEvidence {
   const actions: ObservedAction[] = [];
   const sessionsWithSpan = new Set<string>();
   let runs = 0;
@@ -79,7 +140,7 @@ export function attributeRuns(rows: ToolCallRow[], target: string): RuntimeEvide
       }
       continue; // the Skill row opens/closes a span; it is not itself an action
     }
-    if (active) actions.push({ tool: row.tool, denied: false });
+    if (active) actions.push({ tool: row.tool, denied: false, brokerVerdict: verdictOf?.(row) });
   }
 
   return { actions, runs, sessions: sessionsWithSpan.size, confidence: "span" };
@@ -90,14 +151,24 @@ export function attributeRuns(rows: ToolCallRow[], target: string): RuntimeEvide
  * ORDER BY (session_id, id) reproduces per-session call order so spans reconstruct exactly.
  * Deterministic given the DB. The pure `attributeRuns` does the decision.
  */
-export function readRunEvidence(db: DatabaseSync, target: string): RuntimeEvidence {
+export function readRunEvidence(
+  db: DatabaseSync,
+  target: string,
+  policy?: BrokerPolicy | null,
+): RuntimeEvidence {
   const raw = db
     .prepare("SELECT session_id, tool_name, tool_input FROM tool_uses ORDER BY session_id, id")
     .all() as { session_id: string | null; tool_name: string | null; tool_input: string | null }[];
   const rows: ToolCallRow[] = raw.map((r) => ({
     sessionId: r.session_id ?? "",
     tool: (r.tool_name ?? "").trim(),
+    input: r.tool_input,
     opensSkill: parseSkillOpen(r.tool_name ?? "", r.tool_input),
   }));
-  return attributeRuns(rows, target);
+  // With a signed broker policy, enrich each action with an egress/fs target-scope verdict;
+  // without one, tool-scope adherence still applies (verdicts stay undefined).
+  const verdictOf = policy
+    ? (row: ToolCallRow) => brokerVerdictForRow(row.tool, row.input, policy)
+    : undefined;
+  return attributeRuns(rows, target, verdictOf);
 }


### PR DESCRIPTION
## Description

Extends the `--runtime` recorded-run audit beyond **tool-scope** to **egress/fs target-scope**. When a signed broker scope is present, each span-attributed action is enriched with a broker verdict computed by the **same decisions** the gate-egress / gate-fs enforcers apply — pointed at a transcript row instead of a live tool call.

This catches the exfil-via-allowed-tool vector: a skill that stays within its declared **tools** but uses an allowed `Bash`/`WebFetch` to reach an **off-scope host**, or writes outside the allowed roots. The verdict folds into the existing `adherence` / `negative` checks — `ObservedAction.brokerVerdict` was already in the P2a model for exactly this.

## Type of Change

- [x] New feature (non-breaking) — strengthens an existing opt-in flag

## Changes Made

- **`src/skill/attribute.ts`** — `brokerVerdictForRow` (pure): `Bash` command hosts → `checkEgress`; `WebFetch` url → `checkEgress`; `Write`/`Edit` `file_path` → `checkFsWrite` against `policyFsRoots`. `ToolCallRow` carries `input`; `attributeRuns` takes an optional `verdictOf` callback; `readRunEvidence` takes the policy and builds the closure.
- **`src/commands/skill.ts`** — `gatherRuntime` loads the signed profile broker policy (`profileBrokerPolicy`) best-effort; a missing/invalid scope never breaks the audit (tool-scope adherence still applies).
- **CHANGELOG** entry.

## Honest behavior (no false green)

- **With** a verified scope: an off-scope host reached during a skill's run via an allowed tool → `adherence: fail` / `negative: fail`.
- **Without** a verified scope: verdicts stay `undefined`; tool-scope adherence still applies (unchanged).
- Deterministic given `(transcript, policy)`; zero-LLM; reuses shipped `checkEgress`/`checkFsWrite` (same rules the enforcers use, so the audit can't diverge from enforcement).

## Deferred (documented in the design note)

Denial-based "control held" evidence (`.kit-audit.jsonl` join) stays parked: the gate-deny audit records carry **no session/skill join key**, so correlating a deny to a skill span would be fuzzy time-window guessing that could mis-attribute — against the no-false-green line. It needs a join key added to the gate-deny event first.

## Testing

- [x] Added 6 `brokerVerdictForRow` unit tests (Bash in/out scope, no-host undefined, WebFetch suffix match, Write/Edit roots, non-target/unparseable → undefined) + a `verdictOf` threading test
- [x] All tests pass (`npm test`) — full suite **2951/2951**; tsc, eslint (0 errors), format:check clean

## Design

`kit-research/docs/research/skill-test-p2-runtime-adherence.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)