### PR TITLE
fix(security): secrets/audit/scanner robustness — class F bug-sweep fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Security
 
+- **Secrets, audit, and scanner robustness (four bug-sweep findings, class F).**
+  - **`"manual"` rotation policy no longer crashes the vault.** `storeSecret`/`rotateSecret` did
+    `parseInt(rotation_policy)`, which is `NaN` for the valid `"manual"` value → `new Date(now +
+NaN).toISOString()` threw `RangeError` (and in `rotateSecret`, after the key was already
+    rotated — leaving unaudited, inconsistent state). Day-based policies (`30d`/`60d`/`90d`) are
+    now matched explicitly; `manual`/`never` simply leave `next_rotation_at` unset.
+  - **`kit gha-audit` no longer reports a false green over unreadable workflows.** A workflow it
+    could not read (perms/EISDIR/TOCTOU) was silently skipped, then the run emitted "all actions
+    pinned" — a false pass for a supply-chain scanner. Unreadable workflows now surface a
+    scanner-health `warn` naming them, and the blanket pass is suppressed.
+  - **Staged-secret pre-commit scan no longer falls back to a divergent working copy.** On a
+    `git show :file` failure (e.g. a staged blob over the buffer cap) it read the working copy —
+    which a developer can clean after staging the secret, the exact un-stage bypass the scan
+    exists to stop. The cap is raised so realistic files scan from the staged blob, and an
+    unreadable staged blob now fails **closed** (flagged) instead of trusting the working copy.
+  - **`kit audit secrets --since-days` NaN-guarded** — a non-numeric value silently returned all
+    events (window ignored); it now falls back to 30.
+
 - **Malformed input now yields a verdict, never an uncaught crash (fail-closed parsers).** The
   bug sweep found the historical "malformed file → uncaught throw → empty stdout" class had
   reappeared in several spots, all now fixed:

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -11,7 +11,10 @@ import { hasFlag, flagValue } from "../utils/flags.js";
 async function cmdAuditSecrets(): Promise<boolean> {
   const args = process.argv.slice(4); // after "audit secrets"
   const sinceIdx = args.indexOf("--since-days");
-  const sinceDays = sinceIdx >= 0 && args[sinceIdx + 1] ? parseInt(args[sinceIdx + 1], 10) : 30;
+  // NaN-guard: a non-numeric --since-days would make the cutoff NaN, so the time-window filter
+  // silently no-ops and ALL events are returned (wrong output, no error). Fall back to 30.
+  const sinceRaw = sinceIdx >= 0 && args[sinceIdx + 1] ? parseInt(args[sinceIdx + 1], 10) : 30;
+  const sinceDays = Number.isFinite(sinceRaw) && sinceRaw > 0 ? sinceRaw : 30;
   const keyFilter = flagValue(args, "--key");
   const jsonMode = hasFlag(args, "--json");
 

--- a/src/gha-audit.test.ts
+++ b/src/gha-audit.test.ts
@@ -40,3 +40,36 @@ describe("auditWorkflow", () => {
     assert.deepEqual(auditWorkflow(wf, "ok.yml"), []);
   });
 });
