### PR TITLE
ci(publish): check the CHANGELOG before npm publish, not after

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,24 @@ jobs:
           fi
           echo "Tag $TAG matches package.json version $PKG_VERSION"
 
+      - name: Verify the CHANGELOG documents this version
+        # MUST run before `npm publish`. The release step later in this job also
+        # needs these notes, but it runs AFTER the publish — so if that were the
+        # only check, a missing CHANGELOG section would be caught only once the
+        # version was already burned on npm (published, no release, red job).
+        # Rendering the notes here makes an undocumented release abort while
+        # aborting is still free, and the file is reused verbatim by the release
+        # step so the two can never disagree.
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          if ! node scripts/changelog-section.mjs "$VERSION" > /tmp/release-notes.md; then
+            echo "::error::CHANGELOG.md has no section for $VERSION — refusing to publish an undocumented release. Add a '## [$VERSION]' section, then re-tag."
+            exit 1
+          fi
+          echo "CHANGELOG section for $VERSION renders ($(wc -c < /tmp/release-notes.md) bytes of notes)."
+
       - name: Import maintainer public key
         # A fresh runner has an empty GPG keyring, so verify-tag would have
         # nothing to check against. We import the committed PUBLIC key, but we do
@@ -184,10 +202,10 @@ jobs:
         # created no release at all, so every SBOM step silently no-opped and
         # the SBOMs only ever survived as workflow artifacts (which expire).
         #
-        # Notes come from the CHANGELOG section for this version, not the tag
-        # message — `changelog-section.mjs` exits non-zero when the section is
-        # missing, so an undocumented release fails loudly instead of shipping
-        # empty notes. Idempotent: re-running on an existing release reuses it.
+        # Notes are the file rendered by the "Verify the CHANGELOG documents this
+        # version" step near the top of the job — reused verbatim rather than
+        # regenerated, so the pre-publish check and the published notes can never
+        # disagree. Idempotent: re-running on an existing release reuses it.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
@@ -197,7 +215,10 @@ jobs:
             echo "Release $TAG already exists — reusing it."
             exit 0
           fi
-          node scripts/changelog-section.mjs "$VERSION" > /tmp/release-notes.md
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "::error::/tmp/release-notes.md is missing or empty — the pre-publish CHANGELOG step should have produced it."
+            exit 1
+          fi
           # --verify-tag: refuse to invent a release for a tag that isn't on the
           # remote. Prereleases are flagged so they don't read as stable.
           EXTRA=""

--- a/src/changelog-section.test.ts
+++ b/src/changelog-section.test.ts
@@ -17,6 +17,56 @@ function run(args: string[]) {
   });
 }
 
+// The publish job's step order is load-bearing: the CHANGELOG check only
+// protects anything if it runs BEFORE `npm publish`. It originally sat after
+// it, so a missing section was caught once the version was already burned on
+// npm — published, no release, red job. Pin the order here so that cannot
+// silently come back.
+describe("publish workflow ordering", () => {
+  const wf = readFileSync(join(REPO_ROOT, ".github", "workflows", "publish.yml"), "utf8");
+  const stepIndex = (name: string) => wf.indexOf(`- name: ${name}`);
+
+  it("validates the CHANGELOG before publishing to npm", () => {
+    const check = stepIndex("Verify the CHANGELOG documents this version");
+    const publish = stepIndex("Publish to npm with provenance");
+    assert.ok(check !== -1, "the CHANGELOG verification step is missing from publish.yml");
+    assert.ok(publish !== -1, "the npm publish step is missing from publish.yml");
+    assert.ok(
+      check < publish,
+      "the CHANGELOG check must precede `npm publish` — otherwise a missing section " +
+        "is only caught after the version is already published and unrecoverable",
+    );
+  });
+
+  it("creates the GitHub release before the SBOM steps that attach to it", () => {
+    const release = stepIndex("Create GitHub release");
+    const sbom = stepIndex("Generate SBOM (CycloneDX)");
+    const attach = stepIndex("Attach SBOMs to GitHub release");
+    assert.ok(release !== -1 && sbom !== -1 && attach !== -1);
+    assert.ok(release < sbom, "the release must exist before sbom-action tries to attach to it");
+    assert.ok(sbom < attach, "SBOMs must be generated before they are attached");
+  });
+
+  it("does not swallow failures on the SBOM attach step", () => {
+    // A `|| true` here is what let the SBOMs silently reach no release at all
+    // for every version through 5.10.0.
+    const attach = stepIndex("Attach SBOMs to GitHub release");
+    const next = wf.indexOf("      - name:", attach + 10);
+    const body = wf.slice(attach, next === -1 ? undefined : next);
+    // Comments legitimately mention `|| true` (explaining why it is gone), so
+    // only executable lines count.
+    const code = body
+      .split("\n")
+      .filter((l) => !/^\s*#/.test(l))
+      .join("\n");
+    assert.doesNotMatch(
+      code,
+      /\|\|\s*true/,
+      "the SBOM attach step must fail loudly, not `|| true`",
+    );
+  });
+});
+
 describe("changelog-section", () => {
   it("extracts a version's section from the real CHANGELOG", () => {
     const r = run(["5.10.0"]);


### PR DESCRIPTION
## The defect

#386 added a CHANGELOG-section gate whose failure was meant to stop an undocumented release. **It could not.** The step sat *after* `npm publish`:

```
Publish to npm with provenance   ← line 168
Create GitHub release            ← line 180, ran changelog-section.mjs here
```

So a missing section was caught only once the version was already burned on the registry: published, no GitHub release, red job, version number permanently unusable. The gate detected the problem at the one moment nothing could be done about it.

My own PR body for #386 claimed this "fails loudly instead of shipping empty notes" — true about the notes, wrong about the consequence. This fixes it.

## Changes

- **Render the notes before any publish work**, in a new step next to the existing tag/version check. An undocumented release now aborts while aborting is still free.
- **The release step reuses that file verbatim** instead of regenerating it, so the pre-publish check and the published notes cannot disagree. It fails if the file is missing or empty rather than creating a release with an empty body.

## Ordering is now pinned by tests

This is exactly the kind of regression that reads fine in a diff, so three tests assert the invariants against `publish.yml` itself:

- the CHANGELOG check must precede `npm publish`
- the release must be created before the SBOM steps that attach to it
- the attach step must not carry `|| true`

The third initially failed on a comment reading ``no `|| true` `` — the check now excludes comment lines, so only executable YAML counts.

## Verification

| Gate | Result |
|---|---|
| `npm test` | **3166/3166 pass**, 0 fail (3 new) |
| `npm run lint` | **0 errors** |
| `npm run format:check` | clean |
| `kit self-audit` | 14 rules, **0 fail, 0 warn** |

Note that the publish pipeline as a whole has still never run end-to-end against a real tag — 5.10.0 shipped before #386 landed. The next release is its first live exercise, which is why this ordering fix wants to be in first: with it, a mistake costs a red job; without it, a mistake costs a version number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
