### PR TITLE
feat(doctor): OS-containment posture — verify the sandbox below the tool boundary (5.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.6.0] - 2026-07-22
+
+### Added
+
+- **`kit doctor`: OS-containment posture (defense-in-depth).** Deterministically detects the
+  sandbox *below* the tool boundary from Linux `/proc` (container markers, seccomp mode,
+  no_new_privs, user namespace) and folds it into the posture: `pass` when contained,
+  `warn` when an install/exec gate is wired with **no** OS containment beneath it (pair kit
+  with a sandbox), and honest `skip`/`unknown` on non-Linux — never a false "not contained".
+  New pure `src/containment.ts` (`detectContainment` + `gatherContainmentSignals`).
+  Realizes the containment-as-verified-delegate design: kit detects/verifies a sandbox, it
+  does not become one.
+
 ## [5.5.0] - 2026-07-22
 
 ### Added

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -959,7 +959,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.5.0"
+    "version": "5.6.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/containment.test.ts
+++ b/src/containment.test.ts
@@ -1,0 +1,54 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { detectContainment, parseSeccompMode, cgroupHasContainer } from "./containment.js";
+
+describe("detectContainment", () => {
+  it("returns unknown (not 'not contained') when signals are unreadable", () => {
+    const v = detectContainment({ unreadable: true });
+    assert.equal(v.mechanism, "unknown");
+    assert.equal(v.contained, false);
+    assert.equal(v.confidence, "none");
+  });
+
+  it("detects a container (high confidence when seccomp is also active)", () => {
+    const v = detectContainment({ dockerEnv: true, seccompMode: 2 });
+    assert.equal(v.mechanism, "container");
+    assert.equal(v.contained, true);
+    assert.equal(v.confidence, "high");
+  });
+
+  it("a bare container (no seccomp) is contained but heuristic", () => {
+    const v = detectContainment({ cgroupContainer: true, seccompMode: 0 });
+    assert.equal(v.mechanism, "container");
+    assert.equal(v.contained, true);
+    assert.equal(v.confidence, "heuristic");
+  });
+
+  it("seccomp alone counts as containment", () => {
+    const v = detectContainment({ seccompMode: 2, dockerEnv: false, cgroupContainer: false });
+    assert.equal(v.mechanism, "seccomp");
+    assert.equal(v.contained, true);
+  });
+
+  it("readable but no signal ⇒ none (not unknown)", () => {
+    const v = detectContainment({ dockerEnv: false, cgroupContainer: false, seccompMode: 0 });
+    assert.equal(v.mechanism, "none");
+    assert.equal(v.contained, false);
+  });
+});
+
+describe("parseSeccompMode", () => {
+  it("parses the Seccomp field", () => {
+    assert.equal(parseSeccompMode("Name:\tx\nSeccomp:\t2\nNoNewPrivs:\t1\n"), 2);
+    assert.equal(parseSeccompMode("Seccomp:\t0\n"), 0);
+    assert.equal(parseSeccompMode("no field here"), undefined);
+  });
+});
+
+describe("cgroupHasContainer", () => {
+  it("detects container runtimes", () => {
+    assert.equal(cgroupHasContainer("0::/docker/abc123"), true);
+    assert.equal(cgroupHasContainer("0::/kubepods/pod/x"), true);
+    assert.equal(cgroupHasContainer("0::/user.slice/session.scope"), false);
+  });
+});

