### PR TITLE
chore(release): 5.4.1 — audit-clean re-release (fast-uri high advisory)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.4.1] - 2026-07-22
+
+### Security
+
+- Lockfile bump to clear a newly-published **high** transitive advisory in `fast-uri`
+  (host confusion via failed IDN canonicalization / literal backslash authority delimiter —
+  GHSA-4c8g-83qw-93j6, GHSA-v2hh-gcrm-f6hx) via a non-forcing `npm audit fix`. No source
+  changes; identical CLI surface to 5.4.0. (5.4.0's publish was blocked by the publish gate's
+  `npm audit --audit-level=high` step when the advisory landed; this is the audit-clean
+  re-release.)
+
 ## [5.4.0] - 2026-07-21
 
 ### Added

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -959,7 +959,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.4.0"
+    "version": "5.4.1"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "5.4.0",
+      "version": "5.4.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -1784,7 +1784,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -2018,9 +2020,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
## Description

The `v5.4.0` publish run failed at the publish gate's **`npm audit --audit-level=high`** step: a newly-published **high** advisory landed in the transitive dependency **`fast-uri`** (host confusion via failed IDN canonicalization / literal backslash authority delimiter — GHSA-4c8g-83qw-93j6, GHSA-v2hh-gcrm-f6hx). The GPG-signed-tag and version-match steps passed; only the audit gate blocked it — working exactly as designed (refuse to ship a tarball with a known high CVE).

This PR is the **audit-clean re-release as 5.4.1**: a non-forcing `npm audit fix` clears the high; **no source changes**, identical CLI surface to 5.4.0.

We ship 5.4.1 rather than force-moving the signed `v5.4.0` tag — rewriting a release tag would contradict the publish pipeline's SHA-pinned, anti-tag-rewrite hardening.

## Type of Change

- [x] Security fix (transitive dependency advisory)

## Changes Made

- `npm audit fix` (non-forcing): clears the `fast-uri` high in `package-lock.json`. The 2 remaining advisories are **moderate** (`hono`, `@hono/node-server`), below the publish gate's `high` threshold, and their only fix is a breaking `@modelcontextprotocol/sdk` downgrade — deliberately not taken.
- version 5.4.0 → 5.4.1 (`package.json` + `package-lock.json`).
- CHANGELOG `[5.4.1] - 2026-07-22` (Security).
- regenerated `contracts/kit.opencli.json` (version roll only).

## Testing

- [x] All tests pass locally (`npm test`) — **3080 pass / 0 fail** (807 suites).
- [x] `npm audit --audit-level=high` → 0 high.
- [x] typecheck + build clean.

## Breaking Changes

None / N/A — lockfile + version only; CLI surface identical to 5.4.0.

## Reviewer Notes

After merge, tag `v5.4.1` (GPG-signed) and push to trigger `publish.yml`; approve the `npm-publish` environment gate. This is the version that will actually reach npm `latest` (5.4.0 was never published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)