### PR TITLE
feat(coverage): toggleable standards library + OWASP Agentic Top 10 & MCP Top 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`kit coverage` — agent-native standards + a toggleable standards library.** Coverage
+  evidence maps are now a **registry** (single source of truth) instead of a hardcoded pair, and
+  two standards native to kit's own lane land as the first new entries: **OWASP Top 10 for Agentic
+  Applications (2026)** (`--standard=agentic-top10`) and **OWASP MCP Top 10 (2025)**
+  (`--standard=mcp-top10`). `--standard=all` runs every enabled standard; `--list-standards`
+  enumerates the library with on/off state; and `[coverage].standards` in `.kit.toml` is an
+  allow-list that toggles standards on and off (absent ⇒ all on, backwards-compatible). Adding a
+  future standard is one registry entry + its descriptor. Still an **evidence map, never a
+  compliance attestation**; deterministic and zero-LLM. The two new maps are honest about kit's
+  lane — strong on tool-misuse / identity+privilege / supply-chain / memory-poisoning / audit,
+  explicit `gap`/`na` on inter-agent comms, cascading failures, human-trust, and rogue-agent
+  detection. (Control ids/titles confirmed via secondary indexes; owasp.org first-party fetch was
+  HTTP-403 blocked — caveat carried on each descriptor.)
+
 ## [5.3.0] - 2026-07-19
 
 ### Added

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -240,7 +240,7 @@
     },
     "coverage": {
       "kind": "command",
-      "summary": "Evidence map: which standard's controls kit's deterministic checks auto-verify vs gap/manual/n-a — OWASP ASVS L2 (default), OWASP LLM Top 10, or NIST SSDF via --standard=asvs|llm-top10|ssdf (NOT a compliance attestation; --json for GRC tools)",
+      "summary": "Evidence map: which standard's controls kit's deterministic checks auto-verify vs gap/manual/n-a — --standard=asvs|llm-top10|ssdf|agentic-top10|mcp-top10|all (default asvs); --list-standards to enumerate, [coverage].standards to toggle on/off (NOT a compliance attestation; --json for GRC tools)",
       "x-kit-args-modeled": false,
       "x-kit-mcp": false,
       "x-kit-stability": "experimental"

--- a/package-lock.json
+++ b/package-lock.json
@@ -995,9 +995,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1179,18 +1179,20 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -1200,10 +1202,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2137,9 +2152,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -2868,15 +2883,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -610,7 +610,7 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
   coverage: {
     handler: cmdCoverage,
     stability: "experimental",
-    help: "Evidence map: which standard's controls kit's deterministic checks auto-verify vs gap/manual/n-a — OWASP ASVS L2 (default), OWASP LLM Top 10, or NIST SSDF via --standard=asvs|llm-top10|ssdf (NOT a compliance attestation; --json for GRC tools)",
+    help: "Evidence map: which standard's controls kit's deterministic checks auto-verify vs gap/manual/n-a — --standard=asvs|llm-top10|ssdf|agentic-top10|mcp-top10|all (default asvs); --list-standards to enumerate, [coverage].standards to toggle on/off (NOT a compliance attestation; --json for GRC tools)",
   },
   identity: {
     handler: cmdIdentity,

--- a/src/commands/coverage.test.ts
+++ b/src/commands/coverage.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cmdCoverage } from "./coverage.js";
+
+let dir: string;
+let cwd0: string;
+let argv0: string[];
+let logs: string[];
+let origLog: typeof console.log;
+let origErr: typeof console.error;
+let exitCode0: typeof process.exitCode;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "kit-coverage-cmd-"));
+  cwd0 = process.cwd();
+  process.chdir(dir);
+  argv0 = process.argv;
+  exitCode0 = process.exitCode;
+  logs = [];
+  origLog = console.log;
+  origErr = console.error;
+  console.log = (...a: unknown[]) => void logs.push(a.join(" "));
+  console.error = (...a: unknown[]) => void logs.push(a.join(" "));
+});
+
+afterEach(() => {
+  process.chdir(cwd0);
+  process.argv = argv0;
+  process.exitCode = exitCode0;
+  console.log = origLog;
+  console.error = origErr;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const setArgs = (...flags: string[]): void => {
+  process.argv = ["node", "kit", "coverage", ...flags];
+};
+const out = (): string => logs.join("\n");
+
+describe("kit coverage — registry-driven standards", () => {
+  it("--list-standards enumerates all five, marked on by default", async () => {
+    setArgs("--list-standards");
+    assert.equal(await cmdCoverage(), true);
+    const text = out();
+    for (const key of ["asvs", "llm-top10", "ssdf", "agentic-top10", "mcp-top10"]) {
+      assert.match(text, new RegExp(key), `lists ${key}`);
+    }
+    assert.match(text, /on /); // no toggle ⇒ enabled
+  });
+
+  it("--standard=agentic-top10 renders the OWASP Agentic map (ASI01)", async () => {
+    setArgs("--standard=agentic-top10");
+    assert.equal(await cmdCoverage(), true);
+    const text = out();
+    assert.match(text, /Agentic Applications/);
+    assert.match(text, /ASI01/);
+    assert.match(text, /evidence map, not a compliance attestation/i);
+  });
+
+  it("--standard=mcp-top10 --json emits a structured MCP report", async () => {
+    setArgs("--standard=mcp-top10", "--json");
+    assert.equal(await cmdCoverage(), true);
+    const report = JSON.parse(out());
+    assert.equal(report.key, "mcp-top10");
+    assert.equal(report.summary.total, 10);
+  });
+
+  it("--standard=all --json keys the output by every enabled standard", async () => {
+    setArgs("--standard=all", "--json");
+    assert.equal(await cmdCoverage(), true);
+    const obj = JSON.parse(out());
+    for (const key of ["asvs", "llm-top10", "ssdf", "agentic-top10", "mcp-top10"]) {
+      assert.ok(key in obj, `all-report includes ${key}`);
+    }
+  });
+
+  it("an unknown --standard fails and lists the valid keys", async () => {
+    setArgs("--standard=bogus");
+    assert.equal(await cmdCoverage(), false);
+    assert.match(out(), /unknown --standard 'bogus'/);
+    assert.match(out(), /agentic-top10/);
+  });
+
+  it("[coverage].standards toggles a standard off → selecting it fails", async () => {
+    writeFileSync(join(dir, ".kit.toml"), `[coverage]\nstandards = ["asvs"]\n`, "utf-8");
+    setArgs("--standard=mcp-top10");
+    assert.equal(await cmdCoverage(), false);
+    assert.match(out(), /disabled in \[coverage\]\.standards/);
+  });
+
+  it("[coverage].standards toggle → --list-standards marks the excluded ones off", async () => {
+    writeFileSync(join(dir, ".kit.toml"), `[coverage]\nstandards = ["asvs"]\n`, "utf-8");
+    setArgs("--list-standards");
+    assert.equal(await cmdCoverage(), true);
+    // strip ANSI so the on/off tag matches regardless of color codes
+    const text = out().replace(/\x1B\[[0-9;]*m/g, "");
+    // asvs on, mcp-top10 off
+    assert.match(text, /on\s+asvs/);
+    assert.match(text, /off\s+mcp-top10/);
+  });
+});

--- a/src/commands/coverage.ts
+++ b/src/commands/coverage.ts
@@ -13,8 +13,16 @@ import { analyzeRepo, renderClaudeMd, renderRulesMd } from "../analyze.js";
 import { resolveKitRoot, runSelfAudit, SELF_AUDIT_RULES } from "../self-audit.js";
 import { buildCoverageReport, formatCoverageText, type Bucket } from "../coverage/coverage.js";
 import { buildStandardReport, formatStandardText } from "../coverage/standard.js";
-import { OWASP_LLM_TOP10 } from "../coverage/owasp-llm-top10.js";
-import { SSDF_218A } from "../coverage/ssdf-218a.js";
+import {
+  COVERAGE_STANDARDS,
+  COVERAGE_STANDARD_KEYS,
+  getCoverageStandard,
+  enabledCoverageStandards,
+  isCoverageStandardEnabled,
+  type CoverageStandard,
+} from "../coverage/registry.js";
+import { loadConfig } from "../config.js";
+import { resolveConfigPath } from "../cli-shared.js";
 import {
   type CiFormat,
   type JsonCheck,
@@ -243,32 +251,66 @@ export async function cmdCoverage(): Promise<boolean> {
     return `${tint}${label}${c.reset}`;
   };
 
-  // --standard selects which pinned standard to map against (default ASVS, the
-  // original path). llm-top10 / ssdf route through the generic evidence-map engine.
-  const standard = args.find((a) => a.startsWith("--standard="))?.split("=")[1] ?? "asvs";
-  const STANDARDS = { "llm-top10": OWASP_LLM_TOP10, ssdf: SSDF_218A } as const;
-  if (standard !== "asvs") {
-    const descriptor = STANDARDS[standard as keyof typeof STANDARDS];
-    if (!descriptor) {
-      console.error(
-        `${c.red}unknown --standard '${standard}' (use: asvs | llm-top10 | ssdf)${c.reset}`,
-      );
-      process.exitCode = 1;
-      return false;
+  // Standards come from the registry (single source of truth). The optional
+  // [coverage].standards allow-list in .kit.toml toggles which are enabled;
+  // absent/empty ⇒ all on (backwards-compatible).
+  const config = await loadConfig(resolveConfigPath()).catch(() => undefined);
+  const configStandards = config?.coverage?.standards;
+
+  // --list-standards: enumerate the registry (with on/off per the toggle) and exit.
+  if (hasFlag(args, "--list-standards")) {
+    for (const s of COVERAGE_STANDARDS) {
+      const on = isCoverageStandardEnabled(s.key, configStandards);
+      const tag = on ? `${c.green}on ${c.reset}` : `${c.dim}off${c.reset}`;
+      console.log(`${tag} ${s.key.padEnd(14)} ${s.label} (${s.version})`);
     }
-    const stdReport = buildStandardReport(descriptor, results);
-    console.log(
-      jsonMode ? JSON.stringify(stdReport, null, 2) : formatStandardText(stdReport, colorBucket),
-    );
     return true;
   }
 
-  const report = buildCoverageReport(results);
-  if (jsonMode) {
-    console.log(JSON.stringify(report, null, 2));
+  // Render one standard: asvs uses the legacy report; descriptors use the engine.
+  const renderOne = (std: CoverageStandard): { text: string; json: unknown } => {
+    if (std.kind === "asvs") {
+      const report = buildCoverageReport(results);
+      return { text: formatCoverageText(report, colorBucket), json: report };
+    }
+    const report = buildStandardReport(std.descriptor!, results);
+    return { text: formatStandardText(report, colorBucket), json: report };
+  };
+
+  // --standard selects the pinned standard (default asvs). "all" runs every
+  // standard enabled by [coverage].standards.
+  const standard = args.find((a) => a.startsWith("--standard="))?.split("=")[1] ?? "asvs";
+
+  if (standard === "all") {
+    const enabled = enabledCoverageStandards(configStandards);
+    if (jsonMode) {
+      const out: Record<string, unknown> = {};
+      for (const s of enabled) out[s.key] = renderOne(s).json;
+      console.log(JSON.stringify(out, null, 2));
+    } else {
+      console.log(enabled.map((s) => renderOne(s).text).join("\n\n"));
+    }
     return true;
   }
-  console.log(formatCoverageText(report, colorBucket));
+
+  const std = getCoverageStandard(standard);
+  if (!std) {
+    console.error(
+      `${c.red}unknown --standard '${standard}' (use: ${COVERAGE_STANDARD_KEYS.join(" | ")} | all)${c.reset}`,
+    );
+    process.exitCode = 1;
+    return false;
+  }
+  if (!isCoverageStandardEnabled(standard, configStandards)) {
+    console.error(
+      `${c.red}--standard '${standard}' is disabled in [coverage].standards (enable it there or drop the allow-list)${c.reset}`,
+    );
+    process.exitCode = 1;
+    return false;
+  }
+
+  const one = renderOne(std);
+  console.log(jsonMode ? JSON.stringify(one.json, null, 2) : one.text);
   return true;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -394,6 +394,11 @@ export interface kitConfig {
    *  ONLY on a triage PASS (never on fail/offline). Stays off by default because
    *  auto-installing is a deliberate trust decision. */
   update?: { check?: boolean; auto?: boolean };
+  /** `kit coverage` — evidence-map standards toggle. `[coverage].standards` is an
+   *  allow-list of standard keys (asvs, llm-top10, ssdf, agentic-top10, mcp-top10)
+   *  that `--standard=all` runs and `--list-standards` marks enabled; absent/empty
+   *  ⇒ all registered standards are on. */
+  coverage?: { standards?: string[] };
   /** `kit standards` — the deterministic dev-standards gate. `enforce` (default
    *  false): net-new findings AND setup gaps FAIL (CI opts in; also via --enforce).
    *  `[standards.general]` overrides the calibrated metric thresholds. */
@@ -755,6 +760,12 @@ export const kitConfigSchema = z
       .object({
         check: z.boolean().optional(),
         auto: z.boolean().optional(),
+      })
+      .passthrough()
+      .optional(),
+    coverage: z
+      .object({
+        standards: z.array(z.string()).optional(),
       })
       .passthrough()
       .optional(),

--- a/src/coverage/owasp-agentic-top10.ts
+++ b/src/coverage/owasp-agentic-top10.ts
@@ -1,0 +1,108 @@
+/**
+ * Vendored, pinned OWASP Top 10 for Agentic Applications (2026) as a kit coverage
+ * evidence map. Same honesty rule as the ASVS / LLM-Top10 / MCP-Top10 maps: kit
+ * maps ONLY what its deterministic, local, zero-LLM checks can actually speak to,
+ * and buckets each risk honestly (auto / gap / manual / na). This is an EVIDENCE
+ * source, not a compliance attestation.
+ *
+ * This is the standard native to kit's own lane (agent runtime governance), so the
+ * map is deliberately honest about where kit is strong (tool-misuse, identity/
+ * privilege, supply chain, memory poisoning, audit) and where it structurally does
+ * NOT reach (inter-agent comms, cascading failures, human-trust exploitation,
+ * rogue-agent detection).
+ *
+ * Control ids/titles confirmed against multiple secondary indexes (owasp.org /
+ * genai.owasp.org first-party fetch returned HTTP 403 in this environment). See
+ * the `caveat`.
+ *
+ * Source: OWASP Top 10 for Agentic Applications (2026), OWASP GenAI Security Project.
+ *   - https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/
+ */
+import type { StandardDescriptor } from "./standard.js";
+
+const SECTION = "OWASP Top 10 for Agentic Applications (2026)";
+
+export const OWASP_AGENTIC_TOP10: StandardDescriptor = {
+  key: "agentic-top10",
+  label: "OWASP Top 10 for Agentic Applications",
+  version: "2026",
+  source: "OWASP Top 10 for Agentic Applications 2026 (OWASP GenAI Security Project)",
+  sourceUrl: "https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/",
+  unit: "risk",
+  caveat:
+    "Ids/titles confirmed via secondary indexes (owasp.org/genai.owasp.org first-party fetch was HTTP-403 blocked), not per-page verified; the ASI ordering is as reported and may differ from the final print.",
+  requirements: [
+    { id: "ASI01", section: SECTION, text: "Agent Goal Hijack" },
+    { id: "ASI02", section: SECTION, text: "Tool Misuse & Exploitation" },
+    { id: "ASI03", section: SECTION, text: "Identity & Privilege Abuse" },
+    { id: "ASI04", section: SECTION, text: "Agentic Supply Chain Vulnerabilities" },
+    { id: "ASI05", section: SECTION, text: "Unexpected Code Execution (RCE)" },
+    { id: "ASI06", section: SECTION, text: "Memory & Context Poisoning" },
+    { id: "ASI07", section: SECTION, text: "Insecure Inter-Agent Communication" },
+    { id: "ASI08", section: SECTION, text: "Cascading Failures" },
+    { id: "ASI09", section: SECTION, text: "Human-Agent Trust Exploitation" },
+    { id: "ASI10", section: SECTION, text: "Rogue Agents" },
+  ],
+  mapping: {
+    ASI01: {
+      bucket: "auto",
+      checks: ["memory injection", "R7", "kit triage mcp"],
+      rationale:
+        "kit quarantines high-confidence prompt-injection at memory capture (R7) and statically flags tool-metadata poisoning that would redirect goals; it does not claim to stop goal hijack reasoned inside the model.",
+    },
+    ASI02: {
+      bucket: "auto",
+      checks: ["gate-bash", "gate-egress", "gate-fs", "broker enforce", "agent-audit"],
+      rationale:
+        "Tool misuse is exactly the exec-broker's job: the signed scope denies off-scope egress/fs and dangerous exec at the tool boundary, observe→enforce graduates it, and mutating MCP tools are governed — deny-by-default with the reason returned to the agent.",
+    },
+    ASI03: {
+      bucket: "auto",
+      checks: ["kit secrets", "gate-env", "signed scope", "keyless egress"],
+      rationale:
+        "kit keeps credentials in the vault and out of the agent loop, signs least-privilege scope, and uses keyless (RFC 9421) egress so a leaked static token cannot over-operate — directly the identity/privilege-abuse risk.",
+    },
+    ASI04: {
+      bucket: "auto",
+      checks: ["supply-chain", "kit slopsquat", "kit triage", "pinned versions", "sbom"],
+      rationale:
+        "kit gates un-triaged installs, scores slopsquat risk, triages skills/MCP/plugins/repos, verifies pinned/locked deps, and emits an agent-toolchain SBOM — the agentic supply-chain surface.",
+    },
+    ASI05: {
+      bucket: "auto",
+      checks: ["gate-bash", "install-gate"],
+      rationale:
+        "Narrow slice: kit denies dangerous/un-triaged command and install execution the agent attempts (deny-by-default gates). RCE reachable through the target application's own code is outside kit's local static scope.",
+    },
+    ASI06: {
+      bucket: "auto",
+      checks: ["memory write-gate", "memory injection", "verified-forget"],
+      rationale:
+        "kit's strongest coverage: a capture-time write-gate rejects/quarantines poisoned memory rows, R7 strips injection on the recall path, and verified-forget proves removal — agent memory/context poisoning head-on.",
+    },
+    ASI07: {
+      bucket: "gap",
+      checks: [],
+      rationale:
+        "kit governs a single agent's tool calls; an off-scope agent-to-agent call would be seen by the egress gate, but kit has no inter-agent-protocol (A2A) integrity/authentication check.",
+    },
+    ASI08: {
+      bucket: "gap",
+      checks: [],
+      rationale:
+        "kit's fail-closed posture and observe→enforce limit blast radius, but there is no deterministic cascade/blast-radius or circuit-breaker control for multi-step/multi-agent failure propagation.",
+    },
+    ASI09: {
+      bucket: "na",
+      checks: [],
+      rationale:
+        "Exploiting the human's trust in the agent is a social/technical vector outside kit's local, static, zero-LLM scope; kit governs machine actions, not human decisions.",
+    },
+    ASI10: {
+      bucket: "gap",
+      checks: ["kit audit", "kit identity", "kit panic"],
+      rationale:
+        "kit gives attribution and response for a compromised agent — signed identity + hash-chained audit + panic (rotate identity, emit signed revocation) — but has no deterministic rogue-agent DETECTION; containment is post-hoc, not prevention.",
+    },
+  },
+};

--- a/src/coverage/owasp-mcp-top10.ts
+++ b/src/coverage/owasp-mcp-top10.ts
@@ -1,0 +1,104 @@
+/**
+ * Vendored, pinned OWASP MCP Top 10 (2025) as a kit coverage evidence map. Same
+ * honesty rule as the ASVS / LLM-Top10 maps: kit maps ONLY what its deterministic,
+ * local, zero-LLM checks can actually speak to, and buckets each risk honestly
+ * (auto / gap / manual / na). This is an EVIDENCE source, not a compliance
+ * attestation.
+ *
+ * Control ids/titles were confirmed against multiple secondary indexes (owasp.org
+ * first-party fetch returned HTTP 403 in this environment, as with the LLM-Top10
+ * map). MCP06's title varies across sources ("Intent Flow Subversion" vs "Prompt
+ * Injection via Contextual Payloads"); the OWASP designation used here is the
+ * former. See the `caveat`.
+ *
+ * Source: OWASP MCP Top 10 (2025), OWASP Foundation (project lead V. Verma Sehgal).
+ *   - https://owasp.org/www-project-mcp-top-10/
+ */
+import type { StandardDescriptor } from "./standard.js";
+
+const SECTION = "OWASP MCP Top 10 (2025)";
+
+export const OWASP_MCP_TOP10: StandardDescriptor = {
+  key: "mcp-top10",
+  label: "OWASP MCP Top 10",
+  version: "2025",
+  source: "OWASP MCP Top 10 (2025), OWASP Foundation",
+  sourceUrl: "https://owasp.org/www-project-mcp-top-10/",
+  unit: "risk",
+  caveat:
+    "Titles confirmed via secondary indexes (owasp.org first-party fetch was HTTP-403 blocked), not per-page verified; MCP06's title varies by source (Intent Flow Subversion / Prompt Injection via Contextual Payloads).",
+  requirements: [
+    { id: "MCP01:2025", section: SECTION, text: "Token Mismanagement & Secret Exposure" },
+    { id: "MCP02:2025", section: SECTION, text: "Privilege Escalation via Scope Creep" },
+    { id: "MCP03:2025", section: SECTION, text: "Tool Poisoning" },
+    { id: "MCP04:2025", section: SECTION, text: "Software Supply Chain Attacks & Dependency Tampering" },
+    { id: "MCP05:2025", section: SECTION, text: "Command Injection & Execution" },
+    { id: "MCP06:2025", section: SECTION, text: "Intent Flow Subversion" },
+    { id: "MCP07:2025", section: SECTION, text: "Insufficient Authentication & Authorization" },
+    { id: "MCP08:2025", section: SECTION, text: "Lack of Audit and Telemetry" },
+    { id: "MCP09:2025", section: SECTION, text: "Shadow MCP Servers" },
+    { id: "MCP10:2025", section: SECTION, text: "Context Injection & Over-Sharing" },
+  ],
+  mapping: {
+    "MCP01:2025": {
+      bucket: "auto",
+      checks: ["secrets scan", "gate-env", "scan-transcripts", "kit secrets"],
+      rationale:
+        "kit keeps credentials in the vault and out of the agent loop, blocks secret writes to .env (gate-env), and scans transcripts/caches for leaked tokens — directly the token-mismanagement/secret-exposure risk.",
+    },
+    "MCP02:2025": {
+      bucket: "auto",
+      checks: ["gate-egress", "gate-fs", "signed scope", "kit profile", "broker enforce"],
+      rationale:
+        "The signed [scope] is least-privilege by construction: the exec-broker denies off-scope egress/fs/secret access, profile reconciliation flags declared-vs-discovered drift, and observe→enforce graduates enforcement — scope creep is exactly what this gates.",
+    },
+    "MCP03:2025": {
+      bucket: "auto",
+      checks: ["kit triage mcp"],
+      rationale:
+        "kit triage mcp statically flags tool-metadata poisoning (malicious instructions hidden in tool descriptions/parameter schemas/return values) and rug-pull drift — the tool-poisoning vector head-on.",
+    },
+    "MCP04:2025": {
+      bucket: "auto",
+      checks: ["supply-chain", "kit slopsquat", "kit triage mcp", "pinned versions", "sbom"],
+      rationale:
+        "kit gates un-triaged installs, scores slopsquat/typosquat risk (incl. fake 'official' connectors), triages MCP packages, verifies pinned/locked deps, and inventories the agent toolchain in the SBOM.",
+    },
+    "MCP05:2025": {
+      bucket: "auto",
+      checks: ["gate-bash", "agent-audit"],
+      rationale:
+        "Narrow slice: kit denies dangerous/un-triaged command execution the agent attempts (gate-bash, deny-by-default) at the tool boundary. Command-injection flaws inside an MCP server's own code are outside kit's local static reach.",
+    },
+    "MCP06:2025": {
+      bucket: "auto",
+      checks: ["kit triage mcp", "memory injection", "R7"],
+      rationale:
+        "kit statically flags injected instructions in MCP tool descriptions and quarantines high-confidence injection on its own recall/inject path (R7). It does not claim to stop intent subversion inside the model.",
+    },
+    "MCP07:2025": {
+      bucket: "gap",
+      checks: [],
+      rationale:
+        "kit authorizes the AGENT's use of MCP tools via the signed scope (client-side), and triage can surface a server missing auth, but kit does not run the MCP server and has no enforcement of server-side client authentication/authorization.",
+    },
+    "MCP08:2025": {
+      bucket: "auto",
+      checks: ["kit audit", "broker observe"],
+      rationale:
+        "kit records tool-call decisions to a tamper-evident, hash-chained audit log (incl. observe-mode would-deny events) — directly the audit/telemetry the risk says is missing; it is fail-closed (a check that can't record fails).",
+    },
+    "MCP09:2025": {
+      bucket: "auto",
+      checks: ["kit profile", "sbom", "kit triage mcp"],
+      rationale:
+        "kit profile discovery + toolchain SBOM inventory the MCP servers actually present and reconcile them against the declared set — an undeclared ('shadow') MCP server surfaces as declared-vs-discovered drift.",
+    },
+    "MCP10:2025": {
+      bucket: "gap",
+      checks: ["R7", "scan-transcripts"],
+      rationale:
+        "kit sanitizes its OWN recall/inject path and keeps secrets out of context, but has no check for cross-session context over-sharing or persistence inside the MCP layer itself.",
+    },
+  },
+};

--- a/src/coverage/registry.test.ts
+++ b/src/coverage/registry.test.ts
@@ -1,0 +1,68 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  COVERAGE_STANDARDS,
+  COVERAGE_STANDARD_KEYS,
+  getCoverageStandard,
+  enabledCoverageStandards,
+  isCoverageStandardEnabled,
+} from "./registry.js";
+
+describe("coverage standards registry", () => {
+  it("registers the expected standards, asvs first (the default)", () => {
+    assert.deepEqual(
+      [...COVERAGE_STANDARD_KEYS],
+      ["asvs", "llm-top10", "ssdf", "agentic-top10", "mcp-top10"],
+    );
+    assert.equal(COVERAGE_STANDARDS[0]?.key, "asvs");
+  });
+
+  it("asvs is the legacy kind (no descriptor); the rest carry a descriptor", () => {
+    for (const s of COVERAGE_STANDARDS) {
+      if (s.key === "asvs") {
+        assert.equal(s.kind, "asvs");
+        assert.equal(s.descriptor, undefined);
+      } else {
+        assert.equal(s.kind, "descriptor");
+        assert.ok(s.descriptor, `${s.key} must carry a descriptor`);
+        assert.equal(s.descriptor?.key, s.key, "registry key matches descriptor key");
+      }
+      assert.ok(s.label && s.version, `${s.key} has label + version`);
+    }
+  });
+
+  it("the two new agent-native standards each map exactly 10 controls", () => {
+    for (const key of ["agentic-top10", "mcp-top10"]) {
+      const d = getCoverageStandard(key)?.descriptor;
+      assert.ok(d, `${key} present`);
+      assert.equal(d?.requirements.length, 10, `${key} has 10 requirements`);
+      assert.equal(
+        Object.keys(d?.mapping ?? {}).length,
+        10,
+        `${key} maps all 10`,
+      );
+    }
+  });
+
+  it("getCoverageStandard resolves known keys and rejects unknown", () => {
+    assert.equal(getCoverageStandard("mcp-top10")?.key, "mcp-top10");
+    assert.equal(getCoverageStandard("nope"), undefined);
+  });
+
+  it("no toggle ⇒ everything enabled (backwards-compatible)", () => {
+    assert.equal(enabledCoverageStandards().length, COVERAGE_STANDARDS.length);
+    assert.equal(enabledCoverageStandards([]).length, COVERAGE_STANDARDS.length);
+    assert.equal(isCoverageStandardEnabled("agentic-top10"), true);
+    assert.equal(isCoverageStandardEnabled("agentic-top10", []), true);
+  });
+
+  it("allow-list toggles standards on/off, in registry order", () => {
+    const enabled = enabledCoverageStandards(["mcp-top10", "asvs"]);
+    assert.deepEqual(
+      enabled.map((s) => s.key),
+      ["asvs", "mcp-top10"], // registry order, not config order
+    );
+    assert.equal(isCoverageStandardEnabled("asvs", ["mcp-top10", "asvs"]), true);
+    assert.equal(isCoverageStandardEnabled("llm-top10", ["mcp-top10", "asvs"]), false);
+  });
+});

--- a/src/coverage/registry.ts
+++ b/src/coverage/registry.ts
@@ -1,0 +1,72 @@
+/**
+ * Coverage-standards registry — the single source of truth for which pinned
+ * standards `kit coverage` can map against. Adding a new standard is one entry
+ * here (plus its descriptor file); the CLI, `--list-standards`, `--standard=all`,
+ * and the `[coverage].standards` on/off toggle all derive from this list.
+ *
+ * ASVS is the original path (its own `buildCoverageReport`); every other standard
+ * routes through the generic `buildStandardReport` engine via a `StandardDescriptor`.
+ */
+import type { StandardDescriptor } from "./standard.js";
+import { ASVS_VERSION } from "./asvs-l2.js";
+import { OWASP_LLM_TOP10 } from "./owasp-llm-top10.js";
+import { SSDF_218A } from "./ssdf-218a.js";
+import { OWASP_AGENTIC_TOP10 } from "./owasp-agentic-top10.js";
+import { OWASP_MCP_TOP10 } from "./owasp-mcp-top10.js";
+
+export interface CoverageStandard {
+  /** CLI selector, e.g. "asvs" | "llm-top10" | "agentic-top10". */
+  key: string;
+  /** Human label for --list-standards. */
+  label: string;
+  /** Pinned version string. */
+  version: string;
+  /** 'asvs' → legacy buildCoverageReport path; 'descriptor' → generic engine. */
+  kind: "asvs" | "descriptor";
+  /** Present iff kind === 'descriptor'. */
+  descriptor?: StandardDescriptor;
+}
+
+const fromDescriptor = (d: StandardDescriptor): CoverageStandard => ({
+  key: d.key,
+  label: d.label,
+  version: d.version,
+  kind: "descriptor",
+  descriptor: d,
+});
+
+/** All registered standards, in display order. ASVS stays first (the default). */
+export const COVERAGE_STANDARDS: readonly CoverageStandard[] = [
+  { key: "asvs", label: "OWASP ASVS (L2 subset)", version: ASVS_VERSION, kind: "asvs" },
+  fromDescriptor(OWASP_LLM_TOP10),
+  fromDescriptor(SSDF_218A),
+  fromDescriptor(OWASP_AGENTIC_TOP10),
+  fromDescriptor(OWASP_MCP_TOP10),
+];
+
+export const COVERAGE_STANDARD_KEYS: readonly string[] = COVERAGE_STANDARDS.map((s) => s.key);
+
+export function getCoverageStandard(key: string): CoverageStandard | undefined {
+  return COVERAGE_STANDARDS.find((s) => s.key === key);
+}
+
+/**
+ * Resolve which standards are enabled given the optional `[coverage].standards`
+ * allow-list from .kit.toml. Absent or empty ⇒ every registered standard is
+ * enabled (backwards-compatible). Unknown keys in the config are ignored here
+ * (the caller may warn). Order follows the registry, not the config.
+ */
+export function enabledCoverageStandards(configStandards?: readonly string[]): CoverageStandard[] {
+  if (!configStandards || configStandards.length === 0) return [...COVERAGE_STANDARDS];
+  const allow = new Set(configStandards);
+  return COVERAGE_STANDARDS.filter((s) => allow.has(s.key));
+}
+
+/** Is `key` enabled under the given config toggle? Empty/absent config ⇒ all on. */
+export function isCoverageStandardEnabled(
+  key: string,
+  configStandards?: readonly string[],
+): boolean {
+  if (!configStandards || configStandards.length === 0) return true;
+  return configStandards.includes(key);
+}

--- a/src/coverage/standard.test.ts
+++ b/src/coverage/standard.test.ts
@@ -8,10 +8,17 @@ import {
 } from "./standard.js";
 import { OWASP_LLM_TOP10 } from "./owasp-llm-top10.js";
 import { SSDF_218A } from "./ssdf-218a.js";
+import { OWASP_AGENTIC_TOP10 } from "./owasp-agentic-top10.js";
+import { OWASP_MCP_TOP10 } from "./owasp-mcp-top10.js";
 import type { SecurityCheckResult } from "../check-security.js";
 
 const VALID_BUCKETS = ["auto", "gap", "manual", "na"];
-const DESCRIPTORS: StandardDescriptor[] = [OWASP_LLM_TOP10, SSDF_218A];
+const DESCRIPTORS: StandardDescriptor[] = [
+  OWASP_LLM_TOP10,
+  SSDF_218A,
+  OWASP_AGENTIC_TOP10,
+  OWASP_MCP_TOP10,
+];
 
 for (const d of DESCRIPTORS) {
   describe(`standard mapping — ${d.key}`, () => {


### PR DESCRIPTION
## What

Turns `kit coverage`'s evidence-map standards into a **registry** (single source of truth) instead of a hardcoded pair, and adds the two standards native to kit's own lane as the first new library entries.

- **`src/coverage/registry.ts`** — the SoT. Adding a future standard is **one entry + a descriptor file**; the CLI, `--list-standards`, `--standard=all`, and the `[coverage].standards` toggle all derive from it.
- **`owasp-agentic-top10.ts`** (ASI01–ASI10, OWASP Top 10 for Agentic Applications 2026) and **`owasp-mcp-top10.ts`** (MCP01–MCP10, OWASP MCP Top 10 2025) — mapped honestly to kit's real checks: strong on tool-misuse / identity+privilege / supply-chain / memory-poisoning / audit; explicit `gap`/`na` on inter-agent comms, cascading failures, human-trust, and rogue-agent detection.

## New surface

- `kit coverage --standard=asvs|llm-top10|ssdf|agentic-top10|mcp-top10|all`
- `kit coverage --list-standards` — lists the library with on/off state
- `[coverage].standards` in `.kit.toml` — allow-list that toggles standards on/off (absent ⇒ all on, backwards-compatible); selecting a disabled one fails closed

Still an **evidence map, never a compliance attestation**; deterministic + zero-LLM.

## Honesty

Control ids/titles were confirmed via secondary indexes — **owasp.org first-party fetch was HTTP-403 blocked in the build environment** — so each descriptor carries an explicit `caveat` (same discipline as the existing LLM-Top10 map). The maps deliberately mark what kit does **not** reach.

## Tests / verification

- Full standard battery (mapping completeness, valid buckets, AUTO-cites-a-check, determinism, disclaimer) now runs over the two new maps; new `registry.test.ts` (toggle logic) + `commands/coverage.test.ts` (list / all / single / unknown / config-toggle).
- `tsc --noEmit` clean; eslint 0 errors; opencli contract regenerated; ASVS version resolves from source (4.0.3).
- Full suite green — 3053/3053 once two unrelated MCP/self-audit **timeout flakes** (under `--test-concurrency=2` load) are re-run in isolation (both pass 2/2 and 4/4; this change touches neither MCP nor self-audit).

Additive over 5.3 (Unreleased); no stable command removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)