### PR TITLE
chore(release): 5.5.0 — coverage AIUC-1/GCP-WAF, model-artifact triage, egress-exposure posture, agentskills.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.5.0] - 2026-07-22
+
+### Added
+
+- **coverage: AIUC-1 + GCP Well-Architected Security-pillar evidence maps.** Two new
+  toggleable `kit coverage` standards via the existing registry pattern
+  (`--standard=aiuc-1|gcp-waf-security`, `[coverage].standards`). AIUC-1 is a
+  domain-level map that **prepares for** an AIUC-1 audit (SEC/PRIV/ACC auto; SAF/REL/SOC
+  honest gap) — explicitly NOT a certificate/attestation. GCP WAF Security is a
+  principle-level map (zero-trust/shift-left/use-AI-securely auto; design/compliance
+  manual; **use-AI-for-security = n/a by charter** — kit is zero-LLM). Both carry an
+  explicit "confirmed via secondary indexes" caveat.
+- **`kit triage model <path>` — untrusted AI-artifact triage.** Deterministic, zero-LLM
+  triage of model weights / datasets before loading: code-execution-on-load formats
+  (pickle family) FAIL; gguf/onnx loader-hardening + safetensors/parquet data-only are
+  advisory; unknown = untrusted; flags unverified provenance (a `.sha256`/`.sig` sidecar
+  counts) and zero-byte files. (`--json`.)
+- **`kit doctor`: agent egress-exposure posture.** Warns when an install/exec gate is
+  wired but the exec-broker egress gate is NOT — the exact gap behind the 2026-07
+  OpenAI×HuggingFace eval-escape.
+- **`kit skill test`: agentskills.io invocation-control conformance.** Parses
+  `user-invokable` / `disable-model-invocation` and reports the invocation posture in the
+  scope check (advisory; legacy skills unaffected).
+
+### Changed
+
+- **THREAT_MODEL:** new section positioning kit as one layer of defense-in-depth — names
+  what it does NOT contain (kernel/network containment) and says to pair it with an OS
+  sandbox.
+
 ## [5.4.1] - 2026-07-22
 
 ### Security

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -240,7 +240,7 @@
     },
     "coverage": {
       "kind": "command",
-      "summary": "Evidence map: which standard's controls kit's deterministic checks auto-verify vs gap/manual/n-a — --standard=asvs|llm-top10|ssdf|agentic-top10|mcp-top10|all (default asvs); --list-standards to enumerate, [coverage].standards to toggle on/off (NOT a compliance attestation; --json for GRC tools)",
+      "summary": "Evidence map: which standard's controls kit's deterministic checks auto-verify vs gap/manual/n-a — --standard=asvs|llm-top10|ssdf|agentic-top10|mcp-top10|aiuc-1|gcp-waf-security|all (default asvs); --list-standards to enumerate, [coverage].standards to toggle on/off (NOT a compliance attestation; --json for GRC tools)",
       "x-kit-args-modeled": false,
       "x-kit-mcp": false,
       "x-kit-stability": "experimental"
@@ -959,7 +959,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.4.1"
+    "version": "5.5.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -278,6 +278,28 @@ same boundary the audit anchor documents); and the heuristic tier is advisory,
 not a guarantee. Signing the shared tier with the machine identity and a
 liveness gate for the capture hooks are tracked follow-ups.
 
+## kit is one layer of defense-in-depth (what it does NOT contain)
+
+kit governs the **agent-tool boundary**: it mediates the agent's declared tool
+calls (egress, fs, installs, secrets) through a signed least-privilege scope,
+fail-closed. That is a real, deterministic control — but it is **one layer, not a
+containment sandbox.**
+
+The 2026-07 OpenAI×HuggingFace eval-escape is the worked example: a model with a
+package-install tool found a zero-day *inside* that tool and opened its own socket
+to the open internet. kit's `gate-egress` is a **PreToolUse + scope-level** control;
+it closes the *declared* egress path and raises attacker cost, but a zero-day RCE in
+a spawned subprocess that opens a raw socket is **below** the layer a PreToolUse hook
+can see. kit does not provide kernel/network containment (namespaces, seccomp, a
+network jail) and does not claim to.
+
+The honest posture: **pair kit with a real OS/network sandbox.** kit enforces and
+proves the policy at the tool boundary and attests that the boundary held; the
+sandbox contains what happens *below* the tool boundary. `kit doctor` will warn
+(`agent egress exposure`) when an install/exec capability is wired without a
+scope-bound egress gate — the exact gap that became the escape hatch — but a green
+kit is a governed tool boundary, never a guarantee of containment.
+
 ## Out of scope (and why)
 
 - **LLM-router / orchestrator features.** kit is not Ruflo / Gas Town.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "5.4.1",
+  "version": "5.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "5.4.1",
+      "version": "5.5.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.4.1",
+  "version": "5.5.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/agent-config.test.ts
+++ b/src/agent-config.test.ts
@@ -989,6 +989,7 @@ describe("gateLiveness (enforcement floor must prove it exists)", () => {
         everInstalled: true,
         installGate: true,
         envGate: true,
+        egressGate: false,
       });
     });
   });

--- a/src/agent-config.ts
+++ b/src/agent-config.ts
@@ -497,6 +497,8 @@ export interface GateLiveness {
   installGate: boolean;
   /** PreToolUse env-write-gate (`gate-env`) present. */
   envGate: boolean;
+  /** PreToolUse exec-broker egress gate (`gate-egress`) present. */
+  egressGate: boolean;
 }
 
 /** Machine-local marker recording that kit installed the gates here (gitignored, beside them). */
@@ -531,7 +533,12 @@ export function gateLiveness(
   }
   const has = (suffix: string) =>
     pre.some((g) => g.hooks?.some((h) => h.command?.endsWith(suffix)));
