### PR TITLE
feat(adr): adoption — wire kit adr check into review, pre-commit, and baseline (5.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.10.0] - 2026-07-24
+
+### Added
+
+- **ADR gate adoption — `kit adr check` is now wired into the workflow.** The rule engine shipped
+  in 5.7.0/5.8.0 graduates from a standalone command into the everyday gates, following the
+  `kit standards` pattern:
+  - **`kit review`** now runs an `=== adr ===` stage and fails the review on any ADR violation
+    **or** gap (an unprovable transitive rule is not a pass).
+  - **Recommended pre-commit hook** (`kit setup --recommended`) now includes `kit adr check`
+    alongside the secret-scan and triage gates — a no-op when a repo has no ADRs.
+  - **ADR baseline.** `kit adr freeze` (and `kit baseline freeze`) snapshot current violations/gaps
+    into `.kit-baseline.json` so only **NEW** findings gate; existing ones are frozen. The baseline
+    key deliberately excludes the line number, so an unrelated edit never silently un-freezes a
+    finding. A corrupt baseline fails **open** (gates on everything) and is surfaced, never
+    silently swallowed.
+
+  New embeddable `adrCheck` + `collectAdrFindings` / `freezeAdrBaseline` / `adrFindingKey` exports
+  in `src/commands/adr.ts` (one freezer, shared by both freeze paths, so they never drift). Still
+  zero-LLM.
+
 ## [5.9.0] - 2026-07-24
 
 ### Added

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -966,7 +966,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.9.0"
+    "version": "5.10.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "5.9.0",
+      "version": "5.10.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/commands/adr.test.ts
+++ b/src/commands/adr.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { adrFindingKey, collectAdrFindings, freezeAdrBaseline } from "./adr.js";
+import { baselineGet, type Baseline } from "../baseline.js";
+import type { AdrViolation } from "../adr.js";
+
+describe("adrFindingKey", () => {
+  it("is stable across line-number changes (excludes the line)", () => {
+    const base: AdrViolation = {
+      adrId: "ADR-0001",
+      file: "src/web/h.ts",
+      line: 3,
+      rule: "forbid-import",
+      detail: "pg",
+      message: "no pg",
+      kind: "violation",
+    };
+    const moved = { ...base, line: 99 };
+    assert.equal(adrFindingKey(base), adrFindingKey(moved));
+  });
+
+  it("distinguishes different rule/file/detail", () => {
+    const a: AdrViolation = {
+      adrId: "ADR-1",
+      file: "a.ts",
+      line: 1,
+      rule: "forbid-import",
+      detail: "pg",
+      message: "",
+      kind: "violation",
+    };
+    assert.notEqual(adrFindingKey(a), adrFindingKey({ ...a, file: "b.ts" }));
+    assert.notEqual(adrFindingKey(a), adrFindingKey({ ...a, detail: "mysql" }));
+  });
+});
+
+describe("collectAdrFindings + freezeAdrBaseline (temp repo)", () => {
+  let dir: string;
+
+  before(() => {
+    dir = mkdtempSync(join(tmpdir(), "kit-adr-"));
+    mkdirSync(join(dir, "docs", "adr"), { recursive: true });
+    mkdirSync(join(dir, "src", "web"), { recursive: true });
+    writeFileSync(
+      join(dir, "docs", "adr", "ADR-0001.md"),
+      [
+        "---",
+        "id: ADR-0001",
+        "title: Web must not import pg",
+        "status: accepted",
+        "---",
+        "",
+        "```toml kit-enforce",
+        "[[forbid_import]]",
+        'import = "^pg$"',
+        'paths = "src/web/**/*.ts"',
+        "```",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(join(dir, "src", "web", "h.ts"), "import { Client } from 'pg'\n");
+  });
+
+  after(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("finds the accepted ADR's violation", () => {
+    const f = collectAdrFindings(dir);
+    assert.equal(f.enforcedCount, 1);
+    assert.equal(f.violations.length, 1);
+    assert.equal(f.violations[0].detail, "pg");
+  });
+
+  it("freeze snapshots the finding into the baseline, and it then suppresses", () => {
+    const baseline: Baseline = { version: 1, generated: "", categories: {} };
+    const total = freezeAdrBaseline(baseline, dir);
+    assert.equal(total, 1);
+
+    const frozen = new Set(baselineGet(baseline, "adr", "violations"));
+    const { violations } = collectAdrFindings(dir);
+    const live = violations.filter((v) => !frozen.has(adrFindingKey(v)));
+    assert.equal(live.length, 0, "the frozen violation is suppressed on re-check");
+  });
+});

--- a/src/commands/adr.ts
+++ b/src/commands/adr.ts
@@ -6,20 +6,26 @@
  *   kit adr list    every ADR + status + enforced / documented-only
  *   kit adr check   run accepted ADRs' rules over the repo (default): forbid_pattern,
  *                   require_pattern, and forbid_import (direct + transitive)
+ *   kit adr freeze  snapshot current violations/gaps into .kit-baseline.json so only
+ *                   NEW ones gate (mirrors `kit standards freeze`)
  *
  * kit never interprets ADR prose (off-charter); it enforces only the explicit
  * toml block. Only `accepted` ADRs gate; an accepted ADR with no rules is surfaced
  * as "documented, not enforced" — never silently green. A transitive forbid_import
  * that hits an unresolvable relative import is a `gap` (can't prove), not a pass.
+ *
+ * `adrCheck` is the embeddable gate reused by `kit review` and the pre-commit hook.
  */
 import { readFileSync as read, existsSync as exists } from "node:fs";
 import { relative as rel, join as pathJoin } from "node:path";
 import { c } from "../utils/colors.js";
 import { walkSourceFiles } from "../source-walk.js";
-import { parseAdr, evaluateAdr, adrIsEnforced, type Adr } from "../adr.js";
+import { parseAdr, evaluateAdr, adrIsEnforced, type Adr, type AdrViolation } from "../adr.js";
+import { baselineSet, type Baseline } from "../baseline.js";
 
 const ADR_DIRS = ["docs/adr", "docs/decisions"];
 const CODE_EXTS = [".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".rs", ".java", ".rb", ".php"];
+const BASELINE_CATEGORY = "adr";
 
 function loadAdrs(cwd: string): { adr: Adr; file: string }[] {
   const out: { adr: Adr; file: string }[] = [];
@@ -34,18 +40,57 @@ function loadAdrs(cwd: string): { adr: Adr; file: string }[] {
   return out;
 }
 
-export function cmdAdr(): boolean {
-  const args = process.argv.slice(3);
-  const sub = args[0] === "list" || args[0] === "check" ? args[0] : args[0] ? "help" : "check";
-  const cwd = process.cwd();
+/**
+ * Stable identity of a finding for baselining — deliberately EXCLUDES the line number so an
+ * unrelated edit that shifts lines does not silently un-freeze (or re-raise) a known finding.
+ */
+export function adrFindingKey(v: AdrViolation): string {
+  return `${v.adrId}|${v.rule}|${v.file}|${v.detail}`;
+}
 
-  if (sub === "help") {
-    console.log(`${c.bold}kit adr${c.reset} — enforce architecture decisions (ADR → gate)\n`);
-    console.log("  kit adr list     ADRs + status + enforced/documented");
-    console.log("  kit adr check    gate the repo on accepted ADRs' rules (default)");
-    return true;
+export interface AdrFindings {
+  adrCount: number;
+  enforcedCount: number;
+  violations: AdrViolation[];
+  gaps: AdrViolation[];
+}
+
+/** Gather every accepted ADR's findings over the repo. Pure-ish (reads the repo, no gating). */
+export function collectAdrFindings(cwd: string): AdrFindings {
+  const adrs = loadAdrs(cwd);
+  const files = walkSourceFiles(cwd, { exts: CODE_EXTS, includeTests: true }).map((f) => ({
+    path: rel(cwd, f),
+    content: read(f, "utf-8"),
+  }));
+  const violations: AdrViolation[] = [];
+  const gaps: AdrViolation[] = [];
+  let enforcedCount = 0;
+  for (const { adr } of adrs) {
+    if (!adrIsEnforced(adr)) continue;
+    enforcedCount++;
+    for (const v of evaluateAdr(adr, files)) {
+      (v.kind === "gap" ? gaps : violations).push(v);
+    }
   }
+  return { adrCount: adrs.length, enforcedCount, violations, gaps };
+}
 
+/** Snapshot current ADR violations + gaps into the baseline. Returns the number frozen. */
+export function freezeAdrBaseline(baseline: Baseline, cwd: string): number {
+  const { violations, gaps } = collectAdrFindings(cwd);
+  const vKeys = violations.map(adrFindingKey);
+  const gKeys = gaps.map(adrFindingKey);
+  baselineSet(baseline, BASELINE_CATEGORY, "violations", vKeys);
+  baselineSet(baseline, BASELINE_CATEGORY, "gaps", gKeys);
+  return vKeys.length + gKeys.length;
+}
+
+/**
+ * The embeddable ADR gate. Loads the baseline (fail-open on a corrupt file — a baseline only
+ * ever SUPPRESSES, so an unreadable one gates on everything), suppresses frozen findings, prints,
+ * and returns ok. Shared by `kit adr check`, `kit review`, and the pre-commit hook.
+ */
+export async function adrCheck(cwd = process.cwd()): Promise<boolean> {
   const adrs = loadAdrs(cwd);
   if (adrs.length === 0) {
     console.log(
@@ -54,7 +99,80 @@ export function cmdAdr(): boolean {
     return true;
   }
 
+  const { loadBaselineForGate, baselineGet, BASELINE_FILE } = await import("../baseline.js");
+  const { baseline, ignored } = await loadBaselineForGate(cwd);
+  if (ignored) {
+    console.log(
+      `${c.yellow}!${c.reset} ${BASELINE_FILE} ignored (${ignored}) — gating on all findings`,
+    );
+  }
+  const frozen = new Set([
+    ...baselineGet(baseline, BASELINE_CATEGORY, "violations"),
+    ...baselineGet(baseline, BASELINE_CATEGORY, "gaps"),
+  ]);
+
+  const { enforcedCount, violations, gaps } = collectAdrFindings(cwd);
+  const liveViolations = violations.filter((v) => !frozen.has(adrFindingKey(v)));
+  const liveGaps = gaps.filter((v) => !frozen.has(adrFindingKey(v)));
+
+  for (const v of liveViolations) {
+    console.log(
+      `${c.red}✗${c.reset} ${v.file}:${v.line}  ${v.message}  ${c.dim}(${v.adrId})${c.reset}`,
+    );
+  }
+  for (const v of liveGaps) {
+    console.log(
+      `${c.yellow}?${c.reset} ${v.file}:${v.line}  ${v.message}  ${c.dim}(${v.adrId})${c.reset}`,
+    );
+  }
+
+  if (enforcedCount === 0) {
+    console.log(
+      `${c.yellow}No accepted ADR carries an enforce block — nothing to gate (documented, not enforced).${c.reset}`,
+    );
+    return true;
+  }
+  const suppressed = violations.length - liveViolations.length + (gaps.length - liveGaps.length);
+  const suffix = suppressed ? ` ${c.dim}(${suppressed} baselined)${c.reset}` : "";
+  if (liveViolations.length === 0 && liveGaps.length === 0) {
+    console.log(
+      `${c.green}✓ ${enforcedCount} enforced ADR(s) — no new violations${c.reset}${suffix}`,
+    );
+    return true;
+  }
+  const parts: string[] = [];
+  if (liveViolations.length) parts.push(`${liveViolations.length} violation(s)`);
+  if (liveGaps.length) parts.push(`${liveGaps.length} unprovable rule(s) (unresolved imports)`);
+  console.log(
+    `\n${c.red}${parts.join(" + ")} across ${enforcedCount} enforced ADR(s).${c.reset}${suffix}`,
+  );
+  return false;
+}
+
+export async function cmdAdr(): Promise<boolean> {
+  const args = process.argv.slice(3);
+  const sub =
+    args[0] === "list" || args[0] === "check" || args[0] === "freeze"
+      ? args[0]
+      : args[0]
+        ? "help"
+        : "check";
+  const cwd = process.cwd();
+
+  if (sub === "help") {
+    console.log(`${c.bold}kit adr${c.reset} — enforce architecture decisions (ADR → gate)\n`);
+    console.log("  kit adr list     ADRs + status + enforced/documented");
+    console.log("  kit adr check    gate the repo on accepted ADRs' rules (default)");
+    console.log("  kit adr freeze   snapshot current findings into the baseline");
+    return true;
+  }
+
   if (sub === "list") {
+    const adrs = loadAdrs(cwd);
+    if (adrs.length === 0) {
+      console.log(`${c.dim}No ADRs found in ${ADR_DIRS.join(" or ")}.${c.reset}`);
+      return true;
+    }
     console.log(`${c.bold}ADRs${c.reset}`);
     for (const { adr, file } of adrs) {
       const state = adrIsEnforced(adr)
@@ -67,46 +185,16 @@ export function cmdAdr(): boolean {
     return true;
   }
 
-  // check: gather repo code files once, evaluate every accepted ADR.
-  const files = walkSourceFiles(cwd, { exts: CODE_EXTS, includeTests: true }).map((f) => ({
-    path: rel(cwd, f),
-    content: read(f, "utf-8"),
-  }));
-
-  let violationCount = 0;
-  let gapCount = 0;
-  let enforcedCount = 0;
-  for (const { adr } of adrs) {
-    if (!adrIsEnforced(adr)) continue;
-    enforcedCount++;
-    for (const v of evaluateAdr(adr, files)) {
-      if (v.kind === "gap") {
-        gapCount++;
-        console.log(
-          `${c.yellow}?${c.reset} ${v.file}:${v.line}  ${v.message}  ${c.dim}(${v.adrId})${c.reset}`,
-        );
-      } else {
-        violationCount++;
-        console.log(
-          `${c.red}✗${c.reset} ${v.file}:${v.line}  ${v.message}  ${c.dim}(${v.adrId})${c.reset}`,
-        );
-      }
-    }
-  }
-
-  if (enforcedCount === 0) {
+  if (sub === "freeze") {
+    const { loadBaseline, saveBaseline, BASELINE_FILE } = await import("../baseline.js");
+    const baseline = await loadBaseline(cwd);
+    const total = freezeAdrBaseline(baseline, cwd);
+    await saveBaseline(baseline, cwd);
     console.log(
-      `${c.yellow}No accepted ADR carries an enforce block — nothing to gate (documented, not enforced).${c.reset}`,
+      `${c.green}✓${c.reset} Wrote ${BASELINE_FILE} — ${total} ADR finding(s) frozen. Future runs gate only on NEW findings.`,
     );
     return true;
   }
-  if (violationCount === 0 && gapCount === 0) {
-    console.log(`${c.green}✓ ${enforcedCount} enforced ADR(s) — no violations${c.reset}`);
-    return true;
-  }
-  const parts: string[] = [];
-  if (violationCount) parts.push(`${violationCount} violation(s)`);
-  if (gapCount) parts.push(`${gapCount} unprovable rule(s) (unresolved imports)`);
-  console.log(`\n${c.red}${parts.join(" + ")} across ${enforcedCount} enforced ADR(s).${c.reset}`);
-  return false;
+
+  return adrCheck(cwd);
 }

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -9,6 +9,7 @@ import { hasFlag } from "../utils/flags.js";
 import { cmdCheck } from "./check.js";
 import { cmdDesign } from "./design.js";
 import { cmdStandards } from "./standards.js";
+import { adrCheck } from "./adr.js";
 
 export async function cmdReview(): Promise<boolean> {
   const jsonMode = hasFlag(process.argv, "--json");
@@ -26,6 +27,10 @@ export async function cmdReview(): Promise<boolean> {
   if (!jsonMode) console.log(`\n${c.bold}=== standards ===${c.reset}`);
   const standardsOk = await cmdStandards();
   if (!standardsOk) allOk = false;
+
+  if (!jsonMode) console.log(`\n${c.bold}=== adr ===${c.reset}`);
+  const adrOk = await adrCheck();
+  if (!adrOk) allOk = false;
 
   if (!jsonMode) {
     console.log(

--- a/src/commands/standards.ts
+++ b/src/commands/standards.ts
@@ -179,9 +179,12 @@ export async function cmdBaseline(): Promise<boolean> {
   baselineSet(baseline, "design", "tokens", design.tokens);
   // All standards dimensions (general + specific + plugins + platform) via the shared helper.
   const standardsTotal = await freezeStandardsBaseline(baseline, process.cwd());
+  // ADR violations/gaps, via the ADR command's shared freezer (kept in one place so it never drifts).
+  const { freezeAdrBaseline } = await import("./adr.js");
+  const adrTotal = freezeAdrBaseline(baseline, process.cwd());
   await saveBaseline(baseline);
   console.log(
-    `${c.green}✓${c.reset} Wrote ${BASELINE_FILE} — ${untested.length} untested file(s), ${design.a11y.length} a11y, ${design.tokens.length} design-token, ${standardsTotal} standards finding(s) frozen.`,
+    `${c.green}✓${c.reset} Wrote ${BASELINE_FILE} — ${untested.length} untested file(s), ${design.a11y.length} a11y, ${design.tokens.length} design-token, ${standardsTotal} standards finding(s), ${adrTotal} ADR finding(s) frozen.`,
   );
   console.log(`  Future runs will gate only on NEW findings.`);
   return true;

--- a/src/recommended.test.ts
+++ b/src/recommended.test.ts
@@ -40,6 +40,7 @@ describe("applyRecommendedHardening", () => {
     assert.ok(pc.includes("security scan-staged"), "pre-commit runs security scan-staged");
     assert.ok(pc.includes("triage check-deps"), "pre-commit runs the dep triage gate");
     assert.ok(pc.includes("triage check-skills"), "pre-commit runs the skill triage gate");
+    assert.ok(pc.includes("adr check"), "pre-commit runs the ADR gate");
 
     // pre-push context-check gate (context was declared).
     assert.ok(existsSync(join(g, "hooks", "pre-push")), "pre-push installed when context declared");

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -22,7 +22,8 @@ function kitInvocation(): string {
 /**
  * The opinionated "recommended" hardening layered on top of `kit setup`:
  *   - cross-harness memory capture (the Claude Code hooks)
- *   - a pre-commit gate: secret-scan + triage gates for newly-added deps and staged skills
+ *   - a pre-commit gate: secret-scan + triage gates for newly-added deps and staged skills +
+ *     the ADR gate (accepted ADRs' kit-enforce rules; a no-op when there are no ADRs)
  *   - a pre-push context-check gate (only when `[context]` is declared)
  *
  * The triage gates (`kit triage check-deps` / `check-skills`) were always meant to run at
@@ -47,6 +48,7 @@ export async function applyRecommendedHardening(
       `${kit} security scan-staged`,
       `${kit} triage check-deps`,
       `${kit} triage check-skills`,
+      `${kit} adr check`,
     ],
   };
   // The context-check gate only makes sense once a context is declared.


### PR DESCRIPTION
Graduates the ADR rule engine (shipped in 5.7.0/5.8.0) from a standalone `kit adr` command into the everyday gates, following the `kit standards` adoption pattern. Zero-LLM throughout.

## Added

- **`kit review`** runs a new `=== adr ===` stage and **fails the review on any ADR violation OR gap** (an unprovable transitive `forbid_import` is not a pass).
- **Recommended pre-commit hook** (`kit setup --recommended`) now includes `kit adr check` alongside the secret-scan and triage gates. It's a **no-op when a repo has no ADRs**, so it's safe by default.
- **ADR baseline.** `kit adr freeze` — and the existing `kit baseline freeze` — snapshot current violations/gaps into `.kit-baseline.json` so only **NEW** findings gate; existing ones are frozen.
  - The baseline key **excludes the line number** (`adrId|rule|file|detail`), so an unrelated edit that shifts lines never silently un-freezes (or re-raises) a known finding.
  - A corrupt/unreadable baseline fails **open** — it gates on everything and surfaces the reason — never a silent swallow (a baseline only ever *suppresses*).

## Implementation

- `src/commands/adr.ts`: new embeddable `adrCheck(cwd)` (reused by `kit adr check`, `kit review`, and the pre-commit hook) + pure `collectAdrFindings`, `freezeAdrBaseline`, `adrFindingKey`. `cmdAdr` gains a `freeze` subcommand.
- `src/commands/review.ts`: ADR stage after standards.
- `src/commands/standards.ts`: `kit baseline freeze` now also freezes ADR findings via the **shared** `freezeAdrBaseline` (one freezer, so the two paths never drift).
- `src/recommended.ts`: `kit adr check` added to the recommended pre-commit list.
- Tests: new `src/commands/adr.test.ts` (finding-key stability across line moves, temp-repo collect + freeze→suppress) and an ADR assertion in `src/recommended.test.ts`.

## Verification

- Full suite green (3157 tests), `format:check` clean, zero-LLM boundary intact.
- `contracts/kit.opencli.json` regenerated for the version bump only; no public-surface change (the `freeze` subcommand is parsed within `kit adr`, not a new registry command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)