### PR TITLE
feat(governance): scope-needs adoption — kit declares its own effects, gated against drift (5.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,61 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.16.0] - 2026-07-26
+
+Two adoption arcs with the same shape: a surface that promised something its
+mechanism did not deliver, made honest — and then gated so the dishonesty
+cannot return.
+
+### Added
+
+- **Agent-centric MCP surface.** Deep research into agent tool exposure
+  (Anthropic context-engineering guidance, MCP schema-cost measurements,
+  CLI-vs-MCP evals) concluded kit's MCP list was wrong in both directions.
+  Fixed a genuine dead end: the install gate blocks untriaged packages with
+  the instruction "run `kit triage` first" — which a shell-less MCP client
+  could not follow, because triage was not exposed.
+  - **`kit_triage`** — security-triage npm/pip/docker/brew/repo/skill targets.
+    A PASS records through the SAME triage-log path the CLI uses, so the
+    pre-commit and install gates recognize an MCP-run triage identically.
+    Refuses in read-only mode (an unrecordable pass could not satisfy the
+    gates anyway — fail-closed).
+  - **`kit_memory`** — search cross-session memory + the repo's curated shared
+    tier. Search-only by design: writes stay on the CLI/indexer path, so an
+    MCP client can never inject foreign text into the trusted store. A missing
+    store returns empty rather than materializing a db on read.
+  - **Server `instructions`** (MCP initialize): agents WITH shell access should
+    prefer the CLI (zero standing context cost; `--help` self-documents);
+    canonical loop `check → fix → triage → memory → run`.
+  - **Deprecated on the MCP surface** (marked, removal in kit 6.0 per the
+    stability policy's notice requirement): `kit_ci`, `kit_install`,
+    `kit_login`, `kit_add`, `kit_env`. `kit_run` remains the escape hatch.
+
+- **Scope-needs adoption — kit now dogfoods its own effect declarations.**
+  `withGovernance` has checked `scopeNeeds` against the signed `[scope]`/RoE
+  since the exec-broker landed — but zero production call sites declared
+  anything, making the check a structural no-op on the whole governed CLI
+  surface (the MCP broker path was already declared). Now:
+  - **`secrets.generate` declares** `fsWrites: [".env.local"]` + the named
+    secret keys it materializes. Vault-CLI subprocess egress is deliberately
+    NOT claimed (its network I/O is the CLI's, not kit's — same reasoning as
+    the MCP site).
+  - **`fix` declares** its statically-known repo writes (`skills-lock.json`,
+    `cli-lock.json`, `.env.template`, `.gitignore`). Tool installs remain
+    infrastructure (mise → `$HOME`), which the project RoE does not govern.
+  - **A drift gate makes silence impossible** (`scope-needs-adoption.test.ts`):
+    every `withGovernance` / `runGovernedBrokered` call site must declare its
+    effects or sit on an explicit reviewed list WITH a reason — an undeclared
+    new site is a build failure, never a silent bypass. The reviewed list is
+    itself checked against real call sites, so it cannot rot. Same pattern as
+    the CLI=MCP guard and the publish-ordering tests.
+
+  Under a signed `[scope]`, the declared needs must be inside the RoE; without
+  one, behavior is unchanged (the floor stays advisory). This is increment 2
+  of the 6.0 plan ("scopeNeeds adoption BEFORE flipping the default") — the
+  first honest field-signal measurement (`kit broker enforce-readiness` on kit
+  itself) is now meaningful, because something actually declares.
+
 ## [5.15.0] - 2026-07-25
 
 ### Added

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -966,7 +966,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.15.0"
+    "version": "5.16.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.15.0",
+  "version": "5.16.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -199,6 +199,16 @@ export async function cmdSecrets(): Promise<boolean> {
         store: secretsConfig.store,
         template: secretsConfig.template,
       },
