### PR TITLE
chore(release): 5.2.0 — kit skill test --runtime (proven refrainment) + Swift/Elixir/Nix lockfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.2.0] - 2026-07-18
+
 ### Added
 
 - **`kit skill test --runtime` now proves negative controls HELD, not just detects violations.**

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -936,7 +936,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.1.0"
+    "version": "5.2.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
Minor bump (0 breaking). `[Unreleased]` carried:

- **`kit skill test --runtime`** (#352/357/358/359): recorded-run adherence, egress/fs target-scope checks, and denial-based negative-control "held" evidence. This is the runtime-refrainment seam the 6.0 research flagged, landing additively in 5.x (off by default).
- **Ecosystem-aware lockfiles for Swift/Elixir/Nix** (#356), extending the #354 fix.

OpenCLI snapshot regenerated for the version bump (the release gotcha). 7/7 opencli tests pass.

After merge: signed tag `v5.2.0` → publish.yml → npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)