-  return { everInstalled, installGate: has("gate-bash"), envGate: has("gate-env") };
+  return {
+    everInstalled,
+    installGate: has("gate-bash"),
+    envGate: has("gate-env"),
+    egressGate: has("gate-egress"),
+  };
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -610,7 +610,7 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
   coverage: {
     handler: cmdCoverage,
     stability: "experimental",
-    help: "Evidence map: which standard's controls kit's deterministic checks auto-verify vs gap/manual/n-a — --standard=asvs|llm-top10|ssdf|agentic-top10|mcp-top10|all (default asvs); --list-standards to enumerate, [coverage].standards to toggle on/off (NOT a compliance attestation; --json for GRC tools)",
+    help: "Evidence map: which standard's controls kit's deterministic checks auto-verify vs gap/manual/n-a — --standard=asvs|llm-top10|ssdf|agentic-top10|mcp-top10|aiuc-1|gcp-waf-security|all (default asvs); --list-standards to enumerate, [coverage].standards to toggle on/off (NOT a compliance attestation; --json for GRC tools)",
   },
   identity: {
     handler: cmdIdentity,

--- a/src/commands/triage.ts
+++ b/src/commands/triage.ts
@@ -7,6 +7,8 @@ import { triageMcpTools, extractToolDefs } from "../mcp-triage.js";
 import { discoverPlugins } from "../agent-sbom.js";
 import { scanPluginManifest, manifestHasHighRisk } from "../plugin-triage.js";
 import { triageVaultConfig } from "../vault-triage.js";
+import { triageModelArtifact } from "../model-artifact-triage.js";
+import { existsSync, statSync } from "node:fs";
 
 export async function cmdTriage(): Promise<boolean> {
   const args = process.argv.slice(3);
@@ -31,6 +33,9 @@ export async function cmdTriage(): Promise<boolean> {
   if (typeArg === "vault-config") {
     return cmdTriageVaultConfig();
   }
+  if (typeArg === "model") {
+    return cmdTriageModel(filtered.slice(1));
+  }
   const type = typeArg as TriageType;
   const target = filtered[1];
 
@@ -47,6 +52,9 @@ export async function cmdTriage(): Promise<boolean> {
       "  kit triage brew <formula>            Evaluate Homebrew formula (resolves upstream repo, then repo-scores)",
     );
     console.log("  kit triage repo <github-url>         Evaluate GitHub repository");
+    console.log(
+      "  kit triage model <path>              Evaluate an untrusted AI artifact (model weights / dataset) before loading",
+    );
     console.log("  kit triage skill <path|name>         Evaluate Claude Code / agent skill");
     console.log(
       "  kit triage skill <path|name> --deep  + SkillSpector (NVIDIA) static Stage 1 (no LLM, no egress) when installed",
@@ -698,4 +706,52 @@ async function cmdTriageCheckSkills(): Promise<boolean> {
   );
   console.error(`Bypass with --no-verify is recorded to ${SKIPPED_COMMITS_LOG}.${c.reset}`);
   return false;
+}
+
+/**
+ * `kit triage model <path>` — deterministic, zero-LLM triage of an untrusted AI
+ * artifact (model weights / dataset) BEFORE loading it into an inference runtime.
+ * Classifies the format's load-time risk (code-exec pickle family = fail; gguf/onnx
+ * loader-hardening + data-only = advisory) and flags unverified provenance. A
+ * `<path>.sha256` or `<path>.sig` sidecar counts as verified provenance. Exits
+ * non-zero on a high-confidence (code-exec) finding.
+ */
+export function cmdTriageModel(args: string[]): boolean {
+  const json = hasFlag(args, "--json");
+  const path = args.find((a) => !a.startsWith("--"));
+  if (!path) {
+    console.error("usage: kit triage model <path> [--json]");
+    return false;
+  }
+  let sizeBytes: number | undefined;
+  if (existsSync(path)) {
+    try {
+      sizeBytes = statSync(path).size;
+    } catch {
+      /* stat is best-effort; classification works from the name alone */
+    }
+  }
+  const provenanceVerified = existsSync(`${path}.sha256`) || existsSync(`${path}.sig`);
+  const r = triageModelArtifact(path, { sizeBytes, provenanceVerified });
+
+  if (json) {
+    console.log(JSON.stringify(r, null, 2));
+    return r.passed;
+  }
+
+  console.log(
+    `${c.bold}kit triage model${c.reset} — ${r.artifact} ${c.dim}(${r.formatRisk})${c.reset}`,
+  );
+  for (const f of r.findings) {
+    const tag =
+      f.confidence === "high" ? `${c.red}HIGH${c.reset}` : `${c.dim}advisory${c.reset}`;
+    console.log(`  [${tag}] ${f.label}`);
+    console.log(`      ${c.dim}${f.rationale}${c.reset}`);
+  }
+  console.log(
+    r.passed
+      ? `${c.green}pass${c.reset} — no code-execution-on-load format (still verify provenance + load in a sandbox)`
+      : `${c.red}fail${c.reset} — code-execution-on-load risk; do not load an untrusted file`,
+  );
+  return r.passed;
 }

--- a/src/commands/triage.ts
+++ b/src/commands/triage.ts
@@ -743,8 +743,7 @@ export function cmdTriageModel(args: string[]): boolean {
     `${c.bold}kit triage model${c.reset} — ${r.artifact} ${c.dim}(${r.formatRisk})${c.reset}`,
   );
   for (const f of r.findings) {
-    const tag =
-      f.confidence === "high" ? `${c.red}HIGH${c.reset}` : `${c.dim}advisory${c.reset}`;
+    const tag = f.confidence === "high" ? `${c.red}HIGH${c.reset}` : `${c.dim}advisory${c.reset}`;
     console.log(`  [${tag}] ${f.label}`);
     console.log(`      ${c.dim}${f.rationale}${c.reset}`);
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -403,7 +403,8 @@ export interface kitConfig {
    *  auto-installing is a deliberate trust decision. */
   update?: { check?: boolean; auto?: boolean };
   /** `kit coverage` — evidence-map standards toggle. `[coverage].standards` is an
-   *  allow-list of standard keys (asvs, llm-top10, ssdf, agentic-top10, mcp-top10)
+   *  allow-list of standard keys (asvs, llm-top10, ssdf, agentic-top10, mcp-top10,
+   *  aiuc-1, gcp-waf-security)
    *  that `--standard=all` runs and `--list-standards` marks enabled; absent/empty
    *  ⇒ all registered standards are on. */
   coverage?: { standards?: string[] };

--- a/src/coverage/aiuc-1.ts
+++ b/src/coverage/aiuc-1.ts
@@ -1,0 +1,81 @@
+/**
+ * Vendored, pinned AIUC-1 (AI-agent certification standard) as a kit coverage
+ * evidence map. Same honesty rule as the OWASP / SSDF maps: kit maps ONLY what its
+ * deterministic, local, zero-LLM checks can actually speak to, and buckets each
+ * domain honestly (auto / gap / manual / na).
+ *
+ * IMPORTANT — this is an EVIDENCE map that helps you PREPARE FOR and STAY READY
+ * BETWEEN AIUC-1 audits. It is NOT a certificate and NOT a compliance attestation.
+ * AIUC-1 certification is issued by the Artificial Intelligence Underwriting
+ * Company via an independent third-party audit + quarterly adversarial testing,
+ * and is backed by insurance (Lloyd's of London). kit produces evidence; the
+ * certificate and the underwriting are theirs.
+ *
+ * Structure note: AIUC-1's granular controls were NOT first-party verified
+ * (aiuc-1.com returned HTTP 403 in this environment, as with the OWASP maps), so
+ * this map is at the published DOMAIN level, confirmed via secondary indexes. See
+ * the `caveat`.
+ *
+ * Source: AIUC-1, the Artificial Intelligence Underwriting Company.
+ *   - https://www.aiuc-1.com/
+ */
+import type { StandardDescriptor } from "./standard.js";
+
+const SECTION = "AIUC-1 (AI agent standard)";
+
+export const AIUC_1: StandardDescriptor = {
+  key: "aiuc-1",
+  label: "AIUC-1 (AI agent standard)",
+  version: "2026",
+  source: "AIUC-1, the Artificial Intelligence Underwriting Company",
+  sourceUrl: "https://www.aiuc-1.com/",
+  unit: "domain",
+  caveat:
+    "Domain-level evidence map (granular controls not first-party verified — aiuc-1.com was HTTP-403 blocked; domains confirmed via secondary indexes). This PREPARES FOR an AIUC-1 audit and helps you stay ready between quarterly tests — it is NOT a certificate or attestation. Certification + underwriting are issued by AIUC via independent third-party audit.",
+  requirements: [
+    { id: "AIUC-1:SEC", section: SECTION, text: "Security — attack resistance & operational boundaries" },
+    { id: "AIUC-1:SAF", section: SECTION, text: "Safety — harm prevention & behavioral controls" },
+    { id: "AIUC-1:REL", section: SECTION, text: "Reliability — system dependability & error prevention" },
+    { id: "AIUC-1:PRIV", section: SECTION, text: "Data & privacy — protection of sensitive data" },
+    { id: "AIUC-1:ACC", section: SECTION, text: "Accountability — traceability & auditability" },
+    { id: "AIUC-1:SOC", section: SECTION, text: "Society — broader misuse prevention" },
+  ],
+  mapping: {
+    "AIUC-1:SEC": {
+      bucket: "auto",
+      checks: ["gate-egress", "gate-fs", "signed scope", "kit triage", "R7", "kit secrets"],
+      rationale:
+        "Operational boundaries are exactly kit's exec-broker: deny-by-default off-scope egress/fs/secret access under a signed least-privilege scope; kit triage + R7 add attack resistance (tool poisoning, injection). Directly the security-domain controls kit can enforce deterministically.",
+    },
+    "AIUC-1:SAF": {
+      bucket: "gap",
+      checks: ["gate-bash", "broker enforce"],
+      rationale:
+        "Narrow slice: kit denies dangerous/destructive tool actions at the boundary (gate-bash, deny-by-default). Behavioral/content safety (harmful outputs, refusal quality) is a model-side judgement kit deliberately does not make — delegated, not owned.",
+    },
+    "AIUC-1:REL": {
+      bucket: "gap",
+      checks: ["fail-closed", "no-false-green"],
+      rationale:
+        "kit's fail-closed determinism means a check that cannot run fails rather than passing green, which supports error-prevention — but system reliability (uptime, error rates, load behavior) is a runtime/operational property kit does not measure or enforce.",
+    },
+    "AIUC-1:PRIV": {
+      bucket: "auto",
+      checks: ["kit secrets", "gate-env", "PII redaction", "scan-transcripts"],
+      rationale:
+        "kit keeps credentials in the vault and out of the agent loop, blocks plaintext secret writes to .env (gate-env), redacts PII, and scans transcripts/caches for leaked sensitive data — the data-&-privacy controls directly.",
+    },
+    "AIUC-1:ACC": {
+      bucket: "auto",
+      checks: ["kit audit", "kit identity", "broker observe"],
+      rationale:
+        "Every governance decision is recorded to a tamper-evident, hash-chained audit log attributed to a signed identity (incl. observe-mode would-deny events) — traceability/auditability the accountability domain requires, verifiable offline.",
+    },
+    "AIUC-1:SOC": {
+      bucket: "gap",
+      checks: [],
+      rationale:
+        "Broader misuse prevention (societal harm, dual-use, abuse at scale) is a model-behavior and policy judgement kit does not make. kit governs the tool/loop boundary, not the content the model produces.",
+    },
+  },
+};

--- a/src/coverage/gcp-waf-security.ts
+++ b/src/coverage/gcp-waf-security.ts
@@ -1,0 +1,86 @@
+/**
+ * Vendored, pinned Google Cloud Well-Architected Framework — Security (privacy &
+ * compliance) pillar — as a kit coverage evidence map. Same honesty rule as the
+ * OWASP / SSDF / AIUC-1 maps: kit maps ONLY what its deterministic, local,
+ * zero-LLM checks can actually speak to, and buckets each principle honestly.
+ *
+ * This complements (does not replace) Google's own WAF Security skill: the skill
+ * DRAFTS an interactive assessment with an LLM; this is the DETERMINISTIC evidence
+ * a GRC tool can ingest. It is an evidence map, NOT a compliance attestation.
+ *
+ * Structure note: mapped at the pillar's core-PRINCIPLE level (not per-
+ * recommendation). Principles confirmed via the Google Cloud Architecture Center
+ * docs index; the first-party per-recommendation pages were not exhaustively
+ * verified in this environment. See the `caveat`.
+ *
+ * Source: Google Cloud Well-Architected Framework — Security, privacy, and
+ * compliance pillar.
+ *   - https://docs.cloud.google.com/architecture/framework/security
+ */
+import type { StandardDescriptor } from "./standard.js";
+
+const SECTION = "GCP WAF — Security pillar";
+
+export const GCP_WAF_SECURITY: StandardDescriptor = {
+  key: "gcp-waf-security",
+  label: "GCP Well-Architected — Security pillar",
+  version: "2026",
+  source: "Google Cloud Well-Architected Framework — Security, privacy & compliance pillar",
+  sourceUrl: "https://docs.cloud.google.com/architecture/framework/security",
+  unit: "principle",
+  caveat:
+    "Principle-level evidence map (not per-recommendation; principles confirmed via the GCP Architecture Center docs index, not exhaustively per-page verified). Complements Google's LLM-drafted WAF Security skill with deterministic evidence; NOT a compliance attestation.",
+  requirements: [
+    { id: "GWAF-SEC:DESIGN", section: SECTION, text: "Implement security by design" },
+    { id: "GWAF-SEC:ZEROTRUST", section: SECTION, text: "Implement zero trust" },
+    { id: "GWAF-SEC:SHIFTLEFT", section: SECTION, text: "Implement shift-left security" },
+    { id: "GWAF-SEC:PREEMPTIVE", section: SECTION, text: "Implement preemptive cyber defense" },
+    { id: "GWAF-SEC:AI-SECURE", section: SECTION, text: "Use AI securely and responsibly" },
+    { id: "GWAF-SEC:AI-FOR-SEC", section: SECTION, text: "Use AI for security" },
+    { id: "GWAF-SEC:COMPLIANCE", section: SECTION, text: "Meet regulatory, compliance, and privacy needs" },
+  ],
+  mapping: {
+    "GWAF-SEC:DESIGN": {
+      bucket: "manual",
+      checks: [],
+      rationale:
+        "kit supplies the scaffolding for security-by-design (a declared least-privilege scope, a standards baseline, a versioned profile), but whether the application/infrastructure was actually designed securely is a human architecture judgement kit surfaces evidence for, not one it decides.",
+    },
+    "GWAF-SEC:ZEROTRUST": {
+      bucket: "auto",
+      checks: ["gate-egress", "gate-fs", "signed scope", "kit context check", "broker enforce"],
+      rationale:
+        "The exec-broker is never-trust-always-verify by construction: no verified scope grants nothing, egress/fs/secret access is denied by default off-scope, and per-CLI context-lock verifies each tool points at the declared account/project — zero-trust at the agent-tool boundary.",
+    },
+    "GWAF-SEC:SHIFTLEFT": {
+      bucket: "auto",
+      checks: ["kit check", "kit review", "kit standards", "kit triage", "hooks"],
+      rationale:
+        "Shifting security left is kit's whole premise: the deterministic gate (check/review/standards/triage) runs in pre-commit hooks and CI before code or an install lands — controls early in the SDLC, fail-closed.",
+    },
+    "GWAF-SEC:PREEMPTIVE": {
+      bucket: "gap",
+      checks: ["R7", "kit triage", "kit scan"],
+      rationale:
+        "kit adds preemptive elements — injection detection (R7), pre-install triage, merged scanner verdicts — but proactive threat hunting, red-team exercises, and detonation are broader operational practices kit does not run.",
+    },
+    "GWAF-SEC:AI-SECURE": {
+      bucket: "auto",
+      checks: ["exec-broker", "kit triage skill", "kit triage mcp", "kit secrets", "install-gate"],
+      rationale:
+        "Using AI securely is exactly kit's core: govern the agent loop — least-privilege scope, triage of skills/MCP/packages before use, secrets kept out of the loop, un-triaged installs blocked. Deterministic and fail-closed.",
+    },
+    "GWAF-SEC:AI-FOR-SEC": {
+      bucket: "na",
+      checks: [],
+      rationale:
+        "Out of scope by charter: kit is zero-LLM and deterministic. It deliberately does NOT use AI to make security decisions — it delegates any LLM-based detection to best-of-breed tools and never runs their model stage, keeping its own verdict reproducible (no false green).",
+    },
+    "GWAF-SEC:COMPLIANCE": {
+      bucket: "manual",
+      checks: [],
+      rationale:
+        "kit enforces concrete privacy controls (vaulted secrets, PII redaction) and emits coverage evidence maps + a tamper-evident audit trail a GRC tool ingests — but meeting a specific regulation/compliance regime is an external attestation kit prepares for, never asserts.",
+    },
+  },
+};

--- a/src/coverage/registry.test.ts
+++ b/src/coverage/registry.test.ts
@@ -12,7 +12,7 @@ describe("coverage standards registry", () => {
   it("registers the expected standards, asvs first (the default)", () => {
     assert.deepEqual(
       [...COVERAGE_STANDARD_KEYS],
-      ["asvs", "llm-top10", "ssdf", "agentic-top10", "mcp-top10"],
+      ["asvs", "llm-top10", "ssdf", "agentic-top10", "mcp-top10", "aiuc-1", "gcp-waf-security"],
     );
     assert.equal(COVERAGE_STANDARDS[0]?.key, "asvs");
   });

--- a/src/coverage/registry.ts
+++ b/src/coverage/registry.ts
@@ -13,6 +13,8 @@ import { OWASP_LLM_TOP10 } from "./owasp-llm-top10.js";
 import { SSDF_218A } from "./ssdf-218a.js";
 import { OWASP_AGENTIC_TOP10 } from "./owasp-agentic-top10.js";
 import { OWASP_MCP_TOP10 } from "./owasp-mcp-top10.js";
+import { AIUC_1 } from "./aiuc-1.js";
+import { GCP_WAF_SECURITY } from "./gcp-waf-security.js";
 
 export interface CoverageStandard {
   /** CLI selector, e.g. "asvs" | "llm-top10" | "agentic-top10". */
@@ -42,6 +44,8 @@ export const COVERAGE_STANDARDS: readonly CoverageStandard[] = [
   fromDescriptor(SSDF_218A),
   fromDescriptor(OWASP_AGENTIC_TOP10),
   fromDescriptor(OWASP_MCP_TOP10),
+  fromDescriptor(AIUC_1),
+  fromDescriptor(GCP_WAF_SECURITY),
 ];
 
 export const COVERAGE_STANDARD_KEYS: readonly string[] = COVERAGE_STANDARDS.map((s) => s.key);

--- a/src/coverage/standard.test.ts
+++ b/src/coverage/standard.test.ts
@@ -10,6 +10,8 @@ import { OWASP_LLM_TOP10 } from "./owasp-llm-top10.js";
 import { SSDF_218A } from "./ssdf-218a.js";
 import { OWASP_AGENTIC_TOP10 } from "./owasp-agentic-top10.js";
 import { OWASP_MCP_TOP10 } from "./owasp-mcp-top10.js";
+import { AIUC_1 } from "./aiuc-1.js";
+import { GCP_WAF_SECURITY } from "./gcp-waf-security.js";
 import type { SecurityCheckResult } from "../check-security.js";
 
 const VALID_BUCKETS = ["auto", "gap", "manual", "na"];
@@ -18,6 +20,8 @@ const DESCRIPTORS: StandardDescriptor[] = [
   SSDF_218A,
   OWASP_AGENTIC_TOP10,
   OWASP_MCP_TOP10,
+  AIUC_1,
+  GCP_WAF_SECURITY,
 ];
 
 for (const d of DESCRIPTORS) {

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -480,4 +480,4 @@ describe("agentEgressExposureStatus (OpenAI eval-escape gap)", () => {
     assert.equal(r.status, "warn");
     assert.match(r.detail, /gate-egress|scope-bound|escape/i);
   });
-})
+});

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -4,7 +4,7 @@ import { writeFile, unlink, mkdir, rmdir, rm } from "node:fs/promises";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { runDoctor, triageGateStatus } from "./doctor.js";
+import { runDoctor, triageGateStatus, agentEgressExposureStatus } from "./doctor.js";
 import { loadOrCreateIdentity, identityId } from "./identity.js";
 import { resolveKeyStore } from "./keystore/index.js";
 import {
@@ -465,3 +465,19 @@ describe("triageGateStatus (pure — pre-commit gate posture)", () => {
     assert.match(triageGateStatus(null).detail, /kit setup --recommended/);
   });
 });
+
+describe("agentEgressExposureStatus (OpenAI eval-escape gap)", () => {
+  it("skips when no install/exec gate is wired (nothing to constrain)", () => {
+    const r = agentEgressExposureStatus({ installGate: false, egressGate: false });
+    assert.equal(r.status, "skip");
+  });
+  it("passes when install-gate is present AND egress is scope-bound", () => {
+    const r = agentEgressExposureStatus({ installGate: true, egressGate: true });
+    assert.equal(r.status, "pass");
+  });
+  it("WARNS on the escape-hatch gap: install/exec wired but egress not scope-bound", () => {
+    const r = agentEgressExposureStatus({ installGate: true, egressGate: false });
+    assert.equal(r.status, "warn");
+    assert.match(r.detail, /gate-egress|scope-bound|escape/i);
+  });
+})

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -469,7 +469,8 @@ export function agentEgressExposureStatus(g: { installGate: boolean; egressGate:
   if (!g.installGate) {
     return {
       status: "skip",
-      detail: "no install/exec gate wired here — nothing with an install/exec capability to constrain",
+      detail:
+        "no install/exec gate wired here — nothing with an install/exec capability to constrain",
     };
   }
   if (g.egressGate) {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -452,6 +452,48 @@ async function checkTriageGates(cwd: string): Promise<DoctorCheck> {
 }
 
 /**
+ * Agent egress-exposure posture. The OpenAI×HuggingFace eval-escape incident (2026-07) turned on
+ * exactly this gap: an agent had an install/exec capability but its egress was NOT scope-bound, so a
+ * package/exec tool reached the open internet. kit warns when the install-gate is wired (the agent
+ * CAN install/run tools) but the exec-broker egress gate (`gate-egress`) is NOT — the escape-hatch
+ * class. Never silent:
+ *   skip  no install/exec gate wired here — nothing with that capability to constrain
+ *   pass  install/exec gate present AND egress is scope-bound (gate-egress wired)
+ *   warn  install/exec gate present but egress is NOT scope-bound — the escape-hatch gap
+ * Pure decision split out for testing.
+ */
+export function agentEgressExposureStatus(g: { installGate: boolean; egressGate: boolean }): {
+  status: DoctorCheckStatus;
+  detail: string;
+} {
+  if (!g.installGate) {
+    return {
+      status: "skip",
+      detail: "no install/exec gate wired here — nothing with an install/exec capability to constrain",
+    };
+  }
+  if (g.egressGate) {
+    return {
+      status: "pass",
+      detail:
+        "install/exec gate present and egress is scope-bound (gate-egress wired) — a spawned install/exec tool cannot reach off-scope hosts",
+    };
+  }
+  return {
+    status: "warn",
+    detail:
+      "agent can install/run tools (install-gate wired) but egress is NOT scope-bound — a package/exec tool could reach the open internet (the OpenAI eval-escape class). Wire it: 'kit agent-config --broker-gate' + declare [scope].egress",
+  };
+}
+
+async function checkAgentEgressExposure(cwd: string): Promise<DoctorCheck> {
+  const { gateLiveness } = await import("./agent-config.js");
+  const live = gateLiveness(cwd);
+  const { status, detail } = agentEgressExposureStatus(live);
+  return { name: "agent egress exposure", status, detail, category: "security" };
+}
+
+/**
  * Keyless-credential posture (Pillar 2 tail — "sign, don't store"). Reports whether any hosts are
  * declared keyless (`[scope].sign`) and whether kit can actually sign for them — never silent:
  *   skip  no keyless hosts declared
@@ -583,6 +625,7 @@ export async function runDoctor(config: kitConfig, cwd: string): Promise<DoctorR
   allChecks.push(await checkBrokerScope(cwd));
   allChecks.push(await checkBrokerRuntime(cwd));
   allChecks.push(await checkKeyless(cwd));
+  allChecks.push(await checkAgentEgressExposure(cwd));
   allChecks.push(await checkDeepSkillScanner());
   allChecks.push(await checkTriageGates(cwd));
   allChecks.push(checkControlPlane(cwd));

--- a/src/model-artifact-triage.test.ts
+++ b/src/model-artifact-triage.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { triageModelArtifact } from "./model-artifact-triage.js";
+
+describe("triageModelArtifact", () => {
+  it("FAILS a pickle-family (code-exec-on-load) format with high confidence", () => {
+    for (const f of ["model.pkl", "weights.pt", "ckpt.bin", "x.ckpt", "a.pth"]) {
+      const r = triageModelArtifact(f, { provenanceVerified: true });
+      assert.equal(r.formatRisk, "code-exec", f);
+      assert.equal(r.passed, false, f);
+      assert.ok(r.findings.some((x) => x.confidence === "high"), f);
+    }
+  });
+
+  it("passes .safetensors (data-only) but keeps an untrusted-data advisory", () => {
+    const r = triageModelArtifact("model.safetensors", { provenanceVerified: true });
+    assert.equal(r.formatRisk, "data-only");
+    assert.equal(r.passed, true);
+    assert.ok(r.findings.every((x) => x.confidence === "heuristic"));
+  });
+
+  it("flags .gguf as loader-hardening-sensitive (advisory, still passes)", () => {
+    const r = triageModelArtifact("llama.gguf", { provenanceVerified: true });
+    assert.equal(r.formatRisk, "loader-hardening");
+    assert.equal(r.passed, true);
+    assert.ok(r.findings.some((x) => /loader-hardening/.test(x.label)));
+  });
+
+  it("treats an unknown extension as untrusted (advisory)", () => {
+    const r = triageModelArtifact("weights.xyz", { provenanceVerified: true });
+    assert.equal(r.formatRisk, "unknown");
+    assert.equal(r.passed, true);
+  });
+
+  it("adds an unverified-provenance finding when no verification is supplied", () => {
+    const r = triageModelArtifact("model.safetensors");
+    assert.ok(r.findings.some((x) => /provenance/.test(x.label)));
+  });
+
+  it("flags a zero-byte artifact", () => {
+    const r = triageModelArtifact("model.gguf", { sizeBytes: 0, provenanceVerified: true });
+    assert.ok(r.findings.some((x) => /zero-byte/.test(x.label)));
+  });
+
+  it("is deterministic and strips the directory (basename only)", () => {
+    const a = triageModelArtifact("/tmp/downloads/model.pkl");
+    const b = triageModelArtifact("model.pkl");
+    assert.equal(a.artifact, "model.pkl");
+    assert.equal(a.formatRisk, b.formatRisk);
+    assert.equal(a.passed, b.passed);
+  });
+});

--- a/src/model-artifact-triage.test.ts
+++ b/src/model-artifact-triage.test.ts
@@ -8,7 +8,10 @@ describe("triageModelArtifact", () => {
       const r = triageModelArtifact(f, { provenanceVerified: true });
       assert.equal(r.formatRisk, "code-exec", f);
       assert.equal(r.passed, false, f);
-      assert.ok(r.findings.some((x) => x.confidence === "high"), f);
+      assert.ok(
+        r.findings.some((x) => x.confidence === "high"),
+        f,
+      );
     }
   });
 

--- a/src/model-artifact-triage.ts
+++ b/src/model-artifact-triage.ts
@@ -37,14 +37,33 @@ export interface ModelArtifactTriage {
  * (Python `pickle` and formats that wrap it). The single high-confidence class.
  */
 const CODE_EXEC_EXTS = new Set([
-  ".pkl", ".pickle", ".pt", ".pth", ".bin", ".ckpt", ".joblib", ".dill", ".npy", ".npz", ".h5", ".pb", ".model",
+  ".pkl",
+  ".pickle",
+  ".pt",
+  ".pth",
+  ".bin",
+  ".ckpt",
+  ".joblib",
+  ".dill",
+  ".npy",
+  ".npz",
+  ".h5",
+  ".pb",
+  ".model",
 ]);
 
 /** Formats with no pickle exec but whose LOADERS have had memory-safety CVEs (verify source + integrity). */
 const LOADER_HARDENING_EXTS = new Set([".gguf", ".ggml", ".onnx"]);
 
 /** Formats designed to carry data only (no code exec) — still untrusted DATA, verify integrity/provenance. */
-const DATA_ONLY_EXTS = new Set([".safetensors", ".parquet", ".arrow", ".jsonl", ".csv", ".tfrecord"]);
+const DATA_ONLY_EXTS = new Set([
+  ".safetensors",
+  ".parquet",
+  ".arrow",
+  ".jsonl",
+  ".csv",
+  ".tfrecord",
+]);
 
 /**
  * Triage a single model/dataset artifact by name (and optional size / known-good hash

--- a/src/model-artifact-triage.ts
+++ b/src/model-artifact-triage.ts
@@ -1,0 +1,115 @@
+/**
+ * kit — untrusted AI-artifact triage (model weights / eval datasets).
+ *
+ * A locally-run model file is an UNTRUSTED artifact like any dependency: the
+ * OpenAI×HuggingFace eval-escape (2026-07) entered via a malicious dataset with
+ * code-execution in the data pipeline, and llama.cpp GGUF loaders have shipped
+ * heap-overflow RCEs on crafted `.gguf` files. "Runs locally" is not "runs safely".
+ * This is the deterministic, zero-LLM triage of a model/dataset artifact BEFORE you
+ * load it into an inference runtime.
+ *
+ * Pure + deterministic: classification is by file extension + optional size, with an
+ * honest UNKNOWN when the format can't be classified. Confidence is "high" only for
+ * the pickle/deserialization family (documented arbitrary-code-execution on load);
+ * everything else is "heuristic" advisory. No network, no LLM.
+ */
+import { basename, extname } from "node:path";
+
+export type ArtifactFormatRisk = "code-exec" | "loader-hardening" | "data-only" | "unknown";
+
+export interface ModelArtifactFinding {
+  label: string;
+  rationale: string;
+  confidence: "high" | "heuristic";
+}
+
+export interface ModelArtifactTriage {
+  artifact: string;
+  ext: string;
+  formatRisk: ArtifactFormatRisk;
+  findings: ModelArtifactFinding[];
+  /** No high-confidence (code-exec-on-load) finding. Loader-hardening/unknown stay advisory. */
+  passed: boolean;
+}
+
+/**
+ * Deserialization/code-exec-on-load family: loading these can run arbitrary code
+ * (Python `pickle` and formats that wrap it). The single high-confidence class.
+ */
+const CODE_EXEC_EXTS = new Set([
+  ".pkl", ".pickle", ".pt", ".pth", ".bin", ".ckpt", ".joblib", ".dill", ".npy", ".npz", ".h5", ".pb", ".model",
+]);
+
+/** Formats with no pickle exec but whose LOADERS have had memory-safety CVEs (verify source + integrity). */
+const LOADER_HARDENING_EXTS = new Set([".gguf", ".ggml", ".onnx"]);
+
+/** Formats designed to carry data only (no code exec) — still untrusted DATA, verify integrity/provenance. */
+const DATA_ONLY_EXTS = new Set([".safetensors", ".parquet", ".arrow", ".jsonl", ".csv", ".tfrecord"]);
+
+/**
+ * Triage a single model/dataset artifact by name (and optional size / known-good hash
+ * state). Pure — the caller supplies the facts; this never touches disk or network.
+ */
+export function triageModelArtifact(
+  fileName: string,
+  opts: { sizeBytes?: number; provenanceVerified?: boolean } = {},
+): ModelArtifactTriage {
+  const artifact = basename(fileName);
+  const ext = extname(artifact).toLowerCase();
+  const findings: ModelArtifactFinding[] = [];
+
+  let formatRisk: ArtifactFormatRisk;
+  if (CODE_EXEC_EXTS.has(ext)) {
+    formatRisk = "code-exec";
+    findings.push({
+      label: `code-execution-on-load format (${ext})`,
+      rationale:
+        "This format can execute arbitrary code when deserialized (Python pickle family). Do not load untrusted files; prefer .safetensors, or load in a sandbox with weights-only/trusted-source guarantees.",
+      confidence: "high",
+    });
+  } else if (LOADER_HARDENING_EXTS.has(ext)) {
+    formatRisk = "loader-hardening";
+    findings.push({
+      label: `loader-hardening-sensitive format (${ext})`,
+      rationale:
+        "No pickle code-exec, but the loaders for this format have shipped memory-safety CVEs (e.g. crafted .gguf → heap overflow in llama.cpp). Verify the source and integrity, and keep the runtime patched.",
+      confidence: "heuristic",
+    });
+  } else if (DATA_ONLY_EXTS.has(ext)) {
+    formatRisk = "data-only";
+    findings.push({
+      label: `data-only format (${ext})`,
+      rationale:
+        "Designed to carry data without code execution — but it is still UNTRUSTED input. A malicious dataset can exploit the pipeline that processes it (the OpenAI eval-escape entry vector). Verify integrity/provenance and process in a sandbox.",
+      confidence: "heuristic",
+    });
+  } else {
+    formatRisk = "unknown";
+    findings.push({
+      label: ext ? `unclassified artifact format (${ext})` : "no file extension",
+      rationale:
+        "Cannot classify this artifact's format, so its load-time behavior is unknown. Treat as untrusted: identify the format, prefer a code-exec-free container, and load in a sandbox.",
+      confidence: "heuristic",
+    });
+  }
+
+  if (opts.provenanceVerified !== true) {
+    findings.push({
+      label: "unverified provenance",
+      rationale:
+        "No verified source/signature/known-good hash for this artifact. 'Expert-approved' or 'popular' is not 'verified on your machine' — pin and verify a hash before loading.",
+      confidence: "heuristic",
+    });
+  }
+
+  if (opts.sizeBytes === 0) {
+    findings.push({
+      label: "zero-byte artifact",
+      rationale: "The file is empty — a truncated/failed download or a placeholder; do not load.",
+      confidence: "heuristic",
+    });
+  }
+
+  const passed = !findings.some((f) => f.confidence === "high");
+  return { artifact, ext, formatRisk, findings, passed };
+}

--- a/src/skill/test.test.ts
+++ b/src/skill/test.test.ts
@@ -274,4 +274,4 @@ describe("agentskills.io invocation-control fields", () => {
     );
     assert.equal(skillInvocationPosture(m), "model-invocation disabled, not user-invokable");
   });
-})
+});

--- a/src/skill/test.test.ts
+++ b/src/skill/test.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   parseSkillManifest,
+  skillInvocationPosture,
   checkContract,
   checkTrigger,
   checkScope,
@@ -245,3 +246,32 @@ describe("testSkill — the folded report", () => {
     assert.ok(DISCLAIMED.some((d) => d.id === "rubric" && /never run by kit/.test(d.reason)));
   });
 });