+      // Declared effects (scope-needs adoption): kit's OWN direct effect is the
+      // .env.local write plus materializing the named keys — both statically
+      // known here. The vault CLI resolves values in ITS OWN subprocess, whose
+      // network I/O is the CLI's, not kit's — so egress is not kit's to claim
+      // (same reasoning as the MCP kit_secrets site). Under a signed [scope]
+      // these needs must be inside the RoE; without one, behavior is unchanged.
+      scopeNeeds: {
+        fsWrites: [".env.local"],
+        secrets: Object.keys(secretsConfig.keys ?? {}),
+      },
     },
     async () => {
       const { results, written, fromTemplate, skipped } = await generateSecrets(secretsConfig);

--- a/src/fix.ts
+++ b/src/fix.ts
@@ -231,6 +231,15 @@ export async function cmdFix(): Promise<boolean> {
       operation: "fix",
       operationType: "write",
       metadata: {},
+      // Declared effects (scope-needs adoption): the statically-known repo writes.
+      // Tool installs go through mise into $HOME — infrastructure provisioning the
+      // project [scope] RoE does not govern (mirrors the MCP kit_fix site's
+      // `infrastructure: true`). Git-hook installs resolve their target via
+      // `core.hooksPath` at runtime; they land inside the repo, which the
+      // repo-rooted [scope].fs covers.
+      scopeNeeds: {
+        fsWrites: ["skills-lock.json", "cli-lock.json", ".env.template", ".gitignore"],
+      },
     },
     async () => {
       // Read-only mode: fix installs tools and writes .env.template / .gitignore.

--- a/src/scope-needs-adoption.test.ts
+++ b/src/scope-needs-adoption.test.ts
@@ -1,0 +1,234 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Scope-needs adoption gate.
+ *
+ * `withGovernance` checks `scopeNeeds` against the signed [scope]/RoE — but a
+ * check nobody feeds is a structural no-op: the field existed for a full minor
+ * series with ZERO production call sites declaring anything, which is exactly
+ * the "silently no-op" failure the 6.0 plan warns about. This gate makes that
+ * silence impossible: every `withGovernance` / `runGovernedBrokered` call site
+ * in production code must either declare its effects or sit on the explicit
+ * reviewed list below WITH a reason. An undeclared new site fails the build
+ * instead of quietly bypassing scope mediation.
+ *
+ * Same pattern as the CLI=MCP drift guard and the publish-ordering tests:
+ * drift is a test failure, never a silent regression.
+ */
+
+// Repo root: this compiled test lives at dist/scope-needs-adoption.test.js.
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SRC = join(REPO_ROOT, "src");
+
+/** Keys that count as an effect declaration on either governance wrapper. */
+const DECLARATION_KEYS = [
+  "scopeNeeds", // withGovernance: checked against the signed [scope]
+  "egressTargets", // runGovernedBrokered: broker egress gate
+  "fsWrites", // runGovernedBrokered: broker fs gate
+  "envRequested", // runGovernedBrokered: broker env scoping
+  "declaredEffects", // runGovernedBrokered: explicit "no effects" assertion
+  "infrastructure", // runGovernedBrokered: kit's own provisioning, RoE-exempt
+];
+
+/**
+ * Call sites reviewed and consciously left undeclared. This is NOT a
+ * zero-effects claim — it is "a maintainer looked, and here is why no
+ * declaration is made". Every entry must still match a real call site
+ * (checked below), so the list cannot rot.
+ */
+const REVIEWED_UNDECLARED: { file: string; operation: string; reason: string }[] = [
+  {
+    file: "src/commands/check.ts",
+    operation: "check",
+    reason: "pure read — verification only; no egress, writes, or secret exposure",
+  },
+  {
+    file: "src/commands/ci.ts",
+    operation: "check",
+    reason: "pure read — CI rendering of the same checks",
+  },
+  {
+    file: "src/commands/info.ts",
+    operation: "health",
+    reason:
+      "read-only sensors; the PAL sync writes kit-internal state under ~/.kit, which the project [scope] RoE does not govern",
+  },
+  {
+    file: "src/commands/agent.ts",
+    operation: "escalate",
+    reason: "pure read — lists pending escalations from check results",
+  },
+  {
+    file: "src/commands/install.ts",
+    operation: "tools.install",
+    reason:
+      "infrastructure — mise provisioning into $HOME, mirrors the MCP site's `infrastructure: true`; no project-scope effects to declare",
+  },
+  {
+    file: "src/commands/login.ts",
+    operation: "services.login",
+    reason:
+      "egress happens inside provider CLIs' own subprocesses; hosts are adapter-owned and not statically enumerable — per-adapter needs is a named follow-up",
+  },
+];
+
+/** Strip line/block comments; neutralize brackets inside strings (keeps braces balanced). */
+function stripNoise(source: string): string {
+  let out = "";
+  let i = 0;
+  const n = source.length;
+  while (i < n) {
+    const ch = source[i];
+    const next = source[i + 1];
+    if (ch === "/" && next === "/") {
+      while (i < n && source[i] !== "\n") i++;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      i += 2;
+      while (i < n && !(source[i] === "*" && source[i + 1] === "/")) i++;
+      i += 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      out += quote;
+      i++;
+      while (i < n && source[i] !== quote) {
+        if (source[i] === "\\") {
+          out += "\\" + (source[i + 1] ?? "");
+          i += 2;
+          continue;
+        }
+        // Keep string contents (operation names are matched later) but
+        // neutralize brackets so brace-matching stays balanced.
+        out += /[{}()[\]]/.test(source[i]) ? " " : source[i];
+        i++;
+      }
+      out += quote;
+      i++;
+      continue;
+    }
+    out += ch;
+    i++;
+  }
+  return out;
+}
+
+/** Extract the second argument (the context object literal) of a call starting at `callStart`. */
+function extractContextObject(code: string, callStart: number): string | null {
+  const open = code.indexOf("(", callStart);
+  if (open < 0) return null;
+  // Walk to the first top-level comma (end of arg 1), then brace-match arg 2.
+  let depth = 0;
+  let i = open + 1;
+  for (; i < code.length; i++) {
+    const ch = code[i];
+    if (ch === "(" || ch === "[" || ch === "{") depth++;
+    else if (ch === ")" || ch === "]" || ch === "}") {
+      if (depth === 0) return null; // call ended before a second arg
+      depth--;
+    } else if (ch === "," && depth === 0) break;
+  }
+  const braceStart = code.indexOf("{", i);
+  if (braceStart < 0) return null;
+  let braces = 0;
+  for (let j = braceStart; j < code.length; j++) {
+    if (code[j] === "{") braces++;
+    else if (code[j] === "}") {
+      braces--;
+      if (braces === 0) return code.slice(braceStart, j + 1);
+    }
+  }
+  return null;
+}
+
+interface CallSite {
+  file: string;
+  wrapper: string;
+  operation: string | null;
+  declared: boolean;
+}
+
+function collectSourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) collectSourceFiles(p, out);
+    else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) out.push(p);
+  }
+  return out;
+}
+
+function findCallSites(): CallSite[] {
+  const sites: CallSite[] = [];
+  for (const path of collectSourceFiles(SRC)) {
+    const rel = relative(REPO_ROOT, path).split("\\").join("/");
+    // The wrappers' own definitions are not call sites.
+    if (rel === "src/governance-middleware.ts") continue;
+    const code = stripNoise(readFileSync(path, "utf8"));
+    const callRe = /\b(withGovernance|runGovernedBrokered)\s*(?:<[^>]*>)?\s*\(/g;
+    let m: RegExpExecArray | null;
+    while ((m = callRe.exec(code)) !== null) {
+      const ctx = extractContextObject(code, m.index);
+      if (!ctx) continue; // not a real call (e.g. a re-export or type position)
+      const opMatch = /operation:\s*"([^"]+)"/.exec(ctx);
+      // `key:` (explicit) or `key,`/`key}` (object shorthand, e.g. `egressTargets,`).
+      const declared = DECLARATION_KEYS.some((k) =>
+        new RegExp(`(?:^|[,{\\s])${k}\\s*[:,}]`).test(ctx),
+      );
+      sites.push({ file: rel, wrapper: m[1], operation: opMatch?.[1] ?? null, declared });
+    }
+  }
+  return sites;
+}
+
+describe("scope-needs adoption gate", () => {
+  const sites = findCallSites();
+
+  it("finds the governed call sites at all (the scanner itself must not rot)", () => {
+    // If a refactor renames the wrappers or moves everything, this gate would
+    // otherwise pass vacuously — require a sane minimum.
+    assert.ok(
+      sites.length >= 8,
+      `expected at least 8 governed call sites, found ${sites.length} — did the wrappers get renamed?`,
+    );
+  });
+
+  it("every governed call site declares its effects or is explicitly reviewed", () => {
+    const undeclared = sites.filter(
+      (s) =>
+        !s.declared &&
+        !REVIEWED_UNDECLARED.some((r) => r.file === s.file && r.operation === s.operation),
+    );
+    assert.deepEqual(
+      undeclared.map((s) => `${s.file} (${s.wrapper} "${s.operation}")`),
+      [],
+      "undeclared governed call site(s) — declare scopeNeeds/broker effects, or add a REVIEWED_UNDECLARED entry with a reason",
+    );
+  });
+
+  it("the reviewed list matches real call sites (no rot)", () => {
+    const stale = REVIEWED_UNDECLARED.filter(
+      (r) => !sites.some((s) => s.file === r.file && s.operation === r.operation && !s.declared),
+    );
+    assert.deepEqual(
+      stale.map((r) => `${r.file} ("${r.operation}")`),
+      [],
+      "stale REVIEWED_UNDECLARED entries — the site now declares needs (remove the entry) or moved (update it)",
+    );
+  });
+
+  it("the flagship declarations stay declared", () => {
+    // secrets.generate and fix are the two CLI sites with statically-known
+    // effects — the dogfood proof that scope mediation runs on kit itself.
+    for (const op of ["secrets.generate", "fix"]) {
+      const site = sites.find((s) => s.operation === op && s.wrapper === "withGovernance");
+      assert.ok(site, `withGovernance site for "${op}" not found`);
+      assert.equal(site.declared, true, `"${op}" lost its scopeNeeds declaration`);
+    }
+  });
+});


