### PR TITLE
feat(mcp): agent-centric MCP surface — kit_triage + kit_memory, deprecations, server instructions

### DIFF
--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -579,7 +579,7 @@
       "kind": "group",
       "summary": "Local conversation memory — index transcripts + show stats",
       "x-kit-args-modeled": false,
-      "x-kit-mcp": false,
+      "x-kit-mcp": true,
       "x-kit-stability": "stable"
     },
     "open": {
@@ -937,7 +937,7 @@
       "kind": "command",
       "summary": "Security evaluation before installing packages, images, or skills",
       "x-kit-args-modeled": false,
-      "x-kit-mcp": false,
+      "x-kit-mcp": true,
       "x-kit-stability": "stable"
     },
     "upgrade": {

--- a/contracts/public-surface.json
+++ b/contracts/public-surface.json
@@ -257,8 +257,10 @@
     "kit_install",
     "kit_login",
     "kit_map",
+    "kit_memory",
     "kit_run",
     "kit_secrets",
-    "kit_standards"
+    "kit_standards",
+    "kit_triage"
   ]
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -664,6 +664,11 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
     handler: cmdTriage,
     stability: "stable",
     help: "Security evaluation before installing packages, images, or skills",
+    // MCP-exposed: the install gate blocks untriaged packages and tells the agent
+    // to run `kit triage` — in a shell-less client that instruction was previously
+    // unfollowable. The enforcement layer must never demand an action the exposure
+    // layer cannot perform.
+    mcp: true,
   },
   slopsquat: {
     handler: cmdSlopsquat,
@@ -736,6 +741,9 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
     handler: cmdMemory,
     stability: "stable",
     help: "Local conversation memory — index transcripts + show stats",
+    // MCP-exposed (search only): cross-session recall is stateful — exactly the
+    // case where an MCP tool earns its context cost for shell-less clients.
+    mcp: true,
   },
   "gate-bash": {
     handler: cmdGateBash,

--- a/src/commands/triage.ts
+++ b/src/commands/triage.ts
@@ -437,11 +437,19 @@ interface TriageLogEntry {
   granter: string;
 }
 
-async function recordTriageRun(
+/**
+ * Append a PASS entry to the triage log. Exported so the MCP `kit_triage` tool
+ * records through the SAME path the CLI uses — the pre-commit `check-deps` gate
+ * and the install gate read this log, so an MCP-run triage must satisfy them
+ * identically to a CLI-run one. `cwd` defaults to process.cwd(); the MCP server
+ * passes its per-call working directory.
+ */
+export async function recordTriageRun(
   type: string,
   target: string,
   sandbox: boolean,
   deep = false,
+  cwd?: string,
 ): Promise<void> {
   const { appendFile } = await import("node:fs/promises");
   const { resolve } = await import("node:path");
@@ -455,7 +463,7 @@ async function recordTriageRun(
   };
   try {
     await appendFile(
-      resolve(process.cwd(), TRIAGE_LOG_FILE),
+      resolve(cwd ?? process.cwd(), TRIAGE_LOG_FILE),
       JSON.stringify(entry) + "\n",
       "utf-8",
     );

--- a/src/mcp-server.test.ts
+++ b/src/mcp-server.test.ts
@@ -81,7 +81,9 @@ describe("MCP server tool registration", () => {
       assert.ok(names.includes("kit_run"), "kit_run missing");
       assert.ok(names.includes("kit_context"), "kit_context missing");
       assert.ok(names.includes("kit_map"), "kit_map missing");
-      assert.equal(tools.length, 13);
+      assert.ok(names.includes("kit_triage"), "kit_triage missing");
+      assert.ok(names.includes("kit_memory"), "kit_memory missing");
+      assert.equal(tools.length, 15);
     } finally {
       await cleanup();
     }
@@ -820,6 +822,121 @@ describe("kit_map", () => {
       );
       assert.ok(["codeowners", "git", "none"].includes(data.ownerSource));
     } finally {
+      await rm(dir, { recursive: true, force: true });
+      await cleanup();
+    }
+  });
+});
+
+// ─── kit_triage ───────────────────────────────────────────────────────────────
+
+describe("kit_triage tool", () => {
+  it("refuses in read-only mode (the pass could not be recorded, so fail closed)", async () => {
+    const { client, cleanup } = await createTestClient();
+    process.env.KIT_READ_ONLY = "1";
+    try {
+      const result = await client.callTool({
+        name: "kit_triage",
+        arguments: { type: "npm", target: "left-pad" },
+      });
+      assert.equal(result.isError, true);
+      const content = result.content as Array<{ type: string; text: string }>;
+      assert.match(content[0].text, /read-only mode/);
+    } finally {
+      delete process.env.KIT_READ_ONLY;
+      await cleanup();
+    }
+  });
+
+  it("rejects an unknown triage type at the schema layer", async () => {
+    const { client, cleanup } = await createTestClient();
+    try {
+      // "tools" is a CLI-only listing verb, deliberately NOT in the MCP enum —
+      // the schema must refuse it before any triage logic runs. The SDK surfaces
+      // zod validation failures as an error RESULT (not a transport rejection).
+      const result = await client.callTool({
+        name: "kit_triage",
+        arguments: { type: "tools", target: "x" },
+      });
+      assert.equal(result.isError, true);
+      const content = result.content as Array<{ type: string; text: string }>;
+      assert.match(content[0].text, /invalid|enum/i);
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
+// ─── kit_memory ───────────────────────────────────────────────────────────────
+
+describe("kit_memory tool", () => {
+  it("returns an empty result — and does NOT create a store — when none exists", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kit-mcp-memory-"));
+    const prevDir = process.env.KIT_MEMORY_DIR;
+    const prevDb = process.env.KIT_MEMORY_DB;
+    process.env.KIT_MEMORY_DIR = join(dir, "no-store");
+    delete process.env.KIT_MEMORY_DB;
+    const { client, cleanup } = await createTestClient();
+    try {
+      const result = await client.callTool({
+        name: "kit_memory",
+        arguments: { query: "anything at all", cwd: dir },
+      });
+      const data = parseResult(result) as { messages: unknown[]; shared: unknown[]; note?: string };
+      assert.deepEqual(data.messages, []);
+      assert.deepEqual(data.shared, []);
+      assert.match(data.note ?? "", /no memory store/);
+      // The search must not have materialized a db as a side effect of a read.
+      const { existsSync } = await import("node:fs");
+      assert.equal(
+        existsSync(join(dir, "no-store", "memory.db")),
+        false,
+        "a read-only search created a memory store",
+      );
+    } finally {
+      if (prevDir === undefined) delete process.env.KIT_MEMORY_DIR;
+      else process.env.KIT_MEMORY_DIR = prevDir;
+      if (prevDb !== undefined) process.env.KIT_MEMORY_DB = prevDb;
+      await rm(dir, { recursive: true, force: true });
+      await cleanup();
+    }
+  });
+
+  it("finds an indexed message scoped to the current project", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kit-mcp-memory-hit-"));
+    const prevDir = process.env.KIT_MEMORY_DIR;
+    const prevDb = process.env.KIT_MEMORY_DB;
+    process.env.KIT_MEMORY_DIR = join(dir, "store");
+    delete process.env.KIT_MEMORY_DB;
+    const { client, cleanup } = await createTestClient();
+    try {
+      // Seed a store through the real db API (same path the indexer uses).
+      const { openMemoryDb, upsertSession, insertMessage } = await import("./memory/db.js");
+      const db = openMemoryDb();
+      upsertSession(db, { sessionId: "s1", harness: "claude-code", project: dir });
+      insertMessage(db, {
+        uuid: "m1",
+        sessionId: "s1",
+        type: "user",
+        role: "user",
+        content: "we decided to pin the maintainer GPG fingerprint in CI",
+        // Project scoping filters on the message's cwd column — set it to the
+        // "project" dir so the default project-scoped search finds the row.
+        cwd: dir,
+      });
+      db.close();
+
+      const result = await client.callTool({
+        name: "kit_memory",
+        arguments: { query: "maintainer fingerprint", cwd: dir },
+      });
+      const data = parseResult(result) as { messages: Array<{ content: string }> };
+      assert.equal(data.messages.length, 1);
+      assert.match(data.messages[0].content, /GPG fingerprint/);
+    } finally {
+      if (prevDir === undefined) delete process.env.KIT_MEMORY_DIR;
+      else process.env.KIT_MEMORY_DIR = prevDir;
+      if (prevDb !== undefined) process.env.KIT_MEMORY_DB = prevDb;
       await rm(dir, { recursive: true, force: true });
       await cleanup();
     }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -36,6 +36,12 @@ import { isReadOnlyMode } from "./read-only-mode.js";
 import { escapeWorkflowCmd } from "./utils/ci-escape.js";
 import { runGovernedBrokered } from "./governance-middleware.js";
 import type { kitConfig } from "./config.js";
+import { runTriage, type TriageType } from "./triage.js";
+import { recordTriageRun } from "./commands/triage.js";
+import { openMemoryDb, searchMessages, getMemoryDbPath, recordQuery } from "./memory/db.js";
+import { searchShared } from "./memory/shared.js";
+import { getCurrentProjectRoot } from "./memory/project.js";
+import { existsSync } from "node:fs";
 
 const KIT_FILE = ".kit.toml";
 
@@ -58,7 +64,31 @@ export const KIT_MCP_TOOLS: readonly string[] = [
   "kit_run",
   "kit_context",
   "kit_map",
+  "kit_triage",
+  "kit_memory",
 ];
+
+/**
+ * Server-level instructions (MCP `initialize` result). Clients like Claude Code
+ * surface this to route tool selection, so it carries the one decision that
+ * matters most for context economy: an agent WITH shell access should prefer the
+ * CLI (zero standing context cost, `--help` self-documents all 68 commands);
+ * these MCP tools exist for shell-less clients. Kept well under the ~2KB
+ * truncation limit clients apply.
+ */
+const KIT_MCP_INSTRUCTIONS = `kit is a deterministic, local-first dev-environment manager and fail-closed security gate (zero LLM calls).
+
+If you have shell access, prefer running \`kit <command>\` directly — the CLI covers far more than these tools and \`kit <command> --help\` documents everything. These MCP tools exist for shell-less clients.
+
+Typical loop: kit_check (verify env + security) → kit_fix (auto-repair) → kit_triage (REQUIRED before installing any package kit's gate has not already cleared — the gate blocks untriaged installs) → kit_memory (recall prior cross-session decisions before answering project-specific questions) → kit_run (escape hatch for any other kit command).`;
+
+// Deprecation prefix for tools scheduled for removal from the MCP surface in
+// kit 6.0 (the MCP surface is "Evolving" per docs/API_STABILITY_AND_VERSIONING.md
+// — removal requires notice, so they are marked, not dropped). Rationale: setup-
+// time and CI commands are shell contexts by definition; a shell-less MCP client
+// is never the thing provisioning services or running CI. kit_run remains the
+// escape hatch for all of them.
+const DEPRECATED_6_0 = "DEPRECATED — scheduled for removal from the MCP surface in kit 6.0";
 
 function configPath(cwd?: string): string {
   return resolve(cwd ?? process.cwd(), KIT_FILE);
@@ -108,7 +138,10 @@ async function loadConfigForGovernance(cwd?: string): Promise<kitConfig> {
 }
 
 export function createMcpServer(): McpServer {
-  const server = new McpServer({ name: "kit", version: "0.1.0" }, { capabilities: { tools: {} } });
+  const server = new McpServer(
+    { name: "kit", version: "0.1.0" },
+    { capabilities: { tools: {} }, instructions: KIT_MCP_INSTRUCTIONS },
+  );
 
   // One registrar per tool — keeps this composition flat (was a 774-line
   // function). Each register_* attaches its tool to the server.
@@ -125,6 +158,8 @@ export function createMcpServer(): McpServer {
   register_kit_run(server);
   register_kit_context(server);
   register_kit_map(server);
+  register_kit_triage(server);
+  register_kit_memory(server);
 
   return server;
 }
@@ -274,7 +309,7 @@ function register_kit_install(server: McpServer): void {
   // kit_install — install missing tools via mise
   server.tool(
     "kit_install",
-    "Install missing tools defined in .kit.toml using mise.",
+    `${DEPRECATED_6_0}; setup-time provisioning happens in a shell — use \`kit install\` there, or kit_run. Install missing tools defined in .kit.toml using mise.`,
     { cwd: z.string().optional().describe("Working directory") },
     async ({ cwd }) => {
       if (isReadOnlyMode()) return readOnlyRefusal("kit_install");
@@ -329,7 +364,7 @@ function register_kit_login(server: McpServer): void {
   // kit_login — attempt service logins (non-interactive)
   server.tool(
     "kit_login",
-    "Attempt to log in to services defined in .kit.toml. Runs in non-interactive mode — services requiring interactive auth will be skipped.",
+    `${DEPRECATED_6_0}; service auth is interactive/setup-time — use \`kit login\` in a shell. Attempt to log in to services defined in .kit.toml. Runs in non-interactive mode — services requiring interactive auth will be skipped.`,
     { cwd: z.string().optional().describe("Working directory") },
     async ({ cwd }) => {
       if (isReadOnlyMode()) return readOnlyRefusal("kit_login");
@@ -541,7 +576,7 @@ function register_kit_add(server: McpServer): void {
   // kit_add — provision a service (stripe, supabase, etc.)
   server.tool(
     "kit_add",
-    `Provision a service integration for the project. Available services: ${listAvailableServices().join(", ")}. Writes generated secrets to .env.local and returns provisioning result.`,
+    `${DEPRECATED_6_0}; provisioning is setup-time shell work — use \`kit add\` there, or kit_run. Provision a service integration for the project. Available services: ${listAvailableServices().join(", ")}. Writes generated secrets to .env.local and returns provisioning result.`,
     {
       service: z
         .string()
@@ -595,7 +630,7 @@ function register_kit_env(server: McpServer): void {
   // kit_env — inspect environment variables loaded from .env.local
   server.tool(
     "kit_env",
-    "Inspect environment variables from .env.local. Returns each key's set/missing status. Values are redacted by default.",
+    `${DEPRECATED_6_0}; kit_context includes environment status — prefer it. Inspect environment variables from .env.local. Returns each key's set/missing status. Values are redacted by default.`,
     {
       show_values: z
         .boolean()
@@ -714,7 +749,7 @@ function register_kit_init(server: McpServer): void {
 function register_kit_ci(server: McpServer): void {
   server.tool(
     "kit_ci",
-    "Run kit CI checks and return structured results. Use before deploying or merging to validate the environment is correctly configured. Returns pass/fail/warn status for tools, services, secrets, lock files, and security.",
+    `${DEPRECATED_6_0}; CI runners always have a shell — run \`kit ci\` there. Run kit CI checks and return structured results. Use before deploying or merging to validate the environment is correctly configured. Returns pass/fail/warn status for tools, services, secrets, lock files, and security.`,
     {
       cwd: z.string().optional().describe("Project directory (defaults to process.cwd())"),
       format: z
@@ -1006,6 +1041,160 @@ function register_kit_map(server: McpServer): void {
           coChange: co_change ?? false,
         });
         return { content: [{ type: "text" as const, text: JSON.stringify(report, null, 2) }] };
+      } catch (err) {
+        return {
+          content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function register_kit_triage(server: McpServer): void {
+  // kit_triage — security-evaluate a package/image/repo/skill BEFORE it is
+  // installed. This closes a dead end: the install gate blocks untriaged
+  // packages with the instruction "run kit triage first", which a shell-less
+  // MCP client could not previously follow. A PASS is recorded through the SAME
+  // triage-log path the CLI uses, so the pre-commit and install gates recognize
+  // an MCP-run triage identically.
+  server.tool(
+    "kit_triage",
+    "Security-triage a dependency BEFORE installing it (registry reputation, repo health, known-compromise catalogs). Required by kit's install gate for anything it has not already cleared. A pass is recorded in the triage log the gates read. Deterministic, zero-LLM.",
+    {
+      type: z
+        .enum(["npm", "pip", "docker", "brew", "repo", "skill"])
+        .describe(
+          "Target kind: npm/pip package, docker image, brew formula, GitHub repo, or agent skill",
+        ),
+      target: z.string().describe("Package name, image ref, owner/repo, or skill path"),
+      cwd: z
+        .string()
+        .optional()
+        .describe(
+          "Working directory (defaults to process.cwd()) — where the triage log is written",
+        ),
+    },
+    async ({ type, target, cwd }) => {
+      // Appends to .kit-triage.jsonl on PASS, so read-only mode refuses it —
+      // an unrecordable pass could not satisfy the gates anyway (fail-closed).
+      if (isReadOnlyMode()) return readOnlyRefusal("kit_triage");
+      try {
+        const result = await runTriage(type as TriageType, target);
+        if (result.passed && target) {
+          await recordTriageRun(type, target, false, false, cwd);
+        }
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  passed: result.passed,
+                  type: result.type,
+                  target: result.target,
+                  verdict: result.passed
+                    ? "TRIAGE PASSED — recorded in the triage log; the install gate will now allow this target"
+                    : "TRIAGE FAILED — do not install; inspect the output below",
+                  output: result.output,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+          isError: !result.passed,
+        };
+      } catch (err) {
+        return {
+          content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function register_kit_memory(server: McpServer): void {
+  // kit_memory — search cross-session conversation memory (and the curated
+  // shared tier that travels with the repo). Search-only by design: writes to
+  // the trusted store stay on the CLI/indexer path, so an MCP client can never
+  // inject foreign text into recall. Quarantined (injection-flagged) rows are
+  // excluded, matching the CLI default.
+  server.tool(
+    "kit_memory",
+    "Search kit's local cross-session conversation memory plus the repo's curated shared decisions. Use before answering project-specific questions to recall what was actually said/decided. Read-only search; quarantined rows excluded.",
+    {
+      query: z.string().describe("Search terms"),
+      limit: z.number().int().min(1).max(100).optional().describe("Max raw hits (default 20)"),
+      global: z
+        .boolean()
+        .optional()
+        .describe("Search across all projects instead of only the current one"),
+      cwd: z.string().optional().describe("Project directory (defaults to process.cwd())"),
+    },
+    async ({ query, limit, global: searchGlobal, cwd }) => {
+      try {
+        const root = getCurrentProjectRoot(cwd ?? process.cwd());
+        // No store on this machine → empty result, NOT a freshly-created store:
+        // openMemoryDb would otherwise migrate a new db into existence as a
+        // side effect of a read — wrong for a search tool.
+        if (!existsSync(getMemoryDbPath())) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  {
+                    messages: [],
+                    shared: [],
+                    note: "no memory store on this machine — run `kit memory index` to build one",
+                  },
+                  null,
+                  2,
+                ),
+              },
+            ],
+          };
+        }
+        const db = openMemoryDb();
+        let hits;
+        try {
+          hits = searchMessages(db, query, {
+            limit: limit ?? 20,
+            projectPath: searchGlobal ? undefined : root,
+          });
+          // Same best-effort recall logging as the CLI (adoption metrics read
+          // it); skipped in read-only mode so the tool stays a pure read there.
+          if (!isReadOnlyMode()) {
+            try {
+              recordQuery(db, {
+                query,
+                hitCount: hits.length,
+                projectPath: searchGlobal ? undefined : root,
+              });
+            } catch {
+              // logging is non-critical
+            }
+          }
+        } finally {
+          db.close();
+        }
+        // Curated shared tier — always project-local, best-effort (parity with CLI).
+        let shared: unknown[] = [];
+        try {
+          shared = searchShared(root, query);
+        } catch {
+          // shared tier never gates raw recall
+        }
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ messages: hits, shared }, null, 2),
+            },
+          ],
+        };
       } catch (err) {
         return {
           content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],


### PR DESCRIPTION
## Background

Deep research into how large tool surfaces should reach AI agents (Anthropic's context-engineering guidance, first-party MCP schema-cost measurements, CLI-vs-MCP evals) concluded kit's MCP tool list was wrong in both directions: it exposed setup-time commands a shell-less client can never need, while omitting the agent-centric ones. Key numbers: tool-selection accuracy degrades past 30–50 loaded tools; a CLI reached via shell costs ~0 standing context vs ~200–800 tokens per MCP tool schema; the same task measured 6–32× cheaper via CLI with correctness statistically tied.

kit's answer stays **CLI-first** — the CLI is the product surface for the primary user (agents with shell access); MCP is a compatibility facade for shell-less clients. This PR makes that facade correct.

## The dead end this fixes

The install gate blocks untriaged packages with the instruction *"run `kit triage` first"* — **which a shell-less MCP client could not follow**, because `triage` was not exposed. The enforcement layer must never demand an action the exposure layer cannot perform.

## Changes

**Added `kit_triage`** — security-triage `npm/pip/docker/brew/repo/skill` targets. A PASS records through the *same* triage-log path the CLI uses (`recordTriageRun`, now exported with optional `cwd`), so the pre-commit and install gates recognize an MCP-run triage identically. Refuses in read-only mode — an unrecordable pass could not satisfy the gates anyway (fail-closed).

**Added `kit_memory`** — search cross-session memory + the repo's curated shared tier. Search-only by design: writes stay on the CLI/indexer path, so an MCP client can never inject foreign text into the trusted store. Quarantined rows excluded (CLI default). A missing store returns empty rather than materializing a new db as a side effect of a read.

**Server `instructions`** (MCP initialize result, used by Claude Code to route tool search): agents *with* shell access should prefer the CLI; canonical loop `check → fix → triage → memory → run`.

**Deprecated, not removed** (the MCP surface is "Evolving" per `docs/API_STABILITY_AND_VERSIONING.md` — removal needs notice, lands in kit 6.0): `kit_ci` (CI runners always have a shell), `kit_install`/`kit_login`/`kit_add` (interactive setup-time provisioning), `kit_env` (`kit_context` covers it). `kit_run` remains the escape hatch for all of them.

## Contracts

`public-surface.json` mcpTools 13 → 15; opencli `x-kit-mcp` true for `triage` and `memory`. The three drift-guards (KIT_MCP_TOOLS ↔ registered tools ↔ COMMAND_REGISTRY `mcp` flags) hold in lockstep.

## Verification

| Gate | Result |
|---|---|
| `npm test` | **3214/3214 pass** (4 new: read-only refusal, schema-layer enum rejection, empty-store-without-materialization, project-scoped hit) |
| `npm run lint` | 0 errors |
| `npm run format:check` | clean |
| `kit self-audit` | 14 rules, 0 fail, 0 warn |

## Follow-ups (deliberately out of scope)

- `kit_review` as MCP tool + deprecating `kit_standards` into it — `cmdReview` is console-orchestration today and needs a structured core first.
- `x-kit-audience` field in the opencli contract + consistency test (`audience: human` ⇒ never MCP-exposed).
- Slimming the CLAUDE.md block kit injects downstream (~20 lines → ≤10, hook-enforced rules get zero prose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
