### PR TITLE
chore(deps): eslint 9 → 10 for the brace-expansion advisory, and clear the 43 findings it surfaces

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,6 +40,15 @@ export default tseslint.config(
       // gate on ~80 pre-existing dynamic-boundary anys.
       "@typescript-eslint/no-explicit-any": "warn",
       "no-useless-escape": "warn",
+      // New in eslint 10's recommended set (this repo moved 9 -> 10 to clear the
+      // brace-expansion DoS advisory, GHSA-mh99-v99m-4gvg). Both are legitimate
+      // signal, but they flag 43 pre-existing sites — 33 of the
+      // `let x = ""; try { x = ... } catch { x = ... }` shape, 10 rethrows
+      // missing `{ cause }`. Surfaced as warnings so the security bump stays a
+      // pure dependency change; the backlog is visible on every lint run and gets
+      // fixed on its own, reviewable pass rather than smuggled in here.
+      "no-useless-assignment": "warn",
+      "preserve-caught-error": "warn",
       // This is a terminal CLI — regexes legitimately match ANSI/control chars
       // (e.g. \x1b colour-code stripping). Not a bug class here.
       "no-control-regex": "off",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,15 +40,14 @@ export default tseslint.config(
       // gate on ~80 pre-existing dynamic-boundary anys.
       "@typescript-eslint/no-explicit-any": "warn",
       "no-useless-escape": "warn",
-      // New in eslint 10's recommended set (this repo moved 9 -> 10 to clear the
-      // brace-expansion DoS advisory, GHSA-mh99-v99m-4gvg). Both are legitimate
-      // signal, but they flag 43 pre-existing sites — 33 of the
-      // `let x = ""; try { x = ... } catch { x = ... }` shape, 10 rethrows
-      // missing `{ cause }`. Surfaced as warnings so the security bump stays a
-      // pure dependency change; the backlog is visible on every lint run and gets
-      // fixed on its own, reviewable pass rather than smuggled in here.
-      "no-useless-assignment": "warn",
-      "preserve-caught-error": "warn",
+      // New in eslint 10's recommended set. Both flagged 43 pre-existing sites
+      // (33 dead initializers of the `let x = ""; try { x = ... } catch { x = ... }`
+      // shape, 10 rethrows that dropped the original error); all are fixed, so
+      // these stay at `error` to keep them from creeping back. `preserve-caught-error`
+      // in particular protects debuggability — a rethrow without `{ cause }` throws
+      // the original stack away.
+      "no-useless-assignment": "error",
+      "preserve-caught-error": "error",
       // This is a terminal CLI — regexes legitimately match ANSI/control chars
       // (e.g. \x1b colour-code stripping). Not a bug class here.
       "no-control-regex": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,9 @@
         "kit": "dist/cli.js"
       },
       "devDependencies": {
-        "@eslint/js": "9.39.4",
+        "@eslint/js": "10.0.1",
         "@types/node": "22.19.15",
-        "eslint": "9.39.4",
+        "eslint": "10.8.0",
         "globals": "17.6.0",
         "prettier": "3.8.4",
         "tsx": "4.22.4",
@@ -522,142 +522,89 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.5",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@hono/node-server": {
@@ -773,6 +720,13 @@
           "optional": false
         }
       }
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -984,45 +938,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.61.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
@@ -1063,19 +978,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@upstash/redis": {
@@ -1148,35 +1050,15 @@
         }
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": "18 || 20 || >=22"
       }
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
@@ -1216,14 +1098,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/bytes": {
@@ -1257,60 +1141,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -1507,33 +1337,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
-        "@eslint/plugin-kit": "^0.4.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.7.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
-        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -1543,8 +1373,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -1552,7 +1381,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -1567,30 +1396,32 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -1621,18 +1452,18 @@
       "license": "MIT"
     },
     "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -1989,16 +1820,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "license": "MIT",