+
+import { runGhaAudit } from "./gha-audit.js";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("runGhaAudit — unreadable workflow never yields a false-green pass", () => {
+  it("emits a scanner-health warn (not 'all pinned' pass) when a workflow can't be read", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-gha-"));
+    try {
+      const wfDir = join(dir, ".github", "workflows");
+      mkdirSync(wfDir, { recursive: true });
+      // A clean, readable workflow…
+      writeFileSync(
+        join(wfDir, "ci.yml"),
+        "jobs:\n  b:\n    steps:\n      - uses: actions/checkout@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a\n",
+      );
+      // …and an UNREADABLE one (a directory named *.yml makes readFileSync throw EISDIR).
+      mkdirSync(join(wfDir, "deploy.yml"));
+      const results = runGhaAudit(dir);
+      assert.ok(
+        results.some((r) => r.status === "warn" && /could not read/.test(r.detail ?? "")),
+        "must surface a scanner-health warn for the unreadable workflow",
+      );
+      assert.ok(
+        !results.some((r) => r.status === "pass" && /all actions pinned/.test(r.detail ?? "")),
+        "must NOT emit the blanket all-pinned pass when a workflow was not audited",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/gha-audit.ts
+++ b/src/gha-audit.ts
@@ -100,14 +100,28 @@ export function runGhaAudit(cwd: string): SecurityCheckResult[] {
     ];
   }
   const out: SecurityCheckResult[] = [];
+  const unreadable: string[] = [];
   for (const f of files) {
+    let text: string;
     try {
-      out.push(...auditWorkflow(readFileSync(join(dir, f), "utf8"), f));
+      text = readFileSync(join(dir, f), "utf8");
     } catch {
-      // unreadable file → skip it (fail-open)
+      unreadable.push(f); // do NOT silently skip — an unread workflow must not be reported clean
+      continue;
     }
+    out.push(...auditWorkflow(text, f));
   }
-  if (out.length === 0) {
+  if (unreadable.length > 0) {
+    // Scanner-health: a workflow we could not read was NOT audited, so we must not emit the
+    // blanket "all pinned" pass over it (that would be a false green for a supply-chain scanner).
+    out.push({
+      category: "supply-chain",
+      name: "gha-audit",
+      status: "warn",
+      severity: "medium",
+      detail: `could not read ${unreadable.length} workflow(s): ${unreadable.join(", ")} — not audited`,
+    });
+  } else if (out.length === 0) {
     out.push({
       category: "supply-chain",
       name: "gha-audit",

--- a/src/scan-staged.test.ts
+++ b/src/scan-staged.test.ts
@@ -54,6 +54,26 @@ describe("scanStagedFiles", () => {
     }
   });
 
+  it("scans the STAGED blob, not the working copy (secret survives a working-copy cleanup)", async () => {
+    const dir = tmpGitRepo();
+    try {
+      // Stage a secret, then edit the working copy to remove it. The scanner must still flag the
+      // staged blob — it must NOT read the (now-clean) working copy. This is the un-stage bypass
+      // the fix hardens (the working-copy fallback was removed for divergent reads).
+      writeFileSync(
+        join(dir, ".env"),
+        "STRIPE_SECRET_KEY=sk_te" + "st_51T2AMtJLRlXeUG4dKBwX2nsve3BLEzy\n",
+      );
+      execSync("git add .env", { cwd: dir });
+      writeFileSync(join(dir, ".env"), "STRIPE_SECRET_KEY=redacted\n"); // working copy cleaned
+      const hits = await scanStagedFiles(dir);
+      assert.equal(hits.length, 1);
+      assert.ok(hits[0].findings.some((f) => f.label === "stripe-key"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("flags a staged Supabase service-role JWT", async () => {
     const dir = tmpGitRepo();
     try {

--- a/src/scan-staged.ts
+++ b/src/scan-staged.ts
@@ -1,4 +1,3 @@
-import { readFile } from "node:fs/promises";
 import { findSecrets, type SecretFinding } from "./utils/redactSecrets.js";
 import { exec } from "./utils/exec.js";
 
@@ -49,25 +48,35 @@ export async function scanStagedFiles(cwd: string = process.cwd()): Promise<Stag
     return [];
   }
 
-  const { resolve } = await import("node:path");
   const hits: StagedHit[] = [];
   for (const path of paths) {
     // Read the staged blob (`git show :file`) so a developer can't bypass
-    // by un-staging the change after the hook fires. Cap at 1 MiB.
+    // by un-staging the change after the hook fires.
     let content: string;
     try {
       const { stdout } = await exec("git", ["show", `:${path}`], {
         cwd,
         timeout: 5_000,
-        maxBuffer: 1 * 1024 * 1024,
+        // Raised from 1 MiB so realistic staged text files are scanned from the STAGED blob, not
+        // skipped. (Was 1 MiB — a >1 MiB staged blob overflowed and fell through to the bypass.)
+        maxBuffer: 25 * 1024 * 1024,
       });
       content = stdout;
     } catch {
-      try {
-        content = await readFile(resolve(cwd, path), "utf-8");
-      } catch {
-        continue;
-      }
+      // The staged blob could not be read (too large even for the raised cap, or unreadable). Do
+      // NOT fall back to the working copy: it can diverge from what is being committed (stage the
+      // secret, then edit the working copy clean) — exactly the un-stage bypass this scanner
+      // exists to prevent. Fail closed: flag it so the commit is blocked and handled explicitly.
+      hits.push({
+        file: path,
+        findings: [
+          {
+            label: "unscannable staged blob (fail-closed)",
+            preview: "staged content could not be read to scan for secrets — verify manually",
+          },
+        ],
+      });
+      continue;
     }
     const findings = findSecrets(content);
     if (findings.length > 0) {

--- a/src/secrets-service.test.ts
+++ b/src/secrets-service.test.ts
@@ -95,6 +95,40 @@ describe("secrets-service", () => {
       assert.ok(secret.next_rotation_at);
     });
 
+    it("does not crash on a 'manual' rotation policy (NaN-guard); next_rotation_at stays unset", () => {
+      initializeVault(teamId);
+      // parseInt("manual") is NaN → new Date(now+NaN).toISOString() used to throw RangeError.
+      const { secret, error } = storeSecret(
+        teamId,
+        "manual_key",
+        "secret",
+        "password",
+        userId,
+        "team",
+        "manual",
+      );
+      assert.ok(!error);
+      assert.equal(secret.rotation_policy, "manual");
+      assert.equal(secret.next_rotation_at, undefined);
+    });
+
+    it("rotateSecret does not crash for a 'manual'-policy secret (NaN-guard)", () => {
+      initializeVault(teamId);
+      const { secret } = storeSecret(
+        teamId,
+        "manual_rotate",
+        "secret",
+        "password",
+        userId,
+        "team",
+        "manual",
+      );
+      const { secret: rotated, error } = rotateSecret(teamId, secret.id, userId, "manual");
+      assert.ok(!error);
+      assert.equal(rotated.next_rotation_at, undefined);
+      assert.ok(rotated.last_rotated_at); // rotation completed + recorded, no throw
+    });
+
     it("stores secret with expiry", () => {
       initializeVault(teamId);
       const expireDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();

--- a/src/secrets-service.ts
+++ b/src/secrets-service.ts
@@ -11,6 +11,18 @@ import type {
   AccessLevel,
 } from "./secrets-model.js";
 
+/**
+ * next_rotation_at for a day-based rotation policy ("30d"/"60d"/"90d"); undefined for "never"
+ * and "manual". Guards the NaN trap: parseInt("manual") is NaN, and `new Date(now + NaN)` is an
+ * Invalid Date whose .toISOString() THROWS — crashing storeSecret/rotateSecret on a valid,
+ * typed input. Match the numeric shape explicitly instead of parseInt-ing the whole string.
+ */
+function nextRotationAt(policy: RotationPolicy): string | undefined {
+  const m = /^(\d+)d$/.exec(policy);
+  if (!m) return undefined;
+  return new Date(Date.now() + Number(m[1]) * 24 * 60 * 60 * 1000).toISOString();
+}
+
 const secrets = new Map<string, Secret>();
 const encryptionKeys = new Map<string, EncryptionKey>();
 const secretShares = new Map<string, SecretShare>();
@@ -92,11 +104,9 @@ export function storeSecret(
     tags,
   };
 
-  // Set next rotation date
-  if (rotation_policy !== "never") {
-    const days = parseInt(rotation_policy);
-    secret.next_rotation_at = new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
-  }
+  // Set next rotation date (day-based policies only; "manual"/"never" leave it unset).
+  const next = nextRotationAt(rotation_policy);
+  if (next) secret.next_rotation_at = next;
 
   secrets.set(secret.id, secret);
   logAccess(team_id, created_by, "created", "success", secret.id);
@@ -184,10 +194,8 @@ export function rotateSecret(
   secret.last_rotated_at = new Date().toISOString();
   secret.updated_at = new Date().toISOString();
 
-  if (secret.rotation_policy !== "never") {
-    const days = parseInt(secret.rotation_policy);
-    secret.next_rotation_at = new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
-  }
+  const next = nextRotationAt(secret.rotation_policy);
+  if (next) secret.next_rotation_at = next;
 
   // Record rotation history
   const history: RotationHistory = {


### PR DESCRIPTION
## What

Class F from the internal bug sweep — NaN / silent-wrong / false-green defects. Four fixes.

- **`"manual"` rotation policy no longer crashes the vault.** `storeSecret`/`rotateSecret` did `parseInt(rotation_policy)`, which is `NaN` for the valid `"manual"` value (the `!== "never"` guard let it through) → `new Date(now + NaN).toISOString()` threw `RangeError`. In `rotateSecret` this fired **after** the key was already rotated and re-encrypted, but **before** history/audit were recorded — leaving corrupted, unaudited state. A day-only helper matches `30d`/`60d`/`90d` explicitly; `manual`/`never` leave `next_rotation_at` unset.

- **`kit gha-audit` no longer reports a false green over unreadable workflows.** A workflow it couldn't read (perms / EISDIR / TOCTOU) was silently skipped, then the run emitted the blanket *"N workflow(s): all actions pinned, no pwn-request"* — a **false pass for a supply-chain scanner** (an unpinned action or pwn-request in the unread file goes unreported). Unreadable workflows now surface a scanner-health `warn` naming them, and the blanket pass is suppressed.

- **Staged-secret pre-commit scan no longer falls back to a divergent working copy.** On a `git show :file` failure (notably a staged blob over the old 1 MiB buffer cap) it read the **working copy** — which a developer can clean *after* staging the secret: exactly the un-stage bypass the scan exists to stop. The cap is raised to 25 MiB so realistic files scan from the staged blob, and an unreadable staged blob now fails **closed** (flagged) rather than trusting the working copy.

- **`kit audit secrets --since-days` NaN-guarded.** A non-numeric value made the cutoff `NaN`, so the time-window filter silently no-op'd and **all** events were returned; it now falls back to 30.

## Tests

- `secrets-service.test.ts` — `"manual"` policy `storeSecret` **and** `rotateSecret` complete without throwing, `next_rotation_at` unset.
- `gha-audit.test.ts` — an unreadable workflow (dir named `*.yml` → EISDIR) yields a `warn`, and **not** the "all pinned" pass.
- `scan-staged.test.ts` — a staged secret is still flagged after the working copy is cleaned (scans the staged blob, not the working copy).
- Full suite green (**3008 pass / 0 fail**).

Honest test limit: the `>25 MiB` staged-blob fail-closed branch is covered by inspection — a 25 MiB fixture is impractical to unit-test.

This completes the sweep's actionable fixes: **K** (#365, #366), **A** (#367), **F** (this). The remaining item is **E** — ReDoS in plugin-supplied regex (`standards-plugins.ts`) — a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)