### PR TITLE
chore(release): 5.4.0 — coverage/scanner libraries, memory aging & disclosure, MCP checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`kit memory` rule aging — surface stale machine-origin rules for review, never auto-drop (B2).**
+  Curated shared-tier rules now carry a deterministic **aging class**: only `derived`/`inferred`
+  *active* rules age (fresh < 180d ≤ aging < 360d ≤ stale); an **operator's explicit rule is
+  foundational and never ages** (the human owns its relevance), and superseded/reversed entries are
+  history. `kit memory areas` prints an aging nudge when machine-origin rules go stale; `kit memory
+  area <name>` badges each entry and takes `--stale` to show only aged-out rules for review (JSON
+  carries the `aging` field). kit never deletes — it flags for re-affirm/supersede. Pure core
+  (`classifyAging` / `agingReport`), unit-tested; deterministic, zero-LLM.
+
 - **`kit scan` delegate library — connect what kit shouldn't rebuild, toggleable.** The external
   scanner registry (snyk/trivy/grype/semgrep/osv-scanner/socket) is now a **toggleable delegate
   library**, mirroring the coverage-standards registry: `kit scan --list-delegates` enumerates it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.4.0] - 2026-07-21
+
 ### Added
 
 - **`kit triage mcp` — MCP-Security-Checklist static checks (borrowed from SlowMist/OWASP MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`kit scan` delegate library — connect what kit shouldn't rebuild, toggleable.** The external
+  scanner registry (snyk/trivy/grype/semgrep/osv-scanner/socket) is now a **toggleable delegate
+  library**, mirroring the coverage-standards registry: `kit scan --list-delegates` enumerates it
+  with on/off state, and `[scan].delegates` in `.kit.toml` is an allow-list that picks which
+  scanners run (absent/empty ⇒ all on, backwards-compatible). The principle it encodes: **kit
+  delegates *detection* to best-of-breed tools, never its *verdict*** — findings still merge into
+  one deterministic, fail-closed result. `enabledScanners` / `isScannerEnabled` / `SCANNER_IDS`
+  are exported + unit-tested.
+
 - **`kit coverage` — agent-native standards + a toggleable standards library.** Coverage
   evidence maps are now a **registry** (single source of truth) instead of a hardcoded pair, and
   two standards native to kit's own lane land as the first new entries: **OWASP Top 10 for Agentic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`kit memory export --obsidian <dir>` — the curated shared tier as an Obsidian vault (J3).**
+  Renders each shared decision/convention as an Obsidian note (YAML frontmatter with
+  id/area/kind/status/provenance + `kit/*` tags, an H1 title, body, refs) grouped under `area/`,
+  with `[[wikilinks]]` for supersede/reverse relations and a per-area `_index.md` MOC. Pure,
+  deterministic renderer (`renderObsidianVault`); `--json` emits a dry-run manifest (paths +
+  bytes, no writes); write errors fail closed (never a partial-export "success"). Read-only over
+  already-secret-scanned entries, so the export never re-introduces a secret.
+
 - **`kit memory search --brief` — progressive-disclosure recall (B3).** Returns the *minimal
   sufficient slice* of a recall — top-ranked hits trimmed to budget-bounded snippets — and reports
   how many were **withheld** so you can expand (`--limit` / drop `--brief`), instead of dumping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`kit memory search --brief` — progressive-disclosure recall (B3).** Returns the *minimal
+  sufficient slice* of a recall — top-ranked hits trimmed to budget-bounded snippets — and reports
+  how many were **withheld** so you can expand (`--limit` / drop `--brief`), instead of dumping
+  every match into context. Never silently truncates: the withheld count is explicit (same
+  discipline as `kit map`'s logged drops), and the first hit is always disclosed. Pure core
+  `progressiveDisclose` (deterministic; default 1200-char budget / 240-char snippets / 8 hits),
+  unit-tested; `--json` carries the structured `disclosure`.
+
 - **`kit memory` rule aging — surface stale machine-origin rules for review, never auto-drop (B2).**
   Curated shared-tier rules now carry a deterministic **aging class**: only `derived`/`inferred`
   *active* rules age (fresh < 180d ≤ aging < 360d ≤ stale); an **operator's explicit rule is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **`kit triage mcp` — MCP-Security-Checklist static checks (borrowed from SlowMist/OWASP MCP
+  Top 10).** Beyond tool-poisoning (R7) and rug-pull drift, triage now surfaces four deterministic,
+  static review signals: **dangerous-capability** (a tool name/description implying arbitrary
+  exec/deletion — confirm least-privilege + human approval), **secret-as-parameter** (a param
+  shaped like a credential — inject at the boundary, MCP01), **undocumented** (a tool with no
+  description — can't be triaged), and **unconstrained-input** (`additionalProperties: true`).
+  All **heuristic-confidence and advisory** — they surface for review but never flip the pass/fail
+  verdict, which stays gated on high-confidence poisoning + drift (no false-block). `checklistFindings`
+  is exported + unit-tested; pure and deterministic.
+
 - **`kit memory export --obsidian <dir>` — the curated shared tier as an Obsidian vault (J3).**
   Renders each shared decision/convention as an Obsidian note (YAML frontmatter with
   id/area/kind/status/provenance + `kit/*` tags, an H1 title, body, refs) grouped under `area/`,

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -959,7 +959,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.3.0"
+    "version": "5.4.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -691,7 +691,7 @@
     },
     "scan": {
       "kind": "command",
-      "summary": "Run external scanners (snyk/trivy/grype/semgrep/osv) and merge them into one local verdict (--strict / [governance.scan] required_scanners gate non-running scanners)",
+      "summary": "Run external scanners (snyk/trivy/grype/semgrep/osv) and merge them into one local verdict; --list-delegates shows the toggleable scanner library, [scan].delegates picks which run (--strict / [governance.scan] required_scanners gate non-running scanners)",
       "x-kit-args-modeled": false,
       "x-kit-mcp": false,
       "x-kit-stability": "stable"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -486,7 +486,7 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
   scan: {
     handler: cmdScan,
     stability: "stable",
-    help: "Run external scanners (snyk/trivy/grype/semgrep/osv) and merge them into one local verdict (--strict / [governance.scan] required_scanners gate non-running scanners)",
+    help: "Run external scanners (snyk/trivy/grype/semgrep/osv) and merge them into one local verdict; --list-delegates shows the toggleable scanner library, [scan].delegates picks which run (--strict / [governance.scan] required_scanners gate non-running scanners)",
   },
   airgap: { handler: cmdAirgap, stability: "stable", help: "Air-gap posture tools (verify)" },
   "verify-provenance": {

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -65,6 +65,7 @@ import {
   type SharedProvenance,
   type SharedEntry,
 } from "../memory/shared.js";
+import { renderObsidianVault } from "../memory/obsidian.js";
 import {
   userPromptSubmitReminder,
   maybeStartMidSessionIndex,
@@ -133,6 +134,7 @@ export async function cmdMemory(): Promise<boolean> {
     verify: memVerify,
     areas: memAreas,
     area: memArea,
+    export: memExport,
     context: memContext,
     scan: memScan,
     backup: memBackup,
@@ -413,7 +415,12 @@ async function memHelp(): Promise<boolean> {
     "  kit memory verify           Verify Ed25519 signatures on the shared tier (--strict fails on an un-anchored signer)",
   );
   console.log("  kit memory areas            List shared responsibility areas");
-  console.log("  kit memory area <name>      Show shared entries for one area");
+  console.log(
+    "  kit memory area <name>      Show shared entries for one area (--stale for aged-out rules)",
+  );
+  console.log(
+    "  kit memory export --obsidian <dir>  Render the curated shared tier as an Obsidian vault (--json for a dry-run manifest)",
+  );
   console.log(
     "  kit memory context [paths]  Surface active decisions for the area(s) you're touching (--changed = working tree)",
   );
@@ -1333,6 +1340,56 @@ async function memArea(): Promise<boolean> {
     if (e.body) console.log(`    ${e.body}`);
     if (e.refs.length) console.log(`    ${c.dim}refs: ${e.refs.join(", ")}${c.reset}`);
   }
+  return true;
+}
+
+async function memExport(): Promise<boolean> {
+  const jsonMode = hasFlag(process.argv, "--json");
+  // Only the Obsidian target is implemented; require it explicitly so a future
+  // `--json`-only dry-run or other targets stay unambiguous.
+  if (!hasFlag(process.argv, "--obsidian")) {
+    console.error(
+      `${c.red}usage: kit memory export --obsidian <dir> [--json]${c.reset}  ${c.dim}(renders the curated shared tier as an Obsidian vault)${c.reset}`,
+    );
+    return false;
+  }
+  const root = getCurrentProjectRoot();
+  const entries = readShared(root);
+  const files = renderObsidianVault(entries);
+
+  if (jsonMode) {
+    // Dry-run-friendly: report what WOULD be written (paths + sizes), no side effects.
+    console.log(
+      JSON.stringify({ files: files.map((f) => ({ path: f.path, bytes: f.content.length })) }),
+    );
+    return true;
+  }
+
+  const outDir = flagValue(process.argv, "--obsidian");
+  if (!outDir) {
+    console.error(`${c.red}--obsidian needs a target directory${c.reset}`);
+    return false;
+  }
+  if (!files.length) {
+    console.log(`${c.dim}no curated shared entries to export${c.reset}`);
+    return true;
+  }
+  const base = resolve(outDir);
+  try {
+    for (const f of files) {
+      const full = join(base, f.path);
+      mkdirSync(join(full, ".."), { recursive: true });
+      writeFileSync(full, f.content, { encoding: "utf-8" });
+    }
+  } catch (err) {
+    // Fail-closed on a write error — never report a partial export as success.
+    console.error(`${c.red}✗ export failed: ${(err as Error).message}${c.reset}`);
+    return false;
+  }
+  const areas = new Set(entries.map((e) => e.area)).size;
+  console.log(
+    `${c.green}✓ exported${c.reset} ${files.length} note(s) across ${areas} area(s) → ${c.bold}${base}${c.reset}`,
+  );
   return true;
 }
 

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -9,6 +9,7 @@ import {
   getStats,
   getMemoryDbPath,
   searchMessages,
+  progressiveDisclose,
   recordQuery,
   dailyActivity,
   quarantineInjectedMessages,
@@ -366,7 +367,7 @@ async function memHelp(): Promise<boolean> {
     "  kit memory index            Index all agent transcripts (Claude Code, Codex, Gemini, Cursor, …) into the store",
   );
   console.log(
-    "  kit memory search <query>   Search memory + curated shared decisions (current project; --global for all; --include-quarantined to show flagged rows)",
+    "  kit memory search <query>   Search memory + curated shared decisions (current project; --global for all; --fresh recency-aware; --brief progressive-disclosure; --include-quarantined to show flagged rows)",
   );
   console.log(
     "  kit memory stats            Show what the memory store contains (alias: kit memory status)",
@@ -833,7 +834,7 @@ async function memSearch(): Promise<boolean> {
   const query = terms.join(" ").trim();
   if (!query) {
     console.error(
-      `${c.red}usage: kit memory search <query> [--global] [--project=<path>] [--limit=N] [--fresh]${c.reset}`,
+      `${c.red}usage: kit memory search <query> [--global] [--project=<path>] [--limit=N] [--fresh] [--brief]${c.reset}`,
     );
     return false;
   }
@@ -848,6 +849,10 @@ async function memSearch(): Promise<boolean> {
   // --fresh: recency-aware ranking (RRF-fuse bm25 relevance + recency). Off by default so the
   // relevance-first ordering is unchanged unless asked for.
   const recencyBoost = hasFlag(process.argv, "--fresh");
+  // --brief: progressive-disclosure recall (B3) — return the minimal sufficient
+  // slice (budget-bounded snippets) and report how many hits were withheld, instead
+  // of dumping every match. Never silently truncates.
+  const brief = hasFlag(process.argv, "--brief");
   const db = openMemoryDb();
   const hits = searchMessages(db, query, { limit, projectPath, includeQuarantined, recencyBoost });
   // Record the recall (query_log) — best-effort; never let logging break search.
@@ -871,7 +876,11 @@ async function memSearch(): Promise<boolean> {
   }
 
   if (jsonMode) {
-    console.log(JSON.stringify({ messages: hits, shared }));
+    console.log(
+      JSON.stringify(
+        brief ? { disclosure: progressiveDisclose(hits), shared } : { messages: hits, shared },
+      ),
+    );
     return true;
   }
 
@@ -908,6 +917,27 @@ async function memSearch(): Promise<boolean> {
   if (!hits.length) {
     if (shared.length) return true; // curated results already shown; raw recall empty
     console.log(`${c.dim}no matches for "${query}" ${projectPath ?? "(global)"}${c.reset}`);
+    return true;
+  }
+  if (brief) {
+    // Progressive disclosure (B3): the minimal sufficient slice + an explicit
+    // withheld count (never a silent truncation).
+    const disc = progressiveDisclose(hits);
+    console.log(
+      `${c.bold}${disc.shown}${c.reset} of ${hits.length} match(es) ${scope} ${c.dim}— brief${c.reset}`,
+    );
+    for (const h of disc.hits) {
+      const s = sanitizeForPrompt(h.snippet);
+      const snippet = s.text.replace(/\s+/g, " ");
+      console.log(
+        `  ${c.dim}${h.timestamp ?? "?"}${c.reset} ${c.bold}${h.role ?? h.uuid ?? ""}${c.reset}  ${snippet}${s.flagged ? ` ${c.red}${INJECTION_TAG}${c.reset}` : ""}`,
+      );
+    }
+    if (disc.withheld > 0) {
+      console.log(
+        `${c.dim}  … ${disc.withheld} more withheld (budget ${disc.budgetChars} chars) — drop --brief or raise --limit to expand${c.reset}`,
+      );
+    }
     return true;
   }
   console.log(`${c.bold}${hits.length}${c.reset} match(es) ${scope}`);

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -54,6 +54,8 @@ import {
   readShared,
   effectiveStatus,
   formatAge,
+  classifyAging,
+  agingReport,
   getSharedPath,
   verifySharedTier,
   SHARED_KINDS,
@@ -1222,6 +1224,19 @@ async function memAreas(): Promise<boolean> {
       `  ${c.bold}${a.area}${c.reset} ${c.dim}· ${a.count} entr${a.count === 1 ? "y" : "ies"}${c.reset}`,
     );
   }
+  // Rule-aging nudge (B2): surface machine-origin (derived/inferred) rules that have
+  // aged out so the operator can re-affirm/supersede them. Never auto-dropped;
+  // operator rules are foundational and excluded from aging entirely.
+  const aging = agingReport(readShared(getCurrentProjectRoot()));
+  if (aging.stale.length > 0) {
+    console.log(
+      `\n${c.yellow}⚠ ${aging.stale.length} derived/inferred rule(s) stale (>${aging.thresholdDays * 2}d)${c.reset} ${c.dim}— review with 'kit memory area <name> --stale' (operator rules never age)${c.reset}`,
+    );
+  } else if (aging.aging.length > 0) {
+    console.log(
+      `\n${c.dim}⧖ ${aging.aging.length} derived/inferred rule(s) aging (>${aging.thresholdDays}d) — kit memory area <name> --stale${c.reset}`,
+    );
+  }
   return true;
 }
 
@@ -1234,14 +1249,30 @@ async function memArea(): Promise<boolean> {
   }
   const root = getCurrentProjectRoot();
   const all = readShared(root);
-  const entries = all.filter((e) => e.area === name);
+  // --stale (B2): review view — only machine-origin rules that have aged out.
+  const staleOnly = hasFlag(process.argv, "--stale");
+  let entries = all.filter((e) => e.area === name);
+  if (staleOnly) {
+    entries = entries.filter((e) => classifyAging(e, effectiveStatus(e, all)) === "stale");
+  }
   if (jsonMode) {
-    // Enrich with the EFFECTIVE lifecycle status (computed against the full set).
-    console.log(JSON.stringify(entries.map((e) => ({ ...e, status: effectiveStatus(e, all) }))));
+    // Enrich with the EFFECTIVE lifecycle status + aging class (computed against the full set).
+    console.log(
+      JSON.stringify(
+        entries.map((e) => {
+          const status = effectiveStatus(e, all);
+          return { ...e, status, aging: classifyAging(e, status) };
+        }),
+      ),
+    );
     return true;
   }
   if (!entries.length) {
-    console.log(`${c.dim}no shared memory for area '${name}'${c.reset}`);
+    console.log(
+      staleOnly
+        ? `${c.dim}no stale derived/inferred rules in area '${name}'${c.reset}`
+        : `${c.dim}no shared memory for area '${name}'${c.reset}`,
+    );
     return true;
   }
   console.log(
@@ -1258,9 +1289,16 @@ async function memArea(): Promise<boolean> {
         ? ` ${c.dim}→ ${e.supersedes}${c.reset}`
         : "";
     const age = formatAge(e.ts);
+    const agingCls = classifyAging(e, st);
+    const agingBadge =
+      agingCls === "stale"
+        ? ` ${c.yellow}[stale]${c.reset}`
+        : agingCls === "aging"
+          ? ` ${c.dim}[aging]${c.reset}`
+          : "";
     const prov = `${e.author}${e.source_ref ? ` @${e.source_ref}` : ""}${age ? ` · ${age}` : ""}`;
     console.log(
-      `  ${c.bold}[${e.kind}]${c.reset} ${e.title}${badge}${rel} ${c.dim}— ${prov}${c.reset}`,
+      `  ${c.bold}[${e.kind}]${c.reset} ${e.title}${badge}${agingBadge}${rel} ${c.dim}— ${prov}${c.reset}`,
     );
     if (e.body) console.log(`    ${e.body}`);
     if (e.refs.length) console.log(`    ${c.dim}refs: ${e.refs.join(", ")}${c.reset}`);

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -13,7 +13,8 @@ export async function cmdScan(): Promise<boolean> {
   const { resolveToolBin } = await import("../utils/resolveTool.js");
   const { execFileNoThrow } = await import("../utils/execFileNoThrow.js");
   const { loadBaseline, baselineGet, baselineSet, saveBaseline } = await import("../baseline.js");
-  const { SCANNERS, airGapScanners } = await import("../scanners.js");
+  const { SCANNERS, airGapScanners, enabledScanners, isScannerEnabled } =
+    await import("../scanners.js");
   const cwd = process.cwd();
   // Config-free by design: scanning is project-agnostic, so a missing .kit.toml is
   // NOT an error — fall back to an empty config (air-gap + tooling tokens then come
@@ -21,12 +22,32 @@ export async function cmdScan(): Promise<boolean> {
   const configPath = resolveConfigPath();
   const config = existsSync(configPath) ? await loadConfig(configPath) : ({} as kitConfig);
 
+  // Delegate library: [scan].delegates toggles which external scanners kit shells
+  // out to. kit delegates DETECTION, never its verdict. --list-delegates enumerates
+  // the registry with on/off state and exits.
+  const delegates = config.scan?.delegates;
+  if (hasFlag(process.argv, "--list-delegates")) {
+    for (const s of SCANNERS) {
+      const on = isScannerEnabled(s.id, delegates);
+      const tag = on ? `${c.green}on ${c.reset}` : `${c.dim}off${c.reset}`;
+      const notes = [
+        s.needsToken ? `needs ${s.needsToken}` : null,
+        s.cloudOnly ? "cloud-only" : null,
+      ]
+        .filter(Boolean)
+        .join(", ");
+      console.log(`${tag} ${s.id.padEnd(13)} ${s.format}${notes ? `  (${notes})` : ""}`);
+    }
+    return true;
+  }
+  const selectedScanners = enabledScanners(SCANNERS, delegates);
+
   // Air-gap posture from `.kit.toml [air_gap]` + env (env overrides). When
   // enabled, drop cloud-only scanners and run the rest against local DBs with no
   // network. See docs/AIR_GAP.md.
   const { resolveAirGap } = await import("../airgap/config.js");
   const ag = resolveAirGap(config.air_gap, process.env);
-  const airgap = airGapScanners(SCANNERS, ag.enabled);
+  const airgap = airGapScanners(selectedScanners, ag.enabled);
   if (ag.enabled) {
     console.log(
       `${c.dim}air-gap mode: offline scanners only${airgap.dropped.length ? ` (skipping cloud-only: ${airgap.dropped.join(", ")})` : ""}${c.reset}`,
@@ -84,7 +105,7 @@ export async function cmdScan(): Promise<boolean> {
       project_id: tooling.project_id,
       environment: tooling.env,
     });
-    for (const s of SCANNERS) {
+    for (const s of selectedScanners) {
       if (s.needsToken && !process.env[s.needsToken] && map.has(s.needsToken)) {
         toolingTokens[s.needsToken] = map.get(s.needsToken)!;
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -356,7 +356,15 @@ export interface kitConfig {
   /** `kit scan` / `kit check` scanner settings. `tooling` = an Infisical project to
    *  resolve scanner tokens (SNYK_TOKEN, …) from; `guarddog` = enable the local
    *  behavioral-malware scan in `kit check` (persistent alt to KIT_GUARDDOG=1). */
-  scan?: { tooling?: { project_id?: string; env?: string }; guarddog?: boolean };
+  scan?: {
+    tooling?: { project_id?: string; env?: string };
+    guarddog?: boolean;
+    /** `kit scan` delegate library toggle: an allow-list of scanner ids
+     *  (snyk/trivy/grype/semgrep/osv-scanner/socket) to run. Absent/empty ⇒ all
+     *  registered scanners on (backwards-compatible); `kit scan --list-delegates`
+     *  shows on/off. kit delegates DETECTION here, never its verdict. */
+    delegates?: string[];
+  };
   /**
    * No-egress / air-gapped posture (declarative; see docs/AIR_GAP.md). Equivalent
    * to the `KIT_*` env vars, but checked in so the enclave config is reproducible.
@@ -681,6 +689,7 @@ export const kitConfigSchema = z
           .passthrough()
           .optional(),
         guarddog: z.boolean().optional(),
+        delegates: z.array(z.string()).optional(),
       })
       .passthrough()
       .optional(),

--- a/src/mcp-triage.test.ts
+++ b/src/mcp-triage.test.ts
@@ -5,6 +5,7 @@ import {
   hashToolset,
   classifyDrift,
   triageMcpTools,
+  checklistFindings,
   extractToolDefs,
   type McpToolDef,
 } from "./mcp-triage.js";
@@ -111,5 +112,53 @@ describe("extractToolDefs", () => {
   it("drops entries without a string name and tolerates garbage", () => {
     assert.deepEqual(extractToolDefs([{ description: "no name" }, 5, null]), []);
     assert.deepEqual(extractToolDefs("nonsense"), []);
+  });
+});
+
+describe("checklistFindings (MCP-Security-Checklist static checks)", () => {
+  it("flags a dangerous capability by name/description (heuristic)", () => {
+    const f = checklistFindings([{ name: "run_command", description: "exec a shell command" }]);
+    assert.ok(f.some((x) => x.label.startsWith("dangerous-capability")));
+    assert.ok(f.every((x) => x.confidence === "heuristic"));
+  });
+
+  it("flags a secret-shaped parameter", () => {
+    const f = checklistFindings([
+      {
+        name: "call_api",
+        description: "call it",
+        inputSchema: { type: "object", properties: { api_key: { type: "string" } } },
+      },
+    ]);
+    assert.ok(f.some((x) => x.field === "param:api_key" && /secret-shaped/.test(x.label)));
+  });
+
+  it("flags an undocumented tool and unconstrained input", () => {
+    const f = checklistFindings([
+      { name: "t", description: "", inputSchema: { type: "object", additionalProperties: true } },
+    ]);
+    assert.ok(f.some((x) => /undocumented/.test(x.label)));
+    assert.ok(f.some((x) => /unconstrained input/.test(x.label)));
+  });
+
+  it("a clean, documented, constrained tool yields no checklist findings", () => {
+    const f = checklistFindings([
+      {
+        name: "get_weather",
+        description: "Return the forecast for a city",
+        inputSchema: {
+          type: "object",
+          properties: { city: { type: "string" } },
+          additionalProperties: false,
+        },
+      },
+    ]);
+    assert.equal(f.length, 0);
+  });
+
+  it("checklist findings are advisory — they do NOT flip triageMcpTools.passed", () => {
+    const r = triageMcpTools("s", [{ name: "run_command", description: "exec shell" }]);
+    assert.ok(r.findings.some((x) => x.label.startsWith("dangerous-capability")));
+    assert.equal(r.passed, true); // heuristic-only ⇒ still passes (no high-confidence poisoning, no drift)
   });
 });

--- a/src/mcp-triage.ts
+++ b/src/mcp-triage.ts
@@ -100,6 +100,86 @@ export function analyzeMcpTools(tools: McpToolDef[]): {
   return { findings, toolsetHash: hashToolset(tools) };
 }
 
+/** Recursively collect property-key paths from a JSON schema (for name-based checks). */
+function collectParamNames(schema: unknown, path = ""): string[] {
+  const out: string[] = [];
+  if (!schema || typeof schema !== "object") return out;
+  const obj = schema as Record<string, unknown>;
+  const props = obj.properties;
+  if (props && typeof props === "object") {
+    for (const [key, val] of Object.entries(props as Record<string, unknown>)) {
+      const p = path ? `${path}.${key}` : key;
+      out.push(p);
+      out.push(...collectParamNames(val, p));
+    }
+  }
+  if (obj.items) out.push(...collectParamNames(obj.items, path ? `${path}[]` : "[]"));
+  return out;
+}
+
+// Deterministic patterns derived from the OWASP/SlowMist MCP-Security-Checklist —
+// static, heuristic (never high-confidence, so they surface for review but never
+// flip the pass/fail verdict, which stays gated on high-confidence poisoning + drift).
+const DANGEROUS_CAPABILITY =
+  /\b(exec|eval|shell|spawn|system|sudo|run[_-]?command|delete[_-]?all|drop[_-]?(table|database)|rm\b)/i;
+const SECRET_PARAM =
+  /(^|[_-])(token|secret|password|passwd|api[_-]?key|apikey|credential|private[_-]?key)([_-]|$)/i;
+
+/**
+ * Static MCP-Security-Checklist findings over tool defs (SlowMist / OWASP MCP Top 10).
+ * Deterministic + heuristic-confidence — advisory review signals, NOT verdict-flipping:
+ *  - dangerous-capability: a tool name/description implying arbitrary exec/deletion
+ *    (confirm least-privilege + human approval).
+ *  - secret-as-parameter: a parameter shaped like a credential (inject at the boundary,
+ *    do not accept as a tool arg — MCP01).
+ *  - undocumented: a tool with no description (cannot be triaged; MCP checklist).
+ *  - unconstrained-input: top-level `additionalProperties: true` (validate inputs).
+ */
+export function checklistFindings(tools: McpToolDef[]): McpToolFinding[] {
+  const findings: McpToolFinding[] = [];
+  for (const tool of tools) {
+    const name = tool.name || "(unnamed)";
+    const hay = `${tool.name} ${tool.description ?? ""}`;
+    if (DANGEROUS_CAPABILITY.test(hay)) {
+      findings.push({
+        tool: name,
+        field: "name",
+        label: "dangerous-capability (confirm least-privilege + human approval)",
+        confidence: "heuristic",
+      });
+    }
+    if (!tool.description || tool.description.trim() === "") {
+      findings.push({
+        tool: name,
+        field: "description",
+        label: "undocumented tool (cannot be triaged; add a clear description)",
+        confidence: "heuristic",
+      });
+    }
+    for (const p of collectParamNames(tool.inputSchema)) {
+      const leaf = p.split(".").pop() ?? p;
+      if (SECRET_PARAM.test(leaf)) {
+        findings.push({
+          tool: name,
+          field: `param:${p}`,
+          label: "secret-shaped parameter (inject at the boundary, not as a tool arg)",
+          confidence: "heuristic",
+        });
+      }
+    }
+    const schema = tool.inputSchema as Record<string, unknown> | undefined;
+    if (schema && typeof schema === "object" && schema.additionalProperties === true) {
+      findings.push({
+        tool: name,
+        field: "schema",
+        label: "unconstrained input (additionalProperties: true — validate inputs)",
+        confidence: "heuristic",
+      });
+    }
+  }
+  return findings;
+}
+
 /** Deterministic content hash of a tool set — order-independent, whitespace-exact. */
 export function hashToolset(tools: McpToolDef[]): string {
   const canonical = tools
@@ -136,7 +216,10 @@ export function triageMcpTools(
   tools: McpToolDef[],
   pinnedHash?: string,
 ): McpTriageResult {
-  const { findings, toolsetHash } = analyzeMcpTools(tools);
+  const { findings: poisoning, toolsetHash } = analyzeMcpTools(tools);
+  // Poisoning findings (can be high-confidence → gate) + advisory MCP-checklist
+  // findings (always heuristic → surfaced, never verdict-flipping).
+  const findings = [...poisoning, ...checklistFindings(tools)];
   const drift = classifyDrift(pinnedHash, toolsetHash);
   const hasHighPoisoning = findings.some((f) => f.confidence === "high");
   return {

--- a/src/memory/db.test.ts
+++ b/src/memory/db.test.ts
@@ -14,7 +14,9 @@ import {
   quarantineInjectedMessages,
   countQuarantined,
   fuseByRrf,
+  progressiveDisclose,
 } from "./db.js";
+import type { SearchHit } from "./types.js";
 
 describe("memory db", () => {
   const fresh = () => openMemoryDb(":memory:");
@@ -486,5 +488,64 @@ describe("searchMessages --fresh (recency-aware ranking)", () => {
       `recency-boosted order: ${boosted}`,
     );
     db.close();
+  });
+});
+
+describe("progressiveDisclose (B3)", () => {
+  const hit = (id: number, content: string): SearchHit => ({
+    id,
+    uuid: `u${id}`,
+    sessionId: "s",
+    role: "assistant",
+    content,
+    timestamp: "2026-07-01T00:00:00Z",
+  });
+
+  it("trims each hit to the snippet budget and marks truncation", () => {
+    const long = "x".repeat(500);
+    const d = progressiveDisclose([hit(1, long)], { snippetChars: 100, budgetChars: 10_000 });
+    assert.equal(d.shown, 1);
+    assert.equal(d.hits[0].truncated, true);
+    assert.ok(d.hits[0].snippet.length <= 101); // 100 + ellipsis
+    assert.ok(d.hits[0].snippet.endsWith("…"));
+  });
+
+  it("short content is shown whole, not truncated", () => {
+    const d = progressiveDisclose([hit(1, "short")], { snippetChars: 100 });
+    assert.equal(d.hits[0].truncated, false);
+    assert.equal(d.hits[0].snippet, "short");
+  });
+
+  it("stops at the character budget and reports the withheld count (no silent drop)", () => {
+    const hits = [hit(1, "a".repeat(80)), hit(2, "b".repeat(80)), hit(3, "c".repeat(80))];
+    const d = progressiveDisclose(hits, { snippetChars: 80, budgetChars: 100 });
+    // first fits (80), second would overflow (160 > 100) → stop
+    assert.equal(d.shown, 1);
+    assert.equal(d.withheld, 2);
+  });
+
+  it("always discloses at least the first hit even if it alone exceeds budget", () => {
+    const d = progressiveDisclose([hit(1, "z".repeat(500))], {
+      snippetChars: 500,
+      budgetChars: 10,
+    });
+    assert.equal(d.shown, 1);
+    assert.equal(d.withheld, 0);
+  });
+
+  it("honours maxHits and preserves rank order", () => {
+    const hits = [hit(1, "a"), hit(2, "b"), hit(3, "c"), hit(4, "d")];
+    const d = progressiveDisclose(hits, { maxHits: 2, budgetChars: 10_000 });
+    assert.deepEqual(
+      d.hits.map((h) => h.id),
+      [1, 2],
+    );
+    assert.equal(d.withheld, 2);
+  });
+
+  it("empty input → empty disclosure", () => {
+    const d = progressiveDisclose([]);
+    assert.equal(d.shown, 0);
+    assert.equal(d.withheld, 0);
   });
 });

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -614,6 +614,72 @@ export function searchMessages(
   return fuseByRrf<SearchHit>([pool, byRecency], (h) => h.id).slice(0, limit);
 }
 
+/** One disclosed hit — a compact, budget-trimmed view of a SearchHit. */
+export interface DisclosedHit {
+  id: number;
+  uuid: string | null;
+  sessionId: string;
+  role: string | null;
+  timestamp: string | null;
+  /** Content trimmed to the snippet budget (whole content when it already fits). */
+  snippet: string;
+  /** True when the snippet is shorter than the full content. */
+  truncated: boolean;
+}
+
+export interface Disclosure {
+  hits: DisclosedHit[];
+  /** How many ranked hits were disclosed. */
+  shown: number;
+  /** Ranked hits NOT disclosed (budget or count reached) — surfaced, never silently dropped. */
+  withheld: number;
+  budgetChars: number;
+}
+
+export interface DiscloseOptions {
+  /** Total character budget across all snippets (default 1200). */
+  budgetChars?: number;
+  /** Per-hit snippet cap (default 240). */
+  snippetChars?: number;
+  /** Hard cap on hits shown regardless of budget (default 8). */
+  maxHits?: number;
+}
+
+/**
+ * Progressive-disclosure recall (B3): given RANKED hits, return the minimal
+ * sufficient slice that fits a character budget — the smallest context that still
+ * carries signal — and report how many were WITHHELD so the caller can expand.
+ * Never silently truncates: `withheld` is explicit (same discipline as `kit map`'s
+ * logged drops). Pure + deterministic (input order preserved; no clock/random).
+ */
+export function progressiveDisclose(hits: SearchHit[], opts: DiscloseOptions = {}): Disclosure {
+  const budgetChars = opts.budgetChars ?? 1200;
+  const snippetChars = opts.snippetChars ?? 240;
+  const maxHits = opts.maxHits ?? 8;
+  const shown: DisclosedHit[] = [];
+  let used = 0;
+  for (const h of hits) {
+    if (shown.length >= maxHits) break;
+    const content = h.content ?? "";
+    const full = content.length <= snippetChars;
+    const snippet = full ? content : content.slice(0, snippetChars).trimEnd() + "…";
+    // Stop once this snippet would overflow the budget — but always disclose at
+    // least the first hit so a query never returns an empty-but-nonzero result.
+    if (shown.length > 0 && used + snippet.length > budgetChars) break;
+    shown.push({
+      id: h.id,
+      uuid: h.uuid,
+      sessionId: h.sessionId,
+      role: h.role,
+      timestamp: h.timestamp,
+      snippet,
+      truncated: !full,
+    });
+    used += snippet.length;
+  }
+  return { hits: shown, shown: shown.length, withheld: hits.length - shown.length, budgetChars };
+}
+
 export interface QueryLogInput {
   query: string;
   hitCount: number;

--- a/src/memory/obsidian.test.ts
+++ b/src/memory/obsidian.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { renderObsidianVault, slugify } from "./obsidian.js";
+import type { SharedEntry } from "./shared.js";
+
+const mk = (over: Partial<SharedEntry>): SharedEntry => ({
+  id: over.id ?? "a1b2c3",
+  area: over.area ?? "auth",
+  kind: over.kind ?? "decision",
+  title: over.title ?? "Use Ed25519",
+  body: over.body ?? "platform signing keys",
+  refs: over.refs ?? [],
+  author: over.author ?? "peter",
+  ts: over.ts ?? "2026-06-01T00:00:00Z",
+  ...over,
+});
+
+describe("obsidian export (J3)", () => {
+  it("slugify is filesystem-safe and bounded", () => {
+    assert.equal(slugify("Use Ed25519 / RSA!"), "use-ed25519-rsa");
+    assert.equal(slugify(""), "untitled");
+    assert.equal(slugify("!!!"), "untitled");
+  });
+
+  it("renders one note per entry plus a per-area index", () => {
+    const files = renderObsidianVault([
+      mk({ id: "e1", area: "auth", title: "A" }),
+      mk({ id: "e2", area: "billing", title: "B" }),
+    ]);
+    const paths = files.map((f) => f.path).sort();
+    assert.ok(paths.includes("auth/_index.md"));
+    assert.ok(paths.includes("billing/_index.md"));
+    assert.ok(paths.some((p) => p.startsWith("auth/decision-e1-")));
+    assert.ok(paths.some((p) => p.startsWith("billing/decision-e2-")));
+    assert.equal(files.length, 4); // 2 notes + 2 indexes
+  });
+
+  it("note carries YAML frontmatter (id/area/kind/status/tags) and an H1 title", () => {
+    const [note] = renderObsidianVault([mk({ id: "e1", title: "Use Ed25519" })]);
+    assert.match(note.content, /^---\n/);
+    assert.match(note.content, /\nid: e1\n/);
+    assert.match(note.content, /\nkind: decision\n/);
+    assert.match(note.content, /\nstatus: active\n/);
+    assert.match(note.content, /kit\/area\/auth/);
+    assert.match(note.content, /\n# Use Ed25519\n/);
+  });
+
+  it("supersede relation renders as an Obsidian wikilink to the target note", () => {
+    const files = renderObsidianVault([
+      mk({ id: "old", title: "Old RSA" }),
+      mk({ id: "new", title: "New Ed25519", supersedes: "old" }),
+    ]);
+    const newNote = files.find((f) => f.path.includes("decision-new-"))!;
+    assert.match(newNote.content, /Supersedes \[\[decision-old-old-rsa\]\]/);
+    // and the superseded entry's own note reflects the effective status
+    const oldNote = files.find((f) => f.path.includes("decision-old-"))!;
+    assert.match(oldNote.content, /\nstatus: superseded\n/);
+  });
+
+  it("a missing relation target degrades gracefully (no crash, marked missing)", () => {
+    const [note] = renderObsidianVault([mk({ id: "e1", reverses: "ghost" })]);
+    assert.match(note.content, /Reverses `ghost` \(missing\)/);
+  });
+
+  it("is deterministic — identical input yields identical output", () => {
+    const input = [mk({ id: "e2", area: "b" }), mk({ id: "e1", area: "a" })];
+    assert.deepEqual(renderObsidianVault(input), renderObsidianVault(input));
+  });
+
+  it("empty tier → no files", () => {
+    assert.deepEqual(renderObsidianVault([]), []);
+  });
+});

--- a/src/memory/obsidian.ts
+++ b/src/memory/obsidian.ts
@@ -1,0 +1,130 @@
+/**
+ * Obsidian export (J3) — render the curated shared-memory tier as an Obsidian-
+ * flavored markdown vault: one note per entry (YAML frontmatter + body + refs +
+ * `[[wikilinks]]` for supersede/reverse relations), plus a per-area index (MOC).
+ *
+ * Pure + deterministic (entries → files; no IO, no clock). The command layer does
+ * the writing. Export is read-only over already-secret-scanned curated entries, so
+ * it never re-introduces a secret (they are refused at share time).
+ */
+import type { SharedEntry, SharedStatus } from "./shared.js";
+import { effectiveStatus } from "./shared.js";
+
+export interface ObsidianFile {
+  /** Vault-relative path, POSIX separators. */
+  path: string;
+  content: string;
+}
+
+/** Filesystem-safe slug for a title (display stays in frontmatter/H1). */
+export function slugify(s: string): string {
+  return (
+    s
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 60) || "untitled"
+  );
+}
+
+/** Stable note basename for an entry (unique by id; collision-free). */
+function noteBase(e: SharedEntry): string {
+  return `${e.kind}-${e.id}-${slugify(e.title)}`;
+}
+
+function yamlFrontmatter(fields: Record<string, string | string[] | undefined>): string {
+  const lines: string[] = ["---"];
+  for (const [k, v] of Object.entries(fields)) {
+    if (v === undefined) continue;
+    if (Array.isArray(v)) {
+      if (v.length === 0) continue;
+      lines.push(`${k}:`);
+      for (const item of v) lines.push(`  - ${yamlScalar(item)}`);
+    } else {
+      lines.push(`${k}: ${yamlScalar(v)}`);
+    }
+  }
+  lines.push("---");
+  return lines.join("\n");
+}
+
+/** Quote a scalar when it could confuse the YAML parser; otherwise leave bare. */
+function yamlScalar(v: string): string {
+  return /^[\w.@/+-]+$/.test(v) ? v : JSON.stringify(v);
+}
+
+/**
+ * Render the whole tier to a deterministic set of vault files. Notes are grouped
+ * under `area/`; each area also gets an `_index.md` MOC linking its entries.
+ * `now`-free: status is computed from the entry set, not the clock.
+ */
+export function renderObsidianVault(entries: SharedEntry[]): ObsidianFile[] {
+  const byId = new Map(entries.map((e) => [e.id, e]));
+  const wikilink = (id: string): string => {
+    const target = byId.get(id);
+    return target ? `[[${noteBase(target)}]]` : `\`${id}\` (missing)`;
+  };
+
+  const files: ObsidianFile[] = [];
+  // Sort for deterministic output: area, then ts, then id.
+  const sorted = [...entries].sort(
+    (a, b) => a.area.localeCompare(b.area) || a.ts.localeCompare(b.ts) || a.id.localeCompare(b.id),
+  );
+
+  for (const e of sorted) {
+    const status: SharedStatus = effectiveStatus(e, entries);
+    const fm = yamlFrontmatter({
+      id: e.id,
+      area: e.area,
+      kind: e.kind,
+      status,
+      provenance: e.provenance ?? "operator",
+      confidence: e.confidence,
+      author: e.author,
+      ts: e.ts,
+      source_ref: e.source_ref,
+      tags: ["kit/shared", `kit/kind/${e.kind}`, `kit/area/${e.area}`],
+    });
+    const rel: string[] = [];
+    if (e.supersedes) rel.push(`> Supersedes ${wikilink(e.supersedes)}`);
+    if (e.reverses) rel.push(`> Reverses ${wikilink(e.reverses)}`);
+    const body = [
+      fm,
+      "",
+      `# ${e.title}`,
+      status !== "active" ? `\n> [!warning] ${status}\n` : "",
+      rel.length ? rel.join("\n") + "\n" : "",
+      e.body || "",
+      e.refs.length ? `\n## Refs\n${e.refs.map((r) => `- ${r}`).join("\n")}` : "",
+      "",
+      `---\n*Exported from kit shared memory · area [[_index|${e.area}]]*`,
+      "",
+    ]
+      .filter((s) => s !== "")
+      .join("\n");
+    files.push({ path: `${e.area}/${noteBase(e)}.md`, content: body.replace(/\n{3,}/g, "\n\n") });
+  }
+
+  // Per-area index (MOC).
+  const areas = [...new Set(sorted.map((e) => e.area))].sort();
+  for (const area of areas) {
+    const inArea = sorted.filter((e) => e.area === area);
+    const lines = [
+      yamlFrontmatter({ area, tags: ["kit/shared", "kit/moc", `kit/area/${area}`] }),
+      "",
+      `# ${area}`,
+      "",
+      `${inArea.length} shared entr${inArea.length === 1 ? "y" : "ies"}.`,
+      "",
+      ...inArea.map((e) => {
+        const st = effectiveStatus(e, entries);
+        const badge = st === "active" ? "" : ` _(${st})_`;
+        return `- [[${noteBase(e)}|${e.title}]] · \`${e.kind}\`${badge}`;
+      }),
+      "",
+    ];
+    files.push({ path: `${area}/_index.md`, content: lines.join("\n") });
+  }
+
+  return files;
+}

--- a/src/memory/shared.test.ts
+++ b/src/memory/shared.test.ts
@@ -18,6 +18,9 @@ import {
   recallSafeShared,
   getSharedPath,
   provenanceRank,
+  classifyAging,
+  agingReport,
+  DEFAULT_AGING_THRESHOLD_DAYS,
   SHARED_KINDS,
   type SharedEntry,
 } from "./shared.js";
@@ -393,5 +396,76 @@ describe("shared memory — negative-space kinds + provenance (J1 + B1)", () => 
     assert.ok(!sharedEntryCanonical(base).includes("provenance"));
     const withProv = sharedEntryCanonical({ ...base, provenance: "derived" });
     assert.ok(withProv.includes("derived"));
+  });
+});
+
+describe("shared memory — rule aging (B2)", () => {
+  const NOW = new Date("2026-07-01T00:00:00Z");
+  const daysAgo = (n: number) => new Date(NOW.getTime() - n * 86_400_000).toISOString();
+  const mk = (over: Partial<SharedEntry>): SharedEntry => ({
+    id: over.id ?? "e1",
+    area: "core",
+    kind: "decision",
+    title: "t",
+    body: "b",
+    refs: [],
+    author: "a",
+    ts: over.ts ?? daysAgo(400),
+    ...over,
+  });
+
+  it("operator (and absent-provenance) rules NEVER age — the human owns relevance", () => {
+    const old = mk({ ts: daysAgo(1000), provenance: "operator" });
+    assert.equal(classifyAging(old, "active", NOW), "n/a");
+    const legacy = mk({ ts: daysAgo(1000) }); // absent provenance ⇒ operator
+    assert.equal(classifyAging(legacy, "active", NOW), "n/a");
+  });
+
+  it("derived/inferred rules age by the threshold bands", () => {
+    const T = DEFAULT_AGING_THRESHOLD_DAYS;
+    assert.equal(
+      classifyAging(mk({ provenance: "derived", ts: daysAgo(T - 10) }), "active", NOW),
+      "fresh",
+    );
+    assert.equal(
+      classifyAging(mk({ provenance: "derived", ts: daysAgo(T + 10) }), "active", NOW),
+      "aging",
+    );
+    assert.equal(
+      classifyAging(mk({ provenance: "inferred", ts: daysAgo(T * 2 + 10) }), "active", NOW),
+      "stale",
+    );
+  });
+
+  it("non-active entries (superseded/reversed) are history ⇒ n/a", () => {
+    const e = mk({ provenance: "derived", ts: daysAgo(1000) });
+    assert.equal(classifyAging(e, "superseded", NOW), "n/a");
+    assert.equal(classifyAging(e, "reversed", NOW), "n/a");
+  });
+
+  it("unparseable ts ⇒ n/a (never a spurious stale)", () => {
+    assert.equal(classifyAging(mk({ provenance: "derived", ts: "nope" }), "active", NOW), "n/a");
+  });
+
+  it("agingReport buckets only active machine-origin rules; leaves operator rules out", () => {
+    const entries = [
+      mk({ id: "op", provenance: "operator", ts: daysAgo(1000) }),
+      mk({ id: "fresh", provenance: "derived", ts: daysAgo(10) }),
+      mk({ id: "aging", provenance: "derived", ts: daysAgo(DEFAULT_AGING_THRESHOLD_DAYS + 5) }),
+      mk({
+        id: "stale",
+        provenance: "inferred",
+        ts: daysAgo(DEFAULT_AGING_THRESHOLD_DAYS * 2 + 5),
+      }),
+    ];
+    const r = agingReport(entries, NOW);
+    assert.deepEqual(
+      r.aging.map((e) => e.id),
+      ["aging"],
+    );
+    assert.deepEqual(
+      r.stale.map((e) => e.id),
+      ["stale"],
+    );
   });
 });

--- a/src/memory/shared.ts
+++ b/src/memory/shared.ts
@@ -396,3 +396,63 @@ export function formatAge(ts: string, now: Date = new Date()): string {
   if (days < 365) return `${Math.floor(days / 30)}mo ago`;
   return `${Math.floor(days / 365)}y ago`;
 }
+
+/** Recall-aging class for a curated entry. `n/a` = not subject to aging. */
+export type AgingClass = "fresh" | "aging" | "stale" | "n/a";
+
+/** Default aging threshold (days): fresh < T ≤ aging < 2T ≤ stale. */
+export const DEFAULT_AGING_THRESHOLD_DAYS = 180;
+
+/**
+ * Deterministic recall-aging classification for a single curated entry.
+ *
+ * ONLY machine-origin (`derived` / `inferred`) entries that are currently ACTIVE
+ * age. An operator's explicit rule is foundational — it is NEVER marked stale
+ * (aging is about pruning what kit *guessed*, not overriding what a human decided);
+ * it always classifies `n/a`. Superseded/reversed entries are history ⇒ `n/a`.
+ *
+ * Age bands (by entry `ts` vs `now`): fresh < threshold ≤ aging < 2×threshold ≤ stale.
+ * Pure — no IO, no ambient clock (pass `now`). Never deletes; classification only.
+ */
+export function classifyAging(
+  entry: SharedEntry,
+  effStatus: SharedStatus,
+  now: Date = new Date(),
+  thresholdDays: number = DEFAULT_AGING_THRESHOLD_DAYS,
+): AgingClass {
+  if (effStatus !== "active") return "n/a";
+  const prov = entry.provenance ?? "operator";
+  if (prov === "operator") return "n/a"; // human-owned; the human owns relevance
+  const then = new Date(entry.ts).getTime();
+  if (!Number.isFinite(then)) return "n/a";
+  const days = Math.floor((now.getTime() - then) / 86_400_000);
+  if (days >= thresholdDays * 2) return "stale";
+  if (days >= thresholdDays) return "aging";
+  return "fresh";
+}
+
+export interface AgingReport {
+  thresholdDays: number;
+  aging: SharedEntry[];
+  stale: SharedEntry[];
+}
+
+/**
+ * Classify the whole tier and collect the machine-origin entries that have aged
+ * out. A review aid — the operator decides whether to re-affirm (promote to
+ * `operator` provenance), supersede, or leave them. kit never auto-drops.
+ */
+export function agingReport(
+  entries: SharedEntry[],
+  now: Date = new Date(),
+  thresholdDays: number = DEFAULT_AGING_THRESHOLD_DAYS,
+): AgingReport {
+  const aging: SharedEntry[] = [];
+  const stale: SharedEntry[] = [];
+  for (const e of entries) {
+    const cls = classifyAging(e, effectiveStatus(e, entries), now, thresholdDays);
+    if (cls === "aging") aging.push(e);
+    else if (cls === "stale") stale.push(e);
+  }
+  return { thresholdDays, aging, stale };
+}

--- a/src/scanners.test.ts
+++ b/src/scanners.test.ts
@@ -8,6 +8,9 @@ import {
   airGapScanners,
   isAirGap,
   SCANNERS,
+  SCANNER_IDS,
+  enabledScanners,
+  isScannerEnabled,
   buildSemgrepArgs,
   semgrepConfig,
   isLocalSemgrepConfig,
@@ -396,5 +399,36 @@ describe("verifyAirGapScanners (provable zero-egress reducer)", () => {
     const report = verifyAirGapScanners(withSemgrep, { semgrepConfig: "p/default" });
     assert.equal(report.ok, false);
     assert.ok(report.rows.find((r) => r.id === "semgrep" && !r.ok));
+  });
+});
+
+describe("scanner delegate library toggle ([scan].delegates)", () => {
+  it("SCANNER_IDS lists every registered scanner in registry order", () => {
+    assert.deepEqual(
+      [...SCANNER_IDS],
+      SCANNERS.map((s) => s.id),
+    );
+    assert.ok(SCANNER_IDS.includes("trivy") && SCANNER_IDS.includes("osv-scanner"));
+  });
+
+  it("no toggle ⇒ every scanner enabled (backwards-compatible)", () => {
+    assert.equal(enabledScanners(SCANNERS).length, SCANNERS.length);
+    assert.equal(enabledScanners(SCANNERS, []).length, SCANNERS.length);
+    assert.equal(isScannerEnabled("trivy"), true);
+    assert.equal(isScannerEnabled("trivy", []), true);
+  });
+
+  it("allow-list toggles delegates on/off, in registry order", () => {
+    const enabled = enabledScanners(SCANNERS, ["osv-scanner", "trivy"]);
+    assert.deepEqual(
+      enabled.map((s) => s.id),
+      SCANNERS.filter((s) => s.id === "trivy" || s.id === "osv-scanner").map((s) => s.id),
+    );
+    assert.equal(isScannerEnabled("trivy", ["osv-scanner", "trivy"]), true);
+    assert.equal(isScannerEnabled("snyk", ["osv-scanner", "trivy"]), false);
+  });
+
+  it("unknown ids in the allow-list are ignored (no crash, just filtered out)", () => {
+    assert.equal(enabledScanners(SCANNERS, ["does-not-exist"]).length, 0);
   });
 });

--- a/src/scanners.ts
+++ b/src/scanners.ts
@@ -170,6 +170,31 @@ export const SCANNERS: ScannerDef[] = [
   },
 ];
 
+/** Every registered scanner id, in registry order — the delegate library. */
+export const SCANNER_IDS: readonly string[] = SCANNERS.map((s) => s.id);
+
+/**
+ * Resolve which scanner delegates are enabled given the optional `[scan].delegates`
+ * allow-list from .kit.toml. Absent or empty ⇒ every registered scanner is enabled
+ * (backwards-compatible). Unknown ids in the config are ignored here. Order follows
+ * the registry, not the config. This is the "connect what we should not copy"
+ * toggle — kit delegates DETECTION, never its verdict.
+ */
+export function enabledScanners(
+  defs: ScannerDef[] = SCANNERS,
+  configDelegates?: readonly string[],
+): ScannerDef[] {
+  if (!configDelegates || configDelegates.length === 0) return [...defs];
+  const allow = new Set(configDelegates);
+  return defs.filter((s) => allow.has(s.id));
+}
+
+/** Is scanner `id` enabled under the given `[scan].delegates` toggle? Empty ⇒ all on. */
+export function isScannerEnabled(id: string, configDelegates?: readonly string[]): boolean {
+  if (!configDelegates || configDelegates.length === 0) return true;
+  return configDelegates.includes(id);
+}
+
 /** True when air-gap mode is requested via env (KIT_AIRGAP=1/true/yes). */
 export function isAirGap(env: NodeJS.ProcessEnv = process.env): boolean {
   return ["1", "true", "yes"].includes((env.KIT_AIRGAP ?? "").trim().toLowerCase());


### PR DESCRIPTION
## Description

Rolls kit to **5.4.0** and gathers this release's increments. The common thread is the *toggleable library* pattern the charter now leans on: kit ships a registry of standards / delegates and lets a config allow-list turn entries on and off (absent or empty ⇒ all on, so it stays backwards-compatible). "Connect what we shouldn't copy" — kit delegates *detection* to best-of-breed tools but never their *verdict* — now applies to both coverage standards and scanners. Plus three memory-governance improvements and a static MCP-Security-Checklist pass.

The coverage half of the library (#374 — OWASP Agentic Top 10 & MCP Top 10) already merged; this PR is the remaining five increments and the version roll.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

- Related to #374 (coverage library, already merged)

## Changes Made

- **scan — toggleable scanner delegate library** (`[scan].delegates` + `kit scan --list-delegates`). Same registry pattern as coverage: an allow-list selects which external scanners kit invokes; absent/empty ⇒ all enabled. `SCANNER_IDS` / `enabledScanners` / `isScannerEnabled` added; `--list-delegates` shows on/off with needs-token / cloud-only notes.
- **memory — rule aging (B2)**: only *derived/inferred* ACTIVE rules age (fresh <180d ≤ aging < 360d ≤ stale); operator rules never age (the human owns their relevance) and nothing is ever auto-dropped. `kit memory area --stale`, aging badges, and an aging nudge on `kit memory areas`.
- **memory — progressive-disclosure recall (B3)**: `kit memory search --brief` returns the minimal sufficient slice under a char budget with an explicit `withheld` count (no silent truncation).
- **memory — Obsidian export (J3)**: `kit memory export --obsidian` writes the shared tier to a vault (YAML frontmatter, `[[wikilinks]]` for supersede chains, per-area MOC index).
- **triage — MCP-Security-Checklist static checks**: `kit triage mcp` now surfaces dangerous-capability, secret-shaped-parameter, undocumented and unconstrained-input findings (SlowMist/OWASP MCP Top 10). All heuristic-confidence and **advisory** — they never flip the pass/fail verdict, which stays gated on high-confidence poisoning + drift.
- **release**: version → 5.4.0 (package.json / package-lock.json), CHANGELOG `[5.4.0] - 2026-07-21`, regenerated `contracts/kit.opencli.json`.

## Testing

### Test Coverage
- [x] Added new tests
- [x] Updated existing tests
- [x] All tests pass (`npm test`)

Full suite green locally: **3080 pass / 0 fail** (807 suites). New/extended tests: `src/scanners.test.ts` (delegate toggle), `src/memory/shared.test.ts` (aging), `src/memory/db.test.ts` (progressiveDisclose), `src/memory/obsidian.test.ts`, `src/mcp-triage.test.ts` (checklistFindings — incl. the advisory-does-not-flip-verdict case).

## Breaking Changes

None / N/A — every new library defaults to all-on when no allow-list is configured.

## Checklist

- [x] My code follows the project's style guidelines
- [x] All new code has test coverage
- [x] All tests pass locally (`npm test`)
- [x] No new warnings or errors introduced (typecheck clean, eslint 0, prettier clean)
- [x] Commit messages follow conventions
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

## Performance Impact

- [x] No performance impact

## Migration Guide

N/A

## Reviewer Notes

Each of the five feature commits was verified individually (typecheck + targeted tests + eslint + prettier) before landing. The zero-LLM boundary test still passes — nothing here reaches for an LLM SDK; the MCP checklist and memory aging are pure deterministic heuristics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)