### PR TITLE
feat(broker): enforce-readiness pure core — observe→enforce graduation (E1)

### DIFF
--- a/src/exec-broker/enforce-readiness.test.ts
+++ b/src/exec-broker/enforce-readiness.test.ts
@@ -1,0 +1,112 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseObserveRecords,
+  assessEnforceReadiness,
+  type ObserveRecord,
+} from "./enforce-readiness.js";
+
+/** Shape a real observe audit line as broker.ts writes it: metadata.phase + metadata.wouldDeny. */
+const observeLine = (wouldDeny: string[], extra: Record<string, unknown> = {}): string =>
+  JSON.stringify({
+    operation: "bash",
+    success: true,
+    metadata: { phase: "observe", wouldDeny, ...extra },
+  });
+
+describe("parseObserveRecords", () => {
+  it("keeps only observe-phase lines and lifts wouldDeny verbatim", () => {
+    const jsonl = [
+      observeLine([]),
+      observeLine(["exec-broker: egress api.evil.test not in scope"]),
+      JSON.stringify({ metadata: { phase: "authorized" } }), // non-observe → skipped
+      JSON.stringify({ metadata: { phase: "enforce-enabled" } }), // non-observe → skipped
+    ].join("\n");
+    const records = parseObserveRecords(jsonl);
+    assert.equal(records.length, 2);
+    assert.deepEqual(records[0].wouldDeny, []);
+    assert.deepEqual(records[1].wouldDeny, ["exec-broker: egress api.evil.test not in scope"]);
+  });
+
+  it("is tolerant: blank, whitespace, and malformed lines are skipped, never thrown", () => {
+    const jsonl = ["", "   ", "{not json", observeLine(["r1"]), "null", "42"].join("\n");
+    const records = parseObserveRecords(jsonl);
+    assert.equal(records.length, 1);
+    assert.deepEqual(records[0].wouldDeny, ["r1"]);
+  });
+
+  it("treats a missing or non-array wouldDeny as an empty (would-pass) op", () => {
+    const jsonl = [
+      JSON.stringify({ metadata: { phase: "observe" } }), // no wouldDeny
+      JSON.stringify({ metadata: { phase: "observe", wouldDeny: "oops" } }), // wrong type
+      JSON.stringify({ metadata: { phase: "observe", wouldDeny: [1, "keep", null] } }), // mixed
+    ].join("\n");
+    const records = parseObserveRecords(jsonl);
+    assert.equal(records.length, 3);
+    assert.deepEqual(records[0].wouldDeny, []);
+    assert.deepEqual(records[1].wouldDeny, []);
+    assert.deepEqual(records[2].wouldDeny, ["keep"]); // non-strings filtered out
+  });
+
+  it("returns [] for empty input", () => {
+    assert.deepEqual(parseObserveRecords(""), []);
+    assert.deepEqual(parseObserveRecords("\n\n"), []);
+  });
+});
+
+describe("assessEnforceReadiness", () => {
+  it("no observe data → untested (honest floor, never a green ready)", () => {
+    const r = assessEnforceReadiness([]);
+    assert.equal(r.verdict, "untested");
+    assert.equal(r.opsObserved, 0);
+    assert.equal(r.wouldBlockOps, 0);
+    assert.deepEqual(r.reasons, []);
+  });
+
+  it("all observed ops would pass → ready", () => {
+    const records: ObserveRecord[] = [{ wouldDeny: [] }, { wouldDeny: [] }, { wouldDeny: [] }];
+    const r = assessEnforceReadiness(records);
+    assert.equal(r.verdict, "ready");
+    assert.equal(r.opsObserved, 3);
+    assert.equal(r.wouldBlockOps, 0);
+    assert.deepEqual(r.reasons, []);
+  });
+
+  it("any op with a would-be denial → would-block", () => {
+    const records: ObserveRecord[] = [{ wouldDeny: [] }, { wouldDeny: ["egress X"] }];
+    const r = assessEnforceReadiness(records);
+    assert.equal(r.verdict, "would-block");
+    assert.equal(r.opsObserved, 2);
+    assert.equal(r.wouldBlockOps, 1);
+  });
+
+  it("counts blocking ops (not total reasons) and tallies reasons across ops", () => {
+    const records: ObserveRecord[] = [
+      { wouldDeny: ["egress X", "fs /etc"] }, // one op, two reasons
+      { wouldDeny: ["egress X"] },
+      { wouldDeny: [] },
+    ];
+    const r = assessEnforceReadiness(records);
+    assert.equal(r.opsObserved, 3);
+    assert.equal(r.wouldBlockOps, 2);
+    assert.deepEqual(r.reasons, [
+      { reason: "egress X", count: 2 },
+      { reason: "fs /etc", count: 1 },
+    ]);
+  });
+
+  it("sorts reasons by count desc, then reason asc for a stable, deterministic report", () => {
+    const records: ObserveRecord[] = [
+      { wouldDeny: ["bbb"] },
+      { wouldDeny: ["aaa"] },
+      { wouldDeny: ["aaa"] },
+      { wouldDeny: ["ccc"] },
+    ];
+    const r = assessEnforceReadiness(records);
+    assert.deepEqual(r.reasons, [
+      { reason: "aaa", count: 2 }, // highest count first
+      { reason: "bbb", count: 1 }, // ties broken alphabetically
+      { reason: "ccc", count: 1 },
+    ]);
+  });
+});