+
+describe("agentskills.io invocation-control fields", () => {
+  it("parses user-invokable + disable-model-invocation booleans (dash and underscore)", () => {
+    const m = parseSkillManifest(
+      "---\nname: x\ndescription: does a thing well enough\nuser-invokable: false\ndisable-model-invocation: true\n---\nbody",
+    );
+    assert.equal(m.userInvokable, false);
+    assert.equal(m.disableModelInvocation, true);
+    const m2 = parseSkillManifest(
+      "---\nname: x\ndescription: does a thing well enough\nuser_invokable: true\ndisable_model_invocation: false\n---\nbody",
+    );
+    assert.equal(m2.userInvokable, true);
+    assert.equal(m2.disableModelInvocation, false);
+  });
+
+  it("posture is null when neither field is present (no change to legacy skills)", () => {
+    const m = parseSkillManifest("---\nname: x\ndescription: does a thing well enough\n---\nbody");
+    assert.equal(skillInvocationPosture(m), null);
+    assert.equal(m.userInvokable, undefined);
+    assert.equal(m.disableModelInvocation, undefined);
+  });
+
+  it("posture reports model-invocation disabled + not user-invokable", () => {
+    const m = parseSkillManifest(
+      "---\nname: x\ndescription: does a thing well enough\ndisable-model-invocation: true\nuser-invokable: false\n---\nbody",
+    );
+    assert.equal(skillInvocationPosture(m), "model-invocation disabled, not user-invokable");
+  });
+})

