### PR TITLE
feat(broker): kit broker enforce — guided, signed observe→enforce flip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`kit broker enforce` — the guided observe→enforce flip (Pillar 3 capstone).** Turns the
+  exec-broker from _observational_ to _protective_ in one evidence-gated command. It runs the
+  `enforce-readiness` pre-flight and **refuses without `--force` unless the verdict is `ready`**
+  (fail-closed — it will not silently enable a posture the observed evidence says would break, or
+  one with no evidence at all), then sets `[scope].enforce_runtime = true`, **re-signs** the
+  profile scope (so the flip is attributable — enforce only takes effect under a valid signature),
+  and audits the transition (`phase: "enforce-enabled"`). On a sign failure it surfaces that the
+  scope won't verify until re-signed (never a silent half-enabled state). Completes the
+  observe→enforce ladder: `enforce-readiness` (E1/E2) tells you it's safe; `enforce` does it.
+  Deterministic, zero-LLM. `--json` for machines.
+
 - **`kit memory search --fresh` — recency-aware recall (deterministic, zero-LLM).** By default
   recall is bm25 relevance-first (unchanged). `--fresh` fetches a larger candidate pool and
   **RRF-fuses** two incommensurable signals — bm25 relevance and recency — _by rank_ (no score

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -134,6 +134,13 @@
     },
     "broker": {
       "commands": {
+        "enforce": {
+          "kind": "command",
+          "summary": "Guided observe→enforce flip: readiness pre-flight (refuses unless ready; --force overrides), set [scope].enforce_runtime = true, re-sign the profile scope, and audit the transition",
+          "x-kit-args-modeled": false,
+          "x-kit-mcp": false,
+          "x-kit-stability": "experimental"
+        },
         "enforce-readiness": {
           "kind": "command",
           "summary": "Read the recorded observe window (.kit-audit.jsonl) and report whether it's safe to flip exec-broker to enforce: ready | would-block (+ exactly what breaks) | untested (--gate fails CI on any not-ready verdict)",
@@ -143,7 +150,7 @@
         }
       },
       "kind": "group",
-      "summary": "exec-broker runtime posture — graduate observe→enforce on evidence: enforce-readiness reads the recorded observe window and reports ready | would-block (+ exactly what breaks) | untested (--json, --gate)",
+      "summary": "exec-broker runtime posture — graduate observe→enforce on evidence: enforce-readiness reports ready | would-block (+ what breaks) | untested; enforce does the guided, signed flip (refuses unless ready, --force overrides) (--json, --gate, --force)",
       "x-kit-args-modeled": false,
       "x-kit-mcp": false,
       "x-kit-stability": "experimental"

--- a/contracts/public-surface.json
+++ b/contracts/public-surface.json
@@ -127,6 +127,7 @@
     "baseline",
     "bootstrap",
     "broker",
+    "broker enforce",
     "broker enforce-readiness",
     "check",
     "check verify-attestation",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -714,7 +714,7 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
   broker: {
     handler: cmdBroker,
     stability: "experimental",
-    help: "exec-broker runtime posture — graduate observe→enforce on evidence: enforce-readiness reads the recorded observe window and reports ready | would-block (+ exactly what breaks) | untested (--json, --gate)",
+    help: "exec-broker runtime posture — graduate observe→enforce on evidence: enforce-readiness reports ready | would-block (+ what breaks) | untested; enforce does the guided, signed flip (refuses unless ready, --force overrides) (--json, --gate, --force)",
   },
   pkg: {
     handler: cmdPkg,
@@ -778,6 +778,8 @@ const SUBCOMMAND_HELP: Record<string, string> = {
     "Import a portable bundle on a fresh host — integrity-verify offline, fail-closed on tamper/revoked (authoritative only once the signer is anchored)",
   "broker enforce-readiness":
     "Read the recorded observe window (.kit-audit.jsonl) and report whether it's safe to flip exec-broker to enforce: ready | would-block (+ exactly what breaks) | untested (--gate fails CI on any not-ready verdict)",
+  "broker enforce":
+    "Guided observe→enforce flip: readiness pre-flight (refuses unless ready; --force overrides), set [scope].enforce_runtime = true, re-sign the profile scope, and audit the transition",
   "memory index": "Index ~/.claude transcripts into the SQLite memory store",
   "memory search":
     "Full-text search memory (current project; --global for all; --fresh = recency-aware ranking)",

--- a/src/commands/broker.test.ts
+++ b/src/commands/broker.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { cmdBroker } from "./broker.js";
+import { cmdBroker, enforceGateDecision } from "./broker.js";
+import { loadOrCreateIdentity } from "../identity.js";
+import { loadProfile, PROFILE_FILE } from "../profile/schema.js";
 
 let dir: string;
 let cwd: string;
@@ -130,5 +132,117 @@ describe("cmdBroker enforce-readiness", () => {
     const ok = await cmdBroker();
     assert.equal(ok, false);
     assert.match(logs.join("\n"), /usage: kit broker/);
+  });
+});
+
+describe("enforceGateDecision (pure pre-flight)", () => {
+  const R = (
+    verdict: "ready" | "would-block" | "untested",
+    wouldBlockOps = 0,
+    opsObserved = 0,
+  ) => ({
+    verdict,
+    opsObserved,
+    wouldBlockOps,
+    reasons: [],
+  });
+
+  it("ready → proceed (unforced)", () => {
+    assert.equal(enforceGateDecision(R("ready", 0, 3), false).proceed, true);
+  });
+  it("would-block → refuse unforced, proceed with --force", () => {
+    assert.equal(enforceGateDecision(R("would-block", 2, 5), false).proceed, false);
+    assert.equal(enforceGateDecision(R("would-block", 2, 5), true).proceed, true);
+  });
+  it("untested → refuse unforced, proceed with --force", () => {
+    assert.equal(enforceGateDecision(R("untested"), false).proceed, false);
+    assert.equal(enforceGateDecision(R("untested"), true).proceed, true);
+  });
+});
+
+describe("cmdBroker enforce (guided, signed flip)", () => {
+  let idDir: string;
+  let projDir: string;
+  let cwd0: string;
+  let argv0: string[];
+  let savedId: string | undefined;
+  let logs: string[];
+  let origLog: typeof console.log;
+  let origErr: typeof console.error;
+
+  const SCOPED = `version = 1\n[scope]\negress = ["api.acme.com"]\nfs = ["src"]\n`;
+  const observe = (wouldDeny: string[]) =>
+    JSON.stringify({ operation: "bash", success: true, metadata: { phase: "observe", wouldDeny } });
+
+  beforeEach(() => {
+    idDir = mkdtempSync(join(tmpdir(), "kit-broker-id-"));
+    projDir = mkdtempSync(join(tmpdir(), "kit-broker-enf-"));
+    savedId = process.env.KIT_IDENTITY_DIR;
+    process.env.KIT_IDENTITY_DIR = idDir;
+    loadOrCreateIdentity();
+    writeFileSync(join(projDir, PROFILE_FILE), SCOPED);
+    cwd0 = process.cwd();
+    process.chdir(projDir);
+    argv0 = process.argv;
+    logs = [];
+    origLog = console.log;
+    origErr = console.error;
+    console.log = (...a: unknown[]) => void logs.push(a.join(" "));
+    console.error = (...a: unknown[]) => void logs.push(a.join(" "));
+  });
+
+  afterEach(() => {
+    process.chdir(cwd0);
+    process.argv = argv0;
+    console.log = origLog;
+    console.error = origErr;
+    if (savedId === undefined) delete process.env.KIT_IDENTITY_DIR;
+    else process.env.KIT_IDENTITY_DIR = savedId;
+    rmSync(idDir, { recursive: true, force: true });
+    rmSync(projDir, { recursive: true, force: true });
+  });
+
+  const setArgs = (...sub: string[]): void => {
+    process.argv = ["node", "kit", "broker", ...sub];
+  };
+  const writeAudit = (...lines: string[]): void =>
+    writeFileSync(join(projDir, ".kit-audit.jsonl"), lines.join("\n") + "\n", "utf-8");
+
+  it("refuses when untested (no observe data) without --force; profile unchanged", async () => {
+    setArgs("enforce", "--json");
+    assert.equal(await cmdBroker(), false);
+    const out = JSON.parse(logs.join("\n"));
+    assert.equal(out.enforced, false);
+    assert.equal(out.verdict, "untested");
+    assert.notEqual((await loadProfile(projDir))?.scope?.enforce_runtime, true);
+  });
+
+  it("refuses would-block without --force; profile unchanged", async () => {
+    writeAudit(observe(["egress evil.test not in scope"]));
+    setArgs("enforce");
+    assert.equal(await cmdBroker(), false);
+    assert.notEqual((await loadProfile(projDir))?.scope?.enforce_runtime, true);
+  });
+
+  it("flips + re-signs when ready", async () => {
+    writeAudit(observe([]), observe([]));
+    setArgs("enforce", "--json");
+    assert.equal(await cmdBroker(), true);
+    assert.equal((await loadProfile(projDir))?.scope?.enforce_runtime, true);
+    assert.ok(existsSync(join(projDir, ".kit-profile.sig")), "profile scope re-signed");
+  });
+
+  it("--force flips despite would-block", async () => {
+    writeAudit(observe(["egress evil.test not in scope"]));
+    setArgs("enforce", "--force");
+    assert.equal(await cmdBroker(), true);
+    assert.equal((await loadProfile(projDir))?.scope?.enforce_runtime, true);
+  });
+
+  it("refuses when no [scope] is declared", async () => {
+    writeFileSync(join(projDir, PROFILE_FILE), `version = 1\n`);
+    setArgs("enforce");
+    assert.equal(await cmdBroker(), false);
+    assert.match(logs.join("\n"), /no \[scope\]/);
   });
 });

--- a/src/commands/broker.ts
+++ b/src/commands/broker.ts
@@ -12,10 +12,15 @@
  *   - `enforce-readiness` — read the observe evidence and turn the flip from a leap into a diff:
  *       `ready` (nothing observed would break), `would-block` (+ exactly what breaks), or the
  *       honest `untested` (no observe data — coverage is only what was observed, never a green).
+ *   - `enforce` — the guided flip: run the readiness pre-flight, REFUSE without `--force` unless
+ *       the verdict is `ready` (fail-closed — never silently enable a posture that will break the
+ *       workflow), then set `[scope].enforce_runtime = true`, re-sign the profile scope, and audit
+ *       the transition (`phase: "enforce-enabled"`). The re-sign is why the flip is attributable:
+ *       enforce only takes effect under a valid signature.
  *
- * Reads the recorded audit log only — never executes anything. Deterministic, zero-LLM. The
- * guided `kit broker enforce` flip is a follow-up (E3). `--json` on every subcommand; `--gate`
- * turns a not-`ready` verdict into a non-zero exit for CI.
+ * `enforce-readiness` reads the recorded audit log only — never executes anything. Deterministic,
+ * zero-LLM. `--json` on every subcommand; `enforce-readiness --gate` turns a not-`ready` verdict
+ * into a non-zero exit for CI; `enforce --force` overrides the readiness refusal.
  */
 import { resolve } from "node:path";
 import { readFileSync } from "node:fs";
@@ -26,6 +31,38 @@ import {
   assessEnforceReadiness,
   type EnforceReadiness,
 } from "../exec-broker/enforce-readiness.js";
+
+/**
+ * Pure pre-flight decision for the guided flip: only a `ready` verdict flips unforced. A
+ * `would-block` or `untested` verdict is REFUSED unless `--force` (fail-closed — an operator must
+ * not silently enable a posture the observed evidence says will break, or that has no evidence at
+ * all). Returns whether to proceed + the human reason. Deterministic, no I/O.
+ */
+export function enforceGateDecision(
+  readiness: EnforceReadiness,
+  force: boolean,
+): { proceed: boolean; reason: string } {
+  if (readiness.verdict === "ready") {
+    return {
+      proceed: true,
+      reason: `${readiness.opsObserved} observed op(s), none would be denied`,
+    };
+  }
+  if (force) {
+    return { proceed: true, reason: `forced flip despite '${readiness.verdict}' (--force)` };
+  }
+  if (readiness.verdict === "would-block") {
+    return {
+      proceed: false,
+      reason: `${readiness.wouldBlockOps} of ${readiness.opsObserved} observed op(s) would be denied under enforce — declare them in [scope] and re-sign, or pass --force`,
+    };
+  }
+  return {
+    proceed: false,
+    reason:
+      "no observe evidence yet (untested) — run under observe to gather a clean window first, or pass --force",
+  };
+}
 
 const AUDIT_FILE = ".kit-audit.jsonl";
 
@@ -80,6 +117,107 @@ async function brokerEnforceReadiness(jsonMode: boolean, gate: boolean): Promise
   return gate ? readiness.verdict === "ready" : true;
 }
 