@@ -2070,23 +1891,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2153,29 +1957,6 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
-    "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -2238,13 +2019,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "license": "MIT",
@@ -2291,16 +2065,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -2403,19 +2180,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/parseurl": {
@@ -2555,16 +2319,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/router": {
@@ -2787,32 +2541,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "zod": "4.3.6"
   },
   "devDependencies": {
-    "@eslint/js": "9.39.4",
+    "@eslint/js": "10.0.1",
     "@types/node": "22.19.15",
-    "eslint": "9.39.4",
+    "eslint": "10.8.0",
     "globals": "17.6.0",
     "prettier": "3.8.4",
     "tsx": "4.22.4",

--- a/src/agent-config.ts
+++ b/src/agent-config.ts
@@ -171,7 +171,7 @@ export async function writeAgentConfig(
 
   for (const t of chosen) {
     const path = resolve(cwd, t.file);
-    let existing = "";
+    let existing: string;
     try {
       existing = await readFile(path, "utf-8");
     } catch {
@@ -274,7 +274,7 @@ export async function installAiderRules(cwd: string = process.cwd()): Promise<Ag
 
   // (1) CONVENTIONS.md kit block.
   const convPath = resolve(cwd, file);
-  let existing = "";
+  let existing: string;
   try {
     existing = await readFile(convPath, "utf-8");
   } catch {
@@ -294,7 +294,7 @@ export async function installAiderRules(cwd: string = process.cwd()): Promise<Ag
 
   // (2) .aider.conf.yml `read: CONVENTIONS.md` — the step that makes it non-no-op.
   const confPath = resolve(cwd, ".aider.conf.yml");
-  let conf = "";
+  let conf: string;
   try {
     conf = await readFile(confPath, "utf-8");
   } catch {
@@ -712,7 +712,7 @@ export async function installInstallGateCodex(
     return { file, action: "skipped", detail: "no Codex project detected" };
   }
 
-  let existing = "";
+  let existing: string;
   let existed = false;
   try {
     existing = await readFile(path, "utf-8");
@@ -747,7 +747,7 @@ export async function installInstallGateAmazonQ(
   const dirPath = resolve(cwd, dir);
   const { isReadOnlyMode } = await import("./read-only-mode.js");
   if (isReadOnlyMode()) return { file: dir, action: "skipped", detail: "read-only mode" };
-  let agentFiles: string[] = [];
+  let agentFiles: string[];
   try {
     agentFiles = readdirSync(dirPath)
       .filter((f) => f.endsWith(".json"))
@@ -811,7 +811,7 @@ export async function installInstallGateKiro(
   const dirPath = resolve(cwd, dir);
   const { isReadOnlyMode } = await import("./read-only-mode.js");
   if (isReadOnlyMode()) return { file: dir, action: "skipped", detail: "read-only mode" };
-  let agentFiles: string[] = [];
+  let agentFiles: string[];
   try {
     agentFiles = readdirSync(dirPath)
       .filter((f) => f.endsWith(".json"))

--- a/src/audit-anchor.ts
+++ b/src/audit-anchor.ts
@@ -696,7 +696,7 @@ export function commandExternalAnchor(cmd: string): ExternalTimestampAnchor {
           timeout: 30_000,
         });
       } catch (e) {
-        throw new Error(`external anchor command failed: ${(e as Error).message}`);
+        throw new Error(`external anchor command failed: ${(e as Error).message}`, { cause: e });
       }
       let parsed: unknown;
       try {

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -409,7 +409,7 @@ async function parkPendingEntry(event: AuditEvent, companyId: string): Promise<v
  */
 async function drainPendingQueue(): Promise<void> {
   const queuePath = resolve(process.cwd(), PENDING_QUEUE_FILE);
-  let content = "";
+  let content: string;
   try {
     content = await readFile(queuePath, "utf-8");
   } catch {

--- a/src/baseline.ts
+++ b/src/baseline.ts
@@ -72,6 +72,7 @@ export async function loadBaseline(cwd = process.cwd()): Promise<Baseline> {
   } catch (err) {
     throw new Error(
       `failed to read ${BASELINE_FILE}: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
     );
   }
 }

--- a/src/check-attestation.ts
+++ b/src/check-attestation.ts
@@ -393,7 +393,7 @@ export async function verifyAttestation(
       };
     }
     // The signature is mathematically valid; now decide AUTHENTICITY.
-    let expectedFp: string | null = null;
+    let expectedFp: string | null;
     if (expectedKey) {
       expectedFp = expectedKeyToFingerprint(expectedKey);
       if (!expectedFp) {

--- a/src/check-gitignore.ts
+++ b/src/check-gitignore.ts
@@ -122,7 +122,7 @@ export async function patchGitignore(
     return { added: 0, written: false };
   }
   const path = resolve(cwd, ".gitignore");
-  let existing = "";
+  let existing: string;
   try {
     await access(path);
     existing = await readFile(path, "utf-8");

--- a/src/cli-shared.ts
+++ b/src/cli-shared.ts
@@ -34,7 +34,7 @@ export async function buildHealthCtx(config: kitConfig): Promise<HealthCtx> {
   } catch {
     vercel = undefined;
   }
-  let services: string[] = [];
+  let services: string[];
   try {
     const pkg = JSON.parse(readFileSync(resolve(cwd, "package.json"), "utf8")) as {
       dependencies?: Record<string, string>;

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -109,7 +109,7 @@ async function cmdAuditVerify(): Promise<boolean> {
     /* default: not required */
   }
   const logPath = await resolveAuditLogPath();
-  let content = "";
+  let content: string;
   try {
     content = await readFile(logPath, "utf-8");
   } catch {
@@ -235,7 +235,7 @@ async function cmdAuditAnchor(): Promise<boolean> {
   const { anchorAuditLog } = await import("../audit-anchor.js");
   const { readFile } = await import("node:fs/promises");
   const logPath = await resolveAuditLogPath();
-  let content = "";
+  let content: string;
   try {
     content = await readFile(logPath, "utf-8");
   } catch {

--- a/src/commands/gate.ts
+++ b/src/commands/gate.ts
@@ -18,7 +18,7 @@
  * `kit agent-config --install-gate`. Pure decision lives in install-gate.ts.
  */
 export async function cmdGateBash(): Promise<boolean> {
-  let raw = "";
+  let raw: string;
   try {
     const chunks: Buffer[] = [];
     for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
@@ -74,7 +74,7 @@ export async function cmdGateBash(): Promise<boolean> {
  * fail-open on unparseable payloads (never break the agent), exit-2 deny on block.
  */
 export async function cmdGateEnv(): Promise<boolean> {
-  let raw = "";
+  let raw: string;
   try {
     const chunks: Buffer[] = [];
     for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
@@ -119,7 +119,7 @@ export async function cmdGateEnv(): Promise<boolean> {
  * (never break the agent on garbage), while the scope decisions themselves stay fail-closed.
  */
 async function readHookPayload(): Promise<unknown | null> {
-  let raw = "";
+  let raw: string;
   try {
     const chunks: Buffer[] = [];
     for await (const chunk of process.stdin) chunks.push(chunk as Buffer);

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -395,7 +395,7 @@ async function cmdSecretsOneCli(): Promise<boolean> {
   const placeholder = generatePlaceholder();
   const { writeFile, readFile, access } = await import("node:fs/promises");
   const envPath = `${process.cwd()}/.env.local`;
-  let envContent = "";
+  let envContent: string;
   try {
     await access(envPath);
     envContent = await readFile(envPath, "utf-8");

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -851,7 +851,7 @@ async function offerFirstInstallPrescan(): Promise<void> {
 
   const readline = await import("node:readline/promises");
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  let answer = "";
+  let answer: string;
   let scanPath = "";
   try {
     answer = (await rl.question(`Run a prescan now? [y/N] `)).trim().toLowerCase();

--- a/src/context-lock.ts
+++ b/src/context-lock.ts
@@ -550,7 +550,7 @@ export async function applyContext(
 
   const results: ApplyResult[] = [];
   for (const step of planContext(ctx)) {
-    let ok = false;
+    let ok: boolean;
     try {
       await exec(step.tool, step.argv, { timeout: 8_000, cwd: step.local ? cwd : undefined });
       ok = true;

--- a/src/control-plane/distribute.ts
+++ b/src/control-plane/distribute.ts
@@ -172,7 +172,7 @@ function verifyRevocationBatch(
         reason: `revocation signed by ${rec.by}, not in the org trust anchor`,
       };
     }
-    let sigOk = false;
+    let sigOk: boolean;
     try {
       sigOk = verifySignature(
         revocationStatement(rec.kid, rec.ts, rec.reason),

--- a/src/database.ts
+++ b/src/database.ts
@@ -75,7 +75,7 @@ export class DatabaseManager {
         throw new Error("Database connection test failed");
       }
     } catch (error) {
-      throw new Error(`Failed to connect to database: ${error}`);
+      throw new Error(`Failed to connect to database: ${error}`, { cause: error });
     }
   }
 
@@ -124,7 +124,7 @@ export class DatabaseManager {
         executionTime,
       };
     } catch (error) {
-      throw new Error(`Query failed: ${error}`);
+      throw new Error(`Query failed: ${error}`, { cause: error });
     }
   }
 
@@ -147,7 +147,7 @@ export class DatabaseManager {
     } catch (error) {
       await connection.query("ROLLBACK");
       this.pool.releaseConnection(connection);
-      throw new Error(`Transaction failed: ${error}`);
+      throw new Error(`Transaction failed: ${error}`, { cause: error });
     }
   }
 
@@ -213,7 +213,7 @@ export class DatabaseManager {
           migration.executedAt = new Date().toISOString();
           executedMigrations.push(migration);
         } catch (error) {
-          throw new Error(`Migration ${migration.name} failed: ${error}`);
+          throw new Error(`Migration ${migration.name} failed: ${error}`, { cause: error });
         }
       }
     }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -442,7 +442,7 @@ async function checkTriageGates(cwd: string): Promise<DoctorCheck> {
   }
   const { resolveHooksDir } = await import("./hooks.js");
   const hookPath = join(resolveHooksDir(join(cwd, ".git")), "pre-commit");
-  let content: string | null = null;
+  let content: string | null;
   try {
     content = await readFile(hookPath, "utf-8");
   } catch {

--- a/src/elevation.ts
+++ b/src/elevation.ts
@@ -325,7 +325,7 @@ export async function enrollTotp(opts: {
 
   // Guard against silently overwriting an existing enrollment — that
   // would invalidate the user's already-registered authenticator entry.
-  let exists = false;
+  let exists: boolean;
   try {
     await access(filePath);
     exists = true;

--- a/src/fix.ts
+++ b/src/fix.ts
@@ -358,7 +358,7 @@ export async function cmdFix(): Promise<boolean> {
       console.log(`${c.bold}[4/6] Secrets Template${c.reset}`);
       const templatePath = config.secrets?.template;
       if (templatePath && config.secrets?.keys && Object.keys(config.secrets.keys).length > 0) {
-        let templateExists = false;
+        let templateExists: boolean;
         try {
           await access(templatePath);
           templateExists = true;

--- a/src/hints.ts
+++ b/src/hints.ts
@@ -138,7 +138,7 @@ export async function collectHints(
   for (const rule of RULES) {
     if (out.length >= max) break;
     if (alreadyShown(rule.id)) continue;
-    let hit = false;
+    let hit: boolean;
     try {
       hit = await rule.detect(root);
     } catch {

--- a/src/keystore/command-store.ts
+++ b/src/keystore/command-store.ts
@@ -121,7 +121,7 @@ export class ExternalCommandKeyStore implements KeyStore {
         maxBuffer: 1 << 20,
       });
     } catch (e) {
-      throw new Error(`${SIGN_CMD_ENV} failed: ${(e as Error).message}`);
+      throw new Error(`${SIGN_CMD_ENV} failed: ${(e as Error).message}`, { cause: e });
     }
     const b64 = out.toString("utf-8").trim();
     if (!b64) throw new Error(`${SIGN_CMD_ENV} produced no signature on stdout`);

--- a/src/memory/backup.ts
+++ b/src/memory/backup.ts
@@ -78,6 +78,7 @@ export function maybeGunzip(buf: Buffer, maxBytes: number = MAX_DECOMPRESSED_BYT
     if (e instanceof RangeError) {
       throw new Error(
         `backup decompresses beyond the ${Math.round(maxBytes / (1024 * 1024))} MB limit — refusing (possible gzip bomb)`,
+        { cause: e },
       );
     }
     throw e;

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -463,7 +463,7 @@ export function forgetMemory(db: DatabaseSync, uuid: string, reason?: string): F
   // FTS5 'integrity-check' raises SQLITE_CORRUPT if the shadow index disagrees with
   // the content table — i.e. if a dangling entry for the deleted row survived. No
   // throw ⇒ the index is consistent and the deleted row's terms are truly gone.
-  let ftsConsistent = false;
+  let ftsConsistent: boolean;
   try {
     db.prepare("INSERT INTO messages_fts(messages_fts) VALUES('integrity-check')").run();
     ftsConsistent = true;

--- a/src/memory/install.ts
+++ b/src/memory/install.ts
@@ -82,7 +82,7 @@ export function memoryHooksLiveness(
   markerPath: string = memoryInstallMarkerPath(),
 ): HookLiveness {
   const everInstalled = existsSync(markerPath);
-  let hooks: Record<string, HookGroup[]> = {};
+  let hooks: Record<string, HookGroup[]>;
   try {
     hooks = (readSettings(settingsPath).hooks ?? {}) as Record<string, HookGroup[]>;
   } catch {
@@ -121,6 +121,7 @@ function readSettings(path: string): Settings {
     // statusLine) with only kit's block. Refuse loudly instead of silently clobbering.
     throw new Error(
       `${path} is not valid JSON — refusing to overwrite it (that would drop your other Claude Code settings). Fix or move the file aside, then re-run. Parse error: ${(e as Error).message}`,
+      { cause: e },
     );
   }
 }

--- a/src/memory/parser.ts
+++ b/src/memory/parser.ts
@@ -218,7 +218,7 @@ export function indexClaudeTranscripts(db: DatabaseSync): IndexResult {
 
   for (const projectName of readdirSync(projectsDir).sort()) {
     const projectPath = join(projectsDir, projectName);
-    let isDir = false;
+    let isDir: boolean;
     try {
       isDir = statSync(projectPath).isDirectory();
     } catch {

--- a/src/memory/remote-sync.ts
+++ b/src/memory/remote-sync.ts
@@ -507,7 +507,7 @@ export function maybeSyncNudge(): string | null {
   }
   const marker = join(getMemoryDir(), NUDGE_MARKER);
   if (existsSync(marker)) return null;
-  let worthIt = false;
+  let worthIt: boolean;
   try {
     const p = getMemoryDbPath();
     worthIt = existsSync(p) && statSync(p).size > 64 * 1024; // a non-trivial store

--- a/src/memory/sync.ts
+++ b/src/memory/sync.ts
@@ -52,7 +52,7 @@ export interface SyncOptions {
  */
 function assertIncomingClean(dbPath: string, allowUnsafe: boolean): void {
   if (allowUnsafe || process.env.KIT_MEMORY_ALLOW_UNSAFE === "1") return;
-  let high: { label: string }[] = [];
+  let high: { label: string }[];
   const db = new DatabaseSync(dbPath, { readOnly: true });
   try {
     high = scanDbForInjection(db).filter((f) => f.confidence === "high");
@@ -61,6 +61,7 @@ function assertIncomingClean(dbPath: string, allowUnsafe: boolean): void {
     throw new Error(
       `refusing to merge: could not scan the incoming memory store for injection (${(e as Error).message}). ` +
         "Inspect it, or set KIT_MEMORY_ALLOW_UNSAFE=1 to override.",
+      { cause: e },
     );
   } finally {
     db.close();

--- a/src/policy-check.ts
+++ b/src/policy-check.ts
@@ -103,7 +103,7 @@ export async function evaluatePolicy(
 
   // required_scanners — presence is deterministic (mise-first resolution).
   for (const scanner of doc.required_scanners ?? []) {
-    let present = false;
+    let present: boolean;
     try {
       present = Boolean(await resolveToolBin(scanner));
     } catch {

--- a/src/secrets-sync.ts
+++ b/src/secrets-sync.ts
@@ -188,7 +188,7 @@ async function syncToGitHub(
   // Attempt to use libsodium-wrappers for native encryption.
   // It's an optional peer dependency — fall back to gh CLI if absent.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let sodium: any = null;
+  let sodium: any;
   try {
     sodium = await import("libsodium-wrappers" as string);
     await sodium.ready;

--- a/src/security-prescan.ts
+++ b/src/security-prescan.ts
@@ -213,7 +213,7 @@ const REQUIRED_GITIGNORE = [
 
 async function checkGitignoreHoles(repo: string): Promise<PrescanFinding[]> {
   const path = join(repo, ".gitignore");
-  let text = "";
+  let text: string;
   try {
     text = await readFile(path, "utf-8");
   } catch {

--- a/src/triage-sandbox.ts
+++ b/src/triage-sandbox.ts
@@ -127,8 +127,8 @@ export async function triageNpmSandbox(
   //    can clean up cleanly. --ignore-scripts (+ env var) prevents any
   //    lifecycle script from running while npm resolves/packs the spec.
   const work = await mkdtemp(join(tmpdir(), "kit-triage-"));
-  let tarballPath = "";
-  let tarballSize = 0;
+  let tarballPath: string;
+  let tarballSize: number;
 
   try {
     const { stdout } = await exec("npm", ["pack", spec, "--ignore-scripts", "--json", "--silent"], {


### PR DESCRIPTION
Supersedes #388 (same two commits, one review). Two commits, kept separate so the security fix and the code changes can be read apart.

## 1. Why the eslint major — `chore(deps)`, commit `33935f5`

`GHSA-mh99-v99m-4gvg` (brace-expansion — unbounded expansion causing an OOM crash) was published **after** 5.10.0 shipped. It reaches the tree transitively:

```
eslint → @eslint/config-array → minimatch → brace-expansion
```

That is **5 high** findings, so `npm audit --audit-level=high` now exits non-zero. The publish workflow runs exactly that as a fail-closed gate, which means **the next signed tag would be refused at the audit step**. `Security gate`, `Stage 1 — Dependencies`, and `kit check-security` are currently red on `main` for this reason — it is not branch-specific.

Checked before reaching for a major:

- Plain `npm audit fix` (non-breaking) resolves nothing.
- A `brace-expansion` `overrides` entry resolves nothing either: the advisory range is `<=5.0.7` and the patch landed in `5.0.8`, outside the `^1.1.7` / `^2.0.1` ranges the intermediate packages ask for.
- npm's own `fixAvailable` is `eslint@10.8.0`, `isSemVerMajor: true`.

So: `eslint` 9.39.4 → **10.8.0**, `@eslint/js` 9.39.4 → **10.0.1**, exact pins per repo convention. `typescript-eslint` stays at 8.61.1 — it already declares `^10.0.0` in its peer range, so no cascade.

**`eslint` is a devDependency**, so the published tarball is unchanged. This unblocks the gates; it does not alter what consumers install.

## 2. The 43 findings that bump surfaces — `fix(lint)`, commit `642b1cf`

eslint 10 adds `no-useless-assignment` and `preserve-caught-error` to its recommended set. Both are fixed here and both are set to `error`, so they cannot creep back.

### `preserve-caught-error` — 10 sites

These rethrows interpolated the caught error's *message* into a new `Error` but dropped the error itself, throwing the original stack away. Each now passes `{ cause }`.

- **`database.ts`** — all four paths (connect, query, transaction, migration) swallowed the underlying driver error. A failing migration reported its own name and nothing about *why*.
- **`memory/sync.ts`**, **`memory/install.ts`** — both are deliberately fail-closed ("refusing to merge…", "refusing to overwrite…"). Losing the cause makes a refusal hard to diagnose, which is the opposite of what a fail-closed gate wants.
- `audit-anchor.ts`, `baseline.ts`, `keystore/command-store.ts`, `memory/backup.ts` — external command / parse failures, same treatment.

### `no-useless-assignment` — 33 sites

All one shape: a declaration whose initializer no code can ever read, because every path through the following `try`/`catch` assigns before first use.

```diff
-let existing = "";
+let existing: string;
 try { existing = await readFile(path, "utf-8"); } catch { existing = ""; }
```

Dropping the initializer hands the check to TypeScript's definite-assignment analysis — the real safety net here — and `npm run build` is clean. **Behaviour is unchanged in every case**: the removed values were provably dead, not defaults something relied on.

Spread across `agent-config.ts` (6), `commands/gate.ts` (3), `commands/audit.ts` (2), `triage-sandbox.ts` (2), and 17 other files.

## Verification

| Gate | Result |
|---|---|
| `npm audit --audit-level=high` | **exit 0** (2 moderate remain — the known `@hono/node-server` one) |
| `npm run lint` | **0 errors**, 128 warnings — *exactly* the eslint 9 baseline, so no new noise |
| `npm run build` | **0 TS errors** — proves no path reads an unassigned variable |
| `npm test` | **3157/3157 pass**, 0 fail |
| `npm run format:check` | clean |
| bumblebee deep supply-chain scan | **pass**, 958 packages |
| `kit self-audit` | 14 rules, **0 fail, 0 warn** |
| `kit triage npm eslint 10.8.0` | **PASS**, health 100/100 |
| `kit triage npm @eslint/js 10.0.1` | **PASS**, health 100/100 |

The lint-warning count landing back on 128 is the useful signal: the two new rules are fully satisfied, not partially quieted.

## Notes

- An editor may surface `tseslint.config` as deprecated in `eslint.config.js`. That `@deprecated` marker lives in `typescript-eslint@8.61.1`'s own type definitions — a version this PR does not touch — so it predates this change, and `eslint.config.js` is in the lint ignore list regardless.
- This PR was briefly stacked on `chore/eslint-10` as #389. Workflows here are scoped to `pull_request: branches: [main]`, so a stacked PR gets no CI at all — retargeted to `main` so the full suite actually runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
