### PR TITLE
feat(adr): require_pattern + import-aware forbid_import (direct + transitive) (5.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.8.0] - 2026-07-24
+
+### Added
+
+- **`kit adr` — richer enforce rules (experimental).** Beyond `forbid_pattern`, an accepted
+  ADR's ` ```toml kit-enforce ` block now supports two more deterministic rule types:
+  - **`require_pattern`** — a regex that **must** appear in each matching file; its *absence*
+    gates (e.g. "every `src/web/**` handler must call `withGovernance`").
+  - **`forbid_import`** — an import-statement-aware ban on a module specifier (parses real
+    `import`/`require`/`from`/dynamic-import specifiers, not any line, so `pg-promise` no longer
+    trips a `^pg$` rule). With `transitive = true` it also forbids **reaching** the target
+    through the repo's relative-import graph. A relative import that cannot be resolved within
+    the repo is surfaced as a **`gap`** ("cannot prove") — it fails closed and prints distinctly,
+    never a silent green (no false green).
+
+  New pure exports in `src/adr.ts` (`extractImports`, `resolveRelative`) and a `kind`
+  (`violation` | `gap`) + `rule` discriminator on `AdrViolation`. Still zero-LLM: kit enforces
+  only the explicit rule block, never ADR prose.
+
 ## [5.7.0] - 2026-07-22
 
 ### Added

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -966,7 +966,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.7.0"
+    "version": "5.8.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "5.7.0",
+      "version": "5.8.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/adr.test.ts
+++ b/src/adr.test.ts
@@ -1,6 +1,13 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parseAdr, evaluateAdr, adrIsEnforced, globToRegExp } from "./adr.js";
+import {
+  parseAdr,
+  evaluateAdr,
+  adrIsEnforced,
+  globToRegExp,
+  extractImports,
+  resolveRelative,
+} from "./adr.js";
 
 const ACCEPTED = `---
 id: ADR-0007
@@ -92,5 +99,169 @@ describe("globToRegExp", () => {
     assert.ok(globToRegExp("src/web/**/*.ts").test("src/web/x.ts"));
     assert.ok(!globToRegExp("src/web/**/*.ts").test("src/api/x.ts"));
     assert.ok(!globToRegExp("src/*.ts").test("src/a/b.ts"));
+  });
+});
+
+const REQUIRE = `---
+id: ADR-0010
+title: Web handlers must go through the governance wrapper
+status: accepted
+---
+
+\`\`\`toml kit-enforce
+[[require_pattern]]
+pattern = "withGovernance"
+paths = "src/web/**/*.ts"
+message = "web handlers must call withGovernance"
+\`\`\`
+`;
+
+describe("require_pattern", () => {
+  const adr = parseAdr(REQUIRE)!;
+
+  it("parses as a require-pattern rule", () => {
+    assert.equal(adr.rules.length, 1);
+    assert.equal(adr.rules[0].type, "require-pattern");
+    assert.equal(adrIsEnforced(adr), true);
+  });
+
+  it("flags a matching file that is MISSING the required pattern", () => {
+    const v = evaluateAdr(adr, [{ path: "src/web/handler.ts", content: "export const x = 1\n" }]);
+    assert.equal(v.length, 1);
+    assert.equal(v[0].rule, "require-pattern");
+    assert.equal(v[0].kind, "violation");
+    assert.equal(v[0].line, 1);
+  });
+
+  it("passes when the required pattern is present", () => {
+    const v = evaluateAdr(adr, [
+      { path: "src/web/handler.ts", content: "import { withGovernance } from '../gov.js'\n" },
+    ]);
+    assert.equal(v.length, 0);
+  });
+
+  it("ignores files outside the glob", () => {
+    const v = evaluateAdr(adr, [{ path: "src/lib/util.ts", content: "no wrapper here" }]);
+    assert.equal(v.length, 0);
+  });
+});
+
+const FORBID_IMPORT = `---
+id: ADR-0011
+title: Web must not import the DB driver
+status: accepted
+---
+
+\`\`\`toml kit-enforce
+[[forbid_import]]
+import = "^pg$"
+paths = "src/web/**/*.ts"
+message = "web must not import pg directly"
+\`\`\`
+`;
+
+describe("forbid_import (direct)", () => {
+  const adr = parseAdr(FORBID_IMPORT)!;
+
+  it("parses as a forbid-import rule (non-transitive by default)", () => {
+    assert.equal(adr.rules[0].type, "forbid-import");
+    assert.equal((adr.rules[0] as { transitive?: boolean }).transitive, false);
+  });
+
+  it("flags a direct import of the forbidden specifier, at its line", () => {
+    const v = evaluateAdr(adr, [
+      { path: "src/web/h.ts", content: "const a = 1\nimport { Client } from 'pg'\n" },
+    ]);
+    assert.equal(v.length, 1);
+    assert.equal(v[0].rule, "forbid-import");
+    assert.equal(v[0].detail, "pg");
+    assert.equal(v[0].line, 2);
+  });
+
+  it("does not match a substring specifier (anchored regex)", () => {
+    const v = evaluateAdr(adr, [{ path: "src/web/h.ts", content: "import x from 'pg-promise'\n" }]);
+    assert.equal(v.length, 0);
+  });
+
+  it("does not flag a mere textual mention outside an import", () => {
+    const v = evaluateAdr(adr, [{ path: "src/web/h.ts", content: "// we avoid 'pg' here\n" }]);
+    assert.equal(v.length, 0);
+  });
+});
+
+const FORBID_IMPORT_T = FORBID_IMPORT.replace(
+  `import = "^pg$"`,
+  `import = "^pg$"\ntransitive = true`,
+);
+
+describe("forbid_import (transitive)", () => {
+  const adr = parseAdr(FORBID_IMPORT_T)!;
+
+  it("flags reaching pg through a relative-import chain (intermediate outside the glob)", () => {
+    const v = evaluateAdr(adr, [
+      { path: "src/web/h.ts", content: "import { q } from '../data/repo.js'\n" },
+      { path: "src/data/repo.ts", content: "import { Client } from 'pg'\n" },
+    ]);
+    assert.equal(v.length, 1);
+    assert.equal(v[0].file, "src/web/h.ts");
+    assert.equal(v[0].kind, "violation");
+    assert.ok(v[0].message.includes("via"));
+  });
+
+  it("passes when no reachable file imports pg", () => {
+    const v = evaluateAdr(adr, [
+      { path: "src/web/h.ts", content: "import { q } from '../data/repo.js'\n" },
+      { path: "src/data/repo.ts", content: "export const q = 1\n" },
+    ]);
+    assert.equal(v.length, 0);
+  });
+
+  it("surfaces an unresolvable relative import as a gap, not green", () => {
+    const v = evaluateAdr(adr, [
+      { path: "src/web/h.ts", content: "import { q } from './missing.js'\n" },
+    ]);
+    assert.equal(v.length, 1);
+    assert.equal(v[0].kind, "gap");
+    assert.ok(v[0].message.includes("cannot prove"));
+  });
+
+  it("a bare (external) leaf that isn't the target is not a gap", () => {
+    const v = evaluateAdr(adr, [
+      { path: "src/web/h.ts", content: "import express from 'express'\n" },
+    ]);
+    assert.equal(v.length, 0);
+  });
+});
+
+describe("extractImports", () => {
+  it("finds ES import, re-export, require and dynamic import specifiers", () => {
+    const refs = extractImports(
+      [
+        "import a from 'x'",
+        "export { b } from './y.js'",
+        "const c = require('z')",
+        "const d = await import('./w.js')",
+        "// import 'commented' — still matched (over-flag, never false-green)",
+      ].join("\n"),
+    );
+    assert.deepEqual(
+      refs.map((r) => r.specifier),
+      ["x", "./y.js", "z", "./w.js", "commented"],
+    );
+  });
+});
+
+describe("resolveRelative", () => {
+  const set = new Set(["src/web/repo.ts", "src/web/dir/index.ts"]);
+  it("resolves ./ with an implied extension", () => {
+    assert.equal(resolveRelative("src/web/h.ts", "./repo.js", set), "src/web/repo.ts");
+    assert.equal(resolveRelative("src/web/h.ts", "./repo", set), "src/web/repo.ts");
+  });
+  it("resolves a directory to its index", () => {
+    assert.equal(resolveRelative("src/web/h.ts", "./dir", set), "src/web/dir/index.ts");
+  });
+  it("returns null for bare specifiers and unresolvable paths", () => {
+    assert.equal(resolveRelative("src/web/h.ts", "pg", set), null);
+    assert.equal(resolveRelative("src/web/h.ts", "./nope.js", set), null);
   });
 });

