### PR TITLE
fix(gate): shell redirections are I/O plumbing, not package operands

### DIFF
--- a/src/install-gate-redirects.test.ts
+++ b/src/install-gate-redirects.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseInstallCommand } from "./install-gate.js";
+
+// Redirections are I/O plumbing, never package operands. The gate previously
+// (a) split segments on the `&` INSIDE `2>&1`, shearing the command into a
+// garbage "2>" segment, and (b) fed `>/dev/null` to the positional matcher,
+// which fail-closed legitimate installs with "cannot reduce: 2>". Found live:
+// verifying the 5.18.0 release, `npm i sandstream-kit@5.18.0 --no-audit 2>&1`
+// was blocked by the gate of the tool it was installing.
+//
+// (Separate file from install-gate.test.ts for a reason worth keeping: the
+// LIVE gate scans Bash heredocs, so appending these fixtures via a shell
+// heredoc was itself blocked — the fixtures look like installs. Written via
+// the editor tool instead. The gate gating its own tests is working as
+// designed.)
+describe("parseInstallCommand — shell redirections are plumbing, not packages", () => {
+  const probe = (cmd: string) => parseInstallCommand(cmd);
+
+  it("2>&1 after an install neither splits the segment nor becomes an operand", () => {
+    const p = probe("npm i sandstream-kit@5.18.0 --no-audit --no-fund 2>&1 | tail -1");
+    assert.deepEqual(p.refs, ["npm:sandstream-kit@5.18.0"]);
+    assert.deepEqual(p.unverifiable, []);
+  });
+
+  it(">/dev/null 2>&1 in a compound command leaves only the real package", () => {
+    const p = probe("npm init -y >/dev/null 2>&1 && npm i left-pad --silent");
+    assert.deepEqual(p.refs, ["npm:left-pad"]);
+    assert.deepEqual(p.unverifiable, []);
+  });
+
+  it("a bare operator consumes its separate file target", () => {
+    const p = probe("npm i evil > out.log");
+    assert.deepEqual(p.refs, ["npm:evil"]);
+    assert.deepEqual(p.unverifiable, []);
+  });
+
+  it("&> and 2> with glued targets are dropped", () => {
+    const p = probe("pip install requests &>log 2>err.txt");
+    assert.deepEqual(p.refs, ["pip:requests"]);
+    assert.deepEqual(p.unverifiable, []);
+  });
+
+  it("background `&` still separates segments — the install after it is gated", () => {
+    const p = probe("true & npm i evil");
+    assert.deepEqual(p.refs, ["npm:evil"]);
+  });
+
+  it("stderr-to-stdout dup on a pipeline into xargs keeps its fail-close", () => {
+    // The redirect must not LOOSEN anything: piping into an install-via-xargs
+    // stays unverifiable exactly as before.
+    const p = probe("cat list.txt 2>&1 | xargs npm i");
+    assert.ok(p.unverifiable.includes("xargs-stdin-install"));
+  });
+
+  it("a QUOTED redirect-shaped operand still fail-closes (only bare syntax is plumbing)", () => {
+    const p = probe("npm i '>weird'");
+    assert.ok(p.unverifiable.length > 0, "quoted '>weird' must stay unverifiable");
+  });
+});

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -38,7 +38,12 @@ export interface InstallProbe {
 // long whitespace run (each start position greedily consumes the run, fails, backtracks) —
 // a hot-path DoS on a whitespace-padded command. `scanSegment` trims each segment, so the
 // split output is byte-identical without the padding, and matching is linear.
-const SEGMENT_SPLIT = /&&|\|\||;|\||&|\n/;
+// `&` splits ONLY as a job-control separator — not inside redirections: `2>&1`
+// (preceded by `>`) and `&>` / `&>>` (followed by `>`) are I/O plumbing, and
+// splitting there shears the command into garbage segments ("2>" reached the
+// package matcher and fail-closed legitimate installs). Fixed-length
+// lookaround — no backtracking, so the O(N²) padding note above still holds.
+const SEGMENT_SPLIT = /&&|\|\||;|\||(?<!>)&(?!>)|\n/;
 
 // Leading shell keywords / grouping tokens that precede a real command without
 // changing it. Stripped like PREFIX_BINS so `then npm i evil` / `{ npm i evil; }` /
@@ -751,12 +756,38 @@ function applyMatcher(
   return true;
 }
 
+/**
+ * Drop shell REDIRECTION tokens before matching — they are I/O plumbing, never
+ * package operands (`npm i pkg 2>&1`, `npm init -y >/dev/null`, `pip install x
+ * > log`). Without this, `>/dev/null` / `2>&1` reach the positional matcher,
+ * fail `toName`, and fail-close a legitimate install ("cannot reduce: 2>").
+ * Runs on the UNDEQUOTED tokens: a quoted `">weird"` stays a (bogus) operand
+ * and keeps fail-closing — only bare shell syntax is plumbing.
+ * A bare operator (`>`, `2>`, `<`) consumes its following target token too.
+ */
+const REDIRECT_OP_RE = /^\d*(>>?|<{1,2})(&\d*)?$/; // > >> < << 2> 2>> >& 2>&1 1>&2
+const REDIRECT_WITH_TARGET_RE = /^(\d*(>>?|<{1,2})|&>{1,2})(\/|\.|\w|~|-|"|')/; // >/dev/null 2>file &>log <input
+function stripRedirections(tokens: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const tok = tokens[i];
+    if (tok === "&>" || tok === "&>>" || REDIRECT_OP_RE.test(tok)) {
+      // `2>&1` / `1>&2` name their target inside the token; every other bare
+      // operator (`>`, `2>`, `<`, `>&`, `&>`) takes the NEXT token as its file
+      // target — consume that as plumbing too.
+      const selfContained = /&\d+$/.test(tok);
+      if (!selfContained) i++;
+      continue;
+    }
+    if (REDIRECT_WITH_TARGET_RE.test(tok)) continue; // operator+target glued in one token
+    out.push(tok);
+  }
+  return out;
+}
+
 /** Match one shell segment against the package-manager matchers, mutating `probe`. */
 function scanSegment(segment: string, probe: InstallProbe): void {
-  const raw = stripInlineComment(segment)
-    .trim()
-    .split(/\s+/)
-    .filter(Boolean)
+  const raw = stripRedirections(stripInlineComment(segment).trim().split(/\s+/).filter(Boolean))
     .map(dequote)
     .filter(Boolean);
   const tokens = stripCommandPrefix(raw);


### PR DESCRIPTION
Found live while verifying 5.18.0: the install gate blocked the release-verification install of sandstream-kit itself. Two compounding defects: SEGMENT_SPLIT split on the ampersand inside stderr-dup redirections (shearing commands into a garbage "2>" segment), and redirection tokens reached the positional matcher and fail-closed legitimate installs.

Fix: the ampersand splits only as a job-control separator (fixed-length lookaround), and stripRedirections drops redirect tokens on the UNDEQUOTED stream — a QUOTED redirect-shaped operand keeps fail-closing. Strictly precision, never looseness: all 75 existing install-gate tests (bypass sweeps included) pass unchanged; 7 new tests incl. one pinning that a stderr-dup piped into an xargs install keeps its fail-close.

Meta: the live gate blocked BOTH attempts to write these tests/commit via shell heredoc (fixtures look like installs) — written via the editor instead. The gate gating its own fix is working as designed.

Verified: 3234/3234 tests, lint 0, prettier clean, self-audit 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
