### PR TITLE
feat(adr): ADR → gate — enforce architecture decisions deterministically (5.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.7.0] - 2026-07-22
+
+### Added
+
+- **`kit adr` — ADR → gate (experimental).** Turn the machine-readable part of an
+  Architecture Decision Record into a deterministic gate, cited back to the ADR
+  ("why is this blocked? → ADR-0007"). `kit adr check` runs the `forbid-pattern`
+  rules of **accepted** ADRs (a fenced ` ```toml kit-enforce ` block, parsed with the
+  same smol-toml as `.kit.toml`) over the repo and exits non-zero on a violation;
+  `kit adr list` shows each ADR's status and whether it is enforced or
+  documented-only. kit **never interprets ADR prose** (off-charter) — only the
+  explicit rule block gates, and an accepted ADR with no rules is surfaced as
+  "documented, not enforced", never silently green. New pure `src/adr.ts`
+  (`parseAdr` / `evaluateAdr` / `globToRegExp`). Realizes the
+  architecture-canon-in-the-llm-era thesis: the decision becomes an enforced
+  constraint an agent cannot drift past.
+
 ## [5.6.0] - 2026-07-22
 
 ### Added

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -7,6 +7,13 @@
       "x-kit-mcp": true,
       "x-kit-stability": "stable"
     },
+    "adr": {
+      "kind": "command",
+      "summary": "Enforce architecture decisions (ADR → gate): 'kit adr check' gates the repo on accepted ADRs' deterministic kit-enforce rules, cited to the ADR; 'kit adr list' shows enforced/documented. Zero-LLM (prose is never interpreted).",
+      "x-kit-args-modeled": false,
+      "x-kit-mcp": false,
+      "x-kit-stability": "experimental"
+    },
     "agent-audit": {
       "kind": "command",
       "summary": "Audit agent / MCP / hook configs for plaintext secrets + malware-shaped hooks",
@@ -959,7 +966,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.6.0"
+    "version": "5.7.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/contracts/public-surface.json
+++ b/contracts/public-surface.json
@@ -13,6 +13,7 @@
   },
   "commands": {
     "add": "stable",
+    "adr": "experimental",
     "agent-audit": "stable",
     "agent-config": "stable",
     "airgap": "stable",
@@ -109,6 +110,7 @@
   ],
   "helpKeys": [
     "add",
+    "adr",
     "agent-audit",
     "agent-config",
     "airgap",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "5.6.0",
+  "version": "5.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "5.6.0",
+      "version": "5.7.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.6.0",
+  "version": "5.7.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/adr.test.ts
+++ b/src/adr.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseAdr, evaluateAdr, adrIsEnforced, globToRegExp } from "./adr.js";
+
+const ACCEPTED = `---
+id: ADR-0007
+title: Web layer must not import the DB driver
+status: accepted
+---
+
+## Decision
+Go through the service layer.
+
+\`\`\`toml kit-enforce
+[[forbid_pattern]]
+pattern = "from ['\\"]pg['\\"]"
+paths = "src/web/**/*.ts"
+message = "web must not import pg directly"
+\`\`\`
+`;
+
+describe("parseAdr", () => {
+  it("returns null without frontmatter or without an id", () => {
+    assert.equal(parseAdr("# just markdown"), null);
+    assert.equal(parseAdr("---\ntitle: x\n---\nbody"), null);
+  });
+
+  it("parses id/title/status and the toml kit-enforce block", () => {
+    const adr = parseAdr(ACCEPTED)!;
+    assert.equal(adr.id, "ADR-0007");
+    assert.equal(adr.status, "accepted");
+    assert.equal(adr.hasEnforceBlock, true);
+    assert.equal(adr.rules.length, 1);
+    assert.equal(adr.rules[0].paths, "src/web/**/*.ts");
+  });
+
+  it("an unknown status is normalized, not crashed", () => {
+    const adr = parseAdr("---\nid: A\nstatus: bogus\n---\nx")!;
+    assert.equal(adr.status, "unknown");
+  });
+
+  it("accepted + no enforce block = documented, not enforced", () => {
+    const adr = parseAdr("---\nid: A-1\ntitle: t\nstatus: accepted\n---\nprose only")!;
+    assert.equal(adr.hasEnforceBlock, false);
+    assert.equal(adrIsEnforced(adr), false);
+  });
+
+  it("malformed toml yields zero rules but keeps hasEnforceBlock (surfaced)", () => {
+    const adr = parseAdr(
+      "---\nid: A\nstatus: accepted\n---\n```toml kit-enforce\nnot = = valid\n```",
+    )!;
+    assert.equal(adr.hasEnforceBlock, true);
+    assert.equal(adr.rules.length, 0);
+  });
+});
+
+describe("adrIsEnforced", () => {
+  it("only accepted ADRs with ≥1 rule enforce", () => {
+    assert.equal(adrIsEnforced(parseAdr(ACCEPTED)!), true);
+    const proposed = ACCEPTED.replace("status: accepted", "status: proposed");
+    assert.equal(adrIsEnforced(parseAdr(proposed)!), false);
+  });
+});
+
+describe("evaluateAdr", () => {
+  const adr = parseAdr(ACCEPTED)!;
+
+  it("flags a forbidden pattern in a matching file, cited to the ADR + line", () => {
+    const v = evaluateAdr(adr, [
+      { path: "src/web/handler.ts", content: "import x from 'pg'\nconst y = 1\n" },
+    ]);
+    assert.equal(v.length, 1);
+    assert.equal(v[0].adrId, "ADR-0007");
+    assert.equal(v[0].line, 1);
+  });
+
+  it("ignores files outside the glob", () => {
+    const v = evaluateAdr(adr, [{ path: "src/service/db.ts", content: "import x from 'pg'" }]);
+    assert.equal(v.length, 0);
+  });
+
+  it("a non-accepted ADR never gates", () => {
+    const proposed = parseAdr(ACCEPTED.replace("status: accepted", "status: superseded"))!;
+    const v = evaluateAdr(proposed, [{ path: "src/web/h.ts", content: "from 'pg'" }]);
+    assert.equal(v.length, 0);
+  });
+});
+
+describe("globToRegExp", () => {
+  it("handles ** and *", () => {
+    assert.ok(globToRegExp("src/web/**/*.ts").test("src/web/a/b/c.ts"));
+    assert.ok(globToRegExp("src/web/**/*.ts").test("src/web/x.ts"));
+    assert.ok(!globToRegExp("src/web/**/*.ts").test("src/api/x.ts"));
+    assert.ok(!globToRegExp("src/*.ts").test("src/a/b.ts"));
+  });
+});

--- a/src/adr.ts
+++ b/src/adr.ts
@@ -1,0 +1,161 @@
+/**
+ * kit — ADR → gate. Turn the machine-readable part of an Architecture Decision
+ * Record into a deterministic gate, cited back to the ADR ("why is this blocked?
+ * → ADR-0007"). Design: kit-research/docs/research/adr-as-enforced-rule-design.md.
+ *
+ * kit does NOT interpret ADR prose (that needs an LLM — off-charter). It enforces
+ * only an explicit ` ```toml kit-enforce ` block (parsed with the same smol-toml as
+ * .kit.toml). Only `status: accepted` ADRs enforce; an accepted ADR with no enforce
+ * block is surfaced as "documented, not enforced" — never silently green.
+ *
+ * Pure + deterministic: parse/evaluate are functions of their text inputs (no I/O).
+ */
+import { parse as parseToml } from "smol-toml";
+
+export type AdrStatus = "proposed" | "accepted" | "superseded" | "deprecated" | "unknown";
+
+/** A single deterministic enforce rule. Only forbid-pattern in the first increment. */
+export interface AdrRule {
+  type: "forbid-pattern";
+  /** Regex source that must NOT appear in matching files. */
+  pattern: string;
+  /** Glob of files the rule applies to (minimatch-style). */
+  paths: string;
+  /** Optional human message shown on a violation. */
+  message?: string;
+}
+
+export interface Adr {
+  id: string;
+  title: string;
+  status: AdrStatus;
+  rules: AdrRule[];
+  /** True when a ```toml kit-enforce block was present (even if it parsed to zero rules). */
+  hasEnforceBlock: boolean;
+}
+
+export interface AdrViolation {
+  adrId: string;
+  file: string;
+  line: number;
+  pattern: string;
+  message: string;
+}
+
+const STATUSES: AdrStatus[] = ["proposed", "accepted", "superseded", "deprecated"];
+
+function scalar(frontmatter: string, key: string): string | undefined {
+  const m = frontmatter.match(new RegExp(`^${key}:(.*)$`, "mi"));
+  return m ? m[1].trim().replace(/^["']|["']$/g, "") : undefined;
+}
+
+/**
+ * Parse an ADR markdown file. Returns null when it has no `---` frontmatter or no `id`
+ * (not an ADR). Never throws — a malformed enforce block yields `hasEnforceBlock: true`
+ * with zero rules (surfaced, not a crash).
+ */
+export function parseAdr(raw: string): Adr | null {
+  const text = raw.replace(/\r\n/g, "\n");
+  const fm = text.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!fm) return null;
+  const [, frontmatter, body] = fm;
+  const id = scalar(frontmatter, "id");
+  if (!id) return null;
+  const title = scalar(frontmatter, "title") ?? id;
+  const rawStatus = (scalar(frontmatter, "status") ?? "unknown").toLowerCase();
+  const status: AdrStatus = (STATUSES as string[]).includes(rawStatus)
+    ? (rawStatus as AdrStatus)
+    : "unknown";
+
+  // A fenced ```toml kit-enforce block anywhere in the body.
+  const block = body.match(/```toml\s+kit-enforce\s*\n([\s\S]*?)\n```/);
+  let rules: AdrRule[] = [];
+  const hasEnforceBlock = block !== null;
+  if (block) {
+    try {
+      const parsed = parseToml(block[1]) as { forbid_pattern?: unknown };
+      const list = Array.isArray(parsed.forbid_pattern) ? parsed.forbid_pattern : [];
+      rules = list
+        .map((r): AdrRule | null => {
+          const o = r as Record<string, unknown>;
+          if (typeof o.pattern !== "string" || typeof o.paths !== "string") return null;
+          return {
+            type: "forbid-pattern",
+            pattern: o.pattern,
+            paths: o.paths,
+            message: typeof o.message === "string" ? o.message : undefined,
+          };
+        })
+        .filter((r): r is AdrRule => r !== null);
+    } catch {
+      rules = []; // malformed TOML → zero rules, but hasEnforceBlock stays true (surfaced)
+    }
+  }
+  return { id, title, status, rules, hasEnforceBlock };
+}
+
+/** An accepted ADR that actually carries at least one enforceable rule. */
+export function adrIsEnforced(adr: Adr): boolean {
+  return adr.status === "accepted" && adr.rules.length > 0;
+}
+
+/** Minimal glob → RegExp (supports `**`, `*`, `?`). Anchored full-match. Deterministic. */
+export function globToRegExp(glob: string): RegExp {
+  let re = "";
+  for (let i = 0; i < glob.length; i++) {
+    const ch = glob[i];
+    if (ch === "*") {
+      if (glob[i + 1] === "*") {
+        re += ".*";
+        i++;
+        if (glob[i + 1] === "/") i++; // `**/` matches zero or more dirs
+      } else {
+        re += "[^/]*";
+      }
+    } else if (ch === "?") {
+      re += "[^/]";
+    } else if (".+^${}()|[]\\".includes(ch)) {
+      re += "\\" + ch;
+    } else {
+      re += ch;
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
+/**
+ * Evaluate an accepted ADR's forbid-pattern rules over the provided files. Pure — the caller
+ * supplies `{ path, content }` for the repo; this never touches disk. A non-accepted ADR (or
+ * one with no rules) yields no violations. Line numbers are 1-indexed on the first match.
+ */
+export function evaluateAdr(adr: Adr, files: { path: string; content: string }[]): AdrViolation[] {
+  if (adr.status !== "accepted") return [];
+  const violations: AdrViolation[] = [];
+  for (const rule of adr.rules) {
+    let matcher: RegExp;
+    let globRe: RegExp;
+    try {
+      matcher = new RegExp(rule.pattern);
+      globRe = globToRegExp(rule.paths);
+    } catch {
+      continue; // a malformed regex/glob rule is skipped, never a crash
+    }
+    for (const f of files) {
+      if (!globRe.test(f.path)) continue;
+      const lines = f.content.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        if (matcher.test(lines[i])) {
+          violations.push({
+            adrId: adr.id,
+            file: f.path,
+            line: i + 1,
+            pattern: rule.pattern,
+            message: rule.message ?? `forbidden by ${adr.id}: /${rule.pattern}/`,
+          });
+          break; // one violation per (rule, file) is enough to gate
+        }
+      }
+    }
+  }
+  return violations;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,6 +53,7 @@ import {
   cmdTeam,
 } from "./commands/agent.js";
 import { cmdSelfAudit, cmdCoverage, cmdAnalyze } from "./commands/coverage.js";
+import { cmdAdr } from "./commands/adr.js";
 import {
   cmdGateBash,
   cmdGateEnv,
@@ -694,6 +695,11 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
     handler: cmdReview,
     stability: "stable",
     help: "Full repo audit — runs check + design + standards in one gate (for agents / PR checks)",
+  },
+  adr: {
+    handler: cmdAdr,
+    stability: "experimental",
+    help: "Enforce architecture decisions (ADR → gate): 'kit adr check' gates the repo on accepted ADRs' deterministic kit-enforce rules, cited to the ADR; 'kit adr list' shows enforced/documented. Zero-LLM (prose is never interpreted).",
   },
   insight: {
     handler: cmdInsight,

--- a/src/commands/adr.ts
+++ b/src/commands/adr.ts
@@ -1,0 +1,102 @@
+/**
+ * `kit adr` — ADR → gate. Enforce the machine-readable `kit-enforce` block of an
+ * accepted Architecture Decision Record, cited back to the ADR. Design:
+ * kit-research/docs/research/adr-as-enforced-rule-design.md.
+ *
+ *   kit adr list    every ADR + status + enforced / documented-only
+ *   kit adr check   run accepted ADRs' forbid-pattern rules over the repo (default)
+ *
+ * kit never interprets ADR prose (off-charter); it enforces only the explicit
+ * toml block. Only `accepted` ADRs gate; an accepted ADR with no rules is surfaced
+ * as "documented, not enforced" — never silently green.
+ */
+import { readFileSync as read, existsSync as exists } from "node:fs";
+import { relative as rel, join as pathJoin } from "node:path";
+import { c } from "../utils/colors.js";
+import { walkSourceFiles } from "../source-walk.js";
+import { parseAdr, evaluateAdr, adrIsEnforced, type Adr } from "../adr.js";
+
+const ADR_DIRS = ["docs/adr", "docs/decisions"];
+const CODE_EXTS = [".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".rs", ".java", ".rb", ".php"];
+
+function loadAdrs(cwd: string): { adr: Adr; file: string }[] {
+  const out: { adr: Adr; file: string }[] = [];
+  for (const dir of ADR_DIRS) {
+    const abs = pathJoin(cwd, dir);
+    if (!exists(abs)) continue;
+    for (const f of walkSourceFiles(abs, { exts: [".md"] })) {
+      const adr = parseAdr(read(f, "utf-8"));
+      if (adr) out.push({ adr, file: rel(cwd, f) });
+    }
+  }
+  return out;
+}
+
+export function cmdAdr(): boolean {
+  const args = process.argv.slice(3);
+  const sub = args[0] === "list" || args[0] === "check" ? args[0] : args[0] ? "help" : "check";
+  const cwd = process.cwd();
+
+  if (sub === "help") {
+    console.log(`${c.bold}kit adr${c.reset} — enforce architecture decisions (ADR → gate)\n`);
+    console.log("  kit adr list     ADRs + status + enforced/documented");
+    console.log("  kit adr check    gate the repo on accepted ADRs' rules (default)");
+    return true;
+  }
+
+  const adrs = loadAdrs(cwd);
+  if (adrs.length === 0) {
+    console.log(
+      `${c.dim}No ADRs found in ${ADR_DIRS.join(" or ")}. Add one with a --- frontmatter (id/title/status) and a \`\`\`toml kit-enforce block.${c.reset}`,
+    );
+    return true;
+  }
+
+  if (sub === "list") {
+    console.log(`${c.bold}ADRs${c.reset}`);
+    for (const { adr, file } of adrs) {
+      const state = adrIsEnforced(adr)
+        ? `${c.green}enforced (${adr.rules.length} rule${adr.rules.length === 1 ? "" : "s"})${c.reset}`
+        : adr.status === "accepted"
+          ? `${c.yellow}documented, not enforced${c.reset}`
+          : `${c.dim}${adr.status}${c.reset}`;
+      console.log(`  ${adr.id}  ${adr.title}  [${state}]  ${c.dim}${file}${c.reset}`);
+    }
+    return true;
+  }
+
+  // check: gather repo code files once, evaluate every accepted ADR.
+  const files = walkSourceFiles(cwd, { exts: CODE_EXTS, includeTests: true }).map((f) => ({
+    path: rel(cwd, f),
+    content: read(f, "utf-8"),
+  }));
+
+  let violationCount = 0;
+  let enforcedCount = 0;
+  for (const { adr } of adrs) {
+    if (!adrIsEnforced(adr)) continue;
+    enforcedCount++;
+    const violations = evaluateAdr(adr, files);
+    for (const v of violations) {
+      violationCount++;
+      console.log(
+        `${c.red}✗${c.reset} ${v.file}:${v.line}  ${v.message}  ${c.dim}(${v.adrId})${c.reset}`,
+      );
+    }
+  }
+
+  if (enforcedCount === 0) {
+    console.log(
+      `${c.yellow}No accepted ADR carries an enforce block — nothing to gate (documented, not enforced).${c.reset}`,
+    );
+    return true;
+  }
+  if (violationCount === 0) {
+    console.log(`${c.green}✓ ${enforcedCount} enforced ADR(s) — no violations${c.reset}`);
+    return true;
+  }
+  console.log(
+    `\n${c.red}${violationCount} ADR violation(s) across ${enforcedCount} enforced ADR(s).${c.reset}`,
+  );
+  return false;
+}


### PR DESCRIPTION
## Description

Implements **ADR → gate** — the last charter-clean design-first backlog item (design note: `adr-as-enforced-rule-design` in kit-research). Realizes the `architecture-canon-in-the-llm-era` thesis: in an LLM world you generate architecture faster than you can review it, so the durable, expensive-to-reverse **decision** is what an agent drifts past. kit turns the *machine-readable part* of an Architecture Decision Record into a deterministic gate, **cited back to the ADR** ("why is this blocked? → ADR-0007").

## Type of Change

- [x] New feature (experimental, additive)

## Changes Made

- **`src/adr.ts`** (pure) — `parseAdr` (`---` scalars `id`/`title`/`status` + a fenced ` ```toml kit-enforce ` block parsed with the same `smol-toml` as `.kit.toml`), `evaluateAdr` (runs `forbid-pattern` rules over provided files, cited to the ADR + line), `globToRegExp`, `adrIsEnforced`.
- **`kit adr`** (experimental command) — `check` gates the repo on **accepted** ADRs' rules (exit non-zero on a violation); `list` shows each ADR's status + enforced/documented. Registered in `COMMAND_REGISTRY`; **not** an MCP tool, so the CLI=MCP drift test is untouched.
- Regenerated `contracts/public-surface.json` (`adr` = `experimental`, additive) + `contracts/kit.opencli.json`; roll to 5.7.0.

## Honesty (no false green)

- kit **never interprets ADR prose** (that needs an LLM — off-charter). Only the explicit `kit-enforce` block gates.
- Only `status: accepted` ADRs enforce; a `superseded`/`proposed` decision does not keep gating.
- An accepted ADR with **no** rules is surfaced as "documented, not enforced" — never silently green.
- Stated limit: regex/glob rules catch textual patterns, not semantic violations (a rename/indirect import can evade a naive pattern) — `forbid-import` graph rules are a follow-up.

## Testing

- [x] All tests pass (`npm test`) — **3128 pass / 0 fail** (820 suites; +10).
- [x] typecheck + build clean; eslint 0 errors; full `format:check` clean.
- [x] public-surface + opencli contracts regenerated and drift-tests green.

## Breaking Changes

None / N/A — additive experimental command.

## Reviewer Notes

Pure core (`parseAdr`/`evaluateAdr`/`globToRegExp`) is unit-tested; only file IO in the command is impure. Follow-ups: `require-pattern` / graph-aware `forbid-import` rule types, and wiring `kit adr check` into `kit review` / pre-commit with a baseline so only net-new violations gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)