### PR TITLE
docs(mcp): rewrite the MCP docs against reality, gated against fiction

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,7 +829,7 @@ See [GOVERNANCE.md](./GOVERNANCE.md) for detailed documentation.
 
 ## AI Assistant Setup
 
-kit exposes its capabilities as an MCP server, making it usable directly by Claude Code, Cursor, Windsurf, Cline, and any other MCP-compatible AI assistant. Once registered, assistants can call `kit_check`, `kit_fix`, `kit_add`, and other tools without leaving their context.
+kit exposes its capabilities as an MCP server, making it usable directly by Claude Code, Cursor, Windsurf, Cline, and any other MCP-compatible AI assistant. Once registered, assistants can call `kit_check`, `kit_fix`, `kit_triage`, and other tools without leaving their context. (An agent **with shell access** should prefer the CLI — zero standing context cost, and `kit <command> --help` self-documents; the MCP surface exists for shell-less clients. The server's `instructions` field tells clients exactly this.)
 
 ### Claude Code
 
@@ -898,15 +898,25 @@ For Cline, add the same config to your `cline_mcp_settings.json`.
 
 ### Available MCP Tools
 
-| Tool          | Description                                                                 |
-| ------------- | --------------------------------------------------------------------------- |
-| `kit_check`   | Run all checks, return structured status JSON                               |
-| `kit_install` | Install missing tools via mise                                              |
-| `kit_login`   | Attempt service logins (non-interactive)                                    |
-| `kit_secrets` | Generate `.env.local` from configured sources                               |
-| `kit_fix`     | Auto-fix issues (install tools, generate lock files)                        |
-| `kit_add`     | Provision a service integration (stripe, supabase, etc.)                    |
-| `kit_env`     | Inspect `.env.local`, list keys with set/missing status and redacted values |
+| Tool            | Description                                                                                     |
+| --------------- | ----------------------------------------------------------------------------------------------- |
+| `kit_check`     | Run all checks, return structured status JSON                                                   |
+| `kit_fix`       | Auto-fix issues (install tools, generate lock files)                                            |
+| `kit_triage`    | Security-triage a dependency BEFORE installing it — a pass satisfies the install gate           |
+| `kit_memory`    | Search cross-session memory + the repo's curated shared decisions (search-only)                 |
+| `kit_secrets`   | Generate `.env.local` from configured sources (returns key names, never values)                 |
+| `kit_run`       | Run a command with the secret-loaded env — escape hatch for every other kit command             |
+| `kit_context`   | Gather project context (stack, services, env status)                                            |
+| `kit_map`       | Repo map: import-neighborhood slice around seed paths                                           |
+| `kit_init`      | Detect the stack and generate `.kit.toml` (dry-run supported)                                   |
+| `kit_standards` | Run the dev-standards gate, return structured findings                                          |
+| `kit_env`       | _Deprecated (leaves in 6.0)_ — inspect `.env.local` key status; prefer `kit_context`            |
+| `kit_ci`        | _Deprecated (leaves in 6.0)_ — CI runners have a shell; run `kit ci` there                      |
+| `kit_install`   | _Deprecated (leaves in 6.0)_ — setup-time provisioning; use `kit install` or `kit_run`          |
+| `kit_login`     | _Deprecated (leaves in 6.0)_ — interactive service auth; use `kit login` in a shell             |
+| `kit_add`       | _Deprecated (leaves in 6.0)_ — service provisioning; use `kit add` or `kit_run`                 |
+
+Full reference: [docs/MCP_TOOLS_REFERENCE.md](docs/MCP_TOOLS_REFERENCE.md) · usage guide: [docs/MCP_TOOLS_GUIDE.md](docs/MCP_TOOLS_GUIDE.md)
 
 ### Example: kit_check response
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -4,6 +4,13 @@
 > Pair this with `docs/THREAT_MODEL.md` (what data flows where) and
 > `docs/DATA_FLOW.md` (exact reads/writes per op).
 
+> **Machine-readable surface:** `contracts/kit.opencli.json` describes every
+> command with its stability tier (`x-kit-stability`), MCP exposure
+> (`x-kit-mcp`), and primary audience (`x-kit-audience`: `human` for
+> interactive/setup commands, `harness` for hook stdin protocols like
+> `gate-*`/`statusline` that neither humans nor agents invoke directly, or
+> `all`). Agents should prefer that contract over parsing this document.
+
 ## Global flags
 
 | Flag                         | Effect                                                                                     |

--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -1,319 +1,84 @@
 # kit MCP Tools Guide
 
-kit exposes configuration, adapter, and health management via three MCP tools for Claude Code and other AI assistants.
+kit ships an MCP server (`kit mcp` / `dist/mcp-server.js`) so shell-less
+clients — Claude Desktop, some Cursor modes — can still drive the gates. The
+tool-by-tool reference lives in [MCP_TOOLS_REFERENCE.md](MCP_TOOLS_REFERENCE.md);
+this guide covers how to wire it up and how the surface is meant to be used.
 
-## Tools Overview
+**The CLI-first rule.** An agent with shell access should run `kit <command>`
+directly: the CLI covers all ~68 commands, costs zero standing context, and
+`kit <command> --help` self-documents. The server's own `instructions` field
+(sent in the MCP `initialize` result) says exactly this, so well-behaved
+clients route accordingly. The MCP tools exist for clients that cannot shell
+out — they are a compatibility facade, not the product surface.
 
-| Tool | Purpose | Phase |
-|------|---------|-------|
-| `kit_configure` | Manage project configuration, feature flags, paths | 6C-1a |
-| `kit_adapter_check` | Check adapter health, dependencies, status | 6C-1b |
-| `kit_adapter_install` | Install, configure, setup adapters with env vars | 6C-1c |
+## Registration
 
-## kit_configure
+Claude Code:
 
-Configuration management: get/set/list/validate project settings.
-
-### Actions
-
-**get** — Retrieve configuration value
-```typescript
-{
-  action: "get",
-  key: "app.debug"
-}
+```bash
+claude mcp add kit -- npx -y sandstream-kit mcp
 ```
 
-**set** — Update configuration
-```typescript
-{
-  action: "set",
-  key: "db.host",
-  value: "localhost",
-  scope: "project",  // global | project | user
-  category: "service"  // adapter | tool | service | path | feature
-}
-```
+Or in `.mcp.json` (any MCP-capable client):
 
-**list** — Filter configurations
-```typescript
-{
-  action: "list",
-  scope: "project",
-  category: "feature"
-}
-```
-
-**validate** — Type-check before setting
-```typescript
-{
-  action: "validate",
-  key: "port",
-  value: "8080"
-}
-```
-
-### Examples
-
-```typescript
-// Set database configuration
-kit_configure {
-  action: "set",
-  key: "database.url",
-  value: "postgres://localhost:5432/myapp",
-  scope: "project",
-  category: "service"
-}
-
-// Enable feature flag
-kit_configure {
-  action: "set",
-  key: "feature.dark_mode",
-  value: "true",
-  scope: "project",
-  category: "feature"
-}
-
-// List all project-level features
-kit_configure {
-  action: "list",
-  scope: "project",
-  category: "feature"
-}
-```
-
-## kit_adapter_check
-
-Adapter health monitoring: status, dependencies, metrics.
-
-### Actions
-
-**status** — Full adapter check with recommendations
-```typescript
-{
-  action: "status",
-  adapter: "stripe"
-}
-```
-Returns: overall_status (healthy|degraded|unhealthy), installed, configured, authenticated, checks[], recommendations[]
-
-**dependencies** — Check required tools
-```typescript
-{
-  action: "dependencies",
-  adapter: "github"
-}
-```
-Returns: name, required, installed, version, compatible
-
-**health** — Performance metrics
-```typescript
-{
-  action: "health",
-  adapter: "sendgrid"
-}
-```
-Returns: uptime_seconds, error_count, success_count, average_response_time_ms
-
-### Examples
-
-```typescript
-// Check if Stripe is ready
-kit_adapter_check {
-  action: "status",
-  adapter: "stripe"
-}
-
-// Verify GitHub CLI installed
-kit_adapter_check {
-  action: "dependencies",
-  adapter: "github"
-}
-
-// Monitor adapter performance
-kit_adapter_check {
-  action: "health",
-  adapter: "datadog"
-}
-```
-
-## kit_adapter_install
-
-Adapter provisioning: install, auto/interactive setup, env var management.
-
-### Actions
-
-**install** — Install adapter
-```typescript
-{
-  action: "install",
-  adapter: "slack",
-  version: "1.0.0",
-  auto_configure: false
-}
-```
-Returns: installed, version, configured, setup_required, next_steps
-
-**setup** — Configure with environment variables
-```typescript
-{
-  action: "setup",
-  adapter: "github",
-  mode: "auto",  // auto | interactive
-  env_vars: {
-    token: "ghp_...",
-    owner: "myorg"
-  }
-}
-```
-
-**configure** — Set individual env var
-```typescript
-{
-  action: "configure",
-  key: "API_KEY",
-  value: "sk_test_...",
-  adapter: "stripe",
-  required: true
-}
-```
-
-### Examples
-
-```typescript
-// Install Stripe adapter
-kit_adapter_install {
-  action: "install",
-  adapter: "stripe",
-  version: "2.0.0"
-}
-
-// Auto-configure with env vars
-kit_adapter_install {
-  action: "setup",
-  adapter: "stripe",
-  mode: "auto",
-  env_vars: {
-    secret_key: "sk_test_...",
-    publishable_key: "pk_test_..."
-  }
-}
-
-// Set single env var
-kit_adapter_install {
-  action: "configure",
-  key: "STRIPE_API_KEY",
-  value: "sk_live_...",
-  adapter: "stripe"
-}
-```
-
-## Common Workflows
-
-### Setup New Adapter
-```typescript
-// 1. Install
-kit_adapter_install {
-  action: "install",
-  adapter: "sendgrid",
-  version: "latest"
-}
-
-// 2. Configure
-kit_adapter_install {
-  action: "setup",
-  adapter: "sendgrid",
-  mode: "auto",
-  env_vars: {
-    api_key: "SG.xxxxx"
-  }
-}
-
-// 3. Verify
-kit_adapter_check {
-  action: "status",
-  adapter: "sendgrid"
-}
-```
-
-### Configure Project
-
-```typescript
-// Set database
-kit_configure {
-  action: "set",
-  key: "database.url",
-  value: "postgres://...",
-  scope: "project",
-  category: "service"
-}
-
-// Enable features
-kit_configure {
-  action: "set",
-  key: "feature.analytics",
-  value: "true",
-  scope: "project",
-  category: "feature"
-}
-
-// List what's configured
-kit_configure {
-  action: "list",
-  scope: "project"
-}
-```
-
-### Diagnose Issues
-
-```typescript
-// Check adapter health
-kit_adapter_check {
-  action: "status",
-  adapter: "github"
-}
-
-// Verify dependencies
-kit_adapter_check {
-  action: "dependencies",
-  adapter: "github"
-}
-
-// Get performance metrics
-kit_adapter_check {
-  action: "health",
-  adapter: "github"
-}
-```
-
-## Response Formats
-
-All tools return `{ success: boolean, data?: T, error?: string }`.
-
-### Success Response
 ```json
 {
-  "success": true,
-  "data": {
-    "adapter_name": "stripe",
-    "installed": true,
-    "configured": true,
-    "version": "2.0.0"
+  "mcpServers": {
+    "kit": { "command": "npx", "args": ["-y", "sandstream-kit", "mcp"] }
   }
 }
 ```
 
-### Error Response
-```json
-{
-  "success": false,
-  "error": "Adapter 'nonexistent' not found"
-}
+## The canonical loop
+
+```
+kit_check   → verify env + security; same verdict as `kit check`
+kit_fix     → auto-repair what check found
+kit_triage  → REQUIRED before installing anything the install gate has not
+              already cleared — the gate blocks untriaged installs, and an
+              MCP-run triage satisfies it identically to a CLI-run one
+kit_memory  → recall prior cross-session decisions before answering
+              project-specific questions
+kit_run     → escape hatch: any other kit command
 ```
 
-## Tool Availability
+## Safety model
 
-- **Requires MCP Connection**: Use in Claude Code or MCP-capable clients
-- **Scope**: Project-level configuration and adapter management
-- **Auth**: No authentication required (operates on local config)
-- **Rate Limits**: None (local operations)
+- **Read-only mode.** `KIT_READ_ONLY=1` makes every mutating tool refuse with
+  an explicit error. `kit_triage` also refuses — it appends a PASS to the
+  triage log, and an unrecordable pass could not satisfy the gates anyway
+  (fail-closed).
+- **Governance floor.** Mutating tools pass revocation, budget, permission,
+  and expired-secret checks before executing, and are audited — the same
+  floor the CLI's `withGovernance` applies.
+- **Effect declarations.** Broker-mediated tools declare what they touch
+  (`fsWrites` on `kit_secrets`, extracted `egressTargets` on `kit_run`,
+  `infrastructure` on provisioning) so a signed `[scope]`/RoE can mediate
+  them. Audit evidence lands in the governed project's `.kit-audit.jsonl`.
+- **Memory is search-only.** `kit_memory` never writes: an MCP client cannot
+  inject text into the trusted store. Quarantined (injection-flagged) rows are
+  excluded from recall.
+- **Secrets never round-trip.** `kit_secrets` returns key names and statuses,
+  never values.
+
+## Deprecations
+
+`kit_ci`, `kit_install`, `kit_login`, `kit_add`, and `kit_env` are marked
+deprecated and leave the MCP surface in kit 6.0 (the stability policy requires
+notice before removal). Their descriptions say so and point to the
+replacement; `kit_run` remains the escape hatch for all of them. Rationale:
+CI runners and setup-time provisioning are shell contexts by definition — a
+shell-less MCP client is never the thing running CI or provisioning services.
+
+## Drift guarantees
+
+Three tests keep this surface honest:
+
+- `KIT_MCP_TOOLS` ↔ actually-registered tools ↔ the CLI registry's `mcp`
+  flags (CLI = MCP, `mcp-server.test.ts`);
+- `x-kit-audience`: a human/harness command is never MCP-exposed, modulo the
+  pinned 6.0 deprecations (`opencli.test.ts`);
+- this documentation ↔ `KIT_MCP_TOOLS`, in both directions
+  (`docs-mcp-sync.test.ts`) — every real tool documented, no fictional tool
+  documentable.

--- a/docs/MCP_TOOLS_REFERENCE.md
+++ b/docs/MCP_TOOLS_REFERENCE.md
@@ -1,96 +1,54 @@
 # MCP Tools Quick Reference
 
-## kit_configure
+The authoritative list is `KIT_MCP_TOOLS` in `src/mcp-server.ts`, mirrored in
+`contracts/public-surface.json` (`mcpTools`) and marked per-command as
+`x-kit-mcp` in `contracts/kit.opencli.json`. A drift test
+(`docs-mcp-sync.test.ts`) fails the build if this document and that list
+disagree — in either direction. (This file previously documented a tool set
+that never shipped; the gate exists so that cannot happen again.)
 
-| Action | Params | Use Case |
-|--------|--------|----------|
-| **get** | `key` | Retrieve config value |
-| **set** | `key`, `value`, `scope`, `category` | Update setting |
-| **list** | `scope?`, `category?` | Browse configs |
-| **validate** | `key`, `value` | Type-check before set |
+If your agent has shell access, prefer the CLI (`kit <command>`): it covers far
+more than these tools, costs zero standing context, and `kit <command> --help`
+self-documents. The MCP surface exists for shell-less clients.
 
-**Scopes**: global \| project \| user  
-**Categories**: adapter \| tool \| service \| path \| feature
+## The canonical loop
 
----
-
-## kit_adapter_check
-
-| Action | Params | Returns |
-|--------|--------|---------|
-| **status** | `adapter` | overall_status, installed, configured, authenticated, checks[], recommendations[] |
-| **dependencies** | `adapter` | name[], required, installed, version, compatible |
-| **health** | `adapter` | healthy, uptime_seconds, error_count, success_count, avg_response_time_ms |
-
-**Status Values**: healthy \| degraded \| unhealthy
-
----
-
-## kit_adapter_install
-
-| Action | Params | Returns |
-|--------|--------|---------|
-| **install** | `adapter`, `version?`, `auto_configure?` | installed, version, configured, setup_required, next_steps[] |
-| **setup** | `adapter`, `mode`, `env_vars?` OR `responses?` | configured, env_vars_set[], message |
-| **configure** | `adapter`, `key`, `value`, `required?` | key, value, adapter_name, set_at |
-
-**Setup Modes**: auto \| interactive
-
----
-
-## Response Format
-
-All tools return:
-```json
-{
-  "success": true,
-  "data": { /* tool-specific data */ },
-  "error": null
-}
+```
+kit_check → kit_fix → kit_triage (before any ungated install) → kit_memory → kit_run
 ```
 
----
+## Tools
 
-## Common Tasks
+Every tool accepts an optional `cwd` (defaults to the server's working
+directory). Mutating tools refuse when `KIT_READ_ONLY=1` and pass the
+governance floor (revocation, budget, permissions, expired-secret block).
 
-### Configure Database
-```json
-{ "action": "set", "key": "db.url", "value": "postgres://...", "scope": "project", "category": "service" }
-```
+| Tool | Kind | Purpose |
+| --- | --- | --- |
+| `kit_check` | read | Run all checks — tools, services, secrets, skills, hooks, security, tests, locks — and return the same verdict `kit check` computes. |
+| `kit_fix` | write | Auto-fix what `kit_check` found: install missing tools, generate missing lock files. Returns actions taken. |
+| `kit_triage` | write | Security-triage a dependency **before** installing it (`type`: npm/pip/docker/brew/repo/skill + `target`). A PASS is recorded in the triage log the install gates read, so an MCP-run triage satisfies them identically to a CLI-run one. Refuses in read-only mode — an unrecordable pass could not satisfy the gates anyway. |
+| `kit_memory` | read | Search cross-session conversation memory plus the repo's curated shared decisions (`query`, `limit?`, `global?`). Search-only by design: writes stay on the CLI/indexer path so an MCP client can never inject text into the trusted store. Quarantined rows excluded. A missing store returns empty — it is never created by a read. |
+| `kit_secrets` | write | Generate `.env.local` by resolving secrets defined in `.kit.toml`. Returns written key names — never values. |
+| `kit_run` | write | Execute a command with the secret-loaded env — the escape hatch for every kit command without its own tool. Egress-mediated via extracted hosts. |
+| `kit_context` | read | Gather project context (stack, services, env status) for the agent. |
+| `kit_map` | read | Repo map: import-neighborhood slice around seed paths (`paths`, `depth?`, `budget?`, `co_change?`). |
+| `kit_init` | write | Detect the stack and generate `.kit.toml` for a project that has none (`dryRun` to preview). |
+| `kit_standards` | read | Run the dev-standards gate and return structured findings. |
+| `kit_env` | read | **Deprecated — removed from the MCP surface in kit 6.0.** Inspect `.env.local` key status (values redacted). Prefer `kit_context`. |
+| `kit_ci` | read | **Deprecated — removed in kit 6.0.** CI runners always have a shell; run `kit ci` there. |
+| `kit_install` | write | **Deprecated — removed in kit 6.0.** Setup-time provisioning happens in a shell (`kit install`), or via `kit_run`. |
+| `kit_login` | write | **Deprecated — removed in kit 6.0.** Service auth is interactive/setup-time; use `kit login` in a shell. |
+| `kit_add` | write | **Deprecated — removed in kit 6.0.** Provision a service integration; use `kit add` in a shell, or `kit_run`. |
 
-### Install + Setup Adapter
-```json
-{ "action": "install", "adapter": "stripe" }
-{ "action": "setup", "adapter": "stripe", "mode": "auto", "env_vars": { "key": "value" } }
-```
+## Server instructions
 
-### Check Adapter Health
-```json
-{ "action": "status", "adapter": "stripe" }
-{ "action": "health", "adapter": "stripe" }
-```
+The server's MCP `initialize` result carries an `instructions` field stating
+the CLI-first rule and the canonical loop. Clients like Claude Code use it to
+route tool search — keep it in sync with this document when tools change.
 
-### List Project Features
-```json
-{ "action": "list", "scope": "project", "category": "feature" }
-```
+## Error shape
 
----
-
-## Error Handling
-
-```typescript
-const result = await kit_configure({ action: "set", ... });
-if (!result.success) {
-  console.error(result.error);  // "Configuration key 'x' not found"
-}
-```
-
----
-
-## Tool Status
-
-- **Availability**: Claude Code + MCP-capable clients
-- **Auth**: None (local operations)
-- **Rate Limits**: None (local)
-- **Latency**: <100ms typical
+Tools return `{ content: [{ type: "text", text }], isError? }`. `text` is
+JSON for structured results, or an `Error: …` line. Read-only refusals and
+governance denials are `isError: true` with the reason in `text`.

--- a/src/docs-mcp-sync.test.ts
+++ b/src/docs-mcp-sync.test.ts
@@ -1,0 +1,81 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { KIT_MCP_TOOLS } from "./mcp-server.js";
+
+/**
+ * Docs ↔ MCP-surface drift gate.
+ *
+ * MCP_TOOLS_REFERENCE.md and MCP_TOOLS_GUIDE.md once documented an entire tool
+ * set that never shipped (`kit_configure`, `kit_adapter_*` — a design that was
+ * written down and then diverged), and later missed real tools for a full
+ * minor series. Same disease as the scope-needs no-op: a surface asserting
+ * things its mechanism doesn't do, with no gate forcing sync.
+ *
+ * Two directions, both enforced:
+ *   1. every real tool is documented (nothing ships undocumented);
+ *   2. every `kit_*` name the docs mention IS a real tool (fiction is a build
+ *      failure, not a doc bug someone finds a year later).
+ */
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const DOCS = ["docs/MCP_TOOLS_REFERENCE.md", "docs/MCP_TOOLS_GUIDE.md", "README.md"].map((f) => ({
+  file: f,
+  text: readFileSync(join(REPO_ROOT, f), "utf8"),
+}));
+
+/** Every `kit_*` token in a doc (tool-name shaped; excludes prose words). */
+function mentionedTools(text: string): Set<string> {
+  return new Set(text.match(/\bkit_[a-z][a-z0-9_]*\b/g) ?? []);
+}
+
+describe("docs ↔ MCP surface", () => {
+  it("every registered MCP tool is documented in the reference AND the README table", () => {
+    // Full coverage is required of the LISTING surfaces. The guide is
+    // flow-oriented and only forbidden from fiction (next test) — forcing all
+    // tool names into prose would be padding, not documentation.
+    for (const doc of DOCS.filter((d) => d.file !== "docs/MCP_TOOLS_GUIDE.md")) {
+      const mentioned = mentionedTools(doc.text);
+      const missing = KIT_MCP_TOOLS.filter((t) => !mentioned.has(t));
+      assert.deepEqual(
+        missing,
+        [],
+        `${doc.file} does not mention: ${missing.join(", ")} — document the tool (or, if it was removed, update KIT_MCP_TOOLS first)`,
+      );
+    }
+  });
+
+  it("the docs mention no fictional tools", () => {
+    const real = new Set(KIT_MCP_TOOLS);
+    for (const doc of DOCS) {
+      const fictional = [...mentionedTools(doc.text)].filter((t) => !real.has(t));
+      assert.deepEqual(
+        fictional,
+        [],
+        `${doc.file} documents tool(s) that do not exist: ${fictional.join(", ")}`,
+      );
+    }
+  });
+
+  it("the reference marks exactly the deprecated tools as deprecated", () => {
+    // The five 6.0 removals must carry a deprecation marker in the reference,
+    // and no non-deprecated tool may. When 6.0 removes them, the first
+    // assertion's tool list shrinks and this stays green by construction.
+    const DEPRECATED = ["kit_env", "kit_ci", "kit_install", "kit_login", "kit_add"];
+    const ref = DOCS[0].text;
+    const rows = ref.split("\n").filter((l) => l.startsWith("| `kit_"));
+    for (const row of rows) {
+      const name = /\| `(kit_[a-z0-9_]+)`/.exec(row)?.[1] ?? "";
+      const marked = /[Dd]eprecated/.test(row);
+      assert.equal(
+        marked,
+        DEPRECATED.includes(name),
+        `${name}: deprecation marker ${marked ? "present but tool is not deprecated" : "missing"}`,
+      );
+    }
+    assert.ok(rows.length >= KIT_MCP_TOOLS.length, "reference table lists every tool as a row");
+  });
+});


