### PR TITLE
security(broker): fail-closed PreToolUse gates — symlink-blind fs-gate + gate-exception fail-open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Security
 
+- **exec-broker PreToolUse gates hardened to fail closed (three bypasses, found by an internal
+  bug sweep).** The runtime enforcement point (`kit gate-fs` / `kit gate-egress`) and the CLI's
+  gate dispatch had gaps where an attacker or an internal fault could slip past confinement:
+  - **fs-gate was symlink-blind.** It ran only the pure string-containment check and omitted the
+    symlink-aware realpath check the canonical exec-broker already uses, so a symlink inside the
+    signed `[scope].fs` root pointing outside (e.g. `data → /`) let a write escape scope. The
+    gate now requires **both** checks per root — parity with the broker (the enforcement point
+    must never be weaker than the broker it mirrors). The realpath check now lives in a shared
+    `exec-broker/realpath-check.ts` so there is one source of truth.
+  - **A gate that threw failed OPEN.** Deny is signalled by `exit 2`; any thrown error fell
+    through to the generic `exit 1` (a _non-blocking_ PreToolUse result), so an internal fault
+    (e.g. the working directory removed mid-run → `process.cwd()` throws) would silently ALLOW
+    the very operation the gate exists to mediate. Gate dispatch now runs fail-closed: any
+    handler fault DENIES (exit 2 / Cline `{cancel:true}`).
+
 - **SkillSpector delegate now passes `--no-llm` explicitly** (`kit triage skill --deep`).
   kit ran SkillSpector's Stage-1 static scan only, suppressing the optional Stage-2 LLM pass
   via env scrubbing alone (`SKILLSPECTOR_PROVIDER=""` + stripped provider keys). It now also

--- a/src/broker/gates.test.ts
+++ b/src/broker/gates.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -56,6 +56,7 @@ beforeEach(async () => {
   process.env.KIT_IDENTITY_DIR = idDir;
   loadOrCreateIdentity();
   writeFileSync(join(proj, PROFILE_FILE), SCOPED);
+  mkdirSync(join(proj, "src"), { recursive: true }); // the declared [scope].fs root exists, as in a real project
   await signProfile(proj);
 });
 