--- a/src/exec-broker/enforce-readiness.ts
+++ b/src/exec-broker/enforce-readiness.ts
@@ -1,0 +1,91 @@
+/**
+ * exec-broker — observe→enforce readiness (E1, pure core).
+ *
+ * Design: `kit-research/docs/research/exec-broker-enforce-adoption.md`.
+ *
+ * The observe (dry-run) rung of the Pillar 3 ladder records, per operation, the denials that
+ * enforce mode WOULD apply — an audit event with `metadata.phase === "observe"` and
+ * `metadata.wouldDeny: string[]` (empty ⇒ the op would pass under enforce). This module reads
+ * that recorded evidence and answers the one question that blocks adoption: **is it safe to
+ * flip to enforce, and if not, exactly what would break?** Turning the flip from a leap into a
+ * diff.
+ *
+ * Pure + tolerant: a missing file is "untested", a malformed line is skipped (never thrown).
+ * Deterministic, zero-LLM. Honest floor: no observe data is `untested`, never a green "ready".
+ */
+
+/** One observed operation's would-be denials (empty ⇒ it would pass under enforce). */
+export interface ObserveRecord {
+  wouldDeny: string[];
+}
+
+export type EnforceVerdict =
+  | "ready" // ops observed, none would be denied → safe to flip
+  | "would-block" // at least one observed op would be denied under enforce
+  | "untested"; // no observe data — cannot claim ready
+
+export interface EnforceReadiness {
+  opsObserved: number;
+  /** Observed ops with ≥1 would-be denial (these break on flip unless the scope is widened). */
+  wouldBlockOps: number;
+  /** Distinct would-be-denial reasons, most frequent first (verbatim — no fragile target parsing). */
+  reasons: { reason: string; count: number }[];
+  verdict: EnforceVerdict;
+}
+
+/**
+ * Extract observe records from raw `.kit-audit.jsonl` content: audit lines whose
+ * `metadata.phase === "observe"`, taking `metadata.wouldDeny` (a string[]) as the would-be
+ * denials. Tolerant — blank/malformed lines and non-observe lines are skipped. Pure.
+ */
+export function parseObserveRecords(auditJsonl: string): ObserveRecord[] {
+  const out: ObserveRecord[] = [];
+  for (const line of auditJsonl.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    // Tolerant: a line that parses to null/number/array (not an object) is not an audit event.
+    if (typeof parsed !== "object" || parsed === null) continue;
+    const e = parsed as { metadata?: { phase?: unknown; wouldDeny?: unknown } };
+    if (!e.metadata || e.metadata.phase !== "observe") continue;
+    const raw = e.metadata.wouldDeny;
+    const wouldDeny = Array.isArray(raw)
+      ? raw.filter((r): r is string => typeof r === "string")
+      : [];
+    out.push({ wouldDeny });
+  }
+  return out;
+}
+
+/**
+ * Fold observe records into an enforce-readiness verdict. No records ⇒ `untested` (never a
+ * green pass — coverage is only what was observed). Any op with a would-be denial ⇒
+ * `would-block` (flipping breaks it unless the scope is widened first); otherwise `ready`.
+ * Reasons are tallied verbatim (deterministic; a would-block report lists exactly what breaks).
+ * Pure.
+ */
+export function assessEnforceReadiness(records: ObserveRecord[]): EnforceReadiness {
+  if (records.length === 0) {
+    return { opsObserved: 0, wouldBlockOps: 0, reasons: [], verdict: "untested" };
+  }
+  let wouldBlockOps = 0;
+  const counts = new Map<string, number>();
+  for (const r of records) {
+    if (r.wouldDeny.length > 0) wouldBlockOps++;
+    for (const reason of r.wouldDeny) counts.set(reason, (counts.get(reason) ?? 0) + 1);
+  }
+  const reasons = [...counts.entries()]
+    .map(([reason, count]) => ({ reason, count }))
+    .sort((a, b) => b.count - a.count || (a.reason < b.reason ? -1 : a.reason > b.reason ? 1 : 0));
+  return {
+    opsObserved: records.length,
+    wouldBlockOps,
+    reasons,
+    verdict: wouldBlockOps > 0 ? "would-block" : "ready",
+  };
+}


