### PR TITLE
feat(triage): kit triage model --scan-bytes — ClamAV malware-scan delegate (5.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.11.0] - 2026-07-25
+
+### Added
+
+- **`kit triage model --scan-bytes` — malware-scan delegate (ClamAV).** The byte-level layer
+  beneath the model/dataset format+provenance triage. Connect-don't-copy: kit ships **no**
+  scanning engine and **no** signatures — it invokes a locally-installed ClamAV (`clamscan`) and
+  records the verdict. Contract (verified against ClamAV 1.5.3 on a real host — exit 0/2 paths
+  empirically, exit 1 per ClamAV's documented, stable spec): **exit 0 → clean**, **exit 1 →
+  malicious** (signature names parsed from `<path>: <SIGNATURE> FOUND`), **exit 2/other →
+  scanerror**, **binary absent → not-installed**. A `malicious` result forces an overall
+  **fail**; a `scanerror` / missing scanner is a **gap** — surfaced, never a silent clean
+  (absence of a scan is not a pass). Without `--scan-bytes` the byte layer is skipped (kit does
+  not auto-run a multi-second scan). New pure `interpretClamscan` + `scanFileForMalware` in
+  `src/malware-scan.ts`. Honest limit: kit does not *detect* malware — it records that a verified
+  ClamAV scan ran and what it returned; signature-based AV is known-malware-only.
+
 ## [5.10.1] - 2026-07-25
 
 A maintenance release. No new commands, no behaviour changes to any gate — the

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -966,7 +966,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.10.1"
+    "version": "5.11.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "5.10.0",
+      "version": "5.11.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.10.1",
+  "version": "5.11.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/commands/triage.ts
+++ b/src/commands/triage.ts
@@ -55,6 +55,9 @@ export async function cmdTriage(): Promise<boolean> {
     console.log(
       "  kit triage model <path>              Evaluate an untrusted AI artifact (model weights / dataset) before loading",
     );
+    console.log(
+      "  kit triage model <path> --scan-bytes + byte-level malware scan via a local ClamAV delegate (clean/malicious/gap; never a silent pass)",
+    );
     console.log("  kit triage skill <path|name>         Evaluate Claude Code / agent skill");
     console.log(
       "  kit triage skill <path|name> --deep  + SkillSpector (NVIDIA) static Stage 1 (no LLM, no egress) when installed",
@@ -716,11 +719,12 @@ async function cmdTriageCheckSkills(): Promise<boolean> {
  * `<path>.sha256` or `<path>.sig` sidecar counts as verified provenance. Exits
  * non-zero on a high-confidence (code-exec) finding.
  */
-export function cmdTriageModel(args: string[]): boolean {
+export async function cmdTriageModel(args: string[]): Promise<boolean> {
   const json = hasFlag(args, "--json");
+  const scanBytes = hasFlag(args, "--scan-bytes");
   const path = args.find((a) => !a.startsWith("--"));
   if (!path) {
-    console.error("usage: kit triage model <path> [--json]");
+    console.error("usage: kit triage model <path> [--scan-bytes] [--json]");
     return false;
   }
   let sizeBytes: number | undefined;
@@ -734,9 +738,30 @@ export function cmdTriageModel(args: string[]): boolean {
   const provenanceVerified = existsSync(`${path}.sha256`) || existsSync(`${path}.sig`);
   const r = triageModelArtifact(path, { sizeBytes, provenanceVerified });
 
+  // Optional byte-level layer: delegate to a locally-installed ClamAV. kit records the
+  // verdict; it never becomes the AV. `malicious` forces an overall fail; a scanerror /
+  // missing scanner is a GAP (surfaced, never a silent clean).
+  let scan: import("../malware-scan.js").MalwareScanResult | undefined;
+  if (scanBytes) {
+    if (!existsSync(path)) {
+      scan = {
+        verdict: "scanerror",
+        signatures: [],
+        ranScanner: false,
+        isGap: true,
+        detail: "file does not exist — nothing to scan (gap)",
+      };
+    } else {
+      const { scanFileForMalware } = await import("../malware-scan.js");
+      scan = await scanFileForMalware(path);
+    }
+  }
+
+  const overallPass = r.passed && scan?.verdict !== "malicious";
+
   if (json) {
-    console.log(JSON.stringify(r, null, 2));
-    return r.passed;
+    console.log(JSON.stringify({ ...r, malwareScan: scan ?? null, passed: overallPass }, null, 2));
+    return overallPass;
   }
 
   console.log(
@@ -747,10 +772,26 @@ export function cmdTriageModel(args: string[]): boolean {
     console.log(`  [${tag}] ${f.label}`);
     console.log(`      ${c.dim}${f.rationale}${c.reset}`);
   }
+  if (scan) {
+    const tag =
+      scan.verdict === "malicious"
+        ? `${c.red}MALWARE${c.reset}`
+        : scan.verdict === "clean"
+          ? `${c.green}clean${c.reset}`
+          : `${c.yellow}gap${c.reset}`;
+    console.log(`  [${tag}] byte-scan (ClamAV delegate)`);
+    console.log(`      ${c.dim}${scan.detail}${c.reset}`);
+  } else {
+    console.log(
+      `  ${c.dim}byte-scan: not run (pass --scan-bytes to delegate to a local ClamAV)${c.reset}`,
+    );
+  }
   console.log(
-    r.passed
-      ? `${c.green}pass${c.reset} — no code-execution-on-load format (still verify provenance + load in a sandbox)`
-      : `${c.red}fail${c.reset} — code-execution-on-load risk; do not load an untrusted file`,
+    overallPass
+      ? `${c.green}pass${c.reset} — no code-execution-on-load format${scan?.verdict === "clean" ? " + ClamAV clean" : ""} (still verify provenance + load in a sandbox)`
+      : scan?.verdict === "malicious"
+        ? `${c.red}fail${c.reset} — ClamAV matched a known-malware signature; do not load`
+        : `${c.red}fail${c.reset} — code-execution-on-load risk; do not load an untrusted file`,
   );
-  return r.passed;
+  return overallPass;
 }

--- a/src/malware-scan.test.ts
+++ b/src/malware-scan.test.ts
@@ -1,0 +1,54 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { interpretClamscan, scanFileForMalware } from "./malware-scan.js";
+
+describe("interpretClamscan — verified ClamAV contract", () => {
+  it("exit 0 → clean, conclusive (not a gap)", () => {
+    const r = interpretClamscan(0, "clean.txt: OK");
+    assert.equal(r.verdict, "clean");
+    assert.equal(r.ranScanner, true);
+    assert.equal(r.isGap, false);
+    assert.deepEqual(r.signatures, []);
+  });
+
+  it("exit 1 → malicious, parses the signature name(s) from FOUND lines", () => {
+    const out = "eicar.txt: Win.Test.EICAR_HDB-1 FOUND";
+    const r = interpretClamscan(1, out);
+    assert.equal(r.verdict, "malicious");
+    assert.equal(r.isGap, false);
+    assert.deepEqual(r.signatures, ["Win.Test.EICAR_HDB-1"]);
+    assert.match(r.detail, /Win\.Test\.EICAR_HDB-1/);
+  });
+
+  it("exit 1 with multiple hits collects every signature", () => {
+    const out = ["a.bin: Foo.Bar FOUND", "noise", "b.bin: Baz.Qux-2 FOUND"].join("\n");
+    const r = interpretClamscan(1, out);
+    assert.deepEqual(r.signatures, ["Foo.Bar", "Baz.Qux-2"]);
+  });
+
+  it("exit 2 → scanerror GAP (empirically: nonexistent path / unreadable / stdin)", () => {
+    const r = interpretClamscan(2, "stdin: Can't open file or directory ERROR");
+    assert.equal(r.verdict, "scanerror");
+    assert.equal(r.isGap, true);
+    assert.equal(r.ranScanner, false);
+  });
+
+  it("any other/unknown exit is a GAP, never a silent clean", () => {
+    for (const code of [3, 127, null]) {
+      const r = interpretClamscan(code as number | null, "");
+      assert.equal(r.isGap, true);
+      assert.notEqual(r.verdict, "clean");
+    }
+  });
+});
+
+describe("scanFileForMalware — missing scanner is a gap, not a pass", () => {
+  it("returns a not-installed GAP when the binary can't be resolved", async () => {
+    // Force the "no binary" path deterministically (empty string ⇒ falsy ⇒ not-installed).
+    const r = await scanFileForMalware("/whatever", "");
+    assert.equal(r.verdict, "not-installed");
+    assert.equal(r.isGap, true);
+    assert.equal(r.ranScanner, false);
+    assert.notEqual(r.verdict, "clean");
+  });
+});

--- a/src/malware-scan.ts
+++ b/src/malware-scan.ts
@@ -1,0 +1,126 @@
+/**
+ * kit — malware-scan delegate (ClamAV). Connect-don't-copy: kit builds NO scanning
+ * engine and ships NO signatures — it INVOKES a locally-installed ClamAV (`clamscan`)
+ * and records the verdict. The byte-level layer beneath `kit triage model`'s
+ * format/provenance classification.
+ *
+ * Verified invocation contract (ClamAV 1.5.3, confirmed on a real host):
+ *   exit 0            → Clean          ("… OK", "Infected files: 0")
+ *   exit 1            → Malicious      (one line per hit: "<path>: <SIGNATURE> FOUND")
+ *   exit 2 / other    → ScanError→GAP  (can't open, daemon down, no engine, …)
+ *   binary absent     → not-installed  → GAP (never "clean": absence of a scan is not a pass)
+ *
+ * Honest limit: kit does not *detect* malware — it records that a verified ClamAV scan
+ * ran and what it returned. A ScanError / missing scanner is a GAP, surfaced, never green.
+ * Signature-based AV is known-malware-only; the value kit adds is the deterministic,
+ * attributable record around the scan, not the detection itself.
+ *
+ * The interpreter is a PURE function of (exitCode, stdout) so the whole contract is
+ * unit-tested without ClamAV present; only `scanFileForMalware` touches the system.
+ */
+import { spawnSync } from "node:child_process";
+import { resolveToolBin } from "./utils/resolveTool.js";
+
+export type MalwareVerdict = "clean" | "malicious" | "scanerror" | "not-installed";
+
+export interface MalwareScanResult {
+  verdict: MalwareVerdict;
+  /** Signature names ClamAV reported (only for `malicious`). */
+  signatures: string[];
+  /** True only when a scanner actually ran (clean or malicious). */
+  ranScanner: boolean;
+  /**
+   * `clean`/`malicious` are conclusive; `scanerror`/`not-installed` are GAPS —
+   * the scan could not be completed, so the result must never be presented as a pass.
+   */
+  isGap: boolean;
+  detail: string;
+}
+
+const FOUND_LINE = /^(?:.*): (.+) FOUND$/;
+
+/**
+ * Pure interpretation of a `clamscan` run. Encodes the verified exit-code contract.
+ * `stdout` is parsed only to extract signature names on a `malicious` (exit 1) result.
+ */
+export function interpretClamscan(exitCode: number | null, stdout: string): MalwareScanResult {
+  if (exitCode === 0) {
+    return {
+      verdict: "clean",
+      signatures: [],
+      ranScanner: true,
+      isGap: false,
+      detail: "ClamAV scanned the artifact and found no known-malware signature",
+    };
+  }
+  if (exitCode === 1) {
+    const signatures: string[] = [];
+    for (const line of stdout.split("\n")) {
+      const m = line.trim().match(FOUND_LINE);
+      if (m) signatures.push(m[1].trim());
+    }
+    const named = signatures.length ? `: ${signatures.join(", ")}` : "";
+    return {
+      verdict: "malicious",
+      signatures,
+      ranScanner: true,
+      isGap: false,
+      detail: `ClamAV matched ${signatures.length || "a"} known-malware signature${signatures.length === 1 ? "" : "s"}${named}`,
+    };
+  }
+  // exit 2 or anything else = the scan did not complete → a GAP, not a verdict.
+  return {
+    verdict: "scanerror",
+    signatures: [],
+    ranScanner: false,
+    isGap: true,
+    detail: `ClamAV could not complete the scan (exit ${exitCode ?? "null"}) — treated as a gap, not a pass`,
+  };
+}
+
+/**
+ * Scan a file with a locally-installed ClamAV. Impure (resolves the binary + spawns it),
+ * but never throws: a missing scanner returns a `not-installed` GAP, and a crashed scan is
+ * a `scanerror` GAP. `clamscanBin` is injectable for tests.
+ */
+export async function scanFileForMalware(
+  filePath: string,
+  clamscanBin?: string | null,
+): Promise<MalwareScanResult> {
+  const bin = clamscanBin ?? (await resolveToolBin("clamscan"));
+  if (!bin) {
+    return {
+      verdict: "not-installed",
+      signatures: [],
+      ranScanner: false,
+      isGap: true,
+      detail:
+        "ClamAV (clamscan) is not installed — no byte-level malware scan ran. Install it (`brew install clamav` + `freshclam`) to enable this layer. A missing scanner is a gap, not a clean pass.",
+    };
+  }
+  try {
+    // --no-summary keeps stdout to the per-file verdict lines the interpreter parses.
+    const res = spawnSync(bin, ["--no-summary", filePath], {
+      encoding: "utf-8",
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    if (res.error) {
+      return {
+        verdict: "scanerror",
+        signatures: [],
+        ranScanner: false,
+        isGap: true,
+        detail: `ClamAV failed to run (${res.error.message}) — gap, not a pass`,
+      };
+    }
+    return interpretClamscan(res.status, `${res.stdout ?? ""}\n${res.stderr ?? ""}`);
+  } catch (err) {
+    return {
+      verdict: "scanerror",
+      signatures: [],
+      ranScanner: false,
+      isGap: true,
+      detail: `ClamAV invocation threw (${err instanceof Error ? err.message : String(err)}) — gap`,
+    };
+  }
+}


### PR DESCRIPTION
Adds the byte-level layer beneath `kit triage model`'s format + provenance classification. **Connect-don't-copy:** kit ships **no** scanning engine and **no** signatures — it invokes a locally-installed **ClamAV** (`clamscan`) and records the verdict.

## Added

- **`kit triage model <path> --scan-bytes`** — delegates a byte-level malware scan to ClamAV and folds the result into the triage:
  - `clean` → conclusive; combined with a non-code-exec format it reports `pass … + ClamAV clean`.
  - `malicious` → **forces an overall fail**; signature names are parsed from ClamAV's `<path>: <SIGNATURE> FOUND` lines.
  - `scanerror` / `not-installed` → a **gap**: surfaced distinctly, **never a silent clean** (absence of a scan is not a pass).
  - Without `--scan-bytes` the byte layer is skipped — kit does not auto-run a multi-second scan.

## Verified invocation contract (ClamAV 1.5.3, on a real host)

| exit | verdict | how verified |
|------|---------|--------------|
| 0 | clean | **empirical** (clean file) |
| 1 | malicious (+ signature) | ClamAV's documented, stable spec — EICAR was quarantined by the host OS *before* `clamscan`, and this build's stdin scan is unsupported, so the FOUND path is contract-based, noted honestly |
| 2 / other | scanerror → gap | **empirical x3** (nonexistent path, host-blocked file, stdin) |
| binary absent | not-installed → gap | — |

This is deliberately **not** the fabricated-contract case that (correctly) blocked the Antares delegate: 2 of 3 exit paths are empirically confirmed on this exact build, and the third is ClamAV's stable, decades-old exit-code spec with a defensive parser (extracts whatever sits between `: ` and ` FOUND`).

## Implementation

- `src/malware-scan.ts`: pure `interpretClamscan(exitCode, stdout)` (the whole contract, unit-tested with no ClamAV present) + impure `scanFileForMalware(path)` (resolves the binary, spawns it, never throws; missing binary -> `not-installed` gap).
- `src/commands/triage.ts`: `cmdTriageModel` is now async and runs the optional scan; `--scan-bytes` documented in help.
- `src/malware-scan.test.ts`: exit 0/1/2/other + multi-signature parsing + not-installed gap.

## Honest limits

- kit does **not** detect malware — it records that a *verified ClamAV scan ran* and what it returned. Signature-based AV is known-malware-only; the value kit adds is the deterministic, attributable record around the scan.

## Verification

- Full suite green (3163 tests), `format:check` clean, zero-LLM boundary intact.
- `contracts/kit.opencli.json` regenerated for the version bump only (no public-surface change — `--scan-bytes` lives within `kit triage model`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)