### PR TITLE
fix(broker): audit evidence follows the governed project, not process.cwd()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,21 @@ cannot return.
   first honest field-signal measurement (`kit broker enforce-readiness` on kit
   itself) is now meaningful, because something actually declares.
 
+### Fixed
+
+- **Broker evidence now lands in the governed project's audit log, not
+  `process.cwd()`.** The first real `enforce-readiness` measurement found
+  23/23 observed ops were test fixtures: broker audits resolved
+  `.kit-audit.jsonl` from the process cwd, so an op governed by another
+  project's `[scope]` — an MCP call with its own `cwd`, or a test fixture —
+  wrote its observe records into the host repo's log and poisoned the
+  readiness verdict there. `cwd` now threads through
+  `runBrokered → brokerExec/brokerObserve → audit`, so evidence follows the
+  project whose scope mediates (regression-tested: the polluter suite now
+  leaves the host log untouched). Historical entries are left intact — the
+  log is hash-chained, and deleting lines is tampering by kit's own model; a
+  sanctioned `audit rotate` with anchor re-seal is a named follow-up.
+
 ## [5.15.0] - 2026-07-25
 
 ### Added

--- a/src/exec-broker/broker.test.ts
+++ b/src/exec-broker/broker.test.ts
@@ -455,6 +455,50 @@ enforce_runtime = true
     );
   });
 
