### PR TITLE
chore(release): 5.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,55 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.10.1] - 2026-07-25
+
+A maintenance release. No new commands, no behaviour changes to any gate — the
+user-visible part is better error diagnostics. Its real purpose is to be the
+first release that exercises the repaired publish pipeline end to end.
+
+### Fixed
+
+- **Rethrows now preserve the original error.** Ten `catch` blocks interpolated
+  the caught error's _message_ into a new `Error` but dropped the error itself,
+  so the original stack was lost. Each now passes `{ cause }`. The ones that
+  mattered: `database.ts` swallowed the driver error on all four paths (connect,
+  query, transaction, migration) — a failing migration reported its own name and
+  nothing about _why_ — and the deliberately fail-closed paths in
+  `memory/sync.ts` and `memory/install.ts`, where losing the cause makes a
+  refusal hard to diagnose, which is the opposite of what a fail-closed gate
+  wants. `audit-anchor.ts`, `baseline.ts`, `keystore/command-store.ts`, and
+  `memory/backup.ts` got the same treatment.
+
+### Changed
+
+- **The publish pipeline now produces a GitHub release, and SBOMs that reach
+  it.** Every release through 5.10.0 generated CycloneDX + SPDX SBOMs and then
+  attached them to nothing: the upload was guarded with `|| true` because no
+  release existed, and nothing created one. The SBOMs survived only as workflow
+  artifacts, which expire. The release is now created inside the publish job
+  before the SBOM steps, its notes come from this file's section for the version,
+  and the attach step fails loudly and then verifies both assets are present.
+  Releases for every prior tag (v1.0.1 → v5.10.0) were backfilled by hand.
+- **SBOMs identify themselves.** syft recorded the scanned path (`.`) as the root
+  component, so `metadata.component` read `.@?` and a bare SBOM file could not
+  say which release it described. A generated `.syft.yaml` now sets
+  `source.name` / `source.version` from `package.json`.
+- **An undocumented release aborts before publishing, not after.** The
+  CHANGELOG check initially ran after `npm publish`, so a missing section was
+  caught only once the version was already burned on the registry. It now runs
+  beside the tag/version check, and the ordering is pinned by tests.
+
+### Security
+
+- **eslint 9.39.4 → 10.8.0** (`@eslint/js` → 10.0.1) to clear
+  `GHSA-mh99-v99m-4gvg` — a brace-expansion DoS reaching the tree transitively
+  via `@eslint/config-array → minimatch`. Five high findings, which made
+  `npm audit --audit-level=high` exit non-zero and would have blocked this very
+  release at the publish gate. No smaller fix existed: the advisory range is
+  `<=5.0.7` and the patch landed in `5.0.8`, outside the ranges the intermediate
+  packages ask for. **eslint is a devDependency, so the published tarball is
+  unaffected** — nothing in what you install changed because of this.
+
 ## [5.10.0] - 2026-07-24
 
 ### Added

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -966,7 +966,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.10.0"
+    "version": "5.10.1"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.10.0",
+  "version": "5.10.1",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
Version bump + CHANGELOG for **5.10.1**. Merge this, then push a signed `v5.10.1` tag to publish.

## What's actually in it

Honestly thin, and the CHANGELOG says so. No new commands, no behaviour change to any gate.

**User-visible:** ten rethrows now pass `{ cause }` instead of interpolating the caught error's message and dropping the error itself, so the original stack survives. `database.ts` was the worst offender — connect, query, transaction, and migration all swallowed the driver error, so a failed migration reported its own name and nothing about *why*. Plus the README updates from #385 (`README.md` ships in the tarball).

**Not user-visible:** the eslint 10 bump is a devDependency, so nothing in the installed tarball changed because of it. Same for the workflow fixes.

## Why cut it now

The publish pipeline has never run end to end. 5.10.0 shipped *before* the release/SBOM work landed (#386, #390), so this tag is the first live exercise of:

- creating the GitHub release inside the publish job
- naming the SBOM root component via the generated `.syft.yaml`
- verifying both SBOM assets actually attach, failing the job if not
- aborting *before* `npm publish` when the CHANGELOG has no section for the version

Every prior tag's release was backfilled by hand. From here it should be automatic — this proves whether it is.

## Contracts

`contracts/kit.opencli.json` regenerated for the version string. **`contracts/public-surface.json` is byte-identical**, which is the check that matters for a patch: the command surface did not move.

## Verification (clean tree)

The tree needed `rm -rf dist node_modules && npm ci` first — iCloud had re-created cloud-sync conflict copies, which `self-audit/dup-source` caught and which failed the suite. After cleaning:

| Gate | Result |
|---|---|
| `npm test` | **3166/3166 pass**, 0 fail |
| `npm audit --audit-level=high` | **exit 0** |
| `npm run lint` | **0 errors** |
| `npm run format:check` | clean |
| `kit self-audit` | 14 rules, **0 fail, 0 warn** |
| bumblebee deep supply-chain scan | **pass** |
| `npm publish --dry-run` | resolves `sandstream-kit@5.10.1`, 1019 files |
| `changelog-section.mjs 5.10.1` | renders 2982 bytes — the new pre-publish gate passes |

## To release after merge

```bash
git checkout main && git pull
git tag -s v5.10.1 -m "kit 5.10.1"
git tag -v v5.10.1
git push origin v5.10.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