--- a/src/containment.ts
+++ b/src/containment.ts
@@ -1,0 +1,151 @@
+/**
+ * kit — containment detection (the sandbox BELOW the tool boundary).
+ *
+ * kit governs the tool boundary (PreToolUse + signed scope); a real OS/network
+ * sandbox contains what happens beneath it (the OpenAI eval-escape happened there).
+ * kit must NOT become a sandbox — it DETECTS and VERIFIES one as a delegate, and
+ * folds the fact into its posture. Deterministic, zero-LLM, read-only.
+ *
+ * Design: kit-research/docs/research/containment-delegate-design.md.
+ *
+ * Honest semantics: `contained: true` only on a positive signal; `unknown` when the
+ * signals can't be read (non-Linux, restricted /proc) — never a false "not contained"
+ * (absence of evidence is not evidence of absence).
+ */
+import { readFileSync, existsSync } from "node:fs";
+
+export type ContainmentMechanism = "container" | "seccomp" | "none" | "unknown";
+
+/** Parsed, deterministic containment signals (all optional — unknown when unread). */
+export interface ContainmentSignals {
+  /** `/.dockerenv` (or equivalent) present. */
+  dockerEnv?: boolean;
+  /** cgroup text contained a container runtime marker (docker/containerd/kubepods/lxc/libpod). */
+  cgroupContainer?: boolean;
+  /** `/proc/self/status` Seccomp field: 0 disabled, 1 strict, 2 filter; undefined = unread. */
+  seccompMode?: 0 | 1 | 2;
+  /** `/proc/self/status` NoNewPrivs: true when 1. */
+  noNewPrivs?: boolean;
+  /** A non-identity `/proc/self/uid_map` ⇒ a user namespace is in effect. */
+  userNamespace?: boolean;
+  /** The signal source could not be read at all (e.g. no /proc) ⇒ verdict is `unknown`. */
+  unreadable?: boolean;
+}
+
+export interface ContainmentVerdict {
+  mechanism: ContainmentMechanism;
+  /** True only on a positive isolation signal. Never inferred from absence. */
+  contained: boolean;
+  confidence: "high" | "heuristic" | "none";
+  details: string[];
+}
+
+/**
+ * Pure verdict from parsed signals. `unknown` when nothing could be read; `none` when
+ * readable but no isolation signal present; `container`/`seccomp` on a positive signal.
+ */
+export function detectContainment(s: ContainmentSignals): ContainmentVerdict {
+  if (s.unreadable) {
+    return {
+      mechanism: "unknown",
+      contained: false,
+      confidence: "none",
+      details: [
+        "containment signals unreadable (non-Linux or restricted /proc) — cannot determine; not a 'not contained' verdict",
+      ],
+    };
+  }
+
+  const details: string[] = [];
+  const seccompActive = s.seccompMode === 1 || s.seccompMode === 2;
+  const container = s.dockerEnv === true || s.cgroupContainer === true;
+
+  if (s.dockerEnv) details.push("container marker: /.dockerenv");
+  if (s.cgroupContainer)
+    details.push("container marker: cgroup runtime (docker/containerd/kubepods/…)");
+  if (seccompActive)
+    details.push(`seccomp active (mode ${s.seccompMode === 1 ? "strict" : "filter"})`);
+  if (s.noNewPrivs) details.push("no_new_privs set (privilege escalation blocked)");
+  if (s.userNamespace) details.push("user namespace in effect");
+
+  if (container) {
+    // A container plus syscall filtering is meaningful isolation; a bare container is weaker.
+    return {
+      mechanism: "container",
+      contained: true,
+      confidence: seccompActive ? "high" : "heuristic",
+      details,
+    };
+  }
+  if (seccompActive) {
+    return { mechanism: "seccomp", contained: true, confidence: "heuristic", details };
+  }
+  return {
+    mechanism: "none",
+    contained: false,
+    confidence: "high",
+    details: details.length ? details : ["no container / seccomp isolation signal found"],
+  };
+}
+
+/** Parse the `Seccomp:` line of /proc/self/status content. undefined when absent. */
+export function parseSeccompMode(statusContent: string): 0 | 1 | 2 | undefined {
+  const m = statusContent.match(/^Seccomp:\s*(\d+)/m);
+  if (!m) return undefined;
+  const v = parseInt(m[1], 10);
+  return v === 0 || v === 1 || v === 2 ? v : undefined;
+}
+
+/** Detect a container runtime marker in cgroup text. */
+export function cgroupHasContainer(cgroupContent: string): boolean {
+  return /\b(docker|containerd|kubepods|lxc|libpod)\b/.test(cgroupContent);
+}
+
+/**
+ * Read the deterministic containment signals from the host (Linux /proc). Best-effort:
+ * anything unreadable is left undefined; a total absence of /proc yields `unreadable`.
+ * Impure but never throws.
+ */
+export function gatherContainmentSignals(): ContainmentSignals {
+  // No /proc (macOS/Windows) → we genuinely cannot tell. Honest `unreadable`.
+  if (!existsSync("/proc/self/status")) return { unreadable: true };
+
+  const signals: ContainmentSignals = {};
+  try {
+    signals.dockerEnv = existsSync("/.dockerenv");
+  } catch {
+    /* best-effort */
+  }
+  try {
+    const cg = readSafe("/proc/self/cgroup") + "\n" + readSafe("/proc/1/cgroup");
+    if (cg.trim()) signals.cgroupContainer = cgroupHasContainer(cg);
+  } catch {
+    /* best-effort */
+  }
+  try {
+    const status = readSafe("/proc/self/status");
+    if (status) {
+      signals.seccompMode = parseSeccompMode(status);
+      const nnp = status.match(/^NoNewPrivs:\s*(\d+)/m);
+      if (nnp) signals.noNewPrivs = nnp[1] === "1";
+    }
+  } catch {
+    /* best-effort */
+  }
+  try {
+    const uidMap = readSafe("/proc/self/uid_map").trim();
+    // Identity map "         0          0 4294967295" ⇒ NOT a userns remap.
+    if (uidMap) signals.userNamespace = !/^\s*0\s+0\s+4294967295\s*$/.test(uidMap);
+  } catch {
+    /* best-effort */
+  }
+  return signals;
+}
+
+function readSafe(path: string): string {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return "";
+  }
+}

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -4,7 +4,12 @@ import { writeFile, unlink, mkdir, rmdir, rm } from "node:fs/promises";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { runDoctor, triageGateStatus, agentEgressExposureStatus } from "./doctor.js";
+import {
+  runDoctor,
+  triageGateStatus,
+  agentEgressExposureStatus,
+  containmentPostureStatus,
+} from "./doctor.js";
 import { loadOrCreateIdentity, identityId } from "./identity.js";
 import { resolveKeyStore } from "./keystore/index.js";
 import {
@@ -479,5 +484,37 @@ describe("agentEgressExposureStatus (OpenAI eval-escape gap)", () => {
     const r = agentEgressExposureStatus({ installGate: true, egressGate: false });
     assert.equal(r.status, "warn");
     assert.match(r.detail, /gate-egress|scope-bound|escape/i);
+  });
+});
+
+describe("containmentPostureStatus (sandbox below the tool boundary)", () => {
+  it("skips (not a verdict) when containment is unknown", () => {
+    const r = containmentPostureStatus(
+      { mechanism: "unknown", contained: false, confidence: "none", details: [] },
+      true,
+    );
+    assert.equal(r.status, "skip");
+  });
+  it("passes when contained", () => {
+    const r = containmentPostureStatus(
+      { mechanism: "container", contained: true, confidence: "high", details: ["/.dockerenv"] },
+      true,
+    );
+    assert.equal(r.status, "pass");
+  });
+  it("WARNS when an install/exec gate is wired but there is no OS containment", () => {
+    const r = containmentPostureStatus(
+      { mechanism: "none", contained: false, confidence: "high", details: [] },
+      true,
+    );
+    assert.equal(r.status, "warn");
+    assert.match(r.detail, /sandbox|containment|defense-in-depth/i);
+  });
+  it("skips when no containment AND no install/exec capability wired", () => {
+    const r = containmentPostureStatus(
+      { mechanism: "none", contained: false, confidence: "high", details: [] },
+      false,
+    );
+    assert.equal(r.status, "skip");
   });
 });

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -11,6 +11,7 @@ import { verifyProfileSignature } from "./profile/sign.js";
 import { verifyPolicy, loadPolicy, getPolicyPath } from "./policy-doc.js";
 import { extractRbac } from "./rbac/policy-schema.js";
 import { tryLoadIdentity, isRevoked } from "./identity.js";
