### PR TITLE
feat(memory): classification gate — restrictive memory never recalled into a lesser context (5.14.0, closes #348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.14.0] - 2026-07-25
+
+### Added
+
+- **Memory classification — a restrictive memory can no longer be recalled into a less
+  restrictive context (closes #348).** One local store shared across projects and devices meant
+  a note captured in a restricted codebase could surface while working in a public one. Every
+  memory row now carries a **class**: `public` | `internal` | `restricted`.
+  - **Label source** (the decision that unblocked the issue): a config default with a
+    **per-project override**. `[memory] default_class` in `.kit.toml` sets it — and because kit
+    loads the *project's* `.kit.toml`, a project overrides the inherited default just by
+    declaring its own. `KIT_MEMORY_CLASS` overrides both for an ephemeral session.
+  - **The gate:** recall (`searchMessages` / `recentMessages`) accepts a `contextClass` and
+    returns only rows no more restrictive than it. A row whose class is missing or
+    unrecognized is **excluded from every context** — it is simply absent from the allow-list,
+    so fail-closed needs no special case.
+  - **Deliberately asymmetric fail-closed rules:** a *missing* config value is not a security
+    event → the documented default (`internal`); an *invalid* one is (a typo must never
+    silently widen disclosure) → `restricted`, flagged `recognized: false`. A row that cannot
+    be classified at disclosure time → treated as `restricted`.
+  - Schema v9 adds `messages.class` and backfills pre-existing rows to the configured default
+    (leaving them NULL would make historical memory permanently invisible — data loss dressed
+    as security). New rows are classified at insert; none is born unclassifiable.
+  - Policy lives in pure functions (`src/memory/class.ts`) with unit tests that need no DB,
+    plus integration tests proving the gate against a real SQLite store.
+
+### Fixed
+
+- **The v9 backfill can no longer brick `kit memory`.** `messages` is the external-content
+  source for the `messages_fts` index, and its update trigger re-indexes `content` on *any*
+  write — so a plain backfill `UPDATE` would rewrite the whole FTS index for a column FTS does
+  not index, and on a store whose index is already inconsistent it raises
+  `database disk image is malformed`, which from inside `openMemoryDb` would take down every
+  memory command. The backfill now drops that single trigger for its duration, restores it in a
+  `finally`, and is best-effort: on failure rows keep a NULL class and are excluded by the gate
+  (fail-closed) instead of the CLI failing to open the store at all.
+
 ## [5.13.0] - 2026-07-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Complete reference: [`docs/COMMANDS.md`](./docs/COMMANDS.md). The shortlist:
 - `kit login --plan`: Show the resolved auth strategy (vault/capture/interactive) per service without logging in
 - `kit secrets {set,migrate,rotate,propagate,onecli,validate}`: Secret lifecycle
 - `kit memory {index,search,stats,suggest,merge,save,threads,share,backup}`: Local-first, cross-harness second brain (per-harness `stats`, project recall, saved copilots) + `kit memory pal` pending-action ledger
+  - **Classified memory** (`[memory] default_class` = `public`\|`internal`\|`restricted`, default `internal`; `KIT_MEMORY_CLASS` overrides): every row carries a sensitivity class, and recall never returns a row **more restrictive than the asking context** — so a note captured in a restricted repo cannot surface while you work in a public one. A row whose class is missing or unrecognized is excluded from **every** context (fail-closed); an *invalid* configured value falls back to `restricted` rather than silently widening disclosure.
 - `kit auth {elevate,setup-totp,status,revoke}`: Elevation gate + TOTP
 - `kit mcp {list,auth,set-token,clear}`: MCP-server orchestrator
 - `kit env {list,switch,current,diff}`: Environment routing + drift detection

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -966,7 +966,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.13.0"
+    "version": "5.14.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "5.13.0",
+  "version": "5.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "5.13.0",
+      "version": "5.14.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.13.0",
+  "version": "5.14.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/config.ts
+++ b/src/config.ts
@@ -409,7 +409,14 @@ export interface kitConfig {
   policy?: PolicyConfig;
   /** Memory/PAL behavior. `track_findings` (default true): auto-track `kit check`
    *  findings as PAL items for cross-session reminders + auto-close on re-scan. */
-  memory?: { track_findings?: boolean };
+  /**
+   * `default_class` (#348): sensitivity class for memory captured in this project —
+   * `public` | `internal` | `restricted` (default `internal`). Because kit loads the
+   * PROJECT's `.kit.toml`, declaring it here is the per-project override of the default.
+   * A more restrictive memory is never recalled into a less restrictive context; an
+   * INVALID value fails closed to `restricted`. `KIT_MEMORY_CLASS` overrides it.
+   */
+  memory?: { track_findings?: boolean; default_class?: "public" | "internal" | "restricted" };
   /** Update behavior. `check` (default true): surface a newer published kit in
    *  `kit check` + the update banner. (Set false, or KIT_NO_UPDATE_CHECK=1.)
    *  `auto` (default false, opt-in): when a newer kit is found during `kit check`,
@@ -784,6 +791,7 @@ export const kitConfigSchema = z
     memory: z
       .object({
         track_findings: z.boolean().optional(),
+        default_class: z.enum(["public", "internal", "restricted"]).optional(),
       })
       .passthrough()
       .optional(),

--- a/src/containment.test.ts
+++ b/src/containment.test.ts
@@ -84,6 +84,12 @@ describe("detectGvisorMarker", () => {
       "Linux version 6.18.5 (builder@sandboxing) (gcc (GCC) 15.2.0)",
       "Linux version 6.8.0-51-generic (buildd@lcy02) #52-Ubuntu SMP",
       "vServer",
+      // A real AWS EC2 host (captured from CloudShell): the DMI sys_vendor is "Amazon EC2"
+      // and product_name an instance type. Amazon also OPERATES Firecracker, so this is the
+      // vendor-name false positive worth guarding against explicitly.
+      "Linux version 6.1.175-219.359.amzn2023.x86_64 (mockbuild@ip-10-0-172-126)",
+      "Amazon EC2",
+      "c5a.large",
     ]) {
       assert.equal(detectGvisorMarker(s), false, `false positive on: ${s}`);
       assert.equal(detectFirecrackerMarker(s), false, `false positive on: ${s}`);

--- a/src/memory/class.test.ts
+++ b/src/memory/class.test.ts
@@ -1,0 +1,196 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  MEMORY_CLASSES,
+  DEFAULT_MEMORY_CLASS,
+  MOST_RESTRICTIVE_CLASS,
+  classRank,
+  isMemoryClass,
+  parseMemoryClass,
+  resolveMemoryClass,
+  classPermitsDisclosure,
+  disclosableClasses,
+  type MemoryClass,
+} from "./class.js";
+import { openMemoryDb, insertMessage, upsertSession, searchMessages } from "./db.js";
+import { DatabaseSync } from "node:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("memory class ordering", () => {
+  it("is least → most restrictive, and the order is the policy", () => {
+    assert.deepEqual([...MEMORY_CLASSES], ["public", "internal", "restricted"]);
+    assert.ok(classRank("public") < classRank("internal"));
+    assert.ok(classRank("internal") < classRank("restricted"));
+    assert.equal(MOST_RESTRICTIVE_CLASS, "restricted");
+    assert.equal(DEFAULT_MEMORY_CLASS, "internal");
+  });
+
+  it("recognizes only the known labels", () => {
+    assert.equal(isMemoryClass("internal"), true);
+    for (const v of ["INTERNAL", "secret", "", null, undefined, 3, {}])
+      assert.equal(isMemoryClass(v), false, `must reject ${JSON.stringify(v)}`);
+  });
+});
+
+describe("parseMemoryClass — fails closed", () => {
+  it("passes through a known label", () => {
+    assert.deepEqual(parseMemoryClass("public"), { cls: "public", recognized: true });
+  });
+
+  it("an unknown/garbage label becomes restricted and is flagged unrecognized", () => {
+    for (const v of ["secret", "Public", "", null, undefined, 42]) {
+      const r = parseMemoryClass(v);
+      assert.equal(r.cls, "restricted", `must fail closed for ${JSON.stringify(v)}`);
+      assert.equal(r.recognized, false);
+    }
+  });
+});
+
+describe("resolveMemoryClass — config default + per-project override + env", () => {
+  it("nothing configured ⇒ the documented default, not restricted", () => {
+    const r = resolveMemoryClass({});
+    assert.equal(r.cls, "internal");
+    assert.equal(r.source, "default");
+    assert.equal(r.recognized, true);
+  });
+
+  it("a project's configured value wins over the default", () => {
+    const r = resolveMemoryClass({ configured: "restricted" });
+    assert.equal(r.cls, "restricted");
+    assert.equal(r.source, "config");
+  });
+
+  it("KIT_MEMORY_CLASS overrides config (ephemeral session)", () => {
+    const r = resolveMemoryClass({ env: "public", configured: "restricted" });
+    assert.equal(r.cls, "public");
+    assert.equal(r.source, "env");
+  });
+
+  it("an INVALID configured value fails closed to restricted and is flagged", () => {
+    // A typo must never silently WIDEN disclosure — that is the asymmetry that matters.
+    const r = resolveMemoryClass({ configured: "publik" });
+    assert.equal(r.cls, "restricted");
+    assert.equal(r.source, "config");
+    assert.equal(r.recognized, false);
+  });
+
+  it("an empty/whitespace env value is absent, not invalid (falls through)", () => {
+    assert.equal(resolveMemoryClass({ env: "   ", configured: "public" }).cls, "public");
+    assert.equal(resolveMemoryClass({ env: "" }).source, "default");
+  });
+});
+
+describe("classPermitsDisclosure — the gate", () => {
+  it("a row never flows into a LESS restrictive context", () => {
+    assert.equal(classPermitsDisclosure("restricted", "internal"), false);
+    assert.equal(classPermitsDisclosure("restricted", "public"), false);
+    assert.equal(classPermitsDisclosure("internal", "public"), false);
+  });
+
+  it("a row flows into an equal or MORE restrictive context", () => {
+    assert.equal(classPermitsDisclosure("public", "public"), true);
+    assert.equal(classPermitsDisclosure("public", "restricted"), true);
+    assert.equal(classPermitsDisclosure("internal", "internal"), true);
+    assert.equal(classPermitsDisclosure("internal", "restricted"), true);
+    assert.equal(classPermitsDisclosure("restricted", "restricted"), true);
+  });
+});
+
+describe("disclosableClasses — SQL filter list", () => {
+  it("widens with the context, and never lists a more restrictive class", () => {
+    assert.deepEqual(disclosableClasses("public"), ["public"]);
+    assert.deepEqual(disclosableClasses("internal"), ["public", "internal"]);
+    assert.deepEqual(disclosableClasses("restricted"), ["public", "internal", "restricted"]);
+  });
+
+  it("omits NULL/unknown by construction — an unclassified row fails the IN test", () => {
+    // The gate needs no NULL special-case: a row with no class simply is not in the list.
+    for (const ctx of MEMORY_CLASSES) {
+      const allowed: string[] = disclosableClasses(ctx);
+      assert.ok(!allowed.includes("" as never));
+      assert.ok(!allowed.includes("unknown" as never));
+    }
+  });
+});
+
+describe("class gate against a real store (#348)", () => {
+  const mkMsg = (uuid: string, content: string, memoryClass?: MemoryClass) => ({
+    uuid,
+    sessionId: "s1",
+    type: "user",
+    role: "user",
+    content,
+    timestamp: new Date(0).toISOString(),
+    memoryClass,
+  });
+
+  it("restricted rows never surface in a public or internal context; NULL never leaks", () => {
+    const db = openMemoryDb(":memory:");
+    upsertSession(db, { sessionId: "s1", harness: "claude-code" });
+    insertMessage(db, mkMsg("u-pub", "zebra public note", "public"));
+    insertMessage(db, mkMsg("u-int", "zebra internal note", "internal"));
+    insertMessage(db, mkMsg("u-res", "zebra restricted note", "restricted"));
+    // A row that predates classification / arrived from a peer with no class at all.
+    db.prepare(
+      "INSERT INTO messages (uuid, session_id, type, role, content, timestamp, quarantined, class) VALUES (?,?,?,?,?,?,0,NULL)",
+    ).run("u-null", "s1", "user", "user", "zebra unclassified note", new Date(0).toISOString());
+
+    const classesFor = (ctx: MemoryClass) =>
+      searchMessages(db, "zebra", { contextClass: ctx, limit: 50 })
+        .map((h) => h.uuid)
+        .sort();
+
+    assert.deepEqual(classesFor("public"), ["u-pub"], "public context sees only public");
+    assert.deepEqual(classesFor("internal"), ["u-int", "u-pub"], "internal adds internal");
+    assert.deepEqual(
+      classesFor("restricted"),
+      ["u-int", "u-pub", "u-res"],
+      "restricted sees all CLASSIFIED rows",
+    );
+    // The NULL-class row is excluded from EVERY context — fail-closed by construction.
+    for (const ctx of MEMORY_CLASSES) assert.ok(!classesFor(ctx).includes("u-null"));
+
+    // Omitting contextClass keeps the pre-classification behavior (everything visible).
+    const unfiltered = searchMessages(db, "zebra", { limit: 50 }).map((h) => h.uuid);
+    assert.equal(unfiltered.length, 4);
+    db.close();
+  });
+
+  it("insertMessage classifies with the documented default when the caller passes none", () => {
+    const db = openMemoryDb(":memory:");
+    upsertSession(db, { sessionId: "s1", harness: "claude-code" });
+    insertMessage(db, mkMsg("u-default", "kangaroo unlabelled"));
+    const row = db.prepare("SELECT class FROM messages WHERE uuid = ?").get("u-default") as {
+      class: string;
+    };
+    assert.equal(row.class, DEFAULT_MEMORY_CLASS, "no row is born unclassifiable");
+    db.close();
+  });
+
+  it("the v9 migration backfills pre-existing rows to the configured default", () => {
+    // Simulate a store written before classification: create the table WITHOUT the column,
+    // insert a row, then let openMemoryDb migrate it.
+    const dir = mkdtempSync(join(tmpdir(), "kit-memclass-"));
+    const dbPath = join(dir, "memory.db");
+    const legacy = new DatabaseSync(dbPath);
+    legacy.exec(
+      "CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, uuid TEXT UNIQUE, session_id TEXT NOT NULL, parent_uuid TEXT, type TEXT NOT NULL, role TEXT, content TEXT, model TEXT, input_tokens INTEGER, output_tokens INTEGER, timestamp TEXT, cwd TEXT, git_branch TEXT, version TEXT)",
+    );
+    legacy
+      .prepare(
+        "INSERT INTO messages (uuid, session_id, type, content) VALUES ('old','s0','user','legacy row')",
+      )
+      .run();
+    legacy.close();
+
+    const db = openMemoryDb(dbPath, { defaultClass: "restricted" });
+    const row = db.prepare("SELECT class FROM messages WHERE uuid = 'old'").get() as {
+      class: string;
+    };
+    assert.equal(row.class, "restricted", "backfilled to the configured default, not left NULL");
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/src/memory/class.ts
+++ b/src/memory/class.ts
@@ -1,0 +1,105 @@
+/**
+ * kit — memory classification (issue #348).
+ *
+ * A memory row carries a sensitivity CLASS so a more restrictive memory can never be
+ * recalled into a less restrictive context. Without this, one store shared across
+ * projects/devices means a note captured in a restricted codebase can surface while you
+ * work in a public one — the leak this closes.
+ *
+ * Label source (the decision that unblocked #348): a **config default** with a
+ * **per-project override**. `[memory] default_class` in `.kit.toml` sets it; because kit
+ * loads the project's own `.kit.toml`, a project overrides the inherited default simply by
+ * declaring its own. `KIT_MEMORY_CLASS` overrides both for an ephemeral session.
+ *
+ * Fail-closed rules, deliberately asymmetric:
+ *   - A **missing** config value is not a security event → the documented default
+ *     (`internal`). Silently jumping to `restricted` would break every existing store.
+ *   - An **invalid** config value IS a security event (a typo must not silently widen
+ *     disclosure) → `restricted`, with `recognized: false` so the caller can surface it.
+ *   - A row whose stored class is missing/unrecognized at DISCLOSURE time → treated as
+ *     `restricted`. An unclassifiable row is never handed to a lesser context.
+ *
+ * Everything here is a pure function of its inputs — no DB, no I/O — so the policy is
+ * unit-testable on its own.
+ */
+
+/** Sensitivity classes, ordered least → most restrictive. The order IS the policy. */
+export const MEMORY_CLASSES = ["public", "internal", "restricted"] as const;
+
+export type MemoryClass = (typeof MEMORY_CLASSES)[number];
+
+/** The documented default when nothing is configured. */
+export const DEFAULT_MEMORY_CLASS: MemoryClass = "internal";
+
+/** The fail-closed class: what anything unclassifiable is treated as. */
+export const MOST_RESTRICTIVE_CLASS: MemoryClass = "restricted";
+
+/** Rank of a class — higher means more restrictive. Total order over MEMORY_CLASSES. */
+export function classRank(c: MemoryClass): number {
+  return MEMORY_CLASSES.indexOf(c);
+}
+
+export function isMemoryClass(v: unknown): v is MemoryClass {
+  return typeof v === "string" && (MEMORY_CLASSES as readonly string[]).includes(v);
+}
+
+/**
+ * Parse a class label of unknown provenance (config value, DB column, synced row).
+ * `recognized` is false when the input was present but not a known class — the caller
+ * decides whether that is worth surfacing; the returned class already failed closed.
+ */
+export function parseMemoryClass(raw: unknown): { cls: MemoryClass; recognized: boolean } {
+  if (isMemoryClass(raw)) return { cls: raw, recognized: true };
+  return { cls: MOST_RESTRICTIVE_CLASS, recognized: false };
+}
+
+export interface ClassResolution {
+  cls: MemoryClass;
+  /** Where the value came from — surfaced so an operator can see why a class applies. */
+  source: "env" | "config" | "default";
+  /** False when a value was present but invalid (⇒ failed closed to restricted). */
+  recognized: boolean;
+}
+
+/**
+ * Resolve the effective class for capture and for recall context.
+ * Precedence: `KIT_MEMORY_CLASS` (explicit, ephemeral) → `[memory] default_class`
+ * (config; per-project because the project's own `.kit.toml` is what gets loaded) →
+ * `internal` (documented default).
+ *
+ * An absent value is NOT an error (falls through). A present-but-invalid value fails
+ * closed to `restricted` and reports `recognized: false`.
+ */
+export function resolveMemoryClass(opts: {
+  env?: string | undefined;
+  configured?: unknown;
+}): ClassResolution {
+  const env = typeof opts.env === "string" ? opts.env.trim() : "";
+  if (env) {
+    const p = parseMemoryClass(env);
+    return { cls: p.cls, source: "env", recognized: p.recognized };
+  }
+  if (opts.configured !== undefined && opts.configured !== null && opts.configured !== "") {
+    const p = parseMemoryClass(opts.configured);
+    return { cls: p.cls, source: "config", recognized: p.recognized };
+  }
+  return { cls: DEFAULT_MEMORY_CLASS, source: "default", recognized: true };
+}
+
+/**
+ * May a row of class `rowClass` be disclosed into a context cleared for `contextClass`?
+ * Only when the row is no more restrictive than the context. This is the whole gate:
+ * `restricted` never flows into `internal` or `public`.
+ */
+export function classPermitsDisclosure(rowClass: MemoryClass, contextClass: MemoryClass): boolean {
+  return classRank(rowClass) <= classRank(contextClass);
+}
+
+/**
+ * The classes a context may see, for use in a SQL `IN (…)` filter. A NULL/unrecognized
+ * stored class is absent from this list by construction, so it fails the `IN` test and is
+ * excluded — fail-closed without a special case.
+ */
+export function disclosableClasses(contextClass: MemoryClass): MemoryClass[] {
+  return MEMORY_CLASSES.filter((c) => classPermitsDisclosure(c, contextClass));
+}

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -23,8 +23,9 @@ import { redactSecrets } from "../utils/redactSecrets.js";
 import { secureFile, secureDir } from "../utils/secure-perms.js";
 import { findInjection } from "./injection.js";
 import { evaluateWriteGate, writeGateEnforcing, type WriteGateVerdict } from "./write-gate.js";
+import { DEFAULT_MEMORY_CLASS, disclosableClasses, type MemoryClass } from "./class.js";
 
-export const SCHEMA_VERSION = 8;
+export const SCHEMA_VERSION = 9;
 
 /** True when text carries a HIGH-confidence prompt-injection pattern — used to
  *  quarantine a message on insert so recall never re-injects it into the prompt. */
@@ -97,7 +98,8 @@ CREATE TABLE IF NOT EXISTS messages (
   cwd TEXT,
   git_branch TEXT,
   version TEXT,
-  quarantined INTEGER NOT NULL DEFAULT 0
+  quarantined INTEGER NOT NULL DEFAULT 0,
+  class TEXT
 );
 
 CREATE TABLE IF NOT EXISTS tool_uses (
@@ -189,7 +191,41 @@ function ensureColumn(db: DatabaseSync, table: string, column: string, decl: str
   }
 }
 
-function migrate(db: DatabaseSync): void {
+/**
+ * Backfill `messages.class` for rows that predate classification (v9, #348).
+ *
+ * Two non-obvious hazards this handles:
+ *
+ * 1. `messages` is the external-content source for the `messages_fts` FTS5 index, and the
+ *    `messages_au` trigger re-indexes `content` on ANY update. A bare
+ *    `UPDATE messages SET class = …` would therefore rewrite the entire FTS index for a
+ *    column FTS does not even index — pure waste on a large store. We drop that one trigger
+ *    for the duration and restore it after.
+ * 2. If the FTS index is already inconsistent with the table (a truncated copy, an
+ *    interrupted write), that trigger raises "database disk image is malformed" — which,
+ *    from inside `openMemoryDb`, would BRICK every kit command that touches memory. So the
+ *    backfill is best-effort: on failure the rows keep a NULL class, and NULL is excluded by
+ *    the recall gate (fail-closed — unclassified never leaks), rather than taking the CLI down.
+ */
+function backfillMessageClass(db: DatabaseSync, defaultClass: MemoryClass): void {
+  const needed = db.prepare("SELECT 1 FROM messages WHERE class IS NULL LIMIT 1").get();
+  if (!needed) return; // nothing to do — the common path on an already-migrated store
+  try {
+    db.exec("DROP TRIGGER IF EXISTS messages_au");
+    db.prepare("UPDATE messages SET class = ? WHERE class IS NULL").run(defaultClass);
+  } catch {
+    /* best-effort: unclassified rows stay NULL and are excluded by the gate (fail-closed) */
+  } finally {
+    // Restore the trigger unconditionally — leaving it dropped would silently stop FTS from
+    // tracking edits, which is a far worse failure than an unbackfilled class column.
+    db.exec(`CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
+  INSERT INTO messages_fts(messages_fts, rowid, content) VALUES ('delete', old.id, old.content);
+  INSERT INTO messages_fts(rowid, content) VALUES (new.id, new.content);
+END;`);
+  }
+}
+
+function migrate(db: DatabaseSync, defaultClass: MemoryClass): void {
   db.exec("CREATE TABLE IF NOT EXISTS schema_meta (version INTEGER NOT NULL)");
   db.exec(SCHEMA_SQL);
   // v2: pending_actions.verify_passes (N=2 auto-verify confirmation). Add to
@@ -225,6 +261,13 @@ function migrate(db: DatabaseSync): void {
   // (uuid + content SHA-256, never the content itself) so "forgotten" is a checkable,
   // durable claim. The table is created by SCHEMA_SQL above (CREATE IF NOT EXISTS),
   // so existing stores gain it on next open; no column migration needed.
+  // v9: memory classification (#348). `class` labels a row's sensitivity so a more
+  // restrictive memory is never recalled into a less restrictive context. Existing rows
+  // predate classification and are BACKFILLED to the configured default — leaving them NULL
+  // would make every historical row unclassifiable and (fail-closed) invisible, which is a
+  // silent data loss disguised as security. New rows get their class at insert time.
+  ensureColumn(db, "messages", "class", "TEXT");
+  backfillMessageClass(db, defaultClass);
   const row = db.prepare("SELECT version FROM schema_meta LIMIT 1").get() as
     | { version: number }
     | undefined;
@@ -239,14 +282,17 @@ function migrate(db: DatabaseSync): void {
  * Open (creating + migrating if needed) the memory database. Pass ":memory:" for
  * an ephemeral in-process DB (tests). Otherwise defaults to ~/.kit/memory.db.
  */
-export function openMemoryDb(path?: string): DatabaseSync {
+export function openMemoryDb(
+  path?: string,
+  opts: { defaultClass?: MemoryClass } = {},
+): DatabaseSync {
   const dbPath = path ?? getMemoryDbPath();
   if (dbPath !== ":memory:") ensureMemoryDir();
   const db = new DatabaseSync(dbPath);
   db.exec("PRAGMA journal_mode = WAL");
   db.exec("PRAGMA busy_timeout = 5000");
   db.exec("PRAGMA foreign_keys = OFF");
-  migrate(db);
+  migrate(db, opts.defaultClass ?? DEFAULT_MEMORY_CLASS);
   if (dbPath !== ":memory:" && existsSync(dbPath)) {
     try {
       secureFile(dbPath); // 0o600 on POSIX, icacls owner-only on Windows — #43
@@ -340,8 +386,8 @@ export function insertMessage(db: DatabaseSync, m: MessageInput): boolean {
   const res = db
     .prepare(
       `INSERT OR IGNORE INTO messages
-       (uuid, session_id, parent_uuid, type, role, content, model, input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens, timestamp, cwd, git_branch, version, quarantined)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       (uuid, session_id, parent_uuid, type, role, content, model, input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens, timestamp, cwd, git_branch, version, quarantined, class)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       m.uuid,
@@ -360,6 +406,9 @@ export function insertMessage(db: DatabaseSync, m: MessageInput): boolean {
       m.gitBranch ?? null,
       m.version ?? null,
       quarantined,
+      // Classify at capture time. An absent input class means the caller did not resolve one;
+      // use the documented default rather than NULL so no row is born unclassifiable.
+      m.memoryClass ?? DEFAULT_MEMORY_CLASS,
     );
   if (Number(res.changes) > 0) {
     db.prepare("UPDATE sessions SET message_count = message_count + 1 WHERE session_id = ?").run(
@@ -501,6 +550,13 @@ export function insertToolUse(db: DatabaseSync, t: ToolUseInput): void {
 }
 
 export interface SearchOptions {
+  /**
+   * Sensitivity ceiling for THIS recall context (#348). Rows more restrictive than this are
+   * excluded; a row with no/unrecognized class is excluded too (it is absent from the
+   * allow-list). Omit to disable class filtering — backwards-compatible for callers that
+   * predate classification.
+   */
+  contextClass?: MemoryClass;
   limit?: number;
   /** Restrict to messages whose cwd is this repo root (or a subdirectory). */
   projectPath?: string;
@@ -576,6 +632,15 @@ export function searchMessages(
     const params: (string | number)[] = [match];
     let where = "messages_fts MATCH ?";
     if (!opts.includeQuarantined) where += " AND m.quarantined = 0";
+    // Class gate (#348): only rows no more restrictive than the declared context. A NULL or
+    // unrecognized class is absent from the allow-list, so it fails the IN test and is
+    // excluded — fail-closed with no special case. No contextClass ⇒ no class filtering
+    // (backwards-compatible for callers that predate classification).
+    if (opts.contextClass) {
+      const allowed = disclosableClasses(opts.contextClass);
+      where += ` AND m.class IN (${allowed.map(() => "?").join(", ")})`;
+      params.push(...allowed);
+    }
     if (opts.projectPath) {
       where += " AND (m.cwd = ? OR m.cwd LIKE ?)";
       params.push(opts.projectPath, `${opts.projectPath}/%`);
@@ -710,6 +775,13 @@ export function recentMessages(db: DatabaseSync, opts: SearchOptions = {}): Sear
   const params: (string | number)[] = [];
   let where = "content IS NOT NULL AND content != ''";
   if (!opts.includeQuarantined) where += " AND quarantined = 0";
+  // Same class gate as searchMessages (#348) — see there for the fail-closed rationale.
+  // Pushed here so the bound values stay in the WHERE clause's positional order.
+  if (opts.contextClass) {
+    const allowed = disclosableClasses(opts.contextClass);
+    where += ` AND class IN (${allowed.map(() => "?").join(", ")})`;
+    params.push(...allowed);
+  }
   if (opts.projectPath) {
     where += " AND (cwd = ? OR cwd LIKE ?)";
     params.push(opts.projectPath, `${opts.projectPath}/%`);

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -1,3 +1,4 @@
+import type { MemoryClass } from "./class.js";
 /**
  * kit memory — shared types for the local conversation store.
  */
@@ -31,6 +32,11 @@ export interface MessageInput {
   timestamp?: string;
   cwd?: string;
   gitBranch?: string;
+  /**
+   * Sensitivity class for this row (#348). Resolved by the caller from
+   * `[memory] default_class` / KIT_MEMORY_CLASS; absent ⇒ the documented default.
+   */
+  memoryClass?: MemoryClass;
   version?: string;
 }
 


### PR DESCRIPTION
Closes **#348**, which was blocked on a decision rather than effort: *where does the label come from?*

## The leak this closes

One local store, shared across every project and (via `kit memory push/pull`) every device. A note captured while working in a restricted codebase could surface as recall while you work in a public one. Nothing prevented it.

Every memory row now carries a **class**: `public` | `internal` | `restricted`.

## Label source — config default + per-project override

`[memory] default_class` in `.kit.toml`. Because kit loads the **project's** `.kit.toml`, a project overrides the inherited default simply by declaring its own — the per-project half falls out of how kit already works rather than needing a second mechanism. `KIT_MEMORY_CLASS` overrides both for an ephemeral session.

## The gate

`searchMessages` / `recentMessages` take a `contextClass` and return only rows **no more restrictive** than it:

| context | sees |
|---|---|
| `public` | public |
| `internal` | public, internal |
| `restricted` | public, internal, restricted |

A row whose class is **missing or unrecognized** is absent from the allow-list, so it fails the SQL `IN` test and is excluded from **every** context — fail-closed with no special case to forget. Omitting `contextClass` keeps the pre-classification behavior, so existing callers are unaffected.

## Deliberately asymmetric fail-closed rules

- A **missing** config value is not a security event → the documented default (`internal`). Jumping to `restricted` would make every existing store's recall vanish.
- An **invalid** config value *is* one — a typo must never silently **widen** disclosure → `restricted`, with `recognized: false` so it can be surfaced.
- A row that cannot be classified **at disclosure time** → treated as `restricted`.

## Schema v9 + a hazard the work surfaced

`messages.class` is added and existing rows are **backfilled** to the configured default — leaving them NULL would make historical memory permanently invisible, which is data loss dressed up as security.

Implementing that backfill exposed a real problem worth flagging: `messages` is the external-content source for the `messages_fts` index, and its update trigger re-indexes `content` on *any* write. A plain `UPDATE messages SET class = …` therefore rewrote the entire FTS index for a column FTS doesn't index — and on a store whose index is already inconsistent it raises `database disk image is malformed`, which **from inside `openMemoryDb` would take down every `kit memory` command**. The backfill now drops that single trigger for its duration, restores it in a `finally`, and is best-effort: on failure rows keep a NULL class and are excluded by the gate (fail-closed) rather than the CLI failing to open the store at all.

## Implementation

- **`src/memory/class.ts`** — the whole policy as pure functions (`parseMemoryClass`, `resolveMemoryClass`, `classPermitsDisclosure`, `disclosableClasses`). No DB, no I/O.
- **`src/memory/db.ts`** — v9 column + guarded backfill, class populated at insert, class gate in both recall paths, `openMemoryDb(path, { defaultClass })`.
- **`src/config.ts`** — `[memory] default_class` (zod-validated enum).
- **Tests** — 16 in `class.test.ts`: DB-free policy tests (ordering, fail-closed parsing, precedence, the gate) **plus** integration tests against a real SQLite store proving `restricted` never surfaces in a `public`/`internal` context, that a NULL-class row leaks into *nothing*, that no row is born unclassifiable, and that the v9 migration backfills a legacy store.

## Verification

- Full suite green (**3198** tests), `format:check` clean, zero-LLM boundary intact.
- The OpenCLI snapshot drift test caught a stale contract mid-build (version bumped after generation) and was regenerated — working as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)