+  it("observe evidence lands in the GOVERNED project's audit log, not process.cwd()", async () => {
+    // Regression: broker audits used to resolve .kit-audit.jsonl from
+    // process.cwd(), so an op governed by another project's [scope] — an MCP
+    // call with its own cwd, or a test fixture — wrote its observe records
+    // into the HOST repo's log and poisoned `kit broker enforce-readiness`
+    // there (the first real measurement found 23/23 observed ops were test
+    // fixtures). Evidence must follow the project whose scope mediates.
+    const project = mkdtempSync(join(tmpdir(), "kit-broker-proj-"));
+    try {
+      loadOrCreateIdentity();
+      writeFileSync(
+        join(project, PROFILE_FILE),
+        `version = 1\n[scope]\negress = ["api.acme.com"]\n`,
+      );
+      await signProfile(project);
+      delete process.env.KIT_EXEC_BROKER_POLICY;
+
+      // process.cwd() is `sandbox` (see beforeEach) — the governed project differs.
+      const out = await runBrokered(
+        CTX({ egressTargets: ["https://evil.com"] }),
+        async () => "ok",
+        { cwd: project },
+      );
+      assert.equal(out.ok, true, "observe never denies");
+
+      const projLog = join(project, ".kit-audit.jsonl");
+      assert.ok(existsSync(projLog), "observe record written to the governed project");
+      const projEntries = readFileSync(projLog, "utf-8")
+        .split("\n")
+        .filter((l) => l.trim())
+        .map((l) => JSON.parse(l) as { metadata?: { phase?: string } });
+      assert.ok(
+        projEntries.some((e) => e.metadata?.phase === "observe"),
+        "the observe entry is in the project's log",
+      );
+      assert.ok(
+        !auditLines().some((l) => (l.metadata as { phase?: string })?.phase === "observe"),
+        "no observe entry leaked into process.cwd()'s log",
+      );
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+
   it("explicit enforce_runtime = false → runtime OFF (opt out of mediation entirely)", async () => {
     await writeSignedProfile(
       `version = 1\n[scope]\negress = ["api.acme.com"]\nenforce_runtime = false\n`,

--- a/src/exec-broker/broker.ts
+++ b/src/exec-broker/broker.ts
@@ -93,6 +93,7 @@ export async function brokerExec<T>(
   context: BrokerContext,
   policy: BrokerPolicy | null | undefined,
   run: (scopedEnv: Record<string, string>) => Promise<T>,
+  cwd?: string,
 ): Promise<BrokerOutcome<T>> {
   // Infrastructure exemption: kit's OWN tool-provisioning is not governed by the project [scope]
   // RoE (it writes to $HOME and fetches from tool hosts by design — see BrokerContext.infrastructure).
@@ -101,12 +102,15 @@ export async function brokerExec<T>(
   // the RoE does not govern this op, so its signature/validity is irrelevant here. Fail-closed
   // auditability still applies (refuse if the pre-exec authorization entry can't be written).
   if (context.infrastructure) {
-    const authorized = await appendAuditEventDirect({
-      operation: context.operation,
-      environment: BROKER_ENV,
-      success: true,
-      metadata: { ...context.metadata, phase: "authorized", exemption: "infrastructure" },
-    });
+    const authorized = await appendAuditEventDirect(
+      {
+        operation: context.operation,
+        environment: BROKER_ENV,
+        success: true,
+        metadata: { ...context.metadata, phase: "authorized", exemption: "infrastructure" },
+      },
+      { cwd },
+    );
     if (!authorized) {
       return {
         ok: false,
@@ -115,11 +119,11 @@ export async function brokerExec<T>(
     }
     try {
       const result = await run(scopeEnv(Object.keys(process.env), process.env));
-      await audit(context, true, undefined, { exemption: "infrastructure" });
+      await audit(context, true, undefined, { exemption: "infrastructure" }, cwd);
       return { ok: true, result };
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
-      await audit(context, false, reason, { exemption: "infrastructure" });
+      await audit(context, false, reason, { exemption: "infrastructure" }, cwd);
       return { ok: false, reason };
     }
   }
@@ -127,7 +131,7 @@ export async function brokerExec<T>(
   // Default-deny when policy is absent. run() is NEVER invoked.
   if (!policy) {
     const reason = "exec-broker: no policy (default-deny)";
-    await audit(context, false, reason);
+    await audit(context, false, reason, undefined, cwd);
     return { ok: false, reason };
   }
 
@@ -138,7 +142,7 @@ export async function brokerExec<T>(
   if (!hasDeclaredEffects(context)) {
     const reason =
       "exec-broker: operation declares no effect contract (egress/fs/env) — cannot mediate (fail-closed)";
-    await audit(context, false, reason);
+    await audit(context, false, reason, undefined, cwd);
     return { ok: false, reason };
   }
 
@@ -154,19 +158,22 @@ export async function brokerExec<T>(
     const reason = `exec-broker: denied (${denials.length} violation${
       denials.length === 1 ? "" : "s"
     })`;
-    await audit(context, false, reason, { denials });
+    await audit(context, false, reason, { denials }, cwd);
     return { ok: false, reason, denials };
   }
 
   // Fail-closed auditability (mirrors withGovernance's destructive gate):
   // persist a pre-exec "authorized" entry and REFUSE to run if it can't be
   // written. The post-exec success log alone is fail-open.
-  const authorized = await appendAuditEventDirect({
-    operation: context.operation,
-    environment: BROKER_ENV,
-    success: true,
-    metadata: { ...context.metadata, phase: "authorized" },
-  });
+  const authorized = await appendAuditEventDirect(
+    {
+      operation: context.operation,
+      environment: BROKER_ENV,
+      success: true,
+      metadata: { ...context.metadata, phase: "authorized" },
+    },
+    { cwd },
+  );
   if (!authorized) {
     return {
       ok: false,
@@ -177,11 +184,11 @@ export async function brokerExec<T>(
   // All gates passed → execute with the scoped env, then audit success/failure.
   try {
     const result = await run(scopedEnv);
-    await audit(context, true, undefined);
+    await audit(context, true, undefined, undefined, cwd);
     return { ok: true, result, scopedEnv };
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
-    await audit(context, false, reason);
+    await audit(context, false, reason, undefined, cwd);
     return { ok: false, reason };
   }
 }
@@ -198,11 +205,12 @@ async function brokerObserve<T>(
   context: BrokerContext,
   policy: BrokerPolicy | null | undefined,
   run: (scopedEnv: Record<string, string>) => Promise<T>,
+  cwd?: string,
 ): Promise<BrokerOutcome<T>> {
   const wouldDeny = policy
     ? collectDenials(context, policy)
     : ["exec-broker: no policy (default-deny)"];
-  await audit(context, true, undefined, { phase: "observe", wouldDeny });
+  await audit(context, true, undefined, { phase: "observe", wouldDeny }, cwd);
   try {
     const result = await run(scopeEnv(Object.keys(process.env), process.env));
     return { ok: true, result };
@@ -283,8 +291,8 @@ export async function runBrokered<T>(
       // "observe" = dry-run: mediate the same gates but NEVER deny — record would-be denials so an
       // operator can see what default-on would block before flipping to "enforce" (Pillar 3 ladder).
       return signed.runtimeMode === "observe"
-        ? brokerObserve(context, signed.policy, run)
-        : brokerExec(context, signed.policy, run);
+        ? brokerObserve(context, signed.policy, run, opts.cwd)
+        : brokerExec(context, signed.policy, run, opts.cwd);
     }
     // Undeclared op under runtime enforcement/observe → migration passthrough (unchanged behavior).
     try {
@@ -303,27 +311,38 @@ export async function runBrokered<T>(
       return { ok: false, reason: err instanceof Error ? err.message : String(err) };
     }
   }
-  return brokerExec(context, loadBrokerPolicy(opts.policyOverride), run);
+  return brokerExec(context, loadBrokerPolicy(opts.policyOverride), run, opts.cwd);
 }
 
 /**
  * Best-effort audit of a broker decision. A DENY still returns deny even if this
  * append fails (we never fail-open to allow) — but surface the logging failure to
  * stderr, as audit.ts does, so the denial is not silently unlogged.
+ *
+ * `cwd` is the GOVERNED PROJECT's directory: broker evidence belongs to the
+ * project whose [scope] mediates the op, not to whatever process.cwd() happens
+ * to be (an MCP server's cwd, the test runner's repo root, ...). Without this,
+ * observe records from other projects — including test fixtures — pollute the
+ * host repo's .kit-audit.jsonl and poison `kit broker enforce-readiness`, whose
+ * verdict is only as honest as the evidence file it reads.
  */
 async function audit(
   context: BrokerContext,
   success: boolean,
   error: string | undefined,
   extra?: Record<string, unknown>,
+  cwd?: string,
 ): Promise<void> {
-  const logged = await appendAuditEventDirect({
-    operation: context.operation,
-    environment: BROKER_ENV,
-    success,
-    error,
-    metadata: extra ? { ...context.metadata, ...extra } : context.metadata,
-  });
+  const logged = await appendAuditEventDirect(
+    {
+      operation: context.operation,
+      environment: BROKER_ENV,
+      success,
+      error,
+      metadata: extra ? { ...context.metadata, ...extra } : context.metadata,
+    },
+    { cwd },
+  );
   if (!logged) {
     console.error(`[kit] exec-broker: audit append failed for ${context.operation}`);
   }


### PR DESCRIPTION
## The contaminated measurement

The first real `kit broker enforce-readiness` run — meaningful only since scope-needs adoption (#397) landed — returned **would-block 23/23**. Every observed op was a test fixture (`kit-mcp-secfs-*` temp dirs).

Root cause: broker audits resolved `.kit-audit.jsonl` from `process.cwd()`. An op governed by *another* project's `[scope]` — an MCP call with its own `cwd`, or a test fixture — wrote its observe records into the **host repo's** log and poisoned the readiness verdict there. The measurement channel worked; the evidence was contaminated at the source. This matters beyond tests: readiness's verdict is only as honest as the evidence file it reads, and the 6.0 default-flip is gated on that verdict.

## Fix

`cwd` threads through `runBrokered → brokerExec/brokerObserve → audit → appendAuditEventDirect`, so evidence lands in the project whose scope mediates. Default (no `cwd`) remains `process.cwd()` — CLI callers behave exactly as before; the MCP path already passes the tool's `cwd` into `runBrokered`.

## Proof of decontamination

Ran the polluter suite (mcp-server tests, which sign observe-mode fixtures) against the fixed build:

```
observe entries in host repo log: before=23  after=23  (diff=0)
```

Previously each run added one entry per fixture. A regression test pins the property: an observe op with `opts.cwd ≠ process.cwd()` writes to the governed project's log and leaks nothing into the host's.

## Historical entries

Left intact deliberately: the log is hash-chained, and deleting lines is tampering by kit's own model. A sanctioned `kit audit rotate` with anchor re-seal is a **named follow-up** for machines polluted before this fix — until then, `enforce-readiness` on a developer machine that ran the old tests will still show the stale fixtures.

## Verification

| Gate | Result |
|---|---|
| `npm test` | full suite **0 fail** (broker 33/33 incl. new regression) |
| `npm run lint` | 0 errors |
| `npm run format:check` | clean |
| `kit self-audit` | 14 rules, 0 fail, 0 warn |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