+import type { ContainmentVerdict } from "./containment.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -495,6 +496,53 @@ async function checkAgentEgressExposure(cwd: string): Promise<DoctorCheck> {
 }
 
 /**
+ * OS containment posture (the sandbox BELOW the tool boundary — defense-in-depth). kit
+ * governs the tool boundary; a sandbox contains what happens beneath it. Advisory, never a
+ * hard fail — the sandbox is a complementary layer the operator owns:
+ *   pass  a container / seccomp isolation signal is present
+ *   skip  containment can't be determined (non-Linux / restricted /proc) — NOT "not contained"
+ *   skip  no OS containment, but nothing with an install/exec capability is wired here
+ *   warn  install/exec gate wired AND no OS containment below it — pair kit with a sandbox
+ * Pure decision split out for testing.
+ */
+export function containmentPostureStatus(
+  v: ContainmentVerdict,
+  installGateWired: boolean,
+): { status: DoctorCheckStatus; detail: string } {
+  if (v.mechanism === "unknown") {
+    return {
+      status: "skip",
+      detail: "cannot determine OS containment (non-Linux / restricted /proc) — not a verdict",
+    };
+  }
+  if (v.contained) {
+    return {
+      status: "pass",
+      detail: `running inside ${v.mechanism} isolation (${v.confidence}) — ${v.details.join("; ")}`,
+    };
+  }
+  if (!installGateWired) {
+    return {
+      status: "skip",
+      detail: "no OS containment detected, and no install/exec capability wired here to contain",
+    };
+  }
+  return {
+    status: "warn",
+    detail:
+      "install/exec capability wired with NO OS containment below the tool boundary — kit governs the tool boundary, but pair it with a sandbox (container/seccomp) for the layer beneath (defense-in-depth)",
+  };
+}
+
+async function checkContainment(cwd: string): Promise<DoctorCheck> {
+  const { gatherContainmentSignals, detectContainment } = await import("./containment.js");
+  const { gateLiveness } = await import("./agent-config.js");
+  const verdict = detectContainment(gatherContainmentSignals());
+  const { status, detail } = containmentPostureStatus(verdict, gateLiveness(cwd).installGate);
+  return { name: "OS containment", status, detail, category: "security" };
+}
+
+/**
  * Keyless-credential posture (Pillar 2 tail — "sign, don't store"). Reports whether any hosts are
  * declared keyless (`[scope].sign`) and whether kit can actually sign for them — never silent:
  *   skip  no keyless hosts declared
@@ -627,6 +675,7 @@ export async function runDoctor(config: kitConfig, cwd: string): Promise<DoctorR
   allChecks.push(await checkBrokerRuntime(cwd));
   allChecks.push(await checkKeyless(cwd));
   allChecks.push(await checkAgentEgressExposure(cwd));
+  allChecks.push(await checkContainment(cwd));
   allChecks.push(await checkDeepSkillScanner());
   allChecks.push(await checkTriageGates(cwd));
   allChecks.push(checkControlPlane(cwd));


### PR DESCRIPTION
## Description

Implements the **containment delegate** — the first design-first backlog item (design note: `containment-delegate-design` in kit-research). kit governs the tool boundary; a real OS/network sandbox contains what happens *beneath* it (where the OpenAI×HuggingFace eval-escape occurred). Per the premium/positioning decision, kit must **not become a sandbox** — it **detects and verifies** one as a delegate and folds the fact into its posture. Extends the 5.5.0 `agent egress-exposure` gap.

## Type of Change

- [x] New feature (non-breaking, additive)

## Changes Made

- **`src/containment.ts`** — pure `detectContainment(signals)` + impure `gatherContainmentSignals()` reading Linux `/proc` (container markers via `/.dockerenv` + cgroup, seccomp mode, `no_new_privs`, user namespace). Zero-LLM, read-only, never throws.
- **`kit doctor` "OS containment" posture** — `pass` when contained; `warn` when an install/exec gate is wired with **no** OS containment beneath it (pair kit with a sandbox); honest `skip` when containment can't be determined (non-Linux / restricted `/proc`) or when nothing with an install/exec capability is wired. Advisory, never a hard fail — the sandbox is a complementary layer the operator owns.

## Honesty (no false green)

- `contained: true` only on a **positive** isolation signal — never inferred from absence.
- Non-Linux / unreadable `/proc` ⇒ **`unknown`**, surfaced as `skip`, explicitly *not* a "not contained" verdict.
- kit does **not** claim to retroactively certify a past run, nor to fingerprint gVisor/Firecracker specifically (best-effort, left as a follow-up). It reports "is there meaningful isolation *now*".

## Testing

- [x] All tests pass (`npm test`) — **3118 pass / 0 fail** (816 suites; +11).
- [x] typecheck + build clean; eslint 0 errors; **full `format:check` clean** (learned from the 5.5.0 round).

New tests: `src/containment.test.ts` (detector + parsers), `src/doctor.test.ts` (`containmentPostureStatus`).

## Breaking Changes

None / N/A — additive advisory posture row.

## Reviewer Notes

Pure decisions (`detectContainment`, `containmentPostureStatus`) are split out and unit-tested; the impure `/proc` read is best-effort and degrades to `unknown`. Follow-ups (not here): gVisor/Firecracker fingerprinting, enforce-readiness "require containment", and recording the containment fact in the audit trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)