### PR TITLE
feat(review): structured collectReview core + kit_review MCP tool — kit_standards deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,6 +901,7 @@ For Cline, add the same config to your `cline_mcp_settings.json`.
 | Tool            | Description                                                                                     |
 | --------------- | ----------------------------------------------------------------------------------------------- |
 | `kit_check`     | Run all checks, return structured status JSON                                                   |
+| `kit_review`    | Full repo audit — check + design + standards + ADR gates as one structured report              |
 | `kit_fix`       | Auto-fix issues (install tools, generate lock files)                                            |
 | `kit_triage`    | Security-triage a dependency BEFORE installing it — a pass satisfies the install gate           |
 | `kit_memory`    | Search cross-session memory + the repo's curated shared decisions (search-only)                 |
@@ -909,7 +910,7 @@ For Cline, add the same config to your `cline_mcp_settings.json`.
 | `kit_context`   | Gather project context (stack, services, env status)                                            |
 | `kit_map`       | Repo map: import-neighborhood slice around seed paths                                           |
 | `kit_init`      | Detect the stack and generate `.kit.toml` (dry-run supported)                                   |
-| `kit_standards` | Run the dev-standards gate, return structured findings                                          |
+| `kit_standards` | _Deprecated (leaves in 6.0)_ — `kit_review` runs this gate as its standards stage               |
 | `kit_env`       | _Deprecated (leaves in 6.0)_ — inspect `.env.local` key status; prefer `kit_context`            |
 | `kit_ci`        | _Deprecated (leaves in 6.0)_ — CI runners have a shell; run `kit ci` there                      |
 | `kit_install`   | _Deprecated (leaves in 6.0)_ — setup-time provisioning; use `kit install` or `kit_run`          |

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -770,10 +770,10 @@
     },
     "review": {
       "kind": "command",
-      "summary": "Full repo audit — runs check + design + standards in one gate (for agents / PR checks)",
+      "summary": "Full repo audit — runs check + design + standards + adr in one gate (for agents / PR checks; --json emits one structured report)",
       "x-kit-args-modeled": false,
       "x-kit-audience": "all",
-      "x-kit-mcp": false,
+      "x-kit-mcp": true,
       "x-kit-stability": "stable"
     },
     "run": {

--- a/contracts/public-surface.json
+++ b/contracts/public-surface.json
@@ -258,6 +258,7 @@
     "kit_login",
     "kit_map",
     "kit_memory",
+    "kit_review",
     "kit_run",
     "kit_secrets",
     "kit_standards",

--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -40,6 +40,9 @@ kit_triage  → REQUIRED before installing anything the install gate has not
               MCP-run triage satisfies it identically to a CLI-run one
 kit_memory  → recall prior cross-session decisions before answering
               project-specific questions
+kit_review  → the full audit (check + design + standards + ADR) as one
+              structured report — run before merging; concise:true trims
+              pass/skip rows for context economy
 kit_run     → escape hatch: any other kit command
 ```
 
@@ -64,12 +67,15 @@ kit_run     → escape hatch: any other kit command
 
 ## Deprecations
 
-`kit_ci`, `kit_install`, `kit_login`, `kit_add`, and `kit_env` are marked
-deprecated and leave the MCP surface in kit 6.0 (the stability policy requires
-notice before removal). Their descriptions say so and point to the
-replacement; `kit_run` remains the escape hatch for all of them. Rationale:
+`kit_ci`, `kit_install`, `kit_login`, `kit_add`, `kit_env`, and
+`kit_standards` are marked deprecated and leave the MCP surface in kit 6.0
+(the stability policy requires notice before removal). Their descriptions say
+so and point to the replacement (`kit_review` subsumes `kit_standards` as its
+standards stage); `kit_run` remains the escape hatch for all of them. Rationale:
 CI runners and setup-time provisioning are shell contexts by definition — a
-shell-less MCP client is never the thing running CI or provisioning services.
+shell-less MCP client is never the thing running CI or provisioning services;
+and one audit tool that runs every gate beats a per-gate tool per stage
+(surface economy — each standing tool costs every client context).
 
 ## Drift guarantees
 

--- a/docs/MCP_TOOLS_REFERENCE.md
+++ b/docs/MCP_TOOLS_REFERENCE.md
@@ -14,7 +14,7 @@ self-documents. The MCP surface exists for shell-less clients.
 ## The canonical loop
 
 ```
-kit_check → kit_fix → kit_triage (before any ungated install) → kit_memory → kit_run
+kit_check → kit_fix → kit_triage (before any ungated install) → kit_memory → kit_review (before merging) → kit_run
 ```
 
 ## Tools
@@ -26,6 +26,7 @@ governance floor (revocation, budget, permissions, expired-secret block).
 | Tool | Kind | Purpose |
 | --- | --- | --- |
 | `kit_check` | read | Run all checks — tools, services, secrets, skills, hooks, security, tests, locks — and return the same verdict `kit check` computes. |
+| `kit_review` | read | Full repo audit in one shot — the check, design, standards, and ADR gates as one structured report (`{ ok, failed, stages }`), from the same core `kit review` renders. `concise: true` omits pass/skip rows (per-stage counts stay). |
 | `kit_fix` | write | Auto-fix what `kit_check` found: install missing tools, generate missing lock files. Returns actions taken. |
 | `kit_triage` | write | Security-triage a dependency **before** installing it (`type`: npm/pip/docker/brew/repo/skill + `target`). A PASS is recorded in the triage log the install gates read, so an MCP-run triage satisfies them identically to a CLI-run one. Refuses in read-only mode — an unrecordable pass could not satisfy the gates anyway. |
 | `kit_memory` | read | Search cross-session conversation memory plus the repo's curated shared decisions (`query`, `limit?`, `global?`). Search-only by design: writes stay on the CLI/indexer path so an MCP client can never inject text into the trusted store. Quarantined rows excluded. A missing store returns empty — it is never created by a read. |
@@ -34,7 +35,7 @@ governance floor (revocation, budget, permissions, expired-secret block).
 | `kit_context` | read | Gather project context (stack, services, env status) for the agent. |
 | `kit_map` | read | Repo map: import-neighborhood slice around seed paths (`paths`, `depth?`, `budget?`, `co_change?`). |
 | `kit_init` | write | Detect the stack and generate `.kit.toml` for a project that has none (`dryRun` to preview). |
-| `kit_standards` | read | Run the dev-standards gate and return structured findings. |
+| `kit_standards` | read | **Deprecated — removed from the MCP surface in kit 6.0.** `kit_review` runs this gate as its standards stage; a scoped run (`--category`) goes via `kit_run`. |
 | `kit_env` | read | **Deprecated — removed from the MCP surface in kit 6.0.** Inspect `.env.local` key status (values redacted). Prefer `kit_context`. |
 | `kit_ci` | read | **Deprecated — removed in kit 6.0.** CI runners always have a shell; run `kit ci` there. |
 | `kit_install` | write | **Deprecated — removed in kit 6.0.** Setup-time provisioning happens in a shell (`kit install`), or via `kit_run`. |

--- a/src/check-run.test.ts
+++ b/src/check-run.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runCheckGate, checkRunToJsonChecks, type CheckRunResult } from "./check-run.js";
+
+// runCheckGate is the collection core `kit check`, the MCP `kit_check` tool, and
+// `kit review`'s check stage all share; checkRunToJsonChecks is the one flattening
+// to machine-readable rows. These tests pin the shapes both contracts rest on.
+
+describe("runCheckGate", () => {
+  let tempDir: string;
+  let originalCwd: string;
+  let result: CheckRunResult;
+
+  before(async () => {
+    // The security/test-coverage scanners walk process.cwd() — chdir into an
+    // isolated fixture so the run is about the fixture and stays fast.
+    originalCwd = process.cwd();
+    tempDir = await mkdtemp(join(tmpdir(), "kit-check-run-"));
+    await writeFile(join(tempDir, ".gitignore"), ".env\n.env.local\n.env.*.local\n", "utf-8");
+    await writeFile(
+      join(tempDir, ".kit.toml"),
+      `[secrets.keys]\nAPP_KEY = { source = "config", value = "hello" }\n`,
+      "utf-8",
+    );
+    process.chdir(tempDir);
+    result = await runCheckGate({ cwd: tempDir });
+  });
+
+  after(async () => {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns the verdict and every dimension's raw results", () => {
+    assert.equal(typeof result.ok, "boolean");
+    assert.equal(result.ok, result.verdict.ok);
+    for (const key of [
+      "tools",
+      "services",
+      "skills",
+      "hooks",
+      "security",
+      "tests",
+      "locks",
+    ] as const) {
+      assert.ok(Array.isArray(result[key]), `${key} missing`);
+    }
+    assert.ok("keys" in result.secrets);
+  });
+
+  it("resolves the configured secret exactly like kit check does", () => {
+    assert.equal(result.secrets.keys[0]?.name, "APP_KEY");
+    assert.equal(result.secrets.keys[0]?.available, true);
+    assert.equal(result.verdict.dimensions.secrets, true);
+  });
+});
+
+describe("checkRunToJsonChecks", () => {
+  const base: CheckRunResult = {
+    ok: false,
+    verdict: {
+      ok: false,
+      dimensions: {
+        tools: true,
+        services: false,
+        secrets: true,
+        skills: true,
+        hooks: false,
+        security: true,
+        tests: true,
+        locks: true,
+      },
+      failed: ["services", "hooks"],
+    },
+    tools: [{ name: "node", ok: true, installed: "v22" }],
+    services: [
+      { name: "gh", authenticated: false, informational: true, output: "manual setup" },
+      { name: "vercel", authenticated: false },
+    ],
+    secrets: { templateExists: true, keys: [{ name: "KEY", available: false }] },
+    skills: [{ name: "triage", required: false, installed: false }],
+    hooks: [{ hookName: "pre-commit", installed: true, upToDate: false, detail: "outdated" }],
+    webSearch: null,
+    security: [
+      { category: "secrets", name: "gitleaks", status: "pass", detail: "clean" },
+    ],
+    tests: [{ name: "unit-test coverage", status: "warn", detail: "1 untested" }],
+    locks: [{ category: "skills-lock", exists: true, inSync: true, detail: "in sync" }],
+  } as CheckRunResult;
+
+  it("maps every dimension to rows with the CLI's exact status rules", () => {
+    const rows = checkRunToJsonChecks(base);
+    const byName = Object.fromEntries(rows.map((r) => [r.name, r]));
+    assert.equal(byName["node"].status, "pass");
+    // Informational service (manual setup) warns; a plain unauthenticated one fails.
+    assert.equal(byName["gh"].status, "warn");
+    assert.equal(byName["vercel"].status, "fail");
+    assert.equal(byName["KEY"].status, "fail");
+    // Optional skill missing warns (only required ones fail).
+    assert.equal(byName["triage"].status, "warn");
+    // Installed-but-outdated hook is a warn row even though the verdict dimension is red.
+    assert.equal(byName["pre-commit"].status, "warn");
+    assert.equal(byName["gitleaks"].category, "security/secrets");
+    assert.equal(byName["skills-lock.json"].status, "pass");
+    // webSearch: null contributes no row.
+    assert.equal(rows.length, 9);
+  });
+});

--- a/src/check-run.test.ts
+++ b/src/check-run.test.ts
@@ -84,9 +84,7 @@ describe("checkRunToJsonChecks", () => {
     skills: [{ name: "triage", required: false, installed: false }],
     hooks: [{ hookName: "pre-commit", installed: true, upToDate: false, detail: "outdated" }],
     webSearch: null,
-    security: [
-      { category: "secrets", name: "gitleaks", status: "pass", detail: "clean" },
-    ],
+    security: [{ category: "secrets", name: "gitleaks", status: "pass", detail: "clean" }],
     tests: [{ name: "unit-test coverage", status: "warn", detail: "1 untested" }],
     locks: [{ category: "skills-lock", exists: true, inSync: true, detail: "in sync" }],
   } as CheckRunResult;

--- a/src/check-run.ts
+++ b/src/check-run.ts
@@ -1,0 +1,194 @@
+/**
+ * kit check — the collection core shared by `kit check` (CLI), the MCP `kit_check`
+ * tool, and `kit review`'s check stage (review-run.ts). The verdict rule already
+ * lives in one place (check-verdict.ts); this hoists the other half — WHICH checks
+ * run, in what order, with which baseline handling — so the surfaces can't drift
+ * apart on collection either (same parity discipline as standards-run.ts).
+ *
+ * Pure collection: no printing, no auto-install/self-heal, no PAL sync,
+ * no attestation — those are `kit check`'s own CLI extras and stay in
+ * commands/check.ts. Callers with a progress UI pass `step` to wrap each
+ * dimension (the CLI's spinner); everyone else gets a plain run.
+ */
+import { resolve } from "node:path";
+import { loadConfig, type kitConfig } from "./config.js";
+import { KIT_FILE } from "./cli-shared.js";
+import { checkTools, type ToolStatus } from "./check-tools.js";
+import { checkServices, type ServiceStatus } from "./check-services.js";
+import { checkSecrets, type SecretStatus } from "./check-secrets.js";
+import { checkSkills, type SkillCheckResult } from "./check-skills.js";
+import { checkHooks, isGitRepository, type HookCheckResult } from "./check-hooks.js";
+import { checkWebSearch, type WebSearchStatus } from "./check-web-search.js";
+import { checkSecurity, type SecurityCheckResult, type GateOpts } from "./check-security.js";
+import { checkLockFiles, type LockCheckResult } from "./check-lock.js";
+import { checkTests, type TestCheckResult } from "./check-tests.js";
+import { loadBaselineForGate, baselineGet, BASELINE_FILE } from "./baseline.js";
+import { computeCheckVerdict, type CheckVerdict } from "./check-verdict.js";
+import type { JsonCheck } from "./cli-checks-shared.js";
+
+export interface CheckRunResult {
+  ok: boolean;
+  verdict: CheckVerdict;
+  tools: ToolStatus[];
+  services: ServiceStatus[];
+  secrets: { templateExists: boolean | null; keys: SecretStatus[] };
+  skills: SkillCheckResult[];
+  hooks: HookCheckResult[];
+  webSearch: WebSearchStatus | null;
+  security: SecurityCheckResult[];
+  tests: TestCheckResult[];
+  locks: LockCheckResult[];
+}
+
+export interface RunCheckOptions {
+  cwd?: string;
+  /** Preloaded config (the CLI already has one for governance); else loaded from cwd. */
+  config?: kitConfig;
+  /** Fail (not warn) on untested files — the CLI's --enforce-tests. */
+  enforceTests?: boolean;
+  /** Security gate posture (lenient / fail-on-warning) for the verdict. */
+  gate?: GateOpts;
+  /** Progress hook — the CLI wraps each dimension in a spinner; default runs plain. */
+  step?: <T>(label: string, fn: () => Promise<T>) => Promise<T>;
+}
+
+export async function runCheckGate(opts: RunCheckOptions = {}): Promise<CheckRunResult> {
+  const cwd = opts.cwd ?? process.cwd();
+  const config = opts.config ?? (await loadConfig(resolve(cwd, KIT_FILE)));
+  const step = opts.step ?? (<T>(_label: string, fn: () => Promise<T>): Promise<T> => fn());
+
+  const tools = config.tools ? await step("tools", () => checkTools(config.tools!)) : [];
+  const services = config.services
+    ? await step("services", () => checkServices(config.services!))
+    : [];
+  const secrets = config.secrets
+    ? await step("secrets", () => checkSecrets(config.secrets!))
+    : { templateExists: null, keys: [] };
+  const skills = config.skills ? await step("skills", () => checkSkills(config.skills!)) : [];
+  const hooks =
+    config.hooks && isGitRepository() ? await step("git hooks", () => checkHooks(config.hooks!)) : [];
+  const webSearch = config.web?.search
+    ? await step("web search", () => checkWebSearch(config.web!.search!))
+    : null;
+  const security = await step("security scan", () => checkSecurity());
+  const locks = await step("lock files", () => checkLockFiles(config));
+
+  // Test-coverage is part of the verdict on every surface (omitting it on one
+  // was half of the historical CLI-vs-MCP divergence). Baseline-aware; a
+  // corrupt/tampered baseline is ignored (nothing suppressed) and surfaced as a
+  // finding — fail-closed + visible, never a crash of the gate.
+  const { baseline, ignored: baselineIgnored } = await loadBaselineForGate();
+  if (baselineIgnored) {
+    security.push({
+      category: "secrets",
+      name: "baseline integrity",
+      status: "warn",
+      severity: "low",
+      detail: `${BASELINE_FILE} ignored (${baselineIgnored}) — gating on all findings; re-freeze with 'kit baseline freeze'`,
+    });
+  }
+  const tests = await step("test coverage", () =>
+    checkTests({
+      enforce: opts.enforceTests,
+      baseline: baselineGet(baseline, "tests", "untested_files"),
+    }),
+  );
+
+  const verdict = computeCheckVerdict(
+    {
+      tools,
+      services,
+      secrets: secrets.keys,
+      skills,
+      hooks,
+      security,
+      tests,
+      locks,
+    },
+    opts.gate ?? {},
+  );
+
+  return {
+    ok: verdict.ok,
+    verdict,
+    tools,
+    services,
+    secrets,
+    skills,
+    hooks,
+    webSearch,
+    security,
+    tests,
+    locks,
+  };
+}
+
+/**
+ * Flatten a check run into the machine-readable rows `kit check --json` emits
+ * and `kit review`'s check stage reports — one mapping, so the row shape can't
+ * fork between surfaces.
+ */
+export function checkRunToJsonChecks(r: CheckRunResult): JsonCheck[] {
+  return [
+    ...r.tools.map((t) => ({
+      name: t.name,
+      status: (t.ok ? "pass" : "fail") as JsonCheck["status"],
+      detail: t.installed ? `installed ${t.installed}` : "not installed",
+      category: "tools",
+    })),
+    ...r.services.map((s) => ({
+      name: s.name,
+      status: (s.authenticated ? "pass" : s.informational ? "warn" : "fail") as JsonCheck["status"],
+      detail: s.informational
+        ? s.output || "manual setup (no CLI login)"
+        : (s.output ?? (s.authenticated ? "authenticated" : "not authenticated")),
+      category: "services",
+    })),
+    ...r.secrets.keys.map((s) => ({
+      name: s.name,
+      status: (s.unverified ? "warn" : s.available ? "pass" : "fail") as JsonCheck["status"],
+      detail: s.detail ?? (s.available ? "available" : "missing"),
+      category: "secrets",
+    })),
+    ...r.skills.map((s) => ({
+      name: s.name,
+      status: (s.installed ? "pass" : s.required ? "fail" : "warn") as JsonCheck["status"],
+      detail: s.installed ? "installed" : "not installed",
+      category: "skills",
+    })),
+    ...r.hooks.map((h) => ({
+      name: h.hookName,
+      status: (!h.installed ? "fail" : !h.upToDate ? "warn" : "pass") as JsonCheck["status"],
+      detail: h.detail,
+      category: "hooks",
+    })),
+    ...(r.webSearch
+      ? [
+          {
+            name: r.webSearch.provider,
+            status: (r.webSearch.healthy ? "pass" : "fail") as JsonCheck["status"],
+            detail: r.webSearch.error ?? (r.webSearch.healthy ? "healthy" : "unhealthy"),
+            category: "web-search",
+          },
+        ]
+      : []),
+    ...r.locks.map((l) => ({
+      name: l.category === "skills-lock" ? "skills-lock.json" : "cli-lock.json",
+      status: (l.inSync ? "pass" : l.exists ? "warn" : "fail") as JsonCheck["status"],
+      detail: l.detail,
+      category: "lock",
+    })),
+    ...r.security.map((s) => ({
+      name: s.name,
+      status: s.status,
+      detail: s.detail,
+      category: `security/${s.category}`,
+    })),
+    ...r.tests.map((t) => ({
+      name: t.name,
+      status: t.status,
+      detail: t.detail,
+      category: "tests",
+    })),
+  ];
+}

--- a/src/check-run.ts
+++ b/src/check-run.ts
@@ -66,7 +66,9 @@ export async function runCheckGate(opts: RunCheckOptions = {}): Promise<CheckRun
     : { templateExists: null, keys: [] };
   const skills = config.skills ? await step("skills", () => checkSkills(config.skills!)) : [];
   const hooks =
-    config.hooks && isGitRepository() ? await step("git hooks", () => checkHooks(config.hooks!)) : [];
+    config.hooks && isGitRepository()
+      ? await step("git hooks", () => checkHooks(config.hooks!))
+      : [];
   const webSearch = config.web?.search
     ? await step("web search", () => checkWebSearch(config.web!.search!))
     : null;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -712,7 +712,10 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
   review: {
     handler: cmdReview,
     stability: "stable",
-    help: "Full repo audit — runs check + design + standards in one gate (for agents / PR checks)",
+    help: "Full repo audit — runs check + design + standards + adr in one gate (for agents / PR checks; --json emits one structured report)",
+    // MCP-exposed: THE one-shot audit for shell-less agents (kit_review),
+    // superseding kit_standards on that surface (deprecated, leaves in 6.0).
+    mcp: true,
   },
   adr: {
     handler: cmdAdr,

--- a/src/commands/adr.ts
+++ b/src/commands/adr.ts
@@ -236,27 +236,41 @@ export function freezeAdrBaseline(baseline: Baseline, cwd: string): number {
   return vKeys.length + gKeys.length;
 }
 
+/** Structured result of the ADR gate — what runAdrGate computes and every surface renders. */
+export interface AdrGateResult {
+  ok: boolean;
+  adrCount: number;
+  enforcedCount: number;
+  /** Net-new (not baseline-frozen) violations / unprovable rules. */
+  violations: AdrViolation[];
+  gaps: AdrViolation[];
+  /** How many findings the baseline suppressed. */
+  suppressed: number;
+  baselineIgnored: string | null;
+}
+
 /**
- * The embeddable ADR gate. Loads the baseline (fail-open on a corrupt file — a baseline only
- * ever SUPPRESSES, so an unreadable one gates on everything), suppresses frozen findings, prints,
- * and returns ok. Shared by `kit adr check`, `kit review`, and the pre-commit hook.
+ * The ADR gate core: loads the baseline (fail-open on a corrupt file — a baseline only
+ * ever SUPPRESSES, so an unreadable one gates on everything), suppresses frozen findings,
+ * and returns the structured verdict. No printing — adrCheck (CLI) and `kit review`'s
+ * ADR stage (collectReview) both consume this, so the surfaces can't diverge.
  */
-export async function adrCheck(cwd = process.cwd()): Promise<boolean> {
+export async function runAdrGate(cwd = process.cwd()): Promise<AdrGateResult> {
   const adrs = loadAdrs(cwd);
   if (adrs.length === 0) {
-    console.log(
-      `${c.dim}No ADRs found in ${ADR_DIRS.join(" or ")}. Add one with a --- frontmatter (id/title/status) and a \`\`\`toml kit-enforce block.${c.reset}`,
-    );
-    return true;
+    return {
+      ok: true,
+      adrCount: 0,
+      enforcedCount: 0,
+      violations: [],
+      gaps: [],
+      suppressed: 0,
+      baselineIgnored: null,
+    };
   }
 