### PR DESCRIPTION
## The finding

Asked "does every surface show what we built?", the audit answer was no — and worse than stale:

- `MCP_TOOLS_REFERENCE.md` + `MCP_TOOLS_GUIDE.md` documented a tool set that **never shipped** (`kit_configure`, `kit_adapter_check`, `kit_adapter_install` — a "Phase 6C" design that was written down and then diverged)
- The README's MCP table missed every tool added since — including `kit_triage` and `kit_memory` from #396 — while its intro showcased `kit_add`, a tool now deprecated
- `COMMANDS.md` said nothing about `x-kit-audience`

Same disease as the scope-needs no-op and the ADR engine with zero ADRs: a surface asserting things the mechanism doesn't do, with no gate forcing sync.

## Changes

- **`MCP_TOOLS_REFERENCE.md`** — rewritten as a table of the 15 *real* tools: kind (read/write), purpose, `cwd`/read-only/governance semantics, explicit deprecation markers on the five 6.0 removals.
- **`MCP_TOOLS_GUIDE.md`** — rewritten flow-oriented: registration, the CLI-first rule (and that the server's `instructions` field states it), the canonical `check → fix → triage → memory → run` loop, the safety model, deprecations, drift guarantees.
- **README** — real 15-tool table with deprecation markers; intro names `kit_triage` instead of the deprecated `kit_add`; states the CLI-first rule; links both docs.
- **`COMMANDS.md`** — points agents at the OpenCLI contract and documents `x-kit-audience`.

## The gate (`docs-mcp-sync.test.ts`)

Enforced in **both directions**:

1. every `KIT_MCP_TOOLS` entry must appear in the reference AND the README — nothing ships undocumented
2. no doc may mention a `kit_*` tool that does not exist — **fiction is a build failure**, not a doc bug someone finds a year later
3. the reference must mark exactly the deprecated five as deprecated — when 6.0 removes them, the markers go with them by construction

The guide is exempt from full coverage (flow prose, not a listing) but bound by the fiction ban.

## Verification

| Gate | Result |
| --- | --- |
| test suite | **3224/3224 pass** (3 new gate tests) |
| lint | 0 errors |
| format check | clean |
| `kit self-audit` | 14 rules, 0 fail, 0 warn |

Docs-only + tests — no version bump; rides the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
