### PR TITLE
chore(release): 5.19.0 — install-gate redirect fix + complete hook-skip sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.19.0] - 2026-07-26
+
+### Fixed
+
+- **The install gate no longer trips on shell redirections.** Found live while
+  verifying the 5.18.0 release: the gate blocked the release-verification
+  install of `sandstream-kit` itself, because the segment splitter cut on the
+  `&` inside stderr-dup redirections (shearing commands into a garbage `2>`
+  segment) and redirect tokens like `>/dev/null` reached the package matcher
+  and fail-closed legitimate installs. `&` now splits only as a job-control
+  separator, and redirections are stripped as I/O plumbing on the undequoted
+  token stream — a *quoted* redirect-shaped operand still fail-closes, a
+  background `&` still separates segments, and a stderr-dup piped into an
+  xargs-driven install keeps its fail-close. Strictly precision, never
+  looseness: all 75 existing bypass-resistance tests pass unchanged.
+
+### Added
+
+- **The hook-skip sentinel ships complete.** The tracked pre-commit hook wrote
+  the ran-sentinel, but the post-commit *detector* — which flags
+  `git commit --no-verify` bypasses to `.kit-skipped-commits.jsonl` — sat
+  untracked in the working tree: half a mechanism. Now tracked, and verified
+  live (it flagged a rebase commit exactly as designed). Plus `mise.toml`
+  pinning node 22 to match `engines.node`.
+
 ## [5.18.0] - 2026-07-26
 
 The surface-audit release: asked "does every user-facing surface show what the

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -1099,7 +1099,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.18.0"
+    "version": "5.19.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
Version bump + CHANGELOG for **5.19.0** — documents #405 (install-gate redirect fix, found live when the gate blocked the release-verification install of sandstream-kit itself) and #404 (hook-skip sentinel shipped complete). Merge, then tag from updated main.

`public-surface.json` byte-identical — command surface unmoved.

| Gate | Result |
| --- | --- |
| tests | 3234/3234 |
| lint / format | 0 / clean |
| self-audit | 0 fail, 0 warn |
| changelog gate | renders 1417 bytes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
