### PR TITLE
feat(containment): enforce-readiness — gVisor/Firecracker fingerprints + require-containment gate (5.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.9.0] - 2026-07-24
+
+### Added
+
+- **Containment enforce-readiness (defense-in-depth).** kit's `kit doctor` containment posture
+  (5.6.0) grows two capabilities, both deterministic and zero-LLM:
+  - **Sandboxed-runtime fingerprints** — `detectContainment` now names **gVisor** (`runsc`) and
+    **Firecracker** microVMs from userspace-visible strings (`/proc/version`, DMI vendor). A
+    *positive* fingerprint names the mechanism (`heuristic` confidence); an *absence* claims
+    nothing — these runtimes are deliberately stealthy, so kit never infers "not sandboxed" from
+    a missing marker (no false green).
+  - **`require containment` — a fail-closed gate.** New `[governance.containment] require = true`
+    turns the advisory posture into a hard requirement: `kit doctor` **fails** (not warns) when a
+    container/seccomp/sandbox layer beneath the tool boundary cannot be *positively* established —
+    **including** when it cannot be determined at all (a required control that cannot be proven
+    present is treated as absent). The containment verdict is written to the sealed audit
+    (`doctor.containment`) when the policy is in force.
+
+  New pure exports in `src/containment.ts` (`detectGvisorMarker`, `detectFirecrackerMarker`,
+  `containmentEnforcement`) and a `[governance.containment]` config section. kit still only
+  **detects and verifies** a sandbox as a delegate — it never becomes one.
+
 ## [5.8.0] - 2026-07-24
 
 ### Added

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -966,7 +966,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.8.0"
+    "version": "5.9.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "5.8.0",
+      "version": "5.9.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/audit.test.ts
+++ b/src/audit.test.ts
@@ -37,6 +37,7 @@ describe("logAuditEvent", () => {
       secrets: {},
       revocation: {},
       scan: {},
+      containment: {},
     };
 
     await logAuditEvent(config, {
@@ -69,6 +70,7 @@ describe("logAuditEvent", () => {
       secrets: {},
       revocation: {},
       scan: {},
+      containment: {},
     };
 
     await logAuditEvent(config, {
@@ -107,6 +109,7 @@ describe("logAuditEvent", () => {
       secrets: {},
       revocation: {},
       scan: {},
+      containment: {},
     };
 
     await logAuditEvent(config, {
@@ -145,6 +148,7 @@ describe("logAuditEvent", () => {
       secrets: {},
       revocation: {},
       scan: {},
+      containment: {},
     };
 
     await logAuditEvent(config, {
@@ -179,6 +183,7 @@ describe("logAuditEvent", () => {
       secrets: {},
       revocation: {},
       scan: {},
+      containment: {},
     };
 
     await logAuditEvent(config, {
@@ -244,6 +249,7 @@ describe("readAuditLog", () => {
       secrets: {},
       revocation: {},
       scan: {},
+      containment: {},
     };
 
     // Write some events
@@ -279,6 +285,7 @@ describe("readAuditLog", () => {
       secrets: {},
       revocation: {},
       scan: {},
+      containment: {},
     };
 
     // Write multiple events
@@ -635,6 +642,7 @@ describe("logAuditEvent return value (fail-closed signal)", () => {
       secrets: {},
       revocation: {},
       scan: {},
+      containment: {},
     };
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -254,6 +254,21 @@ export interface GovernanceConfig {
    * of false-greening on findings alone. Parsed from [governance.scan].
    */
   scan?: GovernanceScanConfig;
+  /**
+   * Containment policy. `require = true` makes OS containment a hard requirement: `kit doctor`
+   * FAILS (not warns) when a container/seccomp/sandbox layer beneath the tool boundary cannot be
+   * positively established — including when it cannot be determined (fail-closed). Parsed from
+   * [governance.containment].
+   */
+  containment?: GovernanceContainmentConfig;
+}
+
+/**
+ * Containment-gate policy.
+ * Parsed from [governance.containment]
+ */
+export interface GovernanceContainmentConfig {
+  require?: boolean;
 }
 
 /**
@@ -579,6 +594,12 @@ const GovernanceConfigSchema = z
     scan: z
       .object({
         required_scanners: z.array(z.string()).optional(),
+      })
+      .passthrough()
+      .optional(),
+    containment: z
+      .object({
+        require: z.boolean().optional(),
       })
       .passthrough()
       .optional(),

--- a/src/containment.test.ts
+++ b/src/containment.test.ts
@@ -1,6 +1,13 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { detectContainment, parseSeccompMode, cgroupHasContainer } from "./containment.js";
+import {
+  detectContainment,
+  parseSeccompMode,
+  cgroupHasContainer,
+  detectGvisorMarker,
+  detectFirecrackerMarker,
+  containmentEnforcement,
+} from "./containment.js";
 
 describe("detectContainment", () => {
   it("returns unknown (not 'not contained') when signals are unreadable", () => {
@@ -50,5 +57,63 @@ describe("cgroupHasContainer", () => {
     assert.equal(cgroupHasContainer("0::/docker/abc123"), true);
     assert.equal(cgroupHasContainer("0::/kubepods/pod/x"), true);
     assert.equal(cgroupHasContainer("0::/user.slice/session.scope"), false);
+  });
+});
+
+describe("detectGvisorMarker", () => {
+  it("matches a gVisor / runsc fingerprint (positive only)", () => {
+    assert.equal(detectGvisorMarker("Linux version 4.4.0 ... gVisor"), true);
+    assert.equal(detectGvisorMarker("runsc sandbox"), true);
+    assert.equal(detectGvisorMarker("Linux version 6.1.0-generic (gcc ...)"), false);
+    assert.equal(detectGvisorMarker(""), false);
+  });
+});
+
+describe("detectFirecrackerMarker", () => {
+  it("matches a Firecracker fingerprint (positive only)", () => {
+    assert.equal(detectFirecrackerMarker("Amazon Firecracker"), true);
+    assert.equal(detectFirecrackerMarker("product_name: Standard PC (i440FX)"), false);
+    assert.equal(detectFirecrackerMarker(""), false);
+  });
+});
+
+describe("detectContainment — sandboxed runtimes", () => {
+  it("names gVisor and is contained (heuristic) on a positive fingerprint", () => {
+    const v = detectContainment({ gvisorMarker: true });
+    assert.equal(v.mechanism, "gvisor");
+    assert.equal(v.contained, true);
+    assert.equal(v.confidence, "heuristic");
+  });
+  it("names Firecracker on a positive fingerprint", () => {
+    const v = detectContainment({ firecrackerMarker: true });
+    assert.equal(v.mechanism, "firecracker");
+    assert.equal(v.contained, true);
+  });
+  it("absence of a fingerprint never downgrades — still resolves via container/seccomp signals", () => {
+    // No gvisor/firecracker marker, but a real container signal is present.
+    const v = detectContainment({ cgroupContainer: true, seccompMode: 2 });
+    assert.equal(v.mechanism, "container");
+    assert.equal(v.contained, true);
+  });
+});
+
+describe("containmentEnforcement (fail-closed)", () => {
+  const contained = detectContainment({ cgroupContainer: true, seccompMode: 2 });
+  const none = detectContainment({ cgroupContainer: false, seccompMode: 0 });
+  const unknown = detectContainment({ unreadable: true });
+
+  it("skips when containment is not required", () => {
+    assert.equal(containmentEnforcement(none, false).status, "skip");
+  });
+  it("passes when required and containment is present", () => {
+    assert.equal(containmentEnforcement(contained, true).status, "pass");
+  });
+  it("FAILS when required but not contained", () => {
+    assert.equal(containmentEnforcement(none, true).status, "fail");
+  });
+  it("FAILS when required but undeterminable (fail-closed, not a pass)", () => {
+    const r = containmentEnforcement(unknown, true);
+    assert.equal(r.status, "fail");
+    assert.match(r.detail, /cannot be determined/);
   });
 });

--- a/src/containment.ts
+++ b/src/containment.ts
@@ -14,7 +14,13 @@
  */
 import { readFileSync, existsSync } from "node:fs";
 
-export type ContainmentMechanism = "container" | "seccomp" | "none" | "unknown";
+export type ContainmentMechanism =
+  | "gvisor"
+  | "firecracker"
+  | "container"
+  | "seccomp"
+  | "none"
+  | "unknown";
 
 /** Parsed, deterministic containment signals (all optional — unknown when unread). */
 export interface ContainmentSignals {
@@ -28,6 +34,14 @@ export interface ContainmentSignals {
   noNewPrivs?: boolean;
   /** A non-identity `/proc/self/uid_map` ⇒ a user namespace is in effect. */
   userNamespace?: boolean;
+  /**
+   * A gVisor (runsc) fingerprint was positively matched in a userspace-visible string
+   * (e.g. `/proc/version`). Absence is NOT evidence of no gVisor — these runtimes are
+   * deliberately stealthy — so a false here never downgrades the verdict.
+   */
+  gvisorMarker?: boolean;
+  /** A Firecracker microVM fingerprint was positively matched (DMI vendor / `/proc/version`). */
+  firecrackerMarker?: boolean;
   /** The signal source could not be read at all (e.g. no /proc) ⇒ verdict is `unknown`. */
   unreadable?: boolean;
 }
@@ -68,6 +82,27 @@ export function detectContainment(s: ContainmentSignals): ContainmentVerdict {
   if (s.noNewPrivs) details.push("no_new_privs set (privilege escalation blocked)");
   if (s.userNamespace) details.push("user namespace in effect");
 
+  // Sandboxed runtimes: a POSITIVE fingerprint names the mechanism precisely and is stronger
+  // isolation than a plain container. It is `heuristic` because the fingerprint is a
+  // userspace-visible string, not a cryptographic proof — but a positive is never a false green,
+  // and we never *infer* these from absence (the runtimes are stealthy by design).
+  if (s.gvisorMarker) {
+    return {
+      mechanism: "gvisor",
+      contained: true,
+      confidence: "heuristic",
+      details: [...details, "gVisor (runsc) fingerprint matched — user-space kernel sandbox"],
+    };
+  }
+  if (s.firecrackerMarker) {
+    return {
+      mechanism: "firecracker",
+      contained: true,
+      confidence: "heuristic",
+      details: [...details, "Firecracker microVM fingerprint matched — KVM-isolated guest"],
+    };
+  }
+
   if (container) {
     // A container plus syscall filtering is meaningful isolation; a bare container is weaker.
     return {
@@ -99,6 +134,57 @@ export function parseSeccompMode(statusContent: string): 0 | 1 | 2 | undefined {
 /** Detect a container runtime marker in cgroup text. */
 export function cgroupHasContainer(cgroupContent: string): boolean {
   return /\b(docker|containerd|kubepods|lxc|libpod)\b/.test(cgroupContent);
+}
+
+/**
+ * gVisor (runsc) fingerprint from a userspace-visible string such as `/proc/version`.
+ * gVisor exposes a synthetic /proc; some builds embed "gVisor"/"runsc" in the reported
+ * kernel version. A match is a real positive; a non-match is inconclusive (never "not gVisor").
+ */
+export function detectGvisorMarker(text: string): boolean {
+  return /\b(gvisor|runsc)\b/i.test(text);
+}
+
+/**
+ * Firecracker microVM fingerprint from DMI vendor strings / `/proc/version`. Firecracker is
+ * deliberately minimal (often no DMI at all), so this frequently returns false even inside one —
+ * that is the honest outcome, not a "not contained" claim. Only a positive vendor/version string
+ * is trusted.
+ */
+export function detectFirecrackerMarker(text: string): boolean {
+  return /\bfirecracker\b/i.test(text);
+}
+
+/**
+ * Fail-closed enforcement of a "containment required" policy. Pure. When containment is required
+ * but cannot be positively established — including the `unknown` (unreadable) case — this FAILS:
+ * a required control that cannot be proven present is treated as absent (no false green).
+ */
+export function containmentEnforcement(
+  v: ContainmentVerdict,
+  required: boolean,
+): { status: "pass" | "fail" | "skip"; detail: string } {
+  if (!required) {
+    return { status: "skip", detail: "containment not required by policy (advisory posture only)" };
+  }
+  if (v.contained) {
+    return {
+      status: "pass",
+      detail: `policy requires containment — satisfied by ${v.mechanism} (${v.confidence})`,
+    };
+  }
+  if (v.mechanism === "unknown") {
+    return {
+      status: "fail",
+      detail:
+        "policy requires containment, but it cannot be determined (non-Linux / restricted /proc) — a required control that cannot be proven present is treated as absent (fail-closed)",
+    };
+  }
+  return {
+    status: "fail",
+    detail:
+      "policy requires containment, but no container / seccomp / sandbox isolation was detected below the tool boundary",
+  };
 }
 
 /**
@@ -136,6 +222,21 @@ export function gatherContainmentSignals(): ContainmentSignals {
     const uidMap = readSafe("/proc/self/uid_map").trim();
     // Identity map "         0          0 4294967295" ⇒ NOT a userns remap.
     if (uidMap) signals.userNamespace = !/^\s*0\s+0\s+4294967295\s*$/.test(uidMap);
+  } catch {
+    /* best-effort */
+  }
+  try {
+    // Sandboxed-runtime fingerprints. Concatenate the userspace-visible strings a stealthy
+    // runtime *might* leak into; a positive names the mechanism, an absence claims nothing.
+    const procVersion = readSafe("/proc/version");
+    const dmi = [
+      readSafe("/sys/class/dmi/id/product_name"),
+      readSafe("/sys/class/dmi/id/sys_vendor"),
+      readSafe("/sys/class/dmi/id/bios_vendor"),
+    ].join(" ");
+    const haystack = `${procVersion} ${dmi}`;
+    if (detectGvisorMarker(haystack)) signals.gvisorMarker = true;
+    if (detectFirecrackerMarker(haystack)) signals.firecrackerMarker = true;
   } catch {
     /* best-effort */
   }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -535,11 +535,69 @@ export function containmentPostureStatus(
 }
 
 async function checkContainment(cwd: string): Promise<DoctorCheck> {
-  const { gatherContainmentSignals, detectContainment } = await import("./containment.js");
+  const { gatherContainmentSignals, detectContainment, containmentEnforcement } =
+    await import("./containment.js");
   const { gateLiveness } = await import("./agent-config.js");
   const verdict = detectContainment(gatherContainmentSignals());
+
+  // Is containment a hard requirement? [governance.containment] require = true flips this check
+  // from advisory posture to a fail-closed gate.
+  const required = await containmentRequired(cwd);
+  if (required) {
+    const { status, detail } = containmentEnforcement(verdict, true);
+    await auditContainmentVerdict(cwd, verdict, true, status);
+    return { name: "OS containment", status, detail, category: "security" };
+  }
+
   const { status, detail } = containmentPostureStatus(verdict, gateLiveness(cwd).installGate);
   return { name: "OS containment", status, detail, category: "security" };
+}
+
+/** Read [governance.containment] require from .kit.toml. Best-effort false on any read error. */
+async function containmentRequired(cwd: string): Promise<boolean> {
+  try {
+    const { loadConfig } = await import("./config.js");
+    const { resolve } = await import("node:path");
+    const cfg = await loadConfig(resolve(cwd, ".kit.toml"));
+    return cfg.governance?.containment?.require === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Record the containment verdict to the sealed audit when it is policy-relevant (required).
+ * Best-effort: a missing .kit.toml / audit backend must never abort the doctor check — the
+ * verdict the operator sees is the source of truth, this is the durable evidence of it.
+ */
+async function auditContainmentVerdict(
+  cwd: string,
+  verdict: ContainmentVerdict,
+  required: boolean,
+  status: string,
+): Promise<void> {
+  try {
+    const { loadConfig } = await import("./config.js");
+    const { mergeGovernanceConfigAsync } = await import("./governance.js");
+    const { logAuditEvent } = await import("./audit.js");
+    const { resolve } = await import("node:path");
+    const cfg = await loadConfig(resolve(cwd, ".kit.toml"));
+    const gov = await mergeGovernanceConfigAsync(cfg.governance);
+    await logAuditEvent(gov, {
+      operation: "doctor.containment",
+      environment: gov.environment,
+      success: status === "pass",
+      metadata: {
+        required,
+        mechanism: verdict.mechanism,
+        contained: verdict.contained,
+        confidence: verdict.confidence,
+        status,
+      },
+    });
+  } catch {
+    /* best-effort — the rendered verdict is the source of truth, not this log line */
+  }
 }
 
 /**

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -56,6 +56,9 @@ export const DEFAULT_GOVERNANCE: Required<GovernanceConfig> = {
   scan: {
     required_scanners: [],
   },
+  containment: {
+    require: false,
+  },
 };
 
 /**
@@ -96,6 +99,10 @@ export function mergeGovernanceConfig(userConfig?: GovernanceConfig): Required<G
     scan: {
       ...DEFAULT_GOVERNANCE.scan,
       ...userConfig.scan,
+    },
+    containment: {
+      ...DEFAULT_GOVERNANCE.containment,
+      ...userConfig.containment,
     },
   };
 }


### PR DESCRIPTION
Grows the 5.6.0 `kit doctor` containment posture (which only *detected* container/seccomp) into a fail-closed control. Deterministic, zero-LLM.

## Added

- **Sandboxed-runtime fingerprints.** `detectContainment` now names **gVisor** (`runsc`) and **Firecracker** microVMs from userspace-visible strings (`/proc/version`, DMI vendor fields).
  - A **positive** fingerprint names the mechanism at `heuristic` confidence (a userspace string, not a cryptographic proof).
  - An **absence** claims nothing — these runtimes are deliberately stealthy, so kit never infers "not sandboxed" from a missing marker. **No false green.**
- **`require containment` — a fail-closed gate.** New `[governance.containment] require = true` turns the advisory posture into a hard requirement: `kit doctor` **fails** (not warns) when a container/seccomp/sandbox layer beneath the tool boundary cannot be *positively* established — **including** when it cannot be determined at all (a required control that cannot be proven present is treated as absent).
- **Audit record.** The containment verdict is written to the sealed audit as `doctor.containment` when the policy is in force.

## Implementation

- `src/containment.ts`: `ContainmentMechanism` gains `gvisor` | `firecracker`; new pure exports `detectGvisorMarker`, `detectFirecrackerMarker`, `containmentEnforcement`; new signals wired into `gatherContainmentSignals`.
- `src/config.ts` + `src/governance.ts`: new `[governance.containment]` section (`require`), with default `false` and merge coverage.
- `src/doctor.ts`: `checkContainment` flips to the fail-closed `containmentEnforcement` path and audits the verdict when `require = true`; advisory posture unchanged otherwise.
- Tests: +10 in `src/containment.test.ts` (fingerprint detectors, mechanism naming, absence-never-downgrades, enforcement pass/fail/skip incl. undeterminable → fail).

kit still only **detects and verifies** a sandbox as a delegate — it never becomes one.

## Verification

- Full suite green (3153 tests), `format:check` clean, zero-LLM boundary intact.
- `contracts/kit.opencli.json` regenerated for the version bump only; no top-level public-surface change (the new config lives under `[governance.containment]`).

## Honest limits

- The gVisor/Firecracker fingerprints match documented vendor/version strings; they have **not** been verified against a live gVisor/Firecracker host in this environment, so they resolve to "no marker" (→ existing container/seccomp signals still apply) rather than a false positive. Verifying the exact `/proc`/DMI strings on a real runtime is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)