### PR TITLE
security(triage): SkillSpector delegate passes --no-llm explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Security
+
+- **SkillSpector delegate now passes `--no-llm` explicitly** (`kit triage skill --deep`).
+  kit ran SkillSpector's Stage-1 static scan only, suppressing the optional Stage-2 LLM pass
+  via env scrubbing alone (`SKILLSPECTOR_PROVIDER=""` + stripped provider keys). It now also
+  passes the `--no-llm` flag in the argv itself — belt-and-suspenders, so a future
+  SkillSpector default or ambient config can never silently re-enable the model stage
+  (which would ship file contents to a provider, breaking kit's zero-LLM / no-egress
+  charter). The zero-LLM intent is now legible in the command line, not only the environment.
+
 ## [5.2.0] - 2026-07-18
 
 ### Added

--- a/src/skillspector-delegate.test.ts
+++ b/src/skillspector-delegate.test.ts
@@ -69,10 +69,13 @@ describe("skillspector delegate — zero-LLM enforcement (no egress)", () => {
     assert.equal(base.OPENAI_API_KEY, "sk-x", "base env untouched");
   });
 
-  it("stage1Args never contains an LLM/provider flag", () => {
+  it("stage1Args explicitly disables Stage 2 and never enables an LLM/provider", () => {
     const args = stage1Args("./skill");
-    assert.deepEqual(args, ["scan", "./skill", "--format", "sarif"]);
-    assert.ok(!args.some((a) => /llm|provider|model|openai|anthropic/i.test(a)));
+    assert.deepEqual(args, ["scan", "./skill", "--format", "sarif", "--no-llm"]);
+    // The only LLM-related flag is the DISABLING one; nothing enables a provider/model.
+    assert.ok(args.includes("--no-llm"));
+    assert.ok(!args.includes("--llm"));
+    assert.ok(!args.some((a) => /provider|model|openai|anthropic/i.test(a)));
   });
 });
 

--- a/src/skillspector-delegate.ts
+++ b/src/skillspector-delegate.ts
@@ -15,7 +15,8 @@
  *   break kit's no-egress charter. kit NEVER invokes Stage 2. This is enforced two ways, both testable:
  *     1. SCRUBBED ENV — every SKILLSPECTOR_ (and provider-API-key) var is stripped from the child env, so
  *        Stage 2 cannot silently activate from ambient config (`scrubbedEnv`).
- *     2. STATIC INVOCATION — we run a plain `scan … --format sarif` and read only Stage-1 SARIF.
+ *     2. STATIC INVOCATION — we run `scan … --format sarif --no-llm` (Stage 2 disabled in the
+ *        argv itself, not just the env) and read only Stage-1 SARIF.
  *   Fail-CLOSED: a missing binary or a scan error is a DEGRADED result (never a silent pass); the
  *   caller must not report "deep-clean" when the delegate did not actually run.
  *
@@ -61,9 +62,14 @@ export function scrubbedEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.Proce
   return out;
 }
 
-/** Argv for a static, SARIF-emitting Stage-1 scan. No `--llm`/provider flags are ever added. */
+/**
+ * Argv for a static, SARIF-emitting Stage-1 scan. `--no-llm` explicitly disables the
+ * optional Stage-2 semantic pass in the argv itself — belt-and-suspenders over the env
+ * scrub (`scrubbedEnv`), so a future SkillSpector default or ambient config can never
+ * silently re-enable the LLM stage. No `--llm`/provider flag is ever added.
+ */
 export function stage1Args(target: string): string[] {
-  return ["scan", target, "--format", "sarif"];
+  return ["scan", target, "--format", "sarif", "--no-llm"];
 }
 
 /**


### PR DESCRIPTION
## Description

`kit triage skill --deep` runs NVIDIA SkillSpector's **Stage-1 static** scan only, suppressing the optional **Stage-2 LLM** pass so kit stays zero-LLM / no-egress. Until now that suppression rested on **env-scrubbing alone** (`SKILLSPECTOR_PROVIDER=""` + stripped provider API keys). This adds the explicit **`--no-llm`** flag to the scan argv — belt-and-suspenders.

Surfaced by the SkillSpector delegate-coverage research (kit-research): Stage 2 ships file contents to a provider, so a future SkillSpector default or an ambient config that survives the env scrub could, in principle, re-enable it. Passing `--no-llm` closes that and makes the zero-LLM intent legible in the command line, not only the environment.

## Type of Change

- [x] Security hardening (no behavior change on the happy path — Stage 2 was already suppressed by env)

## Changes Made

- **`src/skillspector-delegate.ts`** — `stage1Args` appends `--no-llm`; module doc + the `stage1Args` doc updated to state the belt-and-suspenders rationale.
- **`src/skillspector-delegate.test.ts`** — the invariant test now asserts `--no-llm` is present, `--llm` is absent, and no provider/model flag appears.
- **CHANGELOG** (Security).

## Why it matters (no false green)

Two independent layers now guarantee the LLM stage can't run: (1) the scrubbed child env (no provider, keys stripped), and (2) the explicit `--no-llm` argv flag. Defense in depth on the exact boundary that keeps `kit triage skill` deterministic and offline.

## Testing

- [x] Updated the delegate invariant test
- [x] All tests pass (`npm test`) — full suite **2964/2964**; tsc, eslint (0 errors), format:check clean

## Context

Research: `kit-research/docs/research/skillspector-delegate-coverage.md` (maps SkillSpector's 68 patterns / 17 categories vs kit's Stage-1-only delegate — high recall across all categories, LLM precision-filter deliberately skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)