### PR TITLE
fix(deps): npm audit fix — fast-uri high-severity host-confusion (GHSA-4c8g-83qw-93j6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1784,7 +1784,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -2018,9 +2020,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
The v5.4.0 publish attempt failed the fail-closed npm-audit-high gate in publish.yml (working as designed, not a CI flake): `fast-uri` 3.0.0-3.1.3, transitive via `@modelcontextprotocol/sdk → ajv → fast-uri`, has a high-severity host-confusion advisory (GHSA-4c8g-83qw-93j6 / GHSA-v2hh-gcrm-f6hx).

`npm audit fix` (non-force) bumps `fast-uri` to the patched version, no breaking change. 2 remaining moderate findings (hono/@hono-node-server chain) require `--force` (downgrades the MCP SDK, breaking) and sit below the `--audit-level=high` gate, so left alone.

Verified: `npm audit --audit-level=high` exits 0, build + cli tests green (38/38).

🤖 Generated with [Claude Code](https://claude.com/claude-code)