### PR TITLE
feat(memory): decision-lifecycle capture — idea/abandoned kinds + provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **kit memory captures the full decision lifecycle — negative-space kinds + provenance.**
+  The curated shared tier gains two kinds for the knowledge that evaporates hardest:
+  **`idea`** (considered / not-yet-built) and **`abandoned`** (tried and dropped, with the
+  reason). `abandoned` entries are re-surfaced on resume for the area you're touching — so
+  the next session sees _"we tried X here and dropped it, because Y"_ **before** re-trying it.
+  Entries also carry optional **`provenance`** (`operator` | `derived` | `inferred`, absent ⇒
+  operator) and **`confidence`**; recall now orders an operator's explicit statement **above**
+  a pattern kit merely derived, then by recency. Both fields are signature-covered and written
+  only when set, so existing entries stay byte-identical. `kit memory share` gains
+  `--provenance` / `--confidence` and now validates `--kind` (a typo no longer persists a
+  garbage kind). Deterministic, zero-LLM.
+
 ### Security
 
 - **SkillSpector delegate now passes `--no-llm` explicitly** (`kit triage skill --deep`).

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -56,8 +56,10 @@ import {
   formatAge,
   getSharedPath,
   verifySharedTier,
+  SHARED_KINDS,
   type SharedKind,
   type SharedStatus,
+  type SharedProvenance,
   type SharedEntry,
 } from "../memory/shared.js";
 import {
@@ -1057,6 +1059,20 @@ async function memUninstall(): Promise<boolean> {
   return true;
 }
 
+/** Validate the enum-valued share flags; returns an error message, or null when all are ok. Pure. */
+function validateShareEnums(
+  kind: SharedKind,
+  provenance: string | undefined,
+  confidence: string | undefined,
+): string | null {
+  if (!SHARED_KINDS.includes(kind)) return `--kind ${kind}: unknown kind`;
+  if (provenance && !["operator", "derived", "inferred"].includes(provenance))
+    return `--provenance ${provenance}: must be operator|derived|inferred`;
+  if (confidence && !["low", "medium", "high"].includes(confidence))
+    return `--confidence ${confidence}: must be low|medium|high`;
+  return null;
+}
+
 async function memShare(): Promise<boolean> {
   const area = flagValue(process.argv, "--area");
   const title = flagValue(process.argv, "--title");
@@ -1067,10 +1083,20 @@ async function memShare(): Promise<boolean> {
   const supersedes = flagValue(process.argv, "--supersedes");
   const reverses = flagValue(process.argv, "--reverses");
   const status = flagValue(process.argv, "--status") as SharedStatus | undefined;
+  const provenance = flagValue(process.argv, "--provenance") as SharedProvenance | undefined;
+  const confidence = flagValue(process.argv, "--confidence") as
+    | "low"
+    | "medium"
+    | "high"
+    | undefined;
+  const usage = `${c.red}usage: kit memory share --area <a> --title <t> [--kind ${SHARED_KINDS.join("|")}] [--body <b>] [--ref <r>] [--provenance operator|derived|inferred] [--confidence low|medium|high] [--supersedes <id>] [--reverses <id>]${c.reset}`;
   if (!area || !title) {
-    console.error(
-      `${c.red}usage: kit memory share --area <a> --title <t> [--kind decision|convention|how-built|status|security|note] [--body <b>] [--ref <r>] [--supersedes <id>] [--reverses <id>]${c.reset}`,
-    );
+    console.error(usage);
+    return false;
+  }
+  const enumError = validateShareEnums(kind, provenance, confidence);
+  if (enumError) {
+    console.error(`${c.red}${enumError}${c.reset}`);
     return false;
   }
   const root = getCurrentProjectRoot();
@@ -1091,7 +1117,18 @@ async function memShare(): Promise<boolean> {
   try {
     const e = shareEntry(
       root,
-      { area, kind, title, body, refs: ref ? [ref] : [], status, supersedes, reverses },
+      {
+        area,
+        kind,
+        title,
+        body,
+        refs: ref ? [ref] : [],
+        status,
+        supersedes,
+        reverses,
+        provenance,
+        confidence,
+      },
       new Date().toISOString(),
     );
     const rel =

--- a/src/memory/hook.ts
+++ b/src/memory/hook.ts
@@ -14,7 +14,13 @@ import { spawn } from "node:child_process";
 import { openMemoryDb, getStats, recentMessages, getMemoryDir, ensureMemoryDir } from "./db.js";
 import { indexClaudeTranscripts, indexAllHarnesses } from "./parser.js";
 import { palList } from "./pal.js";
-import { activeShared, recallSafeShared, formatAge, type SharedEntry } from "./shared.js";
+import {
+  activeShared,
+  recallSafeShared,
+  provenanceRank,
+  formatAge,
+  type SharedEntry,
+} from "./shared.js";
 import { decisionsForPaths, changedPaths } from "./clusters.js";
 import { getCurrentProjectRoot } from "./project.js";
 import { readCachedUpdateSync, getKitVersionSync } from "../update-check.js";
@@ -113,14 +119,27 @@ function touchedDecisionsNotice(root: string = getCurrentProjectRoot()): string 
  * activeShared returns [] on a missing/broken store. Deterministic, no model.
  */
 export function recentDecisions(root: string, limit: number): SharedEntry[] {
-  const DURABLE = new Set<SharedEntry["kind"]>(["decision", "convention", "security", "status"]);
+  // `abandoned` is included: resurfacing "we tried X here and dropped it, because Y" before
+  // someone re-tries it is among the highest-value recall. `idea`/`note`/`how-built` stay
+  // excluded as lower-signal for auto-injection.
+  const DURABLE = new Set<SharedEntry["kind"]>([
+    "decision",
+    "convention",
+    "security",
+    "status",
+    "abandoned",
+  ]);
   try {
     const durable = activeShared(root).filter((e) => DURABLE.has(e.kind));
     // Verify signatures before auto-injecting: drop tampered entries (and, under a
     // `.kit-policy.signers` anchor, anything not org-trusted) so a poisoned/forged team
     // entry is never replayed as a trusted "Curated team decision". (R4/#77)
+    // Order: operator-stated before kit-derived (provenanceRank), then newest-first — a
+    // human's explicit decision outranks a pattern kit merely inferred.
     return recallSafeShared(root, durable)
-      .sort((a, b) => (a.ts < b.ts ? 1 : a.ts > b.ts ? -1 : 0))
+      .sort(
+        (a, b) => provenanceRank(a) - provenanceRank(b) || (a.ts < b.ts ? 1 : a.ts > b.ts ? -1 : 0),
+      )
       .slice(0, limit);
   } catch {
     return [];

--- a/src/memory/shared.test.ts
+++ b/src/memory/shared.test.ts
@@ -17,6 +17,9 @@ import {
   verifySharedTier,
   recallSafeShared,
   getSharedPath,
+  provenanceRank,
+  SHARED_KINDS,
+  type SharedEntry,
 } from "./shared.js";
 import { loadOrCreateIdentity, tryLoadIdentity } from "../identity.js";
 import { addPolicySigner } from "../policy-trust.js";
@@ -313,5 +316,82 @@ describe("shared memory — Ed25519 signing (R4)", () => {
     assert.equal(v.counts.unsigned, 1);
     rmSync(r, { recursive: true, force: true });
     rmSync(emptyId, { recursive: true, force: true });
+  });
+});
+
+describe("shared memory — negative-space kinds + provenance (J1 + B1)", () => {
+  it("SHARED_KINDS includes the negative-space kinds idea + abandoned", () => {
+    assert.ok(SHARED_KINDS.includes("idea"));
+    assert.ok(SHARED_KINDS.includes("abandoned"));
+  });
+
+  it("round-trips an abandoned entry with provenance + confidence", () => {
+    const r = mkdtempSync(join(tmpdir(), "kit-neg-"));
+    const e = shareEntry(
+      r,
+      {
+        area: "auth",
+        kind: "abandoned",
+        title: "tried JWT-in-cookie, dropped it",
+        body: "CSRF surface too large; went with header tokens",
+        provenance: "operator",
+        confidence: "high",
+      },
+      "2026-07-18T00:00:00Z",
+    );
+    assert.equal(e.kind, "abandoned");
+    assert.equal(e.provenance, "operator");
+    assert.equal(e.confidence, "high");
+    const back = readShared(r)[0];
+    assert.equal(back.kind, "abandoned");
+    assert.equal(back.provenance, "operator");
+    assert.equal(back.confidence, "high");
+    rmSync(r, { recursive: true, force: true });
+  });
+
+  it("provenance/confidence are absent on the entry when not provided (byte-compat)", () => {
+    const r = mkdtempSync(join(tmpdir(), "kit-prov0-"));
+    const e = shareEntry(r, { area: "x", kind: "note", title: "t", body: "b" }, "ts");
+    assert.equal(e.provenance, undefined);
+    assert.equal(e.confidence, undefined);
+    // The persisted line carries no provenance/confidence keys at all.
+    const raw = readFileSync(getSharedPath(r), "utf8").trim();
+    assert.ok(!raw.includes("provenance"));
+    assert.ok(!raw.includes("confidence"));
+    rmSync(r, { recursive: true, force: true });
+  });
+
+  it("provenanceRank: operator (or absent) < derived < inferred", () => {
+    const mk = (p?: "operator" | "derived" | "inferred"): SharedEntry => ({
+      id: "1",
+      area: "a",
+      kind: "decision",
+      title: "t",
+      body: "b",
+      refs: [],
+      author: "x",
+      ts: "ts",
+      ...(p ? { provenance: p } : {}),
+    });
+    assert.equal(provenanceRank(mk()), 0); // absent ⇒ operator
+    assert.equal(provenanceRank(mk("operator")), 0);
+    assert.equal(provenanceRank(mk("derived")), 1);
+    assert.equal(provenanceRank(mk("inferred")), 2);
+  });
+
+  it("canonical includes provenance/confidence only when present (legacy stays byte-identical)", () => {
+    const base: SharedEntry = {
+      id: "1",
+      area: "a",
+      kind: "decision",
+      title: "t",
+      body: "b",
+      refs: [],
+      author: "x",
+      ts: "ts",
+    };
+    assert.ok(!sharedEntryCanonical(base).includes("provenance"));
+    const withProv = sharedEntryCanonical({ ...base, provenance: "derived" });
+    assert.ok(withProv.includes("derived"));
   });
 });

--- a/src/memory/shared.ts
+++ b/src/memory/shared.ts
@@ -23,7 +23,36 @@ import { identityId, verifySignature, localPublicKeys } from "../identity.js";
 import { resolveKeyStore, assertHardwareIdentity, hardwareRequired } from "../keystore/index.js";
 import { policySignersMap, hasPolicyAnchor } from "../policy-trust.js";
 
-export type SharedKind = "decision" | "convention" | "how-built" | "status" | "security" | "note";
+export type SharedKind =
+  | "decision"
+  | "convention"
+  | "how-built"
+  | "status"
+  | "security"
+  | "note"
+  // Negative-space kinds — the knowledge that evaporates hardest:
+  | "idea" // considered / not-yet-built
+  | "abandoned"; // tried and dropped, with the reason (re-introducing it should warn)
+
+/** All known kinds — for CLI validation so a typo doesn't persist a garbage kind. */
+export const SHARED_KINDS: readonly SharedKind[] = [
+  "decision",
+  "convention",
+  "how-built",
+  "status",
+  "security",
+  "note",
+  "idea",
+  "abandoned",
+];
+
+/**
+ * Origin of a curated entry — lets recall prefer an operator's explicit statement over a
+ * pattern kit merely derived. `operator` = a human stated it (the default when absent, since
+ * a human promoted the entry); `derived` = kit inferred it (e.g. `memory learn` repetition);
+ * `inferred` = a weaker guess. Ranking: operator > derived > inferred.
+ */
+export type SharedProvenance = "operator" | "derived" | "inferred";
 
 /**
  * Lifecycle of a decision. Append-only: we never edit an old entry, a change is a
@@ -48,6 +77,10 @@ export interface SharedEntry {
   supersedes?: string;
   /** Id of the entry this one reverses (tried + undone — re-introducing it should warn). */
   reverses?: string;
+  /** Origin of the entry; absent ⇒ `operator` (a human promoted it). */
+  provenance?: SharedProvenance;
+  /** Optional operator-supplied confidence; display + tiebreak only, never a gate. */
+  confidence?: "low" | "medium" | "high";
   /** Ed25519 signer id (kid) — set when the entry was signed on write. */
   kid?: string;
   /** Base64 Ed25519 signature over the canonical content (excludes kid/sig itself). */
@@ -63,6 +96,8 @@ export interface ShareInput {
   status?: SharedStatus;
   supersedes?: string;
   reverses?: string;
+  provenance?: SharedProvenance;
+  confidence?: "low" | "medium" | "high";
 }
 
 export function getSharedPath(root: string): string {
@@ -123,6 +158,10 @@ export function sharedEntryCanonical(entry: SharedEntry): string {
   if (entry.status !== undefined) canon.status = entry.status;
   if (entry.supersedes !== undefined) canon.supersedes = entry.supersedes;
   if (entry.reverses !== undefined) canon.reverses = entry.reverses;
+  // Appended last + only-when-present so legacy entries canonicalize byte-identically
+  // (an unsigned pre-provenance entry, if later signed, is unchanged).
+  if (entry.provenance !== undefined) canon.provenance = entry.provenance;
+  if (entry.confidence !== undefined) canon.confidence = entry.confidence;
   return JSON.stringify(canon);
 }
 
@@ -256,6 +295,10 @@ export function shareEntry(root: string, input: ShareInput, now: string): Shared
   if (input.status && input.status !== "active") entry.status = input.status;
   if (input.supersedes) entry.supersedes = input.supersedes;
   if (input.reverses) entry.reverses = input.reverses;
+  // Provenance/confidence are written only when explicitly provided, so an operator-stated
+  // entry (the common case) stays byte-identical to pre-provenance entries; absent ⇒ operator.
+  if (input.provenance) entry.provenance = input.provenance;
+  if (input.confidence) entry.confidence = input.confidence;
   // Sign on write via the ACTIVE keystore (hardware/externally-held when configured, else
   // the file identity) when one exists — attributable provenance a reviewer/colleague can
   // verify offline with just the public key. No identity ⇒ unsigned entry (backward-
@@ -315,6 +358,22 @@ export function effectiveStatus(entry: SharedEntry, all: SharedEntry[]): SharedS
     if (e.supersedes === entry.id) result = "superseded";
   }
   return result;
+}
+
+/**
+ * Recall priority by origin (lower = surfaced first): an operator's explicit statement
+ * outranks something kit derived, which outranks a weak inference. Absent provenance ⇒
+ * `operator` (a human promoted the entry). Pure — surfacing sorts by this, then recency.
+ */
+export function provenanceRank(entry: SharedEntry): number {
+  switch (entry.provenance ?? "operator") {
+    case "operator":
+      return 0;
+    case "derived":
+      return 1;
+    case "inferred":
+      return 2;
+  }
 }
 
 /** The currently-active shared entries (effectiveStatus === "active"). */


### PR DESCRIPTION
## Description

A coherent memory increment (one message, not two features): kit's curated shared tier now captures the **full decision lifecycle** — the negative space that evaporates hardest, plus **where each entry came from**. Deterministic, zero-LLM.

Grounded in the kit-research notes (`kit-memory-as-decision-journal`, the `open-second-brain` near-peer analysis) and **ADR-001** — this is *trust-deepening* memory work, not feature-parity chasing.

## Type of Change

- [x] New feature (non-breaking) — additive kinds + optional fields; existing entries stay byte-identical

## Changes Made

- **Negative-space kinds (J1):** `SharedKind` gains **`idea`** (considered / not-yet-built) and **`abandoned`** (tried and dropped, with the reason). `abandoned` joins the durable set re-surfaced on resume for the area you're touching — so the next session sees _"we tried X here and dropped it, because Y"_ **before** re-trying it. (`idea` stays out of auto-inject as lower-signal.)
- **Provenance + confidence (B1):** entries carry optional **`provenance`** (`operator` | `derived` | `inferred`; absent ⇒ operator) and **`confidence`**. Recall now orders an operator's explicit statement **above** a pattern kit merely derived (`provenanceRank`), then by recency. Both are **signature-covered** (appended last in the canonical, only-when-present) so a pre-provenance entry canonicalizes byte-identically.
- **CLI:** `kit memory share` gains `--provenance` / `--confidence`, and now **validates `--kind`** against `SHARED_KINDS` (a typo no longer persists a garbage kind).

## Backward compatibility (no false green)

- Provenance/confidence are written **only when provided** → existing/committed entries are byte-identical; clean diffs.
- Canonical appends the new fields last and only-when-present → legacy entries verify unchanged; a later signing of an old entry is stable.

## Testing

- [x] +5 unit tests (kinds present, abandoned round-trip with provenance/confidence, byte-compat when absent, `provenanceRank` ordering, canonical only-when-present)
- [x] All tests pass (`npm test`) — full suite **2969/2969**; tsc, eslint (0 errors), format:check clean; contracts unchanged

## Context

Design: `kit-research/docs/research/kit-memory-as-decision-journal.md`, `what-kit-can-learn-from-open-second-brain.md`; decision: `decisions/ADR-001-do-not-replace-kit-memory.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)