### PR DESCRIPTION
## The no-op this fixes

`withGovernance` has checked `scopeNeeds` against the signed `[scope]`/RoE since the exec-broker landed — but **zero production call sites declared anything**. Measured before this PR: `scopeNeeds` appears in production code only at its definition, the check branch, and `checkScopeNeeds` itself. The field existed, the check existed, the tests passed — nothing ever fed it. A structural no-op across the whole governed CLI surface, which is exactly the "silently no-op" failure the 6.0 note warns about.

(The MCP broker path was already honest: `infrastructure` on install/fix, `fsWrites` on secrets, `egressTargets` on run. The gap was CLI-only.)

This is **increment 2 of the 6.0 plan** — *"scopeNeeds adoption BEFORE flipping the default"*.

## A — declare where effects are statically known

- **`secrets.generate`**: `fsWrites: [".env.local"]` + the named secret keys it materializes. Vault-CLI subprocess egress deliberately **not** claimed — its network I/O is the CLI's, not kit's (same reasoning as the MCP site's comment).
- **`fix`**: the statically-known repo writes (`skills-lock.json`, `cli-lock.json`, `.env.template`, `.gitignore`). Tool installs remain infrastructure (mise → `$HOME`), which the project RoE does not govern.

Six sites reviewed and consciously left undeclared, **each with a written reason**: `check`/`ci`/`escalate` (pure reads), `health` (PAL sync writes kit-internal `~/.kit` state, outside the project RoE), `install` (mirrors the MCP `infrastructure: true` exemption), `login` (egress happens inside provider CLIs' own subprocesses; hosts are adapter-owned and not statically enumerable — per-adapter needs is a named follow-up).

## B — the drift gate

`scope-needs-adoption.test.ts`: every `withGovernance` / `runGovernedBrokered` call site in production code must declare its effects or sit on the explicit reviewed list *with* a reason. An undeclared new site is a **build failure**, never a silent bypass. Three anti-rot properties:

- the reviewed list is checked against real call sites (a stale entry fails)
- a floor assertion (≥8 sites found) catches wrapper renames making the gate vacuous
- the two flagship declarations are pinned so they cannot quietly disappear

Scanner is comment/string-aware (strips comments, neutralizes brackets inside strings, handles object-shorthand declarations like `egressTargets,`). Same pattern as the CLI=MCP guard and the publish-ordering tests.

## What was already covered

The `withGovernance → checkScopeNeeds` wiring has allow/deny/never-executes tests in `exec-broker/scope-needs.test.ts` — the gap was adoption, not mechanism. Under a signed `[scope]` the declared needs must now be inside the RoE; without one, behavior is unchanged (the floor stays advisory).

**C follows after merge, as measurement, not code**: `kit broker enforce-readiness` on kit itself is now meaningful, because something actually declares.

## Also in this PR

Version → **5.16.0** with a CHANGELOG section that also documents the agent-centric MCP surface (#396), which merged without a version bump and would otherwise be trapped by the publish gate's CHANGELOG requirement.

## Verification

| Gate | Result |
|---|---|
| `npm test` | **3218/3218 pass** (4 new gate tests) |
| `npm run lint` | 0 errors |
| `npm run format:check` | clean |
| `kit self-audit` | 14 rules, 0 fail, 0 warn |
| `changelog-section.mjs 5.16.0` | renders 3501 bytes — pre-publish gate passes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