--- a/src/skill/test.ts
+++ b/src/skill/test.ts
@@ -41,10 +41,29 @@ export interface SkillManifest {
    *   - `[...]`     → a bounded tool list
    */
   allowedTools?: string[];
+  /**
+   * agentskills.io invocation control — whether a human may trigger the skill via a
+   * slash command. `undefined` → field absent (spec default: user-invokable).
+   */
+  userInvokable?: boolean;
+  /**
+   * agentskills.io invocation control — whether the AGENT may autonomously invoke the
+   * skill. `undefined` → field absent (spec default: model MAY invoke). `true` means the
+   * model is forbidden from auto-invoking (restrict sensitive ops to user-only).
+   */
+  disableModelInvocation?: boolean;
   /** The markdown body after the frontmatter block (trimmed). */
   body: string;
   /** True when a `---` frontmatter block was found at all. */
   hasFrontmatter: boolean;
+}
+
+/** Parse a frontmatter boolean scalar (`true`/`false`, case-insensitive); undefined otherwise. */
+function parseBool(v: string): boolean | undefined {
+  const s = v.trim().replace(/^["']|["']$/g, "").toLowerCase();
+  if (s === "true") return true;
+  if (s === "false") return false;
+  return undefined;
 }
 
 /** Split a comma / inline-array / block-list frontmatter value into trimmed items. */
@@ -92,6 +111,10 @@ export function parseSkillManifest(raw: string): SkillManifest {
 
     if (key === "name") manifest.name = unquote(value);
     else if (key === "description") manifest.description = unquote(value);
+    else if (key === "user-invokable" || key === "user_invokable")
+      manifest.userInvokable = parseBool(value);
+    else if (key === "disable-model-invocation" || key === "disable_model_invocation")
+      manifest.disableModelInvocation = parseBool(value);
     else if (key === "allowed-tools" || key === "allowed_tools") {
       // Collect any following `  - item` block-list lines.
       const blockItems: string[] = [];
@@ -192,7 +215,13 @@ export function checkTrigger(m: SkillManifest, siblings: SiblingSkill[] = []): C
  * runtime job (P2), disclaimed separately. Pure.
  */
 export function checkScope(m: SkillManifest): CheckResult {
-  const s = (status: CheckStatus, detail: string): CheckResult => ({ id: "scope", status, detail });
+  const posture = skillInvocationPosture(m);
+  const suffix = posture ? ` [${posture}]` : "";
+  const s = (status: CheckStatus, detail: string): CheckResult => ({
+    id: "scope",
+    status,
+    detail: detail + suffix,
+  });
   if (m.allowedTools === undefined)
     return s(
       "fail",
@@ -203,6 +232,21 @@ export function checkScope(m: SkillManifest): CheckResult {
   if (m.allowedTools.length === 0)
     return s("pass", "declares zero tools (maximally least-privilege)");
   return s("pass", `declares a bounded scope of ${m.allowedTools.length} tool(s)`);
+}
+
+/**
+ * agentskills.io invocation posture — a short, deterministic description of who may
+ * trigger the skill, derived from the `user-invokable` / `disable-model-invocation`
+ * fields. `null` when neither field is present (nothing to report). Advisory: it
+ * enriches the scope detail; it does not change the pass/fail verdict. The higher-risk
+ * posture is "model-invocable" with a broad tool surface — surfaced here so a reviewer
+ * (or `kit triage skill`) can weigh the autonomous-exposure surface.
+ */
+export function skillInvocationPosture(m: SkillManifest): string | null {
+  if (m.userInvokable === undefined && m.disableModelInvocation === undefined) return null;
+  const modelPart = m.disableModelInvocation === true ? "model-invocation disabled" : "model-invocable";
+  const userPart = m.userInvokable === false ? "not user-invokable" : "user-invokable";
+  return `${modelPart}, ${userPart}`;
 }
 
 /** The canonical, snapshot-able facts about a skill module (order-stable). */

--- a/src/skill/test.ts
+++ b/src/skill/test.ts
@@ -60,7 +60,10 @@ export interface SkillManifest {
 
 /** Parse a frontmatter boolean scalar (`true`/`false`, case-insensitive); undefined otherwise. */
 function parseBool(v: string): boolean | undefined {
-  const s = v.trim().replace(/^["']|["']$/g, "").toLowerCase();
+  const s = v
+    .trim()
+    .replace(/^["']|["']$/g, "")
+    .toLowerCase();
   if (s === "true") return true;
   if (s === "false") return false;
   return undefined;
@@ -244,7 +247,8 @@ export function checkScope(m: SkillManifest): CheckResult {
  */
 export function skillInvocationPosture(m: SkillManifest): string | null {
   if (m.userInvokable === undefined && m.disableModelInvocation === undefined) return null;
-  const modelPart = m.disableModelInvocation === true ? "model-invocation disabled" : "model-invocable";
+  const modelPart =
+    m.disableModelInvocation === true ? "model-invocation disabled" : "model-invocable";
   const userPart = m.userInvokable === false ? "not user-invokable" : "user-invokable";
   return `${modelPart}, ${userPart}`;
 }


### PR DESCRIPTION
## Description

Implements the charter-clean, buildable follow-ups harvested from the `sandstream/kit-research` backlog (the recent Antares / OpenAI-eval-escape / AIUC-1 / Agent-Skills notes). Five increments, each verified individually (typecheck + targeted tests + eslint + prettier) before landing. Common thread: **connect / verify / enforce — never own or attest**.

## Type of Change

- [x] New feature (non-breaking, additive)

## Changes Made

- **coverage — AIUC-1 + GCP Well-Architected Security-pillar evidence maps.** Two new toggleable `kit coverage` standards through the existing registry/descriptor pattern (`--standard=aiuc-1|gcp-waf-security`, `[coverage].standards`). AIUC-1 is a *domain-level* map that **prepares for** an AIUC-1 audit (honest auto/gap split) — explicitly **not** a certificate/attestation. GCP WAF Security is *principle-level* (zero-trust/shift-left/use-AI-securely auto; design/compliance manual; **use-AI-for-security = n/a by charter** — kit is zero-LLM). Both carry a "confirmed via secondary indexes" caveat (first-party sites were HTTP-403).
- **triage — `kit triage model <path>`.** Deterministic, zero-LLM triage of an untrusted AI artifact (weights/dataset) before loading: pickle-family code-exec formats **FAIL** (high confidence); gguf/onnx loader-hardening + safetensors/parquet data-only are advisory; unknown = untrusted; flags unverified provenance (`.sha256`/`.sig` sidecar counts) + zero-byte files. (`--json`.)
- **doctor — agent egress-exposure posture.** Warns when an install/exec gate is wired but the exec-broker egress gate is **not** — the exact gap behind the OpenAI×HuggingFace eval-escape.
- **skill — agentskills.io invocation-control conformance.** `kit skill test` now parses `user-invokable` / `disable-model-invocation` and reports the invocation posture in the scope check (advisory; legacy skills unaffected).
- **docs — THREAT_MODEL.** New section positioning kit as *one layer* of defense-in-depth; names what it does not contain (kernel/network containment) and says to pair it with an OS sandbox.

## Not included (honest scope)

- An **Antares scanner-delegate** entry was deliberately **not** shipped: a real delegate needs `antares-cli`'s invocation/output contract (unverifiable here) + a local model, and the `ScannerDef` model runs a fixed `bin`/`args` — a hardcoded entry would be a fabricated invocation (false green). The untrusted-local-model-file half of that note is delivered by `kit triage model`. Left as a documented follow-up.

## Testing

- [x] All tests pass (`npm test`) — **3107 pass / 0 fail** (812 suites; +27 new).
- [x] typecheck + build clean; eslint 0 errors (pre-existing warnings only); prettier clean.

New/extended tests: `src/coverage/{registry,standard}.test.ts`, `src/model-artifact-triage.test.ts`, `src/doctor.test.ts` (egress posture), `src/skill/test.test.ts` (invocation fields), `src/agent-config.test.ts` (egressGate).

## Breaking Changes

None / N/A — every addition is additive; new coverage standards default to all-on when no allow-list is set.

## Checklist

- [x] All new code has test coverage
- [x] All tests pass locally
- [x] No new warnings or errors (pre-existing lint warnings only)
- [x] No hardcoded secrets or sensitive data
- [x] Code has been self-reviewed

## Reviewer Notes

The "no false green" discipline shows up twice: the coverage maps bucket honestly (real `gap`/`manual`/`na`, incl. `na` where kit's charter deliberately doesn't cover a control), and the Antares delegate was skipped rather than faked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)