### PR TITLE
chore(release): 5.3.0 — the observe→enforce ladder + recency-aware recall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.3.0] - 2026-07-19
+
 ### Added
 
 - **`kit broker enforce` — the guided observe→enforce flip (Pillar 3 capstone).** Turns the

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -959,7 +959,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.2.0"
+    "version": "5.3.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
## What

Cuts the accumulated `[Unreleased]` work into **5.3.0** so the exec-broker graduation story ships to npm.

- `version` 5.2.0 → 5.3.0 (`package.json` + `package-lock.json`)
- `CHANGELOG.md`: `[Unreleased]` → `[5.3.0] - 2026-07-19` (fresh empty `[Unreleased]` on top)
- `contracts/kit.opencli.json` regenerated from the built surface (version field only)

## Headline capabilities in 5.3.0

- **`kit broker enforce` / `kit broker enforce-readiness`** — the guided, evidence-based, signed **observe→enforce** flip. `enforce-readiness` reads the recorded observe window (`.kit-audit.jsonl`) and reports `ready` / `would-block` (+ the exact would-be denials) / honest `untested`; `enforce` refuses unless `ready` (without `--force`), sets `enforce_runtime = true`, **re-signs** the scope, and audits the transition. Turns the flip from a leap into a diff.
- **`kit doctor` evidence-based nudge** — the exec-broker runtime row points to the exact next step (`enforce` on a clean window / `enforce-readiness` on would-be denials / exercise-then-check when untested).
- **`kit memory search --fresh`** — recency-aware recall that RRF-fuses bm25 relevance + recency by rank (relevance still dominates), plus the memory decision-lifecycle kinds (`idea` / `abandoned`) and provenance/confidence ordering.

Deterministic, zero-LLM throughout. Additive over 5.2 — no stable command removed.

## Verification

- `npm run build` clean; `tsc --noEmit` clean
- Contracts regenerated (opencli version → 5.3.0; public-surface unchanged)
- Full suite green: **3026 pass / 0 fail**

Publishing to npm is a separate manual step after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)