### PR TITLE
feat(skill): kit skill test --runtime — denial-based negative-control evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`kit skill test --runtime` now proves negative controls HELD, not just detects violations.**
+  A forbidden action a gate _denied_ never runs, so it is absent from the transcript — it lands
+  in `.kit-audit.jsonl` as a `gate-egress`/`gate-fs` deny. The gate now stamps the PreToolUse
+  `session_id` on that deny event as a **join key**, and the runtime audit attributes each deny
+  to the skill run that was active when it fired (session + span time-window — precise and
+  session-bounded, not a global timestamp guess). The negative-control check can now report
+  **"control held — N forbidden attempt(s) denied"** with evidence, closing the path that was
+  deferred in the previous increment for lack of a join key. Best-effort: no audit log → no
+  denial evidence (never breaks the audit); a denied action is `deniedForbidden`, never counted
+  as a violation that ran. Deterministic, zero-LLM.
+
 - **`kit skill test --runtime` now checks egress/fs target-scope, not just tool-scope.**
   When a signed broker scope is present, each span-attributed action is enriched with a
   broker verdict via the SAME decisions the gate-egress / gate-fs enforcers apply

--- a/src/commands/gate.ts
+++ b/src/commands/gate.ts
@@ -150,7 +150,7 @@ async function gateDeny(label: string, message: string): Promise<boolean> {
  * Wrapped: a missing/unreadable .kit.toml or audit backend must never change the verdict —
  * the deny already happened, and deny is the safe outcome.
  */
-async function auditGateDeny(gate: string, reason: string): Promise<void> {
+async function auditGateDeny(gate: string, reason: string, sessionId?: string): Promise<void> {
   try {
     const { loadConfig } = await import("../config.js");
     const { mergeGovernanceConfigAsync } = await import("../governance.js");
@@ -158,16 +158,30 @@ async function auditGateDeny(gate: string, reason: string): Promise<void> {
     const { resolve } = await import("node:path");
     const cfg = await loadConfig(resolve(process.cwd(), ".kit.toml"));
     const gov = await mergeGovernanceConfigAsync(cfg.governance);
+    // The session_id join key lets `kit skill test --runtime` attribute this deny to the
+    // skill run that was active when it fired (negative-control HELD evidence) — session-bounded,
+    // not a global timestamp guess. Omitted from metadata when the harness gave no session.
+    const metadata: Record<string, unknown> = { phase: "pretooluse-deny" };
+    if (sessionId) metadata.session_id = sessionId;
     await logAuditEvent(gov, {
       operation: gate,
       environment: gov.environment,
       success: false,
       error: reason,
-      metadata: { phase: "pretooluse-deny" },
+      metadata,
     });
   } catch {
     /* best-effort — see above */
   }
+}
+
+/** Read the harness-supplied `session_id` off a PreToolUse payload; "" when absent. */
+function sessionIdOf(payload: unknown): string {
+  if (payload && typeof payload === "object") {
+    const s = (payload as { session_id?: unknown }).session_id;
+    if (typeof s === "string") return s;
+  }
+  return "";
 }
 
 /**
@@ -202,7 +216,7 @@ export async function cmdGateEgress(): Promise<boolean> {
     why = `host(s) outside the signed egress scope: ${denied.join(", ")}`;
   }
   if (denied.length === 0) return true;
-  await auditGateDeny("gate-egress", why);
+  await auditGateDeny("gate-egress", why, sessionIdOf(payload));
   return await gateDeny(
     "egress-gate",
     `${why}\nDeclare the host in .kit-profile.toml [scope].egress and re-sign: \`kit profile sign\`.`,
@@ -231,7 +245,7 @@ export async function cmdGateFs(): Promise<boolean> {
   const { policy } = await profileBrokerPolicy(process.cwd());
   if (!policy) {
     const why = `write to ${write.filePath} denied — no verified scope/RoE (unsigned, tampered, or missing); a wired fs-gate grants nothing`;
-    await auditGateDeny("gate-fs", why);
+    await auditGateDeny("gate-fs", why, sessionIdOf(payload));
     return await gateDeny("fs-gate", `${why}\nSign the profile scope: \`kit profile sign\`.`);
   }
   // Resolve the hook's path against the agent cwd first, then containment-check against each root.

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -28,7 +28,13 @@ import {
   type CheckResult,
   type DisclaimedItem,
 } from "../skill/test.js";
-import { auditRuntime, type RuntimeCheckResult, type RuntimeEvidence } from "../skill/adherence.js";
+import type { DatabaseSync } from "node:sqlite";
+import {
+  auditRuntime,
+  type RuntimeCheckResult,
+  type RuntimeEvidence,
+  type ObservedAction,
+} from "../skill/adherence.js";
 import { readRunEvidence } from "../skill/attribute.js";
 
 /** Snapshot file written next to the SKILL.md it pins. */
@@ -88,6 +94,25 @@ function mark(status: CheckResult["status"]): string {
 }
 
 /**
+ * Denied forbidden attempts for a skill, from `.kit-audit.jsonl` gate-deny records attributed to
+ * its run windows via the `session_id` join key. Best-effort: no audit log / unreadable → no
+ * denial evidence, never breaks the audit.
+ */
+async function gatherDenialActions(db: DatabaseSync, skillName: string): Promise<ObservedAction[]> {
+  try {
+    const { readFileSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+    const jsonl = readFileSync(resolve(process.cwd(), ".kit-audit.jsonl"), "utf-8");
+    const { readToolCallRows, targetSpanWindows } = await import("../skill/attribute.js");
+    const { parseGateDenials, denialActionsForSkill } = await import("../skill/denials.js");
+    const windows = targetSpanWindows(readToolCallRows(db), skillName);
+    return denialActionsForSkill(windows, parseGateDenials(jsonl));
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Gather the two runtime checks (adherence, negative controls) from the transcript index.
  * Honest skips when the skill has no name to attribute by, or the index is unavailable —
  * never a silent pass. The pure `auditRuntime` decides; this only sources the evidence.
@@ -115,7 +140,11 @@ async function gatherRuntime(
     } catch {
       /* no verified scope — tool-scope adherence only */
     }
-    evidence = readRunEvidence(db, skillName, policy);
+    // Denial evidence: gate-deny records in .kit-audit.jsonl, attributed to this skill's run
+    // windows by the session_id join key the gates now stamp. This lets negative-controls report
+    // "control HELD" (a forbidden attempt was blocked), not just detect a violation that ran.
+    const denialActions = await gatherDenialActions(db, skillName);
+    evidence = readRunEvidence(db, skillName, { policy, denialActions });
   } catch {
     return skipBoth("transcript index unavailable — runtime audit skipped");
   }

--- a/src/skill/attribute.test.ts
+++ b/src/skill/attribute.test.ts
@@ -4,6 +4,7 @@ import {
   parseSkillOpen,
   attributeRuns,
   brokerVerdictForRow,
+  targetSpanWindows,
   type ToolCallRow,
 } from "./attribute.js";
 import type { BrokerPolicy } from "../exec-broker/policy.js";
@@ -23,10 +24,16 @@ describe("parseSkillOpen", () => {
   });
 });
 
-const row = (sessionId: string, tool: string, opensSkill: string | null = null): ToolCallRow => ({
+const row = (
+  sessionId: string,
+  tool: string,
+  opensSkill: string | null = null,
+  timestamp = "",
+): ToolCallRow => ({
   sessionId,
   tool,
   input: null,
+  timestamp,
   opensSkill,
 });
 
@@ -122,6 +129,47 @@ const policy: BrokerPolicy = {
   fs: { root: "/repo", roots: ["/repo/extra"] },
   env: { declared: [] },
 };
+
+describe("targetSpanWindows", () => {
+  it("emits a window per target span: [Skill open, next skill open) within a session", () => {
+    const rows: ToolCallRow[] = [
+      row("s1", "Skill", "run-tests", "t1"),
+      row("s1", "Bash", null, "t2"),
+      row("s1", "Skill", "deploy", "t3"), // closes run-tests at t3
+      row("s1", "Bash", null, "t4"),
+    ];
+    assert.deepEqual(targetSpanWindows(rows, "run-tests"), [
+      { sessionId: "s1", start: "t1", end: "t3" },
+    ]);
+  });
+
+  it("a trailing target span is open-ended (end === '')", () => {
+    const rows: ToolCallRow[] = [
+      row("s1", "Skill", "other", "t1"),
+      row("s1", "Skill", "run-tests", "t2"),
+      row("s1", "Bash", null, "t3"),
+    ];
+    assert.deepEqual(targetSpanWindows(rows, "run-tests"), [
+      { sessionId: "s1", start: "t2", end: "" },
+    ]);
+  });
+
+  it("closes an open target span at a session boundary", () => {
+    const rows: ToolCallRow[] = [
+      row("s1", "Skill", "run-tests", "t1"),
+      row("s2", "Skill", "run-tests", "t2"),
+    ];
+    const w = targetSpanWindows(rows, "run-tests");
+    assert.deepEqual(w, [
+      { sessionId: "s1", start: "t1", end: "" },
+      { sessionId: "s2", start: "t2", end: "" },
+    ]);
+  });
+
+  it("returns no windows when the target never opens a span", () => {
+    assert.deepEqual(targetSpanWindows([row("s1", "Skill", "other", "t1")], "run-tests"), []);
+  });
+});
 
 describe("brokerVerdictForRow", () => {
   it("Bash: in-scope when every extracted host is allowed, out-of-scope otherwise", () => {

--- a/src/skill/attribute.ts
+++ b/src/skill/attribute.ts
@@ -34,8 +34,53 @@ export interface ToolCallRow {
   tool: string;
   /** Raw `tool_input` JSON (for egress/fs target-scope verdicts); null when absent. */
   input: string | null;
+  /** ISO timestamp of the call (for denial→span time-window attribution); "" when absent. */
+  timestamp: string;
   /** For a `Skill` row, the invoked skill slug (parsed from `tool_input`); else null. */
   opensSkill: string | null;
+}
+
+/**
+ * The time window of one target-skill run within a session: `[start, end)`. `start` is the
+ * `Skill` call's timestamp; `end` is the NEXT `Skill` call's timestamp in the same session, or
+ * "" (open — until session end). A denial at time T belongs to the span with `start ≤ T < end`
+ * in the SAME session — precise, session-bounded attribution, not a global timestamp guess.
+ */
+export interface SpanWindow {
+  sessionId: string;
+  start: string;
+  end: string;
+}
+
+/**
+ * Compute the target skill's run windows from ordered rows (by `session_id, id`). Each `Skill`
+ * row opens a span whose end is the next `Skill` row's timestamp in that session (any skill), or
+ * "" at session end. Only the target skill's windows are returned. Pure.
+ */
+export function targetSpanWindows(rows: ToolCallRow[], target: string): SpanWindow[] {
+  const windows: SpanWindow[] = [];
+  let curSession: string | null = null;
+  let openTarget: { start: string } | null = null; // an open target span awaiting its end
+
+  const closeOpen = (end: string): void => {
+    if (openTarget && curSession !== null) {
+      windows.push({ sessionId: curSession, start: openTarget.start, end });
+      openTarget = null;
+    }
+  };
+
+  for (const row of rows) {
+    if (row.sessionId !== curSession) {
+      closeOpen(""); // previous session's open target span runs to session end
+      curSession = row.sessionId;
+    }
+    if (row.opensSkill !== null) {
+      closeOpen(row.timestamp); // any new skill closes the prior target span at its start
+      if (row.opensSkill === target) openTarget = { start: row.timestamp };
+    }
+  }
+  closeOpen(""); // final open target span runs to session end
+  return windows;
 }
 
 /** Per-action broker verdict from a signed scope, or undefined when the action carries no target. */
@@ -146,29 +191,45 @@ export function attributeRuns(
   return { actions, runs, sessions: sessionsWithSpan.size, confidence: "span" };
 }
 
+/** Read ordered `tool_uses` rows (by `session_id, id`) so spans reconstruct exactly. */
+export function readToolCallRows(db: DatabaseSync): ToolCallRow[] {
+  const raw = db
+    .prepare(
+      "SELECT session_id, tool_name, tool_input, timestamp FROM tool_uses ORDER BY session_id, id",
+    )
+    .all() as {
+    session_id: string | null;
+    tool_name: string | null;
+    tool_input: string | null;
+    timestamp: string | null;
+  }[];
+  return raw.map((r) => ({
+    sessionId: r.session_id ?? "",
+    tool: (r.tool_name ?? "").trim(),
+    input: r.tool_input,
+    timestamp: r.timestamp ?? "",
+    opensSkill: parseSkillOpen(r.tool_name ?? "", r.tool_input),
+  }));
+}
+
 /**
- * Read ordered `tool_uses` rows from the memory DB and attribute them to `target`. The
- * ORDER BY (session_id, id) reproduces per-session call order so spans reconstruct exactly.
- * Deterministic given the DB. The pure `attributeRuns` does the decision.
+ * Attribute the memory DB's recorded runs to `target`. With a signed broker policy, each action
+ * is enriched with an egress/fs target-scope verdict (without one, tool-scope adherence still
+ * applies). `denialActions` (attributed from the audit log, `denials.ts`) are appended so the
+ * negative-control check can see denied-and-blocked forbidden attempts. Deterministic given the
+ * DB + inputs; the pure `attributeRuns` does the decision.
  */
 export function readRunEvidence(
   db: DatabaseSync,
   target: string,
-  policy?: BrokerPolicy | null,
+  opts: { policy?: BrokerPolicy | null; denialActions?: ObservedAction[] } = {},
 ): RuntimeEvidence {
-  const raw = db
-    .prepare("SELECT session_id, tool_name, tool_input FROM tool_uses ORDER BY session_id, id")
-    .all() as { session_id: string | null; tool_name: string | null; tool_input: string | null }[];
-  const rows: ToolCallRow[] = raw.map((r) => ({
-    sessionId: r.session_id ?? "",
-    tool: (r.tool_name ?? "").trim(),
-    input: r.tool_input,
-    opensSkill: parseSkillOpen(r.tool_name ?? "", r.tool_input),
-  }));
-  // With a signed broker policy, enrich each action with an egress/fs target-scope verdict;
-  // without one, tool-scope adherence still applies (verdicts stay undefined).
-  const verdictOf = policy
-    ? (row: ToolCallRow) => brokerVerdictForRow(row.tool, row.input, policy)
+  const rows = readToolCallRows(db);
+  const verdictOf = opts.policy
+    ? (row: ToolCallRow) => brokerVerdictForRow(row.tool, row.input, opts.policy as BrokerPolicy)
     : undefined;
-  return attributeRuns(rows, target, verdictOf);
+  const evidence = attributeRuns(rows, target, verdictOf);
+  const denialActions = opts.denialActions ?? [];
+  if (denialActions.length === 0) return evidence;
+  return { ...evidence, actions: [...evidence.actions, ...denialActions] };
 }

--- a/src/skill/denials.test.ts
+++ b/src/skill/denials.test.ts
@@ -1,0 +1,85 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseGateDenials, denialActionsForSkill, type GateDenial } from "./denials.js";
+import type { SpanWindow } from "./attribute.js";
+
+const denyLine = (over: Record<string, unknown> = {}): string =>
+  JSON.stringify({
+    timestamp: "2026-07-17T12:00:00Z",
+    operation: "gate-egress",
+    success: false,
+    error: "off-scope",
+    metadata: { phase: "pretooluse-deny", session_id: "s1" },
+    ...over,
+  });
+
+describe("parseGateDenials", () => {
+  it("keeps gate-egress/gate-fs pretooluse denies with a session_id", () => {
+    const jsonl = [denyLine(), denyLine({ operation: "gate-fs" })].join("\n");
+    const out = parseGateDenials(jsonl);
+    assert.equal(out.length, 2);
+    assert.deepEqual(
+      out.map((d) => d.gate),
+      ["gate-egress", "gate-fs"],
+    );
+    assert.equal(out[0].sessionId, "s1");
+  });
+
+  it("drops non-gate ops, successes, non-pretooluse, and session-less denies", () => {
+    const jsonl = [
+      denyLine({ operation: "secrets.get" }), // not a gate
+      denyLine({ success: true }), // not a deny
+      denyLine({ metadata: { phase: "other", session_id: "s1" } }), // not pretooluse
+      denyLine({ metadata: { phase: "pretooluse-deny" } }), // no session_id join key
+    ].join("\n");
+    assert.deepEqual(parseGateDenials(jsonl), []);
+  });
+
+  it("tolerates blank and malformed lines (never throws)", () => {
+    const jsonl = ["", "not json", "{", denyLine()].join("\n");
+    assert.equal(parseGateDenials(jsonl).length, 1);
+  });
+
+  it("empty input → no denials", () => {
+    assert.deepEqual(parseGateDenials(""), []);
+  });
+});
+
+describe("denialActionsForSkill", () => {
+  const windows: SpanWindow[] = [
+    { sessionId: "s1", start: "2026-07-17T12:00:00Z", end: "2026-07-17T12:10:00Z" },
+    { sessionId: "s2", start: "2026-07-17T13:00:00Z", end: "" }, // open-ended
+  ];
+  const deny = (sessionId: string, timestamp: string, gate = "gate-egress"): GateDenial => ({
+    sessionId,
+    timestamp,
+    gate,
+  });
+
+  it("attributes a deny inside a matching session window as a denied out-of-scope action", () => {
+    const actions = denialActionsForSkill(windows, [deny("s1", "2026-07-17T12:05:00Z")]);
+    assert.equal(actions.length, 1);
+    assert.equal(actions[0].denied, true);
+    assert.equal(actions[0].brokerVerdict, "out-of-scope");
+    assert.equal(actions[0].tool, "gate-egress");
+  });
+
+  it("ignores a deny in the right session but outside the window", () => {
+    assert.deepEqual(denialActionsForSkill(windows, [deny("s1", "2026-07-17T12:20:00Z")]), []);
+  });
+
+  it("ignores a deny whose session does not match any window", () => {
+    assert.deepEqual(denialActionsForSkill(windows, [deny("sX", "2026-07-17T12:05:00Z")]), []);
+  });
+
+  it("an open-ended window attributes any later deny in that session", () => {
+    const actions = denialActionsForSkill(windows, [deny("s2", "2026-07-17T20:00:00Z", "gate-fs")]);
+    assert.equal(actions.length, 1);
+    assert.equal(actions[0].tool, "gate-fs");
+  });
+
+  it("the window start is inclusive, the end exclusive", () => {
+    assert.equal(denialActionsForSkill(windows, [deny("s1", "2026-07-17T12:00:00Z")]).length, 1);
+    assert.equal(denialActionsForSkill(windows, [deny("s1", "2026-07-17T12:10:00Z")]).length, 0);
+  });
+});

--- a/src/skill/denials.ts
+++ b/src/skill/denials.ts
@@ -1,0 +1,82 @@
+/**
+ * `kit skill test --runtime` — gate-deny evidence from `.kit-audit.jsonl` (denial-based
+ * negative controls). Design: `kit-research/docs/research/skill-test-p2-runtime-adherence.md`.
+ *
+ * A forbidden action that a gate DENIED never runs, so it is not in the transcript's
+ * `tool_uses` — it lands in the hash-chained audit log as a `gate-egress`/`gate-fs` deny.
+ * This module reads those denies and attributes each to the skill run that was active when it
+ * fired, using the `session_id` the gate now stamps on the deny event + the skill's span time
+ * windows. That makes the "negative control HELD" evidence session-bounded and precise (a deny
+ * credits only the span whose `[start, end)` contains it in the SAME session) — not the fuzzy
+ * global timestamp guess that kept this deferred until the join key existed.
+ *
+ * Pure + tolerant: a missing file is "no denials"; a malformed line is skipped, never thrown.
+ */
+import type { ObservedAction } from "./adherence.js";
+import type { SpanWindow } from "./attribute.js";
+
+/** A gate-deny extracted from the audit log — the join key (`sessionId`) + when + which gate. */
+export interface GateDenial {
+  sessionId: string;
+  timestamp: string;
+  gate: string;
+}
+
+const DENY_GATES = new Set(["gate-egress", "gate-fs"]);
+
+/**
+ * Parse gate-deny records from raw `.kit-audit.jsonl` content. Keeps only PreToolUse denies
+ * (`operation` ∈ gate-egress/gate-fs, `success === false`, `metadata.phase === "pretooluse-deny"`)
+ * that carry a `session_id` join key. Tolerant: blank/malformed lines are skipped. Pure.
+ */
+export function parseGateDenials(auditJsonl: string): GateDenial[] {
+  const out: GateDenial[] = [];
+  for (const line of auditJsonl.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    let e: {
+      operation?: unknown;
+      success?: unknown;
+      timestamp?: unknown;
+      metadata?: { phase?: unknown; session_id?: unknown };
+    };
+    try {
+      e = JSON.parse(trimmed);
+    } catch {
+      continue; // malformed line — skip, never throw
+    }
+    if (typeof e.operation !== "string" || !DENY_GATES.has(e.operation)) continue;
+    if (e.success !== false) continue;
+    if (!e.metadata || e.metadata.phase !== "pretooluse-deny") continue;
+    const sessionId = e.metadata.session_id;
+    if (typeof sessionId !== "string" || sessionId.length === 0) continue;
+    const timestamp = typeof e.timestamp === "string" ? e.timestamp : "";
+    out.push({ sessionId, timestamp, gate: e.operation });
+  }
+  return out;
+}
+
+/** True when `ts` falls inside a window `[start, end)` (end === "" means open — until session end). */
+function inWindow(ts: string, w: SpanWindow): boolean {
+  if (ts < w.start) return false;
+  return w.end === "" ? true : ts < w.end;
+}
+
+/**
+ * Attribute denials to a skill's run windows and emit them as denied, out-of-scope actions —
+ * the positive evidence the negative-control check reads. A denial counts only when its
+ * `sessionId` matches a window AND its `timestamp` falls in that window. Because a gate denies
+ * an action precisely because it was off-scope, each is marked `brokerVerdict: "out-of-scope"`
+ * and `denied: true` → `deniedForbidden`, never a `violation`. Pure.
+ */
+export function denialActionsForSkill(
+  windows: SpanWindow[],
+  denials: GateDenial[],
+): ObservedAction[] {
+  const actions: ObservedAction[] = [];
+  for (const d of denials) {
+    const hit = windows.some((w) => w.sessionId === d.sessionId && inWindow(d.timestamp, w));
+    if (hit) actions.push({ tool: d.gate, brokerVerdict: "out-of-scope", denied: true });
+  }
+  return actions;
+}


### PR DESCRIPTION
## Description

Closes the **"negative control HELD"** path that the previous increment deferred for lack of a join key.

A forbidden action a gate *denied* never runs, so it is absent from the transcript — it lands in `.kit-audit.jsonl` as a `gate-egress`/`gate-fs` deny. The gate now stamps the PreToolUse **`session_id`** onto that deny event, and the runtime audit attributes each deny to the skill run active when it fired, using **session + span time-window** — precise and session-bounded, not the fuzzy global timestamp guess that kept this deferred.

`negative-controls` can now report **"control held — N forbidden attempt(s) denied"** with evidence, instead of only detecting a violation that *ran*.

## Type of Change

- [x] New feature (non-breaking) — strengthens an existing opt-in flag; adds a metadata field to gate-deny audit events

## Changes Made

- **`src/commands/gate.ts`** — `auditGateDeny` stamps `metadata.session_id`; `sessionIdOf` reads it off the PreToolUse payload; both gate handlers pass it. (The join key.)
- **`src/skill/attribute.ts`** — `ToolCallRow` carries `timestamp`; `targetSpanWindows` emits each run's `[start, end)` window; `readRunEvidence` accepts `denialActions` + a `readToolCallRows` helper.
- **`src/skill/denials.ts`** — `parseGateDenials` (tolerant audit parse, keeps only pretooluse denies with a `session_id`) + `denialActionsForSkill` (attributes a deny to a window only when session matches AND timestamp ∈ `[start, end)` → denied out-of-scope actions).
- **`src/commands/skill.ts`** — `gatherDenialActions` reads the audit log best-effort and feeds the evidence.
- **CHANGELOG** entry.

## Honest behavior (no false green)

- A **denied** forbidden attempt → `deniedForbidden` (control held with evidence); it is **never** counted as a violation that ran.
- Attribution is **session-bounded**: a deny credits only the span whose window contains it, in its own session — no cross-skill/cross-session mis-attribution.
- Best-effort: no audit log / unreadable → no denial evidence; never breaks the audit.
- Deterministic given `(transcript, audit log)`; zero-LLM.

## Testing

- [x] 13 new tests — `parseGateDenials` (filtering, tolerance of malformed lines), `denialActionsForSkill` (in/out of window, session match, open-ended window, inclusive-start/exclusive-end), `targetSpanWindows` (span boundaries, trailing open span, session boundary)
- [x] All tests pass (`npm test`) — full suite **2964/2964**; tsc, eslint (0 errors), format:check clean
- [x] Manual: `--runtime` live-verified — clean run + honest skip when no spans present

## Design

`kit-research/docs/research/skill-test-p2-runtime-adherence.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)