+/** Best-effort audit of the observe→enforce transition (design §2: the posture change is on the
+ *  record). A missing .kit.toml / audit backend must never abort the flip — it already happened. */
+async function auditEnforceTransition(
+  cwd: string,
+  opsObserved: number,
+  forced: boolean,
+): Promise<void> {
+  try {
+    const { loadConfig } = await import("../config.js");
+    const { mergeGovernanceConfigAsync } = await import("../governance.js");
+    const { logAuditEvent } = await import("../audit.js");
+    const cfg = await loadConfig(resolve(cwd, ".kit.toml"));
+    const gov = await mergeGovernanceConfigAsync(cfg.governance);
+    await logAuditEvent(gov, {
+      operation: "broker.enforce",
+      environment: gov.environment,
+      success: true,
+      metadata: { phase: "enforce-enabled", opsObserved, forced },
+    });
+  } catch {
+    /* best-effort — the flip + re-sign are the source of truth, not this log line */
+  }
+}
+
+async function brokerEnforce(jsonMode: boolean, force: boolean): Promise<boolean> {
+  const cwd = process.cwd();
+  const { loadProfile, saveProfile } = await import("../profile/schema.js");
+  const { signProfile } = await import("../profile/sign.js");
+
+  const profile = await loadProfile(cwd);
+  if (!profile?.scope) {
+    const why =
+      "no [scope] to enforce — declare a scope in .kit-profile.toml and `kit profile sign` first";
+    if (jsonMode) console.log(JSON.stringify({ enforced: false, reason: why }, null, 2));
+    else console.error(`${c.red}✗ ${why}${c.reset}`);
+    return false;
+  }
+
+  const readiness = assessEnforceReadiness(parseObserveRecords(readAuditJsonl(cwd)));
+  const decision = enforceGateDecision(readiness, force);
+  if (!decision.proceed) {
+    if (jsonMode) {
+      console.log(
+        JSON.stringify(
+          { enforced: false, verdict: readiness.verdict, reason: decision.reason },
+          null,
+          2,
+        ),
+      );
+    } else {
+      console.error(
+        `${c.red}✗ refusing to flip to enforce${c.reset} ${c.dim}— ${decision.reason}${c.reset}`,
+      );
+      for (const { reason, count } of readiness.reasons) {
+        console.error(`    ${c.yellow}⚠${c.reset} ${c.bold}${count}×${c.reset}  ${reason}`);
+      }
+    }
+    return false;
+  }
+
+  if (profile.scope.enforce_runtime === true) {
+    const msg = "already enforcing ([scope].enforce_runtime = true) — nothing to do";
+    if (jsonMode) console.log(JSON.stringify({ enforced: true, alreadyEnforcing: true }, null, 2));
+    else console.log(`${c.green}✓${c.reset} ${c.dim}${msg}${c.reset}`);
+    return true;
+  }
+
+  // Flip + re-sign: enforce only takes effect under a valid signature, so the transition is
+  // attributable. On a sign failure the scope won't verify → the runtime stays effectively off
+  // (not a silent enforce), and we surface it so the operator re-signs.
+  profile.scope.enforce_runtime = true;
+  await saveProfile(profile, cwd);
+  const sig = await signProfile(cwd);
+  if (!sig.ok) {
+    const why = `set enforce_runtime = true, but re-signing failed (${sig.error}); the scope will not verify until signed — run \`kit profile sign\``;
+    if (jsonMode)
+      console.log(JSON.stringify({ enforced: false, signed: false, reason: why }, null, 2));
+    else console.error(`${c.red}✗ ${why}${c.reset}`);
+    return false;
+  }
+  await auditEnforceTransition(cwd, readiness.opsObserved, force);
+
+  if (jsonMode) {
+    console.log(
+      JSON.stringify(
+        { enforced: true, forced: force, fingerprint: sig.fingerprint, kid: sig.kid },
+        null,
+        2,
+      ),
+    );
+    return true;
+  }
+  console.log(
+    `${c.green}✓ enforce enabled${c.reset} ${c.dim}— ${decision.reason}; scope re-signed (${sig.fingerprint})${c.reset}`,
+  );
+  console.log(
+    `${c.dim}the exec-broker now DENIES declared ops outside [scope]. Commit .kit-profile.toml + .kit-profile.sig.${c.reset}`,
+  );
+  return true;
+}
+
 export async function cmdBroker(): Promise<boolean> {
   // A flag in the subcommand slot (`kit broker --json`) means "no subcommand" → default.
   const rawSub = process.argv[3];
@@ -88,6 +226,11 @@ export async function cmdBroker(): Promise<boolean> {
   if (sub === "enforce-readiness") {
     return await brokerEnforceReadiness(jsonMode, hasFlag(process.argv, "--gate"));
   }
-  console.error(`${c.red}usage: kit broker <enforce-readiness> [--json] [--gate]${c.reset}`);
+  if (sub === "enforce") {
+    return await brokerEnforce(jsonMode, hasFlag(process.argv, "--force"));
+  }
+  console.error(
+    `${c.red}usage: kit broker <enforce-readiness | enforce> [--json] [--gate] [--force]${c.reset}`,
+  );
   return false;
 }


### PR DESCRIPTION
## What

The Pillar 3 capstone (E3) — turns the exec-broker from **observational** to **protective** in one evidence-gated command. Completes the observe→enforce ladder: **E1** (pure readiness core), **E2** (`enforce-readiness` report), **E3** (this — the flip).

`kit broker enforce`:
1. **Readiness pre-flight** (reuses E1/E2): reads the recorded observe window and computes the verdict.
2. **Refuses without `--force` unless `ready`** — fail-closed. It will not silently enable a posture the observed evidence says would break (`would-block`) or one with no evidence at all (`untested`). `--force` overrides, knowingly.
3. On proceed: sets `[scope].enforce_runtime = true`, saves, and **re-signs** the profile scope. The re-sign is what makes the flip attributable — enforce only takes effect under a valid signature.
4. **Audits** the transition (`phase: "enforce-enabled"`).

Behaviour details:
- **Idempotent** when already enforcing (reports, no-op).
- On a **sign failure**, surfaces that the scope won't verify until re-signed — never a silent half-enabled state.
- **Refuses** when no `[scope]` is declared (nothing to enforce).
- Deterministic, zero-LLM. `--json` for machines.

## Why this is the capstone

E1/E2 made the flip *legible* (a diff, not a leap). E3 makes it *safe to perform*: evidence-gated, signed, audited. This is the SkillCamo/ADR-001 lesson made concrete — an off-scope egress a hidden instruction triggers is now **denied**, not just noted — and it's the sharpest GTM line: *governance that protects, proven safe to turn on.*

## Tests

- `enforceGateDecision` (pure): all three verdicts × `force`.
- Integration (real identity + signed profile): `untested`/`would-block` refused unforced with the **profile unchanged**; `ready` flips **and re-signs** (`.kit-profile.sig` written); `--force` flips despite `would-block`; no-`[scope]` refused.
- Registry/subcommand help + OpenCLI/public-surface contracts regenerated. Full suite green (**3024 pass / 0 fail**).

## Follow-up (small)

A `kit doctor` nudge suggesting `kit broker enforce` when observe has a clean window — deferred to keep this PR focused on the command itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)