@@ -115,5 +116,15 @@ describe("kit gate-fs (subprocess)", () => {
 
   it("passes non-write tool calls through", () => {
     assert.equal(runGate("gate-fs", bash("ls")).status, 0);
+  });
+
+  it("denies a write through a symlink that escapes the signed root (realpath parity with broker)", () => {
+    // A symlink INSIDE the signed `src` root pointing outside the project passes the pure
+    // string-containment check but must be caught by the symlink-aware realpath check — exactly
+    // what the canonical broker does. Without it the write escapes [scope].fs. (src/ is created in beforeEach.)
+    symlinkSync(tmpdir(), join(proj, "src", "out")); // src/out -> outside the project
+    const r = runGate("gate-fs", write("src/out/evil.txt"));
+    assert.equal(r.status, 2);
+    assert.match(r.stderr, /outside the signed fs scope/);
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,7 +53,13 @@ import {
   cmdTeam,
 } from "./commands/agent.js";
 import { cmdSelfAudit, cmdCoverage, cmdAnalyze } from "./commands/coverage.js";
-import { cmdGateBash, cmdGateEnv, cmdGateEgress, cmdGateFs } from "./commands/gate.js";
+import {
+  cmdGateBash,
+  cmdGateEnv,
+  cmdGateEgress,
+  cmdGateFs,
+  runGateFailClosed,
+} from "./commands/gate.js";
 import { cmdCi } from "./commands/ci.js";
 import { cmdSentinel } from "./commands/sentinel.js";
 import { cmdStandards, cmdBaseline } from "./commands/standards.js";
@@ -333,7 +339,11 @@ async function main(): Promise<void> {
       const handler = COMMANDS[resolved];
       if (handler) {
         emitDeprecationWarning(resolved);
-        ok = await handler();
+        // PreToolUse gates must fail CLOSED: an internal fault has to DENY (exit 2), never fall
+        // through to the generic catch below (exit 1 = non-blocking = the op would proceed).
+        ok = GATE_VERBS.has(resolved)
+          ? await runGateFailClosed(resolved, handler)
+          : await handler();
       } else {
         console.error(`Unknown command: ${command}`);
         const { didYouMean } = await import("./utils/didYouMean.js");
@@ -741,6 +751,10 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
     help: "PreToolUse fs-gate (exec-broker): block (exit 2) Write/Edit outside the signed [scope].fs — fail-closed without a verified scope",
   },
 };
+
+// PreToolUse deny gates: an internal fault in one must DENY (exit 2), never fall through to the
+// generic exit-1 path (non-blocking → the op would proceed). Dispatched via runGateFailClosed.
+const GATE_VERBS = new Set(["gate-bash", "gate-env", "gate-egress", "gate-fs"]);
 
 // Help for multi-word sub-commands (e.g. `kit memory search`). Help-only: no
 // dispatch handler or stability tier of their own — merged into COMMAND_HELP below.

--- a/src/commands/gate.test.ts
+++ b/src/commands/gate.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { runGateFailClosed } from "./gate.js";
+
+describe("runGateFailClosed", () => {
+  let origExit: typeof process.exit | undefined;
+  let origArgv: string[] | undefined;
+  let origLog: typeof console.log | undefined;
+
+  afterEach(() => {
+    if (origExit) process.exit = origExit;
+    if (origArgv) process.argv = origArgv;
+    if (origLog) console.log = origLog;
+    origExit = origArgv = origLog = undefined;
+  });
+
+  it("passes the handler's boolean through when it does not throw", async () => {
+    assert.equal(await runGateFailClosed("gate-fs", () => true), true);
+    assert.equal(await runGateFailClosed("gate-fs", async () => false), false);
+  });
+
+  it("a throwing handler DENIES via exit 2 (fail-closed) — never returns allow", async () => {
+    origExit = process.exit;
+    let exitCode: number | undefined;
+    process.exit = ((code?: number) => {
+      exitCode = code;
+      throw new Error("__exit__"); // stand in for process.exit's non-return
+    }) as unknown as typeof process.exit;
+
+    await assert.rejects(
+      runGateFailClosed("gate-fs", () => {
+        throw new Error("cwd removed mid-run");
+      }),
+      /__exit__/,
+    );
+    assert.equal(exitCode, 2); // exit 2 = PreToolUse deny, NOT exit 1 (which would allow)
+  });
+
+  it("uses the Cline cancel contract (no exit 2) under --format cline", async () => {
+    origArgv = process.argv;
+    process.argv = ["node", "kit", "gate-fs", "--format", "cline"];
+    origLog = console.log;
+    const logs: string[] = [];
+    console.log = (...a: unknown[]) => void logs.push(a.join(" "));
+
+    const r = await runGateFailClosed("gate-fs", () => {
+      throw new Error("boom");
+    });
+    assert.equal(r, false); // Cline blocks via stdout {cancel:true}, returns (no exit 2)
+    assert.match(logs.join("\n"), /"cancel":true/);
+    assert.match(logs.join("\n"), /fail-closed/);
+  });
+});

--- a/src/commands/gate.ts
+++ b/src/commands/gate.ts
@@ -146,6 +146,33 @@ async function gateDeny(label: string, message: string): Promise<boolean> {
 }
 
 /**
+ * Run a PreToolUse gate FAIL-CLOSED: any unexpected error from the handler DENIES (exit 2 —
+ * the block signal) instead of propagating to the CLI's generic error path, which sets exit 1.
+ * Exit 1 is a NON-BLOCKING error per the PreToolUse contract, i.e. the tool call would proceed —
+ * so an internal fault (e.g. `process.cwd()` throwing ENOENT because the cwd was removed
+ * mid-run) would silently ALLOW the very operation the gate exists to mediate. A security gate
+ * must fail closed: on any fault, block. Cline uses its stdout {cancel:true} contract instead of
+ * exit 2. Returns the handler's boolean when it does not throw.
+ */
+export async function runGateFailClosed(
+  label: string,
+  handler: () => boolean | Promise<boolean>,
+): Promise<boolean> {
+  try {
+    return await handler();
+  } catch (err) {
+    const reason = `gate error (fail-closed): ${err instanceof Error ? err.message : String(err)}`;
+    if (gateFormat() === "cline") {
+      console.log(JSON.stringify({ cancel: true, errorMessage: `kit ${label}: ${reason}` }));
+      return false;
+    }
+    const { writeSync } = await import("node:fs");
+    writeSync(2, `kit ${label}: BLOCKED — ${reason}\n`);
+    process.exit(2); // PreToolUse deny — never let an internal fault fail open
+  }
+}
+
+/**
  * Best-effort audit of a broker-gate deny (design §3.3: every deny leaves an audit entry).
  * Wrapped: a missing/unreadable .kit.toml or audit backend must never change the verdict —
  * the deny already happened, and deny is the safe outcome.
@@ -240,6 +267,7 @@ export async function cmdGateFs(): Promise<boolean> {
   // allowed root, checked with the shared decisions.checkFsWrite. No verified scope → deny.
   const { profileBrokerPolicy } = await import("../exec-broker/profile-policy.js");
   const { checkFsWrite } = await import("../exec-broker/decisions.js");
+  const { checkFsWriteRealpath } = await import("../exec-broker/realpath-check.js");
   const { policyFsRoots } = await import("../exec-broker/policy.js");
   const { resolve } = await import("node:path");
   const { policy } = await profileBrokerPolicy(process.cwd());
@@ -248,9 +276,18 @@ export async function cmdGateFs(): Promise<boolean> {
     await auditGateDeny("gate-fs", why, sessionIdOf(payload));
     return await gateDeny("fs-gate", `${why}\nSign the profile scope: \`kit profile sign\`.`);
   }
-  // Resolve the hook's path against the agent cwd first, then containment-check against each root.
+  // Resolve the hook's path against the agent cwd, then require BOTH gates per root — the pure
+  // string/traversal check AND the symlink-aware realpath check — exactly as the canonical broker
+  // (broker.ts collectDenials) does. Without the realpath check a symlink inside a signed root
+  // pointing outside would let the write escape scope (the enforcement point must not be weaker
+  // than the broker it mirrors).
   const abs = resolve(process.cwd(), write.filePath);
-  if (policyFsRoots(policy).some((root) => checkFsWrite(abs, root).ok)) return true;
+  if (
+    policyFsRoots(policy).some(
+      (root) => checkFsWrite(abs, root).ok && checkFsWriteRealpath(abs, root).ok,
+    )
+  )
+    return true;
   const why = `write outside the signed fs scope: ${write.filePath}`;
   await auditGateDeny("gate-fs", why);
   return await gateDeny(

--- a/src/exec-broker/broker.ts
+++ b/src/exec-broker/broker.ts
@@ -23,8 +23,8 @@
 //
 // Zero LLM, zero network. Deterministic + offline.
 
-import { existsSync, realpathSync } from "node:fs";
-import { dirname, resolve, sep } from "node:path";
+import { existsSync } from "node:fs";
+import { checkFsWriteRealpath } from "./realpath-check.js";
 import type { OperationContext } from "../governance-middleware.js";
 import { appendAuditEventDirect } from "../audit.js";
 import { checkEgress, checkFsWrite, scopeEnv } from "./decisions.js";
@@ -304,30 +304,6 @@ export async function runBrokered<T>(
     }
   }
   return brokerExec(context, loadBrokerPolicy(opts.policyOverride), run);
-}
-
-/**
- * Symlink-aware fs-write check (impure companion to the pure decisions.checkFsWrite).
- * Realpath the nearest EXISTING ancestor of the resolved target and confirm it is
- * the real root or strictly under it — catching a symlink inside the root that
- * points outside. The not-yet-existing tail of the path cannot contain symlinks
- * (nothing is there to be one). Any fs/realpath error → fail-closed deny.
- */
-function checkFsWriteRealpath(path: string, projectRoot: string): { ok: boolean; reason?: string } {
-  try {
-    const root = realpathSync(resolve(projectRoot));
-    let cur = resolve(root, path);
-    while (!existsSync(cur)) {
-      const parent = dirname(cur);
-      if (parent === cur) break; // reached the filesystem root
-      cur = parent;
-    }
-    const real = realpathSync(cur);
-    if (real === root || real.startsWith(root + sep)) return { ok: true };
-    return { ok: false, reason: `fs-write: real path ${real} escapes root ${root}` };
-  } catch {
-    return { ok: false, reason: "fs-write: realpath check failed (fail-closed)" };
-  }
 }
 
 /**

--- a/src/exec-broker/realpath-check.ts
+++ b/src/exec-broker/realpath-check.ts
@@ -1,0 +1,36 @@
+/**
+ * Symlink-aware fs-write check — the IMPURE companion to the pure `decisions.checkFsWrite`.
+ *
+ * `checkFsWrite` is a pure string/traversal gate and, by design, cannot follow symlinks: a
+ * symlink INSIDE the signed root that points outside would pass the string check yet write
+ * outside. This closes that hole by resolving real paths at the actual filesystem. It lives in
+ * its own module (not in the pure `decisions.ts`) so BOTH the exec-broker runtime (`broker.ts`)
+ * and the PreToolUse `gate-fs` (`commands/gate.ts`) call ONE source of truth — the enforcement
+ * point must never be weaker than the broker it mirrors.
+ *
+ * Realpath the nearest EXISTING ancestor of the resolved target and confirm it is the real root
+ * or strictly under it. The not-yet-existing tail cannot contain symlinks (nothing is there to
+ * be one). Any fs/realpath error → fail-closed deny.
+ */
+import { existsSync, realpathSync } from "node:fs";
+import { dirname, resolve, sep } from "node:path";
+
+export function checkFsWriteRealpath(
+  path: string,
+  projectRoot: string,
+): { ok: boolean; reason?: string } {
+  try {
+    const root = realpathSync(resolve(projectRoot));
+    let cur = resolve(root, path);
+    while (!existsSync(cur)) {
+      const parent = dirname(cur);
+      if (parent === cur) break; // reached the filesystem root
+      cur = parent;
+    }
+    const real = realpathSync(cur);
+    if (real === root || real.startsWith(root + sep)) return { ok: true };
+    return { ok: false, reason: `fs-write: real path ${real} escapes root ${root}` };
+  } catch {
+    return { ok: false, reason: "fs-write: realpath check failed (fail-closed)" };
+  }
+}


### PR DESCRIPTION
## What

Closes two enforcement-layer bypasses where the PreToolUse gates could be sidestepped or fail **open** — both surfaced by an internal bug sweep, both against kit's fail-closed charter.

### 1. `gate-fs` was symlink-blind
The fs-gate (`cmdGateFs`) ran only the pure string-containment check (`checkFsWrite`) and **omitted the symlink-aware realpath check the canonical exec-broker already uses** (`broker.ts` `collectDenials`). So a symlink **inside** the signed `[scope].fs` root pointing outside — e.g. `data → /` — passed the string check, and a `Write` to `data/.ssh/authorized_keys` was **allowed** while the real write landed outside scope. The enforcement point was weaker than the broker it mirrors.

**Fix:** the gate now requires **both** checks per root (`checkFsWrite(abs,root).ok && checkFsWriteRealpath(abs,root).ok`), exactly like the broker. The realpath check moved to a shared `src/exec-broker/realpath-check.ts` so broker + gate share **one source of truth** (was module-private in `broker.ts`).

### 2. A gate that threw failed **open**
Deny is signalled by `process.exit(2)`. Any *thrown* error in a gate handler fell through to the CLI's generic catch → `exit 1`, which is a **non-blocking** PreToolUse result — so the pending tool call would **proceed**. E.g. the working dir removed mid-run → `process.cwd()` throws ENOENT → `exit 1` → the op the gate exists to mediate is silently allowed.

**Fix:** the four gate verbs now dispatch through `runGateFailClosed`, which converts **any** handler fault into a deny (`exit 2`, or the Cline `{cancel:true}` contract). A security gate fails closed.

## Not in this PR

The third sweep finding — the egress-gate recognizing network targets **only** via explicit `http(s)://` URLs (so `curl evil.com` / `wget` / `nc host 443` slip past) — is a **follow-up PR**. It changes host extraction (`broker/extract.ts`) and needs its own false-positive analysis, so it doesn't ride along in this clean fail-closed change.

## Behaviour note (broker parity)

Bringing the gate to realpath parity means a `Write` into a **declared `[scope].fs` root that doesn't exist yet** is now denied by the gate — the same as the broker already does (realpath can't verify a nonexistent dir → fail-closed). Real projects have their declared dirs; one existing test that asserted the weaker behavior (write into a non-created `src/`) was updated to create the root, matching real usage and broker parity.

## Tests

- `src/broker/gates.test.ts` — new subprocess case: a write through a symlink escaping the signed root now returns **exit 2**.
- `src/commands/gate.test.ts` (new) — unit-tests `runGateFailClosed`: throwing handler → `exit 2`; passthrough of the handler's boolean; Cline `{cancel:true}` contract.
- Full suite green (**2992 pass / 0 fail**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)