### PR TITLE
feat(adr): kit adopts its own ADR gate — three enforced architecture decisions

### DIFF
--- a/docs/adr/0001-zero-llm-core.md
+++ b/docs/adr/0001-zero-llm-core.md
@@ -1,0 +1,29 @@
+---
+id: ADR-0001
+title: Zero-LLM core — kit never calls a model
+status: accepted
+---
+
+# ADR-0001: Zero-LLM core
+
+## Decision
+
+kit's core is deterministic: no code path in `src/` may import an LLM SDK.
+"Green = honest" only works when the verdict is reproducible — a model call in
+the gate loop would make every result probabilistic, add an egress dependency
+to the trust boundary, and put a prompt-injection surface inside the security
+tool itself.
+
+## Consequences
+
+Anything model-shaped lives OUTSIDE kit (the agent calls kit, never the
+reverse). The zero-LLM boundary test (`zero-llm-boundary.test.ts`) enforces
+this at the dependency level; the rule below enforces it at the import level,
+so an attempt is caught in review before a dependency is even added.
+
+```toml kit-enforce
+[[forbid_import]]
+import = "^(openai|@anthropic-ai/|@google/generative|@aws-sdk/client-bedrock|langchain|@langchain/|ollama|cohere-ai|@mistralai/)"
+paths = "src/**"
+message = "kit's core is zero-LLM by contract (docs/ZERO_LLM_CONTRACT.md) — model calls live in the agent, never in the gate"
+```

--- a/docs/adr/0002-dependency-floor.md
+++ b/docs/adr/0002-dependency-floor.md
@@ -1,0 +1,28 @@
+---
+id: ADR-0002
+title: Dependency floor — four runtime deps, stdlib otherwise
+status: accepted
+---
+
+# ADR-0002: Dependency floor
+
+## Decision
+
+kit is a supply-chain gate; its own supply chain is the first thing an auditor
+reads. The runtime dependency set stays at the minimum that cannot reasonably
+be stdlib (`@modelcontextprotocol/sdk`, `@upstash/redis`, `smol-toml`, `zod`).
+Utility libraries are forbidden — Node's stdlib covers them (`node:` builtins,
+global `fetch`, `structuredClone`, …).
+
+## Consequences
+
+Adding a runtime dependency is an ADR-level decision, not a convenience call.
+The rule below blocks the common utility imports outright; anything else new
+must argue its case in a PR that updates this ADR.
+
+```toml kit-enforce
+[[forbid_import]]
+import = "^(lodash|lodash-es|lodash\\.|underscore|ramda|axios|node-fetch|request|moment|dayjs|bluebird|jquery)"
+paths = "src/**"
+message = "stdlib only — a new runtime dependency is an ADR-level decision (see ADR-0002)"
+```

--- a/docs/adr/0003-core-coverage-isolation.md
+++ b/docs/adr/0003-core-coverage-isolation.md
@@ -1,0 +1,33 @@
+---
+id: ADR-0003
+title: Core never imports coverage frameworks
+status: accepted
+---
+
+# ADR-0003: Core / coverage isolation
+
+## Decision
+
+`src/coverage/*` holds vendored, curated framework mappings (OWASP ASVS,
+NIST 800-53, AIUC-1, …) — evidence emitters with an unbounded growth curve
+and permanent curation debt. They consume kit's check results; the check path
+must never consume them. This keeps the frameworks extractable to a plugin
+package (the stated direction) without core surgery.
+
+## Consequences
+
+Only the `coverage`/`analyze`/`self-audit` command cluster
+(`src/commands/coverage.ts`) may import from `src/coverage/`. The gate loop —
+check, fix, review's other stages, security scanners — stays framework-free.
+
+```toml kit-enforce
+[[forbid_import]]
+import = "coverage/(registry|standard|aiuc-1|gcp-waf-security|nist-800-53)"
+paths = "src/check*.ts"
+message = "the check path consumes no framework mappings — coverage imports live only in the coverage command cluster (ADR-0003)"
+
+[[forbid_import]]
+import = "coverage/(registry|standard|aiuc-1|gcp-waf-security|nist-800-53)"
+paths = "src/commands/check.ts"
+message = "the check path consumes no framework mappings (ADR-0003)"
+```


### PR DESCRIPTION
The ADR engine shipped in 5.7–5.10 and is wired into `kit review` and the recommended pre-commit hook — and kit's own repo had **zero ADRs**. Third occurrence of the same disease this session (scopeNeeds: a check nobody fed; MCP docs: a surface asserting fiction): *mechanism without adoption*. This closes it, and encodes the monster-analysis boundary that has so far lived only in prose.

## The three ADRs

| ADR | Decision | Rule |
| --- | --- | --- |
| **ADR-0001** Zero-LLM core | kit never calls a model — the verdict must be reproducible, and a model call inside the gate loop is a prompt-injection surface in the security tool itself | `forbid_import` of LLM SDKs (`openai`, `@anthropic-ai/`, `langchain`, …) in `src/**` — the import-level complement to the dependency-level `zero-llm-boundary` test; an attempt is caught in review before a dependency is even added |
| **ADR-0002** Dependency floor | four runtime deps, stdlib otherwise; a new runtime dependency is an ADR-level decision, not a convenience call | `forbid_import` of utility libraries (`lodash`, `axios`, `moment`, …) in `src/**` |
| **ADR-0003** Core/coverage isolation | the check path never consumes the vendored framework mappings (OWASP ASVS, NIST 800-53, AIUC-1) — evidence emitters with permanent curation debt stay extractable to a plugin without core surgery | `forbid_import` of `coverage/(registry\|standard\|…)` from `src/check*.ts` and `src/commands/check.ts` |

## Verification

Each rule **canary-tested**: a violating file fires the rule with the ADR's own message; the current tree is clean.

```
kit adr check → ✓ 3 enforced ADR(s) — no new violations
kit review    → === adr === stage runs them
kit self-audit → 14 rules, 0 fail, 0 warn
```

## Engine note (observed, not fixed here)

The import scanner reads one import per physical line — two import statements on one line hide the second. Prettier-formatted code never produces this, so it is noted rather than fixed; worth a line in the engine's backlog.

Docs + CHANGELOG (Unreleased) only — rides the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
