### PR TITLE
security(standards): reject ReDoS-prone plugin regexes at load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Security
 
+- **Standards plugins reject ReDoS-prone regexes at load (class E — completes the bug sweep).**
+  A declarative standards plugin's `match` was compiled and run over every source line with no
+  protection against catastrophic backtracking, so a crafted plugin (`match = '(a+)+$'`) could
+  hang `kit check` indefinitely — a fail-open DoS via a PR-submitted TOML. A deterministic,
+  dependency-free detector (`hasReDoSRisk`) now flags the classic nested-unbounded-quantifier
+  shape (`(a+)+`, `(\d*)*`, `((ab)+)+`, `(a{2,})+`) and **rejects** such a plugin at load with an
+  integrity warning — it is never compiled into the per-line evaluator. Honest limit: it catches
+  the nested-quantifier class (the common, cited ReDoS), not every catastrophic regex; the
+  existing max-line-length cap remains as defense-in-depth.
+
 - **Secrets, audit, and scanner robustness (four bug-sweep findings, class F).**
   - **`"manual"` rotation policy no longer crashes the vault.** `storeSecret`/`rotateSecret` did
     `parseInt(rotation_policy)`, which is `NaN` for the valid `"manual"` value → `new Date(now +

--- a/src/standards-plugins.test.ts
+++ b/src/standards-plugins.test.ts
@@ -10,6 +10,7 @@ import {
   checkStandardsPlugins,
   collectPluginKeys,
   pluginKey,
+  hasReDoSRisk,
   DEFAULT_PLUGIN_DIR,
 } from "./standards-plugins.js";
 
@@ -179,6 +180,48 @@ describe("standards-plugins — evaluate + gate", () => {
     const repo = tmpRepo();
     try {
       assert.deepEqual(checkStandardsPlugins({ cwd: repo, language: "typescript" }), []);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("standards-plugins — hasReDoSRisk (nested-quantifier detector)", () => {
+  it("flags nested unbounded quantifiers (catastrophic backtracking)", () => {
+    for (const re of ["(a+)+", "(a+)+$", "(a*)*", "(\\d+)+", "([a-z]+)+", "((ab)+)+", "(a{2,})+"]) {
+      assert.equal(hasReDoSRisk(re), true, `should flag: ${re}`);
+    }
+  });
+
+  it("does not flag safe patterns (no false positives)", () => {
+    for (const re of [
+      "console\\.log",
+      "(abc)+", // quantified group, no INNER quantifier
+      "a+",
+      "\\d+",
+      "[a-z]+",
+      "(ab)*cd+",
+      "(a|b)+", // alternation of single chars, no inner quantifier
+      "(a{2,5})+", // BOUNDED inner quantifier is safe
+      "foo(bar)?baz",
+      "\\(a+\\)+", // escaped parens are literals, not a group
+    ]) {
+      assert.equal(hasReDoSRisk(re), false, `should NOT flag: ${re}`);
+    }
+  });
+});
+
+describe("standards-plugins — ReDoS-prone plugin rejected at load", () => {
+  it("drops a nested-quantifier match with an integrity warn (never compiled/run)", () => {
+    const repo = tmpRepo();
+    try {
+      writePlugin(repo, "redos.toml", `[standard]\nid = "redos"\ntitle = "x"\nmatch = '(a+)+$'\n`);
+      const { plugins, integrity } = loadStandardPlugins(repo, [DEFAULT_PLUGIN_DIR]);
+      assert.equal(plugins.length, 0, "the ReDoS-prone plugin must not load");
+      assert.ok(
+        integrity.some((i) => i.status === "warn" && /ReDoS-prone/.test(i.detail)),
+        "must surface a ReDoS integrity warning",
+      );
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }

--- a/src/standards-plugins.ts
+++ b/src/standards-plugins.ts
@@ -19,7 +19,8 @@
  *     surfaces a `plugin integrity` warning, never crashing the gate (the lesson from
  *     the .kit-baseline.json crash fix).
  *   - Deterministic by construction: a regex over the repo's own files is a pure
- *     function of the repo. Line length is capped to bound pathological regexes.
+ *     function of the repo. A ReDoS-prone `match` (nested unbounded quantifier) is REJECTED at
+ *     load (never run); line length is additionally capped as defense-in-depth.
  *   - Net-new gating on stable `plugin/<id>:<file>:<line>` keys, same as every other
  *     standards dimension.
  *
@@ -154,6 +155,18 @@ export function loadStandardPlugins(cwd: string, dirs: string[]): LoadPluginsRes
         integrity.push(integrityWarn(rel, `invalid match regex (${(e as Error).message})`));
         continue;
       }
+      // Reject a ReDoS-prone pattern (nested unbounded quantifier) at LOAD — never compile it into
+      // the per-line evaluator, where a crafted plugin could hang `kit check` with catastrophic
+      // backtracking. Fail closed: the plugin is dropped with an integrity warning.
+      if (hasReDoSRisk(s.match)) {
+        integrity.push(
+          integrityWarn(
+            rel,
+            `match regex is ReDoS-prone (nested quantifier) — rejected: ${s.match}`,
+          ),
+        );
+        continue;
+      }
       plugins.push({
         id: s.id,
         title: s.title,
@@ -211,6 +224,70 @@ export function globToRegExp(glob: string): RegExp {
 
 function isExcluded(relFile: string, patterns: RegExp[]): boolean {
   return patterns.some((re) => re.test(relFile));
+}
+
+/** Length of an UNBOUNDED quantifier token at position i, else 0. `*`, `+`, `{n,}` are unbounded
+ *  (catastrophic when nested); `?`, `{n}`, `{n,m}` are bounded (safe). Absorbs a lazy/possessive
+ *  suffix so `*?`/`+?`/`*+` isn't mis-read as a second quantifier. */
+function unboundedQuantLen(p: string, i: number): number {
+  const ch = p[i];
+  if (ch === "*" || ch === "+") return p[i + 1] === "?" || p[i + 1] === "+" ? 2 : 1;
+  if (ch === "{") {
+    const m = /^\{\d*,\}/.exec(p.slice(i)); // {n,} (unbounded upper); {n} / {n,m} do NOT match
+    if (m) return p[i + m[0].length] === "?" ? m[0].length + 1 : m[0].length;
+  }
+  return 0;
+}
+
+/**
+ * Conservative ReDoS-shape detector: true when the pattern applies an UNBOUNDED quantifier to a
+ * group whose body ALSO contains an unbounded quantifier — the classic exponential-backtracking
+ * shape (`(a+)+`, `(\d*)*`, `(a+)*$`, `((ab)+)+`). Deterministic, dependency-free. Assumes the
+ * pattern is already syntactically valid (call after `new RegExp` succeeds). Honest limit: it
+ * catches the nested-quantifier class (the common, cited ReDoS), not every catastrophic regex
+ * (e.g. overlapping alternation `(a|a)+`) — those stay bounded only by MAX_LINE_LEN.
+ */
+export function hasReDoSRisk(pattern: string): boolean {
+  const bodyHadUnbounded: boolean[] = []; // per currently-open group: has its body seen `*`/`+`/`{n,}`?
+  const markParent = (): void => {
+    if (bodyHadUnbounded.length > 0) bodyHadUnbounded[bodyHadUnbounded.length - 1] = true;
+  };
+  let inClass = false; // inside [...] — parens/quantifiers are literal there
+  for (let i = 0; i < pattern.length; i++) {
+    const ch = pattern[i];
+    if (ch === "\\") {
+      i++; // escaped char → literal, skip it
+      continue;
+    }
+    if (inClass) {
+      if (ch === "]") inClass = false;
+      continue;
+    }
+    if (ch === "[") {
+      inClass = true;
+      continue;
+    }
+    if (ch === "(") {
+      bodyHadUnbounded.push(false);
+      continue;
+    }
+    if (ch === ")") {
+      const inner = bodyHadUnbounded.pop() ?? false;
+      const qlen = unboundedQuantLen(pattern, i + 1);
+      if (qlen > 0) {
+        if (inner) return true; // (…unbounded…) followed by an unbounded quantifier → ReDoS
+        markParent(); // the quantified group is itself an unbounded atom in the parent's body
+        i += qlen;
+      }
+      continue;
+    }
+    const qlen = unboundedQuantLen(pattern, i);
+    if (qlen > 0) {
+      markParent();
+      i += qlen - 1; // -1: the loop's i++ advances the last char
+    }
+  }
+  return false;
 }
 
 export interface PluginFinding {


### PR DESCRIPTION
## What

Class E — the **last of 15** bug-sweep findings. A declarative standards plugin's `match` regex was compiled and run over **every source line** with no protection against catastrophic backtracking. A crafted plugin —

```toml
[standard]
id = "boom"
match = '(a+)+$'
```

— could hang `kit check` indefinitely on any file with a line like `aaaa…aX`: a **fail-open DoS via a PR-submitted TOML**. The only prior guard (a max-line-length cap) bounds *linear* cost but does nothing against *exponential* backtracking.

## Fix

**`hasReDoSRisk(pattern)`** — a pure, deterministic, dependency-free detector for the classic **nested-unbounded-quantifier** shape: an unbounded quantifier (`*`, `+`, `{n,}`) applied to a group whose body *itself* contains an unbounded quantifier (`(a+)+`, `(\d*)*`, `((ab)+)+`, `(a{2,})+`). It handles escapes and character classes; bounded inner quantifiers (`{n,m}`) and non-grouped quantifiers are correctly treated as safe.

`loadStandardPlugins` now runs it right after the syntax check and **rejects** a ReDoS-prone `match` at **load** with an integrity warning — so the dangerous pattern is **never compiled into the per-line evaluator**. Fail-closed: the plugin is dropped, not run.

## Honest limit

Catches the nested-quantifier class (the common, cited ReDoS), **not** every catastrophic regex (e.g. overlapping alternation `(a|a)+`). Those remain bounded only by `MAX_LINE_LEN`, which stays as defense-in-depth. Stated in the code + docstring — no false green. (A linear-time engine like RE2 would be complete but adds a native dep against kit's minimal-deps doctrine.)

## Tests

- `hasReDoSRisk`: flags `(a+)+`, `(a+)+$`, `(a*)*`, `(\d+)+`, `([a-z]+)+`, `((ab)+)+`, `(a{2,})+`; **no false positives** on `(abc)+`, `a+`, `[a-z]+`, `(ab)*cd+`, `(a|b)+`, `(a{2,5})+`, `foo(bar)?baz`, escaped `\(a+\)+`.
- `loadStandardPlugins`: a `(a+)+$` plugin is dropped at load with a `ReDoS-prone` integrity warn (0 plugins loaded).
- Full suite green (**3016 pass / 0 fail**).

With this, the internal bug sweep is fully remediated: **K** (#365, #366), **A** (#367), **F** (#368), **E** (this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)