### PR TITLE
feat(doctor): evidence-based observe→enforce nudge on the exec-broker runtime row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   and audits the transition (`phase: "enforce-enabled"`). On a sign failure it surfaces that the
   scope won't verify until re-signed (never a silent half-enabled state). Completes the
   observe→enforce ladder: `enforce-readiness` (E1/E2) tells you it's safe; `enforce` does it.
-  Deterministic, zero-LLM. `--json` for machines.
+  Deterministic, zero-LLM. `--json` for machines. `kit doctor`'s exec-broker-runtime row now
+  gives an **evidence-based nudge**: in observe with a clean window it points to `kit broker
+enforce`; with would-be denials it points to `kit broker enforce-readiness` to see them first.
 
 - **`kit memory search --fresh` — recency-aware recall (deterministic, zero-LLM).** By default
   recall is bm25 relevance-first (unchanged). `--fresh` fetches a larger candidate pool and

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -379,6 +379,65 @@ describe("runDoctor — keyless credentials row (Pillar 2 tail)", () => {
   });
 });
 
+describe("runDoctor — exec-broker runtime observe→enforce nudge (E3)", () => {
+  let idDir: string;
+  let proj: string;
+  let savedId: string | undefined;
+
+  beforeEach(() => {
+    idDir = mkdtempSync(join(tmpdir(), "kit-id-"));
+    proj = mkdtempSync(join(tmpdir(), "kit-nudge-"));
+    savedId = process.env.KIT_IDENTITY_DIR;
+    process.env.KIT_IDENTITY_DIR = idDir;
+    loadOrCreateIdentity();
+  });
+
+  afterEach(() => {
+    if (savedId === undefined) delete process.env.KIT_IDENTITY_DIR;
+    else process.env.KIT_IDENTITY_DIR = savedId;
+    rmSync(idDir, { recursive: true, force: true });
+    rmSync(proj, { recursive: true, force: true });
+  });
+
+  const observe = (wouldDeny: string[]) =>
+    JSON.stringify({ operation: "bash", success: true, metadata: { phase: "observe", wouldDeny } });
+  const rtRow = async () =>
+    (await runDoctor({}, proj)).checks.find((c) => c.name === "exec-broker runtime");
+
+  async function signedObserveProfile(): Promise<void> {
+    writeFileSync(
+      join(proj, PROFILE_FILE),
+      `version = 1\n[scope]\negress = ["api.acme.com"]\nenforce_runtime = "observe"\n`,
+      "utf-8",
+    );
+    await signProfile(proj);
+  }
+
+  it("a clean observe window nudges to 'kit broker enforce'", async () => {
+    await signedObserveProfile();
+    writeFileSync(join(proj, ".kit-audit.jsonl"), `${observe([])}\n${observe([])}\n`, "utf-8");
+    const row = await rtRow();
+    assert.ok(row);
+    assert.equal(row.status, "warn");
+    assert.match(row.detail, /kit broker enforce/);
+    assert.match(row.detail, /none would be denied/);
+  });
+
+  it("a would-block observe window points to enforce-readiness, not the flip", async () => {
+    await signedObserveProfile();
+    writeFileSync(
+      join(proj, ".kit-audit.jsonl"),
+      `${observe(["egress evil.test not in scope"])}\n`,
+      "utf-8",
+    );
+    const row = await rtRow();
+    assert.ok(row);
+    assert.equal(row.status, "warn");
+    assert.match(row.detail, /enforce-readiness/);
+    assert.doesNotMatch(row.detail, /Safe to graduate/);
+  });
+});
+
 describe("triageGateStatus (pure — pre-commit gate posture)", () => {
   it("pass when both triage gates are wired into the pre-commit hook", () => {
     const hook =

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -306,6 +306,15 @@ async function scopeDegradationStatus(cwd: string): Promise<"warn" | "fail"> {
  *   pass  enforce_runtime set + scope verified — governed MCP ops are mediated against the signed scope
  *   fail  enforce_runtime set + scope unsigned/tampered — opted in but untrustworthy: governed ops fail-closed-denied
  */
+/** Read the recorded audit log for the observe→enforce nudge; "" when absent/unreadable. */
+async function readAuditLog(cwd: string): Promise<string> {
+  try {
+    return await readFile(join(cwd, ".kit-audit.jsonl"), "utf-8");
+  } catch {
+    return "";
+  }
+}
+
 async function checkBrokerRuntime(cwd: string): Promise<DoctorCheck> {
   const name = "exec-broker runtime";
   const category = "security";
@@ -326,14 +335,29 @@ async function checkBrokerRuntime(cwd: string): Promise<DoctorCheck> {
   if (runtimeMode === "observe") {
     // Dry-run: never denies. warn (not pass) — mediation is not actually protecting yet; the point is
     // to read the would-be denials in the audit trail, then graduate to enforce.
-    return {
-      name,
-      status: "warn",
-      detail: policy
-        ? "runtime mediation in OBSERVE mode — gates run but never deny; would-be denials are recorded to the audit trail. Review them, then set enforce_runtime = true"
-        : "runtime OBSERVE mode but the scope is unsigned/invalid — every declared op would be denied under enforce; run 'kit profile sign' before graduating",
-      category,
-    };
+    if (!policy) {
+      return {
+        name,
+        status: "warn",
+        detail:
+          "runtime OBSERVE mode but the scope is unsigned/invalid — every declared op would be denied under enforce; run 'kit profile sign' before graduating",
+        category,
+      };
+    }
+    // Evidence-based nudge (E3): read the recorded observe window and point to the exact next step.
+    const { parseObserveRecords, assessEnforceReadiness } =
+      await import("./exec-broker/enforce-readiness.js");
+    const r = assessEnforceReadiness(parseObserveRecords(await readAuditLog(cwd)));
+    let detail: string;
+    if (r.verdict === "ready") {
+      detail = `runtime in OBSERVE — ${r.opsObserved} op(s) observed, none would be denied. Safe to graduate: run 'kit broker enforce'`;
+    } else if (r.verdict === "would-block") {
+      detail = `runtime in OBSERVE — ${r.wouldBlockOps} of ${r.opsObserved} observed op(s) would be denied under enforce; run 'kit broker enforce-readiness' to see them, then declare in [scope] + re-sign`;
+    } else {
+      detail =
+        "runtime in OBSERVE — gates run but never deny, and no would-be denials are recorded yet. Exercise the workflow, then 'kit broker enforce-readiness' before graduating";
+    }
+    return { name, status: "warn", detail, category };
   }
   if (policy) {
     return {


### PR DESCRIPTION
## What

The small deferred sub-item of E3 (#371) — closes out the observe→enforce adoption work.

When a **signed** scope is in **OBSERVE** mode, `kit doctor`'s `exec-broker runtime` row now reads the recorded observe window (`.kit-audit.jsonl`) and points to the exact next step instead of a generic "set enforce_runtime = true":

- **clean window** (verdict `ready`) → *"…N op(s) observed, none would be denied. Safe to graduate: run `kit broker enforce`"*
- **would-be denials** (`would-block`) → *"…K of N observed op(s) would be denied under enforce; run `kit broker enforce-readiness` to see them, then declare in `[scope]` + re-sign"*
- **no evidence yet** (`untested`) → *"…gates run but never deny, and no would-be denials are recorded yet. Exercise the workflow, then `kit broker enforce-readiness` before graduating"*

Adoption by a gentle, **evidence-based** prompt — not a scary manual TOML edit. Deterministic, zero-LLM (reads the audit log + the signed scope). The unsigned-observe message is unchanged (still says re-sign first).

## Tests

- `doctor.test.ts` — a signed clean-window observe profile nudges to `kit broker enforce`; a would-block window points to `enforce-readiness` and **not** "Safe to graduate".
- Full suite green (**3026 pass / 0 fail**).

With this, the exec-broker observe→enforce ladder (E1–E3 + nudge) is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)