--- a/src/adr.ts
+++ b/src/adr.ts
@@ -8,22 +8,46 @@
  * .kit.toml). Only `status: accepted` ADRs enforce; an accepted ADR with no enforce
  * block is surfaced as "documented, not enforced" — never silently green.
  *
- * Pure + deterministic: parse/evaluate are functions of their text inputs (no I/O).
+ * Rule types (all deterministic, pure functions of the text inputs — no I/O):
+ *   [[forbid_pattern]]  a regex that must NOT appear in matching files.
+ *   [[require_pattern]] a regex that MUST appear in each matching file (absence gates).
+ *   [[forbid_import]]   an import specifier (regex) a matching file must not import.
+ *                       `transitive = true` also forbids reaching it through the
+ *                       repo's relative-import graph; a relative import we cannot
+ *                       resolve is surfaced as a *gap* (can't prove), never green.
  */
 import { parse as parseToml } from "smol-toml";
 
 export type AdrStatus = "proposed" | "accepted" | "superseded" | "deprecated" | "unknown";
 
-/** A single deterministic enforce rule. Only forbid-pattern in the first increment. */
-export interface AdrRule {
-  type: "forbid-pattern";
-  /** Regex source that must NOT appear in matching files. */
-  pattern: string;
-  /** Glob of files the rule applies to (minimatch-style). */
-  paths: string;
-  /** Optional human message shown on a violation. */
-  message?: string;
-}
+export type AdrRuleType = "forbid-pattern" | "require-pattern" | "forbid-import";
+
+/** A single deterministic enforce rule (discriminated on `type`). */
+export type AdrRule =
+  | {
+      type: "forbid-pattern";
+      /** Regex source that must NOT appear in matching files. */
+      pattern: string;
+      /** Glob of files the rule applies to. */
+      paths: string;
+      message?: string;
+    }
+  | {
+      type: "require-pattern";
+      /** Regex source that MUST appear at least once in each matching file. */
+      pattern: string;
+      paths: string;
+      message?: string;
+    }
+  | {
+      type: "forbid-import";
+      /** Regex source matched against a module specifier a file imports. */
+      import: string;
+      paths: string;
+      /** Also forbid reaching the target through the relative-import graph. */
+      transitive?: boolean;
+      message?: string;
+    };
 
 export interface Adr {
   id: string;
@@ -38,8 +62,16 @@ export interface AdrViolation {
   adrId: string;
   file: string;
   line: number;
-  pattern: string;
+  rule: AdrRuleType;
+  /** The offending (or missing / unresolved) detail — pattern source or specifier. */
+  detail: string;
   message: string;
+  /**
+   * `violation` — the rule is broken (gates). `gap` — the rule could not be proven
+   * (e.g. a transitive check hit an unresolvable relative import); fails closed but is
+   * labeled distinctly so it is never presented as a clean pass (no false green).
+   */
+  kind: "violation" | "gap";
 }
 
 const STATUSES: AdrStatus[] = ["proposed", "accepted", "superseded", "deprecated"];
@@ -47,6 +79,10 @@ const STATUSES: AdrStatus[] = ["proposed", "accepted", "superseded", "deprecated
 function scalar(frontmatter: string, key: string): string | undefined {
   const m = frontmatter.match(new RegExp(`^${key}:(.*)$`, "mi"));
   return m ? m[1].trim().replace(/^["']|["']$/g, "") : undefined;
+}
+
+function str(o: Record<string, unknown>, k: string): string | undefined {
+  return typeof o[k] === "string" ? (o[k] as string) : undefined;
 }
 
 /**
@@ -73,25 +109,45 @@ export function parseAdr(raw: string): Adr | null {
   const hasEnforceBlock = block !== null;
   if (block) {
     try {
-      const parsed = parseToml(block[1]) as { forbid_pattern?: unknown };
-      const list = Array.isArray(parsed.forbid_pattern) ? parsed.forbid_pattern : [];
-      rules = list
-        .map((r): AdrRule | null => {
-          const o = r as Record<string, unknown>;
-          if (typeof o.pattern !== "string" || typeof o.paths !== "string") return null;
-          return {
-            type: "forbid-pattern",
-            pattern: o.pattern,
-            paths: o.paths,
-            message: typeof o.message === "string" ? o.message : undefined,
-          };
-        })
-        .filter((r): r is AdrRule => r !== null);
+      const parsed = parseToml(block[1]) as Record<string, unknown>;
+      rules = [
+        ...arr(parsed.forbid_pattern).map((r): AdrRule | null => {
+          const pattern = str(r, "pattern");
+          const paths = str(r, "paths");
+          return pattern && paths
+            ? { type: "forbid-pattern", pattern, paths, message: str(r, "message") }
+            : null;
+        }),
+        ...arr(parsed.require_pattern).map((r): AdrRule | null => {
+          const pattern = str(r, "pattern");
+          const paths = str(r, "paths");
+          return pattern && paths
+            ? { type: "require-pattern", pattern, paths, message: str(r, "message") }
+            : null;
+        }),
+        ...arr(parsed.forbid_import).map((r): AdrRule | null => {
+          const imp = str(r, "import");
+          const paths = str(r, "paths");
+          return imp && paths
+            ? {
+                type: "forbid-import",
+                import: imp,
+                paths,
+                transitive: r.transitive === true,
+                message: str(r, "message"),
+              }
+            : null;
+        }),
+      ].filter((r): r is AdrRule => r !== null);
     } catch {
       rules = []; // malformed TOML → zero rules, but hasEnforceBlock stays true (surfaced)
     }
   }
   return { id, title, status, rules, hasEnforceBlock };
+}
+
+function arr(v: unknown): Record<string, unknown>[] {
+  return Array.isArray(v) ? (v as Record<string, unknown>[]) : [];
 }
 
 /** An accepted ADR that actually carries at least one enforceable rule. */
@@ -123,39 +179,222 @@ export function globToRegExp(glob: string): RegExp {
   return new RegExp(`^${re}$`);
 }
 
+/** A module specifier imported by a file, with its 1-indexed source line. */
+export interface ImportRef {
+  specifier: string;
+  line: number;
+}
+
+// A quoted module specifier used in an import / require / from / dynamic-import context.
+const IMPORT_LINE = /(?:^|[^\w$])(?:import|require|from)\b[^'"\n]*['"]([^'"\n]+)['"]/;
+
+/** Extract quoted module specifiers (ES import / re-export / require / dynamic import). */
+export function extractImports(content: string): ImportRef[] {
+  const out: ImportRef[] = [];
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(IMPORT_LINE);
+    if (m) out.push({ specifier: m[1], line: i + 1 });
+  }
+  return out;
+}
+
+const RESOLVE_EXTS = ["", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
+
+/** POSIX-normalize a path (resolve `.`/`..`, no I/O). Used for relative-import resolution. */
+function normalizePosix(p: string): string {
+  const parts = p.split("/");
+  const out: string[] = [];
+  for (const seg of parts) {
+    if (seg === "" || seg === ".") continue;
+    if (seg === "..") out.pop();
+    else out.push(seg);
+  }
+  return out.join("/");
+}
+
+function dirOf(p: string): string {
+  const i = p.lastIndexOf("/");
+  return i < 0 ? "" : p.slice(0, i);
+}
+
 /**
- * Evaluate an accepted ADR's forbid-pattern rules over the provided files. Pure — the caller
- * supplies `{ path, content }` for the repo; this never touches disk. A non-accepted ADR (or
- * one with no rules) yields no violations. Line numbers are 1-indexed on the first match.
+ * Resolve a *relative* specifier (`./` `../`) against `fromFile` to a member of `fileSet`.
+ * Returns null for bare specifiers (npm packages — intentionally graph leaves) and for
+ * relative specifiers that resolve to nothing in the set (surfaced as a gap by the caller).
+ */
+export function resolveRelative(
+  fromFile: string,
+  specifier: string,
+  fileSet: Set<string>,
+): string | null {
+  if (!specifier.startsWith(".")) return null; // bare specifier = external leaf
+  const base = normalizePosix(`${dirOf(fromFile)}/${specifier}`);
+  // A `.js`/`.jsx`/`.mjs`/`.cjs` specifier resolves to the `.ts`-family source (ESM/TS
+  // convention), so also try the extension-stripped base.
+  const bases = [base];
+  const jsExt = base.match(/\.(js|jsx|mjs|cjs)$/);
+  if (jsExt) bases.push(base.slice(0, -jsExt[0].length));
+  for (const b of bases) {
+    for (const ext of RESOLVE_EXTS) {
+      if (fileSet.has(b + ext)) return b + ext;
+    }
+    for (const ext of RESOLVE_EXTS.slice(1)) {
+      if (fileSet.has(`${b}/index${ext}`)) return `${b}/index${ext}`;
+    }
+  }
+  return null;
+}
+
+function isRelative(specifier: string): boolean {
+  return specifier.startsWith(".");
+}
+
+/**
+ * Evaluate an accepted ADR's rules over the provided files. Pure — the caller supplies
+ * `{ path, content }` for the repo; this never touches disk. A non-accepted ADR (or one
+ * with no rules) yields no violations. Line numbers are 1-indexed.
  */
 export function evaluateAdr(adr: Adr, files: { path: string; content: string }[]): AdrViolation[] {
   if (adr.status !== "accepted") return [];
-  const violations: AdrViolation[] = [];
+  const out: AdrViolation[] = [];
+  const fileSet = new Set(files.map((f) => f.path));
+  // Import graph is built lazily and only once, only if a transitive rule needs it.
+  let importCache: Map<string, ImportRef[]> | null = null;
+  const importsOf = (path: string, content: string): ImportRef[] => {
+    if (!importCache) importCache = new Map();
+    let refs = importCache.get(path);
+    if (!refs) {
+      refs = extractImports(content);
+      importCache.set(path, refs);
+    }
+    return refs;
+  };
+  const contentByPath = new Map(files.map((f) => [f.path, f.content] as const));
+
   for (const rule of adr.rules) {
-    let matcher: RegExp;
     let globRe: RegExp;
     try {
-      matcher = new RegExp(rule.pattern);
       globRe = globToRegExp(rule.paths);
     } catch {
-      continue; // a malformed regex/glob rule is skipped, never a crash
+      continue;
     }
-    for (const f of files) {
-      if (!globRe.test(f.path)) continue;
-      const lines = f.content.split("\n");
-      for (let i = 0; i < lines.length; i++) {
-        if (matcher.test(lines[i])) {
-          violations.push({
-            adrId: adr.id,
-            file: f.path,
-            line: i + 1,
-            pattern: rule.pattern,
-            message: rule.message ?? `forbidden by ${adr.id}: /${rule.pattern}/`,
-          });
-          break; // one violation per (rule, file) is enough to gate
+    const matched = files.filter((f) => globRe.test(f.path));
+
+    if (rule.type === "forbid-pattern") {
+      const matcher = safeRegExp(rule.pattern);
+      if (!matcher) continue;
+      for (const f of matched) {
+        const idx = firstMatchingLine(f.content, matcher);
+        if (idx >= 0)
+          out.push(v(adr.id, f.path, idx + 1, "forbid-pattern", rule.pattern, "violation", rule.message ?? `forbidden by ${adr.id}: /${rule.pattern}/`)); // prettier-ignore
+      }
+    } else if (rule.type === "require-pattern") {
+      const matcher = safeRegExp(rule.pattern);
+      if (!matcher) continue;
+      for (const f of matched) {
+        if (firstMatchingLine(f.content, matcher) < 0)
+          out.push(v(adr.id, f.path, 1, "require-pattern", rule.pattern, "violation", rule.message ?? `${adr.id} requires /${rule.pattern}/ — missing in this file`)); // prettier-ignore
+      }
+    } else if (rule.type === "forbid-import") {
+      const matcher = safeRegExp(rule.import);
+      if (!matcher) continue;
+      for (const f of matched) {
+        if (rule.transitive) {
+          out.push(
+            ...evalTransitiveImport(
+              adr.id,
+              rule,
+              f.path,
+              matcher,
+              fileSet,
+              importsOf,
+              contentByPath,
+            ),
+          );
+        } else {
+          for (const ref of importsOf(f.path, f.content)) {
+            if (matcher.test(ref.specifier))
+              out.push(v(adr.id, f.path, ref.line, "forbid-import", ref.specifier, "violation", rule.message ?? `${adr.id} forbids importing "${ref.specifier}"`)); // prettier-ignore
+          }
         }
       }
     }
   }
-  return violations;
+  return out;
+}
+
+function safeRegExp(src: string): RegExp | null {
+  try {
+    return new RegExp(src);
+  } catch {
+    return null;
+  }
+}
+
+function firstMatchingLine(content: string, matcher: RegExp): number {
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i++) if (matcher.test(lines[i])) return i;
+  return -1;
+}
+
+function v(
+  adrId: string,
+  file: string,
+  line: number,
+  rule: AdrRuleType,
+  detail: string,
+  kind: "violation" | "gap",
+  message: string,
+): AdrViolation {
+  return { adrId, file, line, rule, detail, message, kind };
+}
+
+/**
+ * Transitive forbid-import: BFS the relative-import graph from `startFile`. A direct or
+ * reachable import whose specifier matches → one violation (cited to the start file, with
+ * the chain in the message). Any relative import that does not resolve within the repo is
+ * surfaced as a `gap` (we cannot prove the target is unreachable) — never silent green.
+ * Bare specifiers are leaves: only the matched one gates, unmatched ones are not gaps.
+ */
+function evalTransitiveImport(
+  adrId: string,
+  rule: Extract<AdrRule, { type: "forbid-import" }>,
+  startFile: string,
+  matcher: RegExp,
+  fileSet: Set<string>,
+  importsOf: (path: string, content: string) => ImportRef[],
+  contentByPath: Map<string, string>,
+): AdrViolation[] {
+  const seen = new Set<string>([startFile]);
+  const queue: { file: string; chain: string[] }[] = [{ file: startFile, chain: [startFile] }];
+  const gaps: AdrViolation[] = [];
+  while (queue.length) {
+    const { file, chain } = queue.shift()!;
+    const content = contentByPath.get(file);
+    if (content === undefined) continue;
+    for (const ref of importsOf(file, content)) {
+      if (matcher.test(ref.specifier)) {
+        const via = chain.length > 1 ? ` (via ${chain.join(" → ")})` : "";
+        const line = file === startFile ? ref.line : 1;
+        const base = rule.message ?? `${adrId} forbids reaching "${ref.specifier}"`;
+        return [v(adrId, startFile, line, "forbid-import", ref.specifier, "violation", base + via)];
+      }
+      if (isRelative(ref.specifier)) {
+        const resolved = resolveRelative(file, ref.specifier, fileSet);
+        if (resolved === null) {
+          gaps.push(
+            v(adrId, startFile, file === startFile ? ref.line : 1, "forbid-import", ref.specifier, "gap",
+              `${adrId}: cannot prove — unresolved import "${ref.specifier}" in ${file}`), // prettier-ignore
+          );
+        } else if (!seen.has(resolved)) {
+          seen.add(resolved);
+          queue.push({ file: resolved, chain: [...chain, resolved] });
+        }
+      }
+    }
+  }
+  // No violation found; surface at most one gap per start file (deduped) so an unresolved
+  // edge downgrades the result from clean-green to "unproven" without flooding output.
+  return gaps.length ? [gaps[0]] : [];
 }

--- a/src/commands/adr.ts
+++ b/src/commands/adr.ts
@@ -4,11 +4,13 @@
  * kit-research/docs/research/adr-as-enforced-rule-design.md.
  *
  *   kit adr list    every ADR + status + enforced / documented-only
- *   kit adr check   run accepted ADRs' forbid-pattern rules over the repo (default)
+ *   kit adr check   run accepted ADRs' rules over the repo (default): forbid_pattern,
+ *                   require_pattern, and forbid_import (direct + transitive)
  *
  * kit never interprets ADR prose (off-charter); it enforces only the explicit
  * toml block. Only `accepted` ADRs gate; an accepted ADR with no rules is surfaced
- * as "documented, not enforced" — never silently green.
+ * as "documented, not enforced" — never silently green. A transitive forbid_import
+ * that hits an unresolvable relative import is a `gap` (can't prove), not a pass.
  */
 import { readFileSync as read, existsSync as exists } from "node:fs";
 import { relative as rel, join as pathJoin } from "node:path";
@@ -72,16 +74,23 @@ export function cmdAdr(): boolean {
   }));
 
   let violationCount = 0;
+  let gapCount = 0;
   let enforcedCount = 0;
   for (const { adr } of adrs) {
     if (!adrIsEnforced(adr)) continue;
     enforcedCount++;
-    const violations = evaluateAdr(adr, files);
-    for (const v of violations) {
-      violationCount++;
-      console.log(
-        `${c.red}✗${c.reset} ${v.file}:${v.line}  ${v.message}  ${c.dim}(${v.adrId})${c.reset}`,
-      );
+    for (const v of evaluateAdr(adr, files)) {
+      if (v.kind === "gap") {
+        gapCount++;
+        console.log(
+          `${c.yellow}?${c.reset} ${v.file}:${v.line}  ${v.message}  ${c.dim}(${v.adrId})${c.reset}`,
+        );
+      } else {
+        violationCount++;
+        console.log(
+          `${c.red}✗${c.reset} ${v.file}:${v.line}  ${v.message}  ${c.dim}(${v.adrId})${c.reset}`,
+        );
+      }
     }
   }
 
@@ -91,12 +100,13 @@ export function cmdAdr(): boolean {
     );
     return true;
   }
-  if (violationCount === 0) {
+  if (violationCount === 0 && gapCount === 0) {
     console.log(`${c.green}✓ ${enforcedCount} enforced ADR(s) — no violations${c.reset}`);
     return true;
   }
-  console.log(
-    `\n${c.red}${violationCount} ADR violation(s) across ${enforcedCount} enforced ADR(s).${c.reset}`,
-  );
+  const parts: string[] = [];
+  if (violationCount) parts.push(`${violationCount} violation(s)`);
+  if (gapCount) parts.push(`${gapCount} unprovable rule(s) (unresolved imports)`);
+  console.log(`\n${c.red}${parts.join(" + ")} across ${enforcedCount} enforced ADR(s).${c.reset}`);
   return false;
 }


### PR DESCRIPTION
Extends the `kit adr` → gate rule set (5.7.0 shipped `forbid_pattern` only) with two more deterministic, zero-LLM rule types.

## Added

- **`require_pattern`** — a regex that **must** appear in each matching file; its *absence* gates. Enforces positive invariants like "every `src/web/**` handler calls `withGovernance`".
- **`forbid_import`** — an **import-statement-aware** ban on a module specifier. Parses real `import` / `require` / `from` / dynamic-import specifiers (not any line), so `pg-promise` no longer trips a `^pg$` rule.
  - `transitive = true` also forbids **reaching** the target through the repo's relative-import graph (`./`/`../` resolution, incl. the `.js`→`.ts` ESM convention and `index` files).
  - A relative import that cannot be resolved within the repo is surfaced as a **`gap`** ("cannot prove") — it fails closed and prints distinctly (`?` yellow), never a silent green. **No false green.**

## Implementation

- `src/adr.ts`: `AdrRule` is now a discriminated union; new pure exports `extractImports`, `resolveRelative`; `AdrViolation` gains `rule` + `kind` (`violation` | `gap`). Everything stays a pure function of its text inputs — no I/O in the evaluator.
- `src/commands/adr.ts`: `kit adr check` reports violations and gaps separately; a gap alone is enough to exit non-zero.
- `src/adr.test.ts`: +13 tests (require_pattern, forbid_import direct + transitive + gap, `extractImports`, `resolveRelative`).

Still zero-LLM: kit enforces only the explicit ` ```toml kit-enforce ` block, never ADR prose.

## Verification

- Full suite green (3144 tests), `format:check` clean, zero-LLM boundary test intact.
- `contracts/kit.opencli.json` regenerated for the version bump only (no public-surface change — no new command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)