-  const { loadBaselineForGate, baselineGet, BASELINE_FILE } = await import("../baseline.js");
+  const { loadBaselineForGate, baselineGet } = await import("../baseline.js");
   const { baseline, ignored } = await loadBaselineForGate(cwd);
-  if (ignored) {
-    console.log(
-      `${c.yellow}!${c.reset} ${BASELINE_FILE} ignored (${ignored}) — gating on all findings`,
-    );
-  }
   const frozen = new Set([
     ...baselineGet(baseline, BASELINE_CATEGORY, "violations"),
     ...baselineGet(baseline, BASELINE_CATEGORY, "gaps"),
@@ -265,6 +279,47 @@ export async function adrCheck(cwd = process.cwd()): Promise<boolean> {
   const { enforcedCount, violations, gaps } = collectAdrFindings(cwd);
   const liveViolations = violations.filter((v) => !frozen.has(adrFindingKey(v)));
   const liveGaps = gaps.filter((v) => !frozen.has(adrFindingKey(v)));
+  const suppressed = violations.length - liveViolations.length + (gaps.length - liveGaps.length);
+  // No enforced ADR ⇒ nothing to gate (documented, not enforced) — ok by definition.
+  const ok = enforcedCount === 0 || (liveViolations.length === 0 && liveGaps.length === 0);
+  return {
+    ok,
+    adrCount: adrs.length,
+    enforcedCount,
+    violations: liveViolations,
+    gaps: liveGaps,
+    suppressed,
+    baselineIgnored: ignored,
+  };
+}
+
+/**
+ * The embeddable ADR gate, rendered. Prints runAdrGate's verdict and returns ok.
+ * Shared by `kit adr check` and the pre-commit hook (`kit review` renders the
+ * structured result itself via collectReview).
+ */
+export async function adrCheck(cwd = process.cwd()): Promise<boolean> {
+  const {
+    ok,
+    adrCount,
+    enforcedCount,
+    violations: liveViolations,
+    gaps: liveGaps,
+    suppressed,
+    baselineIgnored,
+  } = await runAdrGate(cwd);
+  if (adrCount === 0) {
+    console.log(
+      `${c.dim}No ADRs found in ${ADR_DIRS.join(" or ")}. Add one with a --- frontmatter (id/title/status) and a \`\`\`toml kit-enforce block.${c.reset}`,
+    );
+    return true;
+  }
+  if (baselineIgnored) {
+    const { BASELINE_FILE } = await import("../baseline.js");
+    console.log(
+      `${c.yellow}!${c.reset} ${BASELINE_FILE} ignored (${baselineIgnored}) — gating on all findings`,
+    );
+  }
 
   for (const v of liveViolations) {
     console.log(
@@ -283,9 +338,8 @@ export async function adrCheck(cwd = process.cwd()): Promise<boolean> {
     );
     return true;
   }
-  const suppressed = violations.length - liveViolations.length + (gaps.length - liveGaps.length);
   const suffix = suppressed ? ` ${c.dim}(${suppressed} baselined)${c.reset}` : "";
-  if (liveViolations.length === 0 && liveGaps.length === 0) {
+  if (ok) {
     console.log(
       `${c.green}✓ ${enforcedCount} enforced ADR(s) — no new violations${c.reset}${suffix}`,
     );

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -24,14 +24,7 @@ import {
   printSecurityTable,
   printSummary,
 } from "../output.js";
-import { checkTools } from "../check-tools.js";
-import { checkServices } from "../check-services.js";
-import { checkSecrets } from "../check-secrets.js";
-import { checkSkills } from "../check-skills.js";
-import { checkHooks, isGitRepository } from "../check-hooks.js";
-import { checkWebSearch } from "../check-web-search.js";
-import { checkSecurity } from "../check-security.js";
-import { checkLockFiles } from "../check-lock.js";
+import { runCheckGate, checkRunToJsonChecks } from "../check-run.js";
 import { syncSecurityFindings } from "../findings-track.js";
 import { collectHints } from "../hints.js";
 import {
@@ -73,69 +66,29 @@ export async function cmdCheck(): Promise<boolean> {
       const step = <T>(label: string, fn: () => Promise<T>): Promise<T> =>
         live ? runStep(label, fn) : fn();
 
-      const toolResults = config.tools ? await step("tools", () => checkTools(config.tools!)) : [];
-      const serviceResults = config.services
-        ? await step("services", () => checkServices(config.services!))
-        : [];
-      const secretResults = config.secrets
-        ? await step("secrets", () => checkSecrets(config.secrets!))
-        : { templateExists: null, keys: [] };
-      const skillResults = config.skills
-        ? await step("skills", () => checkSkills(config.skills!))
-        : [];
-      const hookResults =
-        config.hooks && isGitRepository()
-          ? await step("git hooks", () => checkHooks(config.hooks!))
-          : [];
-      const webSearchResult = config.web?.search
-        ? await step("web search", () => checkWebSearch(config.web!.search!))
-        : null;
       await autoInstallScanners(config, live); // self-heal missing scanners before scanning
-      const securityResults = await step("security scan", () => checkSecurity());
-      const lockResults = await step("lock files", () => checkLockFiles(config));
-
-      // Test-coverage enforcement (--enforce-tests CLI flag overrides config).
-      // Baseline-aware: pre-existing untested files only warn; net-new fail.
-      const { checkTests } = await import("../check-tests.js");
-      const { loadBaselineForGate, baselineGet, BASELINE_FILE } = await import("../baseline.js");
-      const { baseline, ignored: baselineIgnored } = await loadBaselineForGate();
-      if (baselineIgnored) {
-        // Fail-closed + visible: a corrupt/tampered baseline is ignored (nothing
-        // suppressed) and surfaced as a finding, never a crash of the gate.
-        securityResults.push({
-          category: "secrets",
-          name: "baseline integrity",
-          status: "warn",
-          severity: "low",
-          detail: `${BASELINE_FILE} ignored (${baselineIgnored}) — gating on all findings; re-freeze with 'kit baseline freeze'`,
-        });
-      }
-      const testResults = await step("test coverage", () =>
-        checkTests({
-          enforce: enforceTests,
-          baseline: baselineGet(baseline, "tests", "untested_files"),
-        }),
-      );
-
-      // Single source of truth for the green/ok verdict — the SAME function the
-      // MCP `kit_check` tool uses, so the two surfaces can never disagree. Applies
-      // scanner-health-strict security gating, the informational-service exemption,
-      // and test-coverage in one place.
-      const { computeCheckVerdict } = await import("../check-verdict.js");
-      const verdict = computeCheckVerdict(
-        {
-          tools: toolResults,
-          services: serviceResults,
-          secrets: secretResults.keys,
-          skills: skillResults,
-          hooks: hookResults,
-          security: securityResults,
-          tests: testResults,
-          locks: lockResults,
-        },
-        { lenient, failOnWarning },
-      );
-      const allOk = verdict.ok;
+      // Collection + verdict live in the shared core (check-run.ts) — the SAME
+      // path the MCP `kit_check` tool and `kit review` use, so the surfaces can
+      // never disagree on what runs or what "green" means. The CLI adds its
+      // extras around it: spinners (step), PAL sync, attestation, hints.
+      const run = await runCheckGate({
+        config,
+        enforceTests,
+        gate: { lenient, failOnWarning },
+        step,
+      });
+      const {
+        tools: toolResults,
+        services: serviceResults,
+        secrets: secretResults,
+        skills: skillResults,
+        hooks: hookResults,
+        webSearch: webSearchResult,
+        security: securityResults,
+        tests: testResults,
+        locks: lockResults,
+      } = run;
+      const allOk = run.ok;
 
       // Track security findings in the PAL ledger (cross-session reminders +
       // auto-close on a clean re-scan). Opt out with [memory] track_findings = false.
@@ -150,73 +103,8 @@ export async function cmdCheck(): Promise<boolean> {
       }
 
       if (jsonMode) {
-        const checks: JsonCheck[] = [
-          ...toolResults.map((t) => ({
-            name: t.name,
-            status: (t.ok ? "pass" : "fail") as JsonCheck["status"],
-            detail: t.installed ? `installed ${t.installed}` : "not installed",
-            category: "tools",
-          })),
-          ...serviceResults.map((s) => ({
-            name: s.name,
-            status: (s.authenticated
-              ? "pass"
-              : s.informational
-                ? "warn"
-                : "fail") as JsonCheck["status"],
-            detail: s.informational
-              ? s.output || "manual setup (no CLI login)"
-              : (s.output ?? (s.authenticated ? "authenticated" : "not authenticated")),
-            category: "services",
-          })),
-          ...secretResults.keys.map((s) => ({
-            name: s.name,
-            status: (s.unverified ? "warn" : s.available ? "pass" : "fail") as JsonCheck["status"],
-            detail: s.detail ?? (s.available ? "available" : "missing"),
-            category: "secrets",
-          })),
-          ...skillResults.map((s) => ({
-            name: s.name,
-            status: (s.installed ? "pass" : s.required ? "fail" : "warn") as JsonCheck["status"],
-            detail: s.installed ? "installed" : "not installed",
-            category: "skills",
-          })),
-          ...hookResults.map((h) => ({
-            name: h.hookName,
-            status: (!h.installed ? "fail" : !h.upToDate ? "warn" : "pass") as JsonCheck["status"],
-            detail: h.detail,
-            category: "hooks",
-          })),
-          ...(webSearchResult
-            ? [
-                {
-                  name: webSearchResult.provider,
-                  status: (webSearchResult.healthy ? "pass" : "fail") as JsonCheck["status"],
-                  detail:
-                    webSearchResult.error ?? (webSearchResult.healthy ? "healthy" : "unhealthy"),
-                  category: "web-search",
-                },
-              ]
-            : []),
-          ...lockResults.map((l) => ({
-            name: l.category === "skills-lock" ? "skills-lock.json" : "cli-lock.json",
-            status: (l.inSync ? "pass" : l.exists ? "warn" : "fail") as JsonCheck["status"],
-            detail: l.detail,
-            category: "lock",
-          })),
-          ...securityResults.map((s) => ({
-            name: s.name,
-            status: s.status,
-            detail: s.detail,
-            category: `security/${s.category}`,
-          })),
-          ...testResults.map((t) => ({
-            name: t.name,
-            status: t.status,
-            detail: t.detail,
-            category: "tests",
-          })),
-        ];
+        // One flattening, shared with `kit review`'s check stage (check-run.ts).
+        const checks: JsonCheck[] = checkRunToJsonChecks(run);
 
         const summary = checks.reduce(
           (acc, c) => {

--- a/src/commands/design.ts
+++ b/src/commands/design.ts
@@ -1,10 +1,35 @@
 /**
  * `kit design` command — extracted from cli.ts (5.0-alpha god-module split).
- * Self-contained (a11y + design-token consistency, baseline-aware). cmdReview
- * (still in cli.ts) calls the exported cmdDesign. Imports only sibling core modules.
+ * Self-contained (a11y + design-token consistency, baseline-aware). runDesignGate
+ * is the structured core; cmdDesign renders it, and `kit review`'s design stage
+ * (collectReview) consumes it directly — same parity discipline as standards-run.
  */
 import { c } from "../utils/colors.js";
 import { hasFlag } from "../utils/flags.js";
+import type { DesignCheckResult } from "../check-design.js";
+
+export interface DesignRunResult {
+  ok: boolean;
+  checks: DesignCheckResult[];
+  baselineIgnored: string | null;
+}
+
+/** The design gate core: baseline-aware a11y + design-token checks, no printing. */
+export async function runDesignGate(
+  opts: { cwd?: string; enforce?: boolean } = {},
+): Promise<DesignRunResult> {
+  const { checkDesign } = await import("../check-design.js");
+  const { loadBaselineForGate, baselineGet } = await import("../baseline.js");
+  const { baseline, ignored } = await loadBaselineForGate(opts.cwd);
+  const checks = await checkDesign({
+    enforce: opts.enforce,
+    baseline: {
+      a11y: baselineGet(baseline, "design", "a11y"),
+      tokens: baselineGet(baseline, "design", "tokens"),
+    },
+  });
+  return { ok: checks.every((r) => r.status !== "fail"), checks, baselineIgnored: ignored };
+}
 
 /**
  * `kit design` — a11y + design-token consistency, baseline-aware.
@@ -12,26 +37,16 @@ import { hasFlag } from "../utils/flags.js";
 export async function cmdDesign(): Promise<boolean> {
   const enforce = hasFlag(process.argv, "--enforce");
   const jsonMode = hasFlag(process.argv, "--json");
-  const { checkDesign } = await import("../check-design.js");
-  const { loadBaselineForGate, baselineGet, BASELINE_FILE } = await import("../baseline.js");
-  const { baseline, ignored: baselineIgnored } = await loadBaselineForGate();
+  const { ok, checks: results, baselineIgnored } = await runDesignGate({ enforce });
   if (baselineIgnored) {
+    const { BASELINE_FILE } = await import("../baseline.js");
     console.error(
       `${c.yellow}!${c.reset} ${BASELINE_FILE} ignored (${baselineIgnored}) — gating on all findings`,
     );
   }
-  const results = await checkDesign({
-    enforce,
-    baseline: {
-      a11y: baselineGet(baseline, "design", "a11y"),
-      tokens: baselineGet(baseline, "design", "tokens"),
-    },
-  });
   if (jsonMode) {
-    console.log(
-      JSON.stringify({ ok: results.every((r) => r.status !== "fail"), checks: results }, null, 2),
-    );
-    return results.every((r) => r.status !== "fail");
+    console.log(JSON.stringify({ ok, checks: results }, null, 2));
+    return ok;
   }
   console.log(`${c.bold}Design${c.reset}`);
   for (const r of results) {
@@ -46,5 +61,5 @@ export async function cmdDesign(): Promise<boolean> {
     console.log(`  ${icon} ${r.name}  ${c.dim}${r.detail}${c.reset}`);
     if (r.files) for (const f of r.files) console.log(`      ${c.dim}- ${f}${c.reset}`);
   }
-  return results.every((r) => r.status !== "fail");
+  return ok;
 }

--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { collectReview, type ReviewReport } from "./review.js";
+
+// collectReview is the single core BOTH `kit review` (CLI renderer) and the MCP
+// `kit_review` tool consume — these tests pin the report contract that keeps the
+// two surfaces honest: stage order, per-stage summaries, and verdict aggregation.
+describe("collectReview", () => {
+  let tempDir: string;
+  let originalCwd: string;
+  let report: ReviewReport;
+
+  before(async () => {
+    // The underlying scanners (design/a11y, standards, security) walk
+    // process.cwd() — chdir into an isolated fixture so the report is about
+    // the fixture, not this repo, and the run stays fast.
+    originalCwd = process.cwd();
+    tempDir = await mkdtemp(join(tmpdir(), "kit-review-"));
+    await writeFile(join(tempDir, ".gitignore"), ".env\n.env.local\n.env.*.local\n", "utf-8");
+    await writeFile(join(tempDir, ".kit.toml"), "# empty kit config\n", "utf-8");
+    process.chdir(tempDir);
+    report = await collectReview({ cwd: tempDir });
+  });
+
+  after(async () => {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns the four stages in the order the CLI always ran them", () => {
+    assert.deepEqual(
+      report.stages.map((s) => s.stage),
+      ["check", "design", "standards", "adr"],
+    );
+  });
+
+  it("every stage summary counts exactly its findings", () => {
+    for (const s of report.stages) {
+      const counts = { pass: 0, fail: 0, warn: 0, skip: 0 };
+      for (const f of s.findings) counts[f.status]++;
+      assert.deepEqual(s.summary, counts, `${s.stage} summary drifted from its findings`);
+    }
+  });
+
+  it("ok aggregates the stage verdicts and failed names exactly the red stages", () => {
+    assert.equal(
+      report.ok,
+      report.stages.every((s) => s.ok),
+    );
+    assert.deepEqual(
+      report.failed,
+      report.stages.filter((s) => !s.ok).map((s) => s.stage),
+    );
+  });
+
+  it("adr stage is an explicit skip — never a silent pass — when the repo has no ADRs", () => {
+    const adr = report.stages.find((s) => s.stage === "adr")!;
+    assert.equal(adr.ok, true);
+    assert.equal(adr.findings.length, 1);
+    assert.equal(adr.findings[0].status, "skip");
+    assert.match(adr.findings[0].detail, /no ADRs found/);
+  });
+
+  it("design stage skips (not fails) in a repo without component files", () => {
+    const design = report.stages.find((s) => s.stage === "design")!;
+    assert.equal(design.ok, true);
+    assert.ok(design.findings.every((f) => f.status !== "fail"));
+  });
+});

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -1,41 +1,199 @@
 /**
- * `kit review` — meta-runner: check + design + standards in one shot.
- * Convenient single-command gate for AI agents and PR checks. Extracted from
- * cli.ts (5.0-alpha god-module split); orchestrates the now-extracted check,
- * design, and standards clusters, so it moves out only after they do.
+ * `kit review` — meta-runner: check + design + standards + ADR in one shot.
+ * Convenient single-command gate for AI agents and PR checks.
+ *
+ * collectReview is the structured core: it runs every stage's shared gate
+ * (check-run, design, standards-run, adr) and returns one ReviewReport.
+ * cmdReview is a renderer on top; the MCP `kit_review` tool serializes the
+ * same report — the computeCheckVerdict pattern, so the CLI and MCP surfaces
+ * can never diverge on what a review runs or what "green" means.
+ *
+ * Pure read: no PAL sync, attestation, hints, or scanner self-heal — those are
+ * `kit check`'s own CLI extras. `kit review` is the gate, not the fixer.
  */
 import { c } from "../utils/colors.js";
-import { hasFlag } from "../utils/flags.js";
-import { cmdCheck } from "./check.js";
-import { cmdDesign } from "./design.js";
-import { cmdStandards } from "./standards.js";
-import { adrCheck } from "./adr.js";
+import { hasFlag, envTruthy } from "../utils/flags.js";
+import { loadConfig, type kitConfig } from "../config.js";
+import { resolveConfigPath } from "../cli-shared.js";
+import { withGovernance } from "../governance-middleware.js";
+import { runCheckGate, checkRunToJsonChecks } from "../check-run.js";
+import { runStandardsGate } from "../standards-run.js";
+import { runDesignGate } from "./design.js";
+import { runAdrGate } from "./adr.js";
+import type { JsonCheck } from "../cli-checks-shared.js";
+import type { GateOpts } from "../check-security.js";
+
+export type ReviewStageName = "check" | "design" | "standards" | "adr";
+
+export interface ReviewStageReport {
+  stage: ReviewStageName;
+  /** The stage gate's own verdict — authoritative. Findings are presentation:
+   *  a stage can be red on a warn-level row (e.g. an outdated hook), so do not
+   *  re-derive ok from finding statuses. */
+  ok: boolean;
+  summary: { pass: number; fail: number; warn: number; skip: number };
+  findings: JsonCheck[];
+}
+
+export interface ReviewReport {
+  ok: boolean;
+  /** The stages that are NOT ok — for a precise "red because: …" message. */
+  failed: ReviewStageName[];
+  stages: ReviewStageReport[];
+}
+
+export interface CollectReviewOptions {
+  cwd?: string;
+  /** Preloaded config for the check stage (the CLI already has one for governance). */
+  config?: kitConfig;
+  /** Fail (not warn) on net-new design/standards findings and setup gaps (CI posture). */
+  enforce?: boolean;
+  /** Fail (not warn) on untested files — `--enforce-tests`. */
+  enforceTests?: boolean;
+  /** Security gate posture (lenient / fail-on-warning) for the check stage. */
+  gate?: GateOpts;
+}
+
+function summarize(findings: JsonCheck[]): ReviewStageReport["summary"] {
+  const summary = { pass: 0, fail: 0, warn: 0, skip: 0 };
+  for (const f of findings) summary[f.status]++;
+  return summary;
+}
+
+function stageReport(stage: ReviewStageName, ok: boolean, findings: JsonCheck[]): ReviewStageReport {
+  return { stage, ok, summary: summarize(findings), findings };
+}
+
+/** ADR gate result → review findings (one row per live violation/gap, or one summary row). */
+function adrFindings(adr: Awaited<ReturnType<typeof runAdrGate>>): JsonCheck[] {
+  if (adr.adrCount === 0) {
+    return [
+      {
+        name: "adr",
+        status: "skip",
+        detail: "no ADRs found in docs/adr or docs/decisions",
+        category: "adr",
+      },
+    ];
+  }
+  if (adr.enforcedCount === 0) {
+    return [
+      {
+        name: "adr",
+        status: "skip",
+        detail: `${adr.adrCount} ADR(s), none carries an enforce block — documented, not enforced`,
+        category: "adr",
+      },
+    ];
+  }
+  const rows: JsonCheck[] = [
+    ...adr.violations.map((v) => ({
+      name: v.adrId,
+      status: "fail" as const,
+      detail: `${v.file}:${v.line} ${v.message}`,
+      category: "adr",
+    })),
+    ...adr.gaps.map((v) => ({
+      name: v.adrId,
+      status: "warn" as const,
+      detail: `${v.file}:${v.line} ${v.message} (unprovable — unresolved import)`,
+      category: "adr",
+    })),
+  ];
+  if (rows.length === 0) {
+    rows.push({
+      name: "adr",
+      status: "pass",
+      detail:
+        `${adr.enforcedCount} enforced ADR(s) — no new violations` +
+        (adr.suppressed ? ` (${adr.suppressed} baselined)` : ""),
+      category: "adr",
+    });
+  }
+  return rows;
+}
+
+/**
+ * Run every review stage and return the structured report. Read-only; stages run
+ * in the order the CLI always ran them (check → design → standards → adr).
+ */
+export async function collectReview(opts: CollectReviewOptions = {}): Promise<ReviewReport> {
+  const check = await runCheckGate({
+    cwd: opts.cwd,
+    config: opts.config,
+    enforceTests: opts.enforceTests,
+    gate: opts.gate,
+  });
+  const design = await runDesignGate({ cwd: opts.cwd, enforce: opts.enforce });
+  const standards = await runStandardsGate({ cwd: opts.cwd, enforce: opts.enforce });
+  const adr = await runAdrGate(opts.cwd ?? process.cwd());
+
+  const stages: ReviewStageReport[] = [
+    stageReport("check", check.ok, checkRunToJsonChecks(check)),
+    stageReport("design", design.ok, design.checks),
+    stageReport("standards", standards.ok, standards.checks),
+    stageReport("adr", adr.ok, adrFindings(adr)),
+  ];
+  const failed = stages.filter((s) => !s.ok).map((s) => s.stage);
+  return { ok: failed.length === 0, failed, stages };
+}
+
+const ICON: Record<JsonCheck["status"], string> = {
+  pass: `${c.green}✓${c.reset}`,
+  fail: `${c.red}✗${c.reset}`,
+  warn: `${c.yellow}!${c.reset}`,
+  skip: `${c.dim}-${c.reset}`,
+};
 
 export async function cmdReview(): Promise<boolean> {
   const jsonMode = hasFlag(process.argv, "--json");
-  let allOk = true;
-  if (!jsonMode) console.log(`${c.bold}kit review${c.reset} — full repo audit\n`);
+  const enforce = hasFlag(process.argv, "--enforce");
+  const enforceTests = hasFlag(process.argv, "--enforce-tests");
+  const lenient = hasFlag(process.argv, "--lenient") || envTruthy(process.env.KIT_CI_LENIENT);
+  const failOnWarning =
+    hasFlag(process.argv, "--fail-on-warning") ||
+    hasFlag(process.argv, "--strict") ||
+    envTruthy(process.env.KIT_CI_STRICT);
+  const config = await loadConfig(resolveConfigPath());
 
-  if (!jsonMode) console.log(`${c.bold}=== check ===${c.reset}`);
-  const checkOk = await cmdCheck();
-  if (!checkOk) allOk = false;
+  return await withGovernance(
+    config,
+    { operation: "review", operationType: "read", metadata: {} },
+    async () => {
+      if (!jsonMode) console.log(`${c.bold}kit review${c.reset} — full repo audit\n`);
+      const report = await collectReview({
+        config,
+        enforce,
+        enforceTests,
+        gate: { lenient, failOnWarning },
+      });
 
-  if (!jsonMode) console.log(`\n${c.bold}=== design ===${c.reset}`);
-  const designOk = await cmdDesign();
-  if (!designOk) allOk = false;
+      if (jsonMode) {
+        console.log(JSON.stringify(report, null, 2));
+        return report.ok;
+      }
 
-  if (!jsonMode) console.log(`\n${c.bold}=== standards ===${c.reset}`);
-  const standardsOk = await cmdStandards();
-  if (!standardsOk) allOk = false;
+      for (const stage of report.stages) {
+        console.log(`${c.bold}=== ${stage.stage} ===${c.reset}`);
+        for (const f of stage.findings) {
+          console.log(`  ${ICON[f.status]} ${f.name}  ${c.dim}${f.detail}${c.reset}`);
+          if (f.files) for (const file of f.files) console.log(`      ${c.dim}- ${file}${c.reset}`);
+        }
+        const s = stage.summary;
+        const verdict = stage.ok ? `${c.green}✓ ok${c.reset}` : `${c.red}✗ failed${c.reset}`;
+        console.log(
+          `  ${verdict} ${c.dim}(${s.pass} pass · ${s.fail} fail · ${s.warn} warn · ${s.skip} skip)${c.reset}\n`,
+        );
+      }
 
-  if (!jsonMode) console.log(`\n${c.bold}=== adr ===${c.reset}`);
-  const adrOk = await adrCheck();
-  if (!adrOk) allOk = false;
-
-  if (!jsonMode) {
-    console.log(
-      `\n${c.bold}${allOk ? `${c.green}✓ review passed` : `${c.red}✗ review failed`}${c.reset}`,
-    );
-  }
-  return allOk;
+      console.log(
+        `${c.bold}${
+          report.ok
+            ? `${c.green}✓ review passed`
+            : `${c.red}✗ review failed — ${report.failed.join(", ")}`
+        }${c.reset}`,
+      );
+      return report.ok;
+    },
+  );
 }

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -60,7 +60,11 @@ function summarize(findings: JsonCheck[]): ReviewStageReport["summary"] {
   return summary;
 }
 
-function stageReport(stage: ReviewStageName, ok: boolean, findings: JsonCheck[]): ReviewStageReport {
+function stageReport(
+  stage: ReviewStageName,
+  ok: boolean,
+  findings: JsonCheck[],
+): ReviewStageReport {
   return { stage, ok, summary: summarize(findings), findings };
 }
 

--- a/src/commands/standards.ts
+++ b/src/commands/standards.ts
@@ -1,8 +1,7 @@
 /**
  * `kit standards` + `kit baseline` commands — extracted from cli.ts (5.0-alpha
  * god-module split). freezeStandardsBaseline is shared by `standards freeze` and
- * `baseline freeze` (both here), so it stays module-private. cmdReview stays in
- * cli.ts (it orchestrates cmdCheck + cmdDesign, still inline). Imports only
+ * `baseline freeze` (both here), so it stays module-private. Imports only
  * sibling core modules.
  */
 import { c } from "../utils/colors.js";

--- a/src/docs-mcp-sync.test.ts
+++ b/src/docs-mcp-sync.test.ts
@@ -64,7 +64,14 @@ describe("docs ↔ MCP surface", () => {
     // The six 6.0 removals must carry a deprecation marker in the reference,
     // and no non-deprecated tool may. When 6.0 removes them, the first
     // assertion's tool list shrinks and this stays green by construction.
-    const DEPRECATED = ["kit_env", "kit_ci", "kit_install", "kit_login", "kit_add", "kit_standards"];
+    const DEPRECATED = [
+      "kit_env",
+      "kit_ci",
+      "kit_install",
+      "kit_login",
+      "kit_add",
+      "kit_standards",
+    ];
     const ref = DOCS[0].text;
     const rows = ref.split("\n").filter((l) => l.startsWith("| `kit_"));
     for (const row of rows) {

--- a/src/docs-mcp-sync.test.ts
+++ b/src/docs-mcp-sync.test.ts
@@ -61,10 +61,10 @@ describe("docs ↔ MCP surface", () => {
   });
 
   it("the reference marks exactly the deprecated tools as deprecated", () => {
-    // The five 6.0 removals must carry a deprecation marker in the reference,
+    // The six 6.0 removals must carry a deprecation marker in the reference,
     // and no non-deprecated tool may. When 6.0 removes them, the first
     // assertion's tool list shrinks and this stays green by construction.
-    const DEPRECATED = ["kit_env", "kit_ci", "kit_install", "kit_login", "kit_add"];
+    const DEPRECATED = ["kit_env", "kit_ci", "kit_install", "kit_login", "kit_add", "kit_standards"];
     const ref = DOCS[0].text;
     const rows = ref.split("\n").filter((l) => l.startsWith("| `kit_"));
     for (const row of rows) {

--- a/src/mcp-server.test.ts
+++ b/src/mcp-server.test.ts
@@ -69,6 +69,7 @@ describe("MCP server tool registration", () => {
       const { tools } = await client.listTools();
       const names = tools.map((t) => t.name);
       assert.ok(names.includes("kit_check"), "kit_check missing");
+      assert.ok(names.includes("kit_review"), "kit_review missing");
       assert.ok(names.includes("kit_standards"), "kit_standards missing");
       assert.ok(names.includes("kit_install"), "kit_install missing");
       assert.ok(names.includes("kit_login"), "kit_login missing");
@@ -83,7 +84,7 @@ describe("MCP server tool registration", () => {
       assert.ok(names.includes("kit_map"), "kit_map missing");
       assert.ok(names.includes("kit_triage"), "kit_triage missing");
       assert.ok(names.includes("kit_memory"), "kit_memory missing");
-      assert.equal(tools.length, 15);
+      assert.equal(tools.length, 16);
     } finally {
       await cleanup();
     }
@@ -185,6 +186,81 @@ describe("kit_check", () => {
       assert.ok("secrets" in data);
       assert.ok("security" in data);
       assert.ok("locks" in data);
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
+// ─── kit_review ──────────────────────────────────────────────────────────────
+
+describe("kit_review", () => {
+  let tempDir: string;
+  let originalCwd: string;
+
+  // Review's underlying scanners (design/standards/security) walk process.cwd()
+  // — chdir into an isolated fixture so the audit covers the fixture, not this
+  // repo (same isolation pattern as the kit_fix suite).
+  before(async () => {
+    originalCwd = process.cwd();
+    tempDir = await mkdtemp(join(tmpdir(), "kit-mcp-review-"));
+    await writeFile(join(tempDir, ".gitignore"), GITIGNORE, "utf-8");
+    await writeFile(join(tempDir, ".kit.toml"), FIXTURE_EMPTY, "utf-8");
+    process.chdir(tempDir);
+  });
+
+  after(async () => {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns the structured report: ok, failed, and the four stages in order", async () => {
+    const { client, cleanup } = await createTestClient();
+    try {
+      const result = await client.callTool({ name: "kit_review", arguments: { cwd: tempDir } });
+      const data = parseResult(result) as {
+        ok: boolean;
+        failed: string[];
+        stages: Array<{ stage: string; ok: boolean; summary: Record<string, number> }>;
+      };
+      assert.ok("ok" in data);
+      assert.ok(Array.isArray(data.failed));
+      assert.deepEqual(
+        data.stages.map((s) => s.stage),
+        ["check", "design", "standards", "adr"],
+      );
+      assert.equal(
+        data.ok,
+        data.stages.every((s) => s.ok),
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("concise:true strips pass/skip rows but keeps the per-stage counts honest", async () => {
+    const { client, cleanup } = await createTestClient();
+    try {
+      const result = await client.callTool({
+        name: "kit_review",
+        arguments: { cwd: tempDir, concise: true },
+      });
+      const data = parseResult(result) as {
+        stages: Array<{
+          stage: string;
+          findings: Array<{ status: string }>;
+          summary: { pass: number; fail: number; warn: number; skip: number };
+        }>;
+      };
+      for (const s of data.stages) {
+        assert.ok(
+          s.findings.every((f) => f.status === "fail" || f.status === "warn"),
+          `${s.stage}: concise mode leaked a ${s.findings.find((f) => f.status !== "fail" && f.status !== "warn")?.status} row`,
+        );
+        // The summary still covers the dropped rows — nothing silently truncated.
+        assert.ok("pass" in s.summary && "skip" in s.summary);
+        assert.equal(s.findings.length, s.summary.fail + s.summary.warn);
+      }
     } finally {
       await cleanup();
     }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -9,14 +9,10 @@ import { checkSecrets } from "./check-secrets.js";
 import { checkSecurity } from "./check-security.js";
 import { checkSkills } from "./check-skills.js";
 import { checkLockFiles } from "./check-lock.js";
-import { checkTests } from "./check-tests.js";
-import { loadBaselineForGate, baselineGet, BASELINE_FILE } from "./baseline.js";
-import { computeCheckVerdict } from "./check-verdict.js";
+import { runCheckGate } from "./check-run.js";
 import { installTools } from "./install.js";
 import { loginServices } from "./login.js";
 import { generateSecrets } from "./secrets.js";
-import { checkWebSearch } from "./check-web-search.js";
-import { checkHooks, isGitRepository } from "./check-hooks.js";
 import {
   readSkillsLock,
   readCliLock,
@@ -52,6 +48,7 @@ const KIT_FILE = ".kit.toml";
 // this list, so the snapshot can never silently drift.
 export const KIT_MCP_TOOLS: readonly string[] = [
   "kit_check",
+  "kit_review",
   "kit_standards",
   "kit_install",
   "kit_login",
@@ -80,7 +77,7 @@ const KIT_MCP_INSTRUCTIONS = `kit is a deterministic, local-first dev-environmen
 
 If you have shell access, prefer running \`kit <command>\` directly — the CLI covers far more than these tools and \`kit <command> --help\` documents everything. These MCP tools exist for shell-less clients.
 
-Typical loop: kit_check (verify env + security) → kit_fix (auto-repair) → kit_triage (REQUIRED before installing any package kit's gate has not already cleared — the gate blocks untriaged installs) → kit_memory (recall prior cross-session decisions before answering project-specific questions) → kit_run (escape hatch for any other kit command).`;
+Typical loop: kit_check (verify env + security) → kit_fix (auto-repair) → kit_triage (REQUIRED before installing any package kit's gate has not already cleared — the gate blocks untriaged installs) → kit_memory (recall prior cross-session decisions before answering project-specific questions) → kit_review (full audit — check + design + standards + ADR — before merging) → kit_run (escape hatch for any other kit command).`;
 
 // Deprecation prefix for tools scheduled for removal from the MCP surface in
 // kit 6.0 (the MCP surface is "Evolving" per docs/API_STABILITY_AND_VERSIONING.md
@@ -146,6 +143,7 @@ export function createMcpServer(): McpServer {
   // One registrar per tool — keeps this composition flat (was a 774-line
   // function). Each register_* attaches its tool to the server.
   register_kit_check(server);
+  register_kit_review(server);
   register_kit_standards(server);
   register_kit_install(server);
   register_kit_login(server);
@@ -171,79 +169,34 @@ export async function startMcpServer(): Promise<void> {
 }
 
 function register_kit_check(server: McpServer): void {
-  // kit_check — run all checks, return structured JSON
+  // kit_check — run all checks, return structured JSON. Collection + verdict come
+  // from the shared core (check-run.ts) — the SAME path `kit check` runs, so the
+  // two surfaces can never disagree on what runs or what "green" means.
   server.tool(
     "kit_check",
     "Run kit check and return structured status for all tools, services, secrets, and security checks.",
     { cwd: z.string().optional().describe("Working directory (defaults to process.cwd())") },
     async ({ cwd }) => {
       try {
-        const config = await loadConfig(configPath(cwd));
-
-        const toolResults = config.tools ? await checkTools(config.tools) : [];
-        const serviceResults = config.services ? await checkServices(config.services) : [];
-        const secretResults = config.secrets
-          ? await checkSecrets(config.secrets)
-          : { templateExists: null, keys: [] };
-        const skillResults = config.skills ? await checkSkills(config.skills) : [];
-        const hookResults = config.hooks && isGitRepository() ? await checkHooks(config.hooks) : [];
-        const webSearchResult = config.web?.search ? await checkWebSearch(config.web.search) : null;
-        const securityResults = await checkSecurity();
-        const lockResults = await checkLockFiles(config);
-        // Include test-coverage in the verdict — the CLI does, and omitting it here
-        // was one half of the CLI-vs-MCP divergence. Baseline-aware, same as `kit check`.
-        const { baseline, ignored: baselineIgnored } = await loadBaselineForGate();
-        if (baselineIgnored) {
-          // Same fail-closed baseline handling as `kit check` — parity so the two
-          // surfaces never disagree on the verdict.
-          securityResults.push({
-            category: "secrets",
-            name: "baseline integrity",
-            status: "warn",
-            severity: "low",
-            detail: `${BASELINE_FILE} ignored (${baselineIgnored}) — gating on all findings; re-freeze with 'kit baseline freeze'`,
-          });
-        }
-        const testResults = await checkTests({
-          baseline: baselineGet(baseline, "tests", "untested_files"),
-        });
-
-        // The SAME verdict rule `kit check` uses (scanner-health-strict security via
-        // gateStatus, informational-service exemption, tests) — no second, divergent
-        // definition of "green" on the MCP surface.
-        const verdict = computeCheckVerdict(
-          {
-            tools: toolResults,
-            services: serviceResults,
-            secrets: secretResults.keys,
-            skills: skillResults,
-            hooks: hookResults,
-            security: securityResults,
-            tests: testResults,
-            locks: lockResults,
-          },
-          {},
-        );
-        const ok = verdict.ok;
-
+        const r = await runCheckGate({ cwd });
         return {
           content: [
             {
               type: "text" as const,
               text: JSON.stringify(
                 {
-                  ok,
-                  dimensions: verdict.dimensions,
-                  failed: verdict.failed,
-                  tools: toolResults,
-                  services: serviceResults,
-                  secrets: secretResults.keys,
-                  skills: skillResults,
-                  hooks: hookResults,
-                  webSearch: webSearchResult,
-                  security: securityResults,
-                  tests: testResults,
-                  locks: lockResults,
+                  ok: r.ok,
+                  dimensions: r.verdict.dimensions,
+                  failed: r.verdict.failed,
+                  tools: r.tools,
+                  services: r.services,
+                  secrets: r.secrets.keys,
+                  skills: r.skills,
+                  hooks: r.hooks,
+                  webSearch: r.webSearch,
+                  security: r.security,
+                  tests: r.tests,
+                  locks: r.locks,
                 },
                 null,
                 2,
@@ -261,13 +214,62 @@ function register_kit_check(server: McpServer): void {
   );
 }
 
+function register_kit_review(server: McpServer): void {
+  // kit_review — the full repo audit (check + design + standards + ADR) as ONE
+  // structured report, via the same collectReview core `kit review` renders.
+  // Replaces kit_standards on the MCP surface (that stage is one of its four).
+  // Read-only: no writes, so no governance/read-only gating.
+  server.tool(
+    "kit_review",
+    "Full repo audit in one shot — runs the check, design, standards, and ADR gates and returns one structured report ({ ok, failed, stages }). The same core `kit review` renders, so the surfaces cannot disagree. Read-only. Use concise:true to omit pass/skip rows (per-stage counts stay).",
+    {
+      cwd: z.string().optional().describe("Working directory (defaults to process.cwd())"),
+      enforce: z
+        .boolean()
+        .optional()
+        .describe("Fail on net-new design/standards findings AND setup gaps (CI posture)"),
+      concise: z
+        .boolean()
+        .optional()
+        .describe(
+          "Return only fail/warn findings; per-stage summary counts still cover everything",
+        ),
+    },
+    async ({ cwd, enforce, concise }) => {
+      try {
+        const { collectReview } = await import("./commands/review.js");
+        const report = await collectReview({ cwd, enforce });
+        const payload = concise
+          ? {
+              ...report,
+              stages: report.stages.map((s) => ({
+                ...s,
+                findings: s.findings.filter((f) => f.status === "fail" || f.status === "warn"),
+              })),
+            }
+          : report;
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+        };
+      } catch (err) {
+        return {
+          content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
 function register_kit_standards(server: McpServer): void {
   // kit_standards — run the dev-standards gate (general + per-language + plugins +
   // platform) and return the SAME { ok, checks, summary } envelope as `kit standards`.
-  // Read-only: no writes, so no governance/read-only gating.
+  // Read-only: no writes, so no governance/read-only gating. Deprecated for 6.0:
+  // kit_review runs this gate as its standards stage (with --category parity via
+  // kit_run for the rare scoped call), so a second standalone tool is surface bloat.
   server.tool(
     "kit_standards",
-    "Run kit standards (deterministic dev-standards gate: complexity/duplication/size + per-language linters + user plugins + container) and return structured findings. Read-only.",
+    `${DEPRECATED_6_0}; kit_review runs this gate as its standards stage — prefer it (or kit_run with \`kit standards --category …\` for a scoped run). Run kit standards (deterministic dev-standards gate: complexity/duplication/size + per-language linters + user plugins + container) and return structured findings. Read-only.`,
     {
       cwd: z.string().optional().describe("Working directory (defaults to process.cwd())"),
       enforce: z

--- a/src/scope-needs-adoption.test.ts
+++ b/src/scope-needs-adoption.test.ts
@@ -52,6 +52,12 @@ const REVIEWED_UNDECLARED: { file: string; operation: string; reason: string }[]
     reason: "pure read — CI rendering of the same checks",
   },
   {
+    file: "src/commands/review.ts",
+    operation: "review",
+    reason:
+      "pure read — the four audit stages (check/design/standards/adr) via collectReview; no egress, writes, or secret exposure",
+  },
+  {
     file: "src/commands/info.ts",
     operation: "health",
     reason:


### PR DESCRIPTION
## What

`kit review` was console-orchestration — it printed each stage's output but returned only a bool, and `--json` emitted four concatenated sub-documents (adr ignored the flag entirely). This PR makes the review verdict a structured artifact, applying the `computeCheckVerdict` parity pattern to the whole audit.

### The core

- **`check-run.ts` / `runCheckGate`** — the check collection + verdict, now shared by `kit check` (CLI), the MCP `kit_check` tool, and review's check stage. `checkRunToJsonChecks` is the single row-flattening (previously duplicated in the CLI's `--json` path). The CLI keeps its extras (spinners, PAL sync, attestation, hints, scanner self-heal) around the shared core.
- **`collectReview`** (`commands/review.ts`) — runs check → design → standards → adr and returns one `ReviewReport { ok, failed, stages: [{ stage, ok, summary, findings }] }`. `cmdReview` is now a renderer on top; `kit review --json` emits ONE document and exits 1 on red.
- **`runDesignGate` / `runAdrGate`** — design and ADR gates split core-from-render (same pattern), consumed by both their CLI commands and `collectReview`.

### The MCP surface

- **`kit_review`** — the full audit for shell-less agents, on top of `collectReview`. `concise: true` drops pass/skip rows while per-stage summary counts keep totals honest (nothing silently truncated).
- **`kit_standards` deprecated** (leaves in 6.0) — `kit_review` subsumes it as its standards stage; scoped runs go via `kit_run`. With the existing five deprecations the surface lands at 10 tools after 6.0.

### Drift gates (all updated themselves, as designed)

- `docs-mcp-sync.test.ts`: deprecated set now six; reference/README/guide rows added — the docs gate forced the documentation
- `scope-needs-adoption.test.ts`: caught the new `withGovernance("review")` site on the first full run — added the reviewed pure-read entry
- `contracts/kit.opencli.json` + `contracts/public-surface.json` regenerated; `KIT_MCP_TOOLS` ↔ registry ↔ registered tools stay pinned

## Verification

- Full suite: **3244/3244 pass** (new: `check-run.test.ts`, `commands/review.test.ts`, two `kit_review` MCP tests incl. concise filtering)
- Real stdio smoke against `dist/cli.js mcp`: 16 tools, `kit_review(cwd, enforce, concise)` registered, `kit_standards` description carries the deprecation marker, server instructions mention the new loop
- `kit review` run on this repo: renders all four stages, exits 1 on the known machine-env findings; `--json` verified as one document
- `npm run lint`: 0 errors

## Behavioral notes

- `kit review` output format changed (compact per-stage rows + summary instead of full check tables). Exit-code semantics unchanged.
- `kit review` is now a **pure read**: it no longer triggers `kit check`'s side effects (PAL sync, attestation emission, update check, scanner auto-install). `kit check` keeps all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