### PR DESCRIPTION
## What

The exec-broker runtime ladder is **off → observe → enforce**. observe runs the same gates but **never denies** — it records each would-be denial to the hash-chained audit log (`metadata.phase === "observe"`, `metadata.wouldDeny: string[]`). enforce requires `[scope].enforce_runtime = true` in the **signed** profile scope and actually denies.

The adoption gap is the human step between them: an operator in observe has **no evidence-based way to answer "is it safe to flip to enforce?"** So people stay in observe forever — and observe only watches, it doesn't protect. All the governance value sits on the other side of a flip nobody dares make.

This PR adds the **pure core** that turns that flip from a leap into a **diff**.

## Surface

`src/exec-broker/enforce-readiness.ts` (pure, deterministic, zero-LLM):

- **`parseObserveRecords(auditJsonl)`** — lifts the would-be denials observe already records. Tolerant by construction: blank / malformed / non-object (`null`, numbers) / non-observe lines are skipped, never thrown; a missing or non-array `wouldDeny` is treated as a would-pass op; non-string entries are filtered out.
- **`assessEnforceReadiness(records)`** → verdict:
  - no observe data → **`untested`** (honest floor — never a green "ready"; coverage is only what was observed)
  - any observed op with a would-be denial → **`would-block`**, plus the exact reasons tallied verbatim (count-desc, then reason-asc → deterministic report of precisely what breaks)
  - otherwise → **`ready`**

## Scope of this PR

Pure core only. **No command surface yet** — `kit broker enforce-readiness` (E2) and the guided `kit broker enforce` flip + `kit doctor` nudge (E3) are follow-ups. This is the tested foundation they call, shipped on its own so it can be reviewed in isolation.

## Honest limits (by construction)

- **Coverage = observed ops.** A `ready` verdict means "nothing *we saw* would break," not "nothing ever will." Same honest floor as the skill-test runtime audit.
- No observe data is `untested`, deliberately not a reassuring green.

## Tests

`src/exec-broker/enforce-readiness.test.ts` — 9 unit tests: observe-line filtering, tolerance (blank/whitespace/malformed/`null`/numeric lines), missing/non-array/mixed-type `wouldDeny`, and all three verdicts incl. reason tally + deterministic sort. Full suite green (2978 pass / 0 fail), zero-LLM boundary test included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)