### PR TITLE
fix(scanners): comment-aware a11y/token scan + workspace-aware dep pinning

### DIFF
--- a/src/check-design.test.ts
+++ b/src/check-design.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { stripComments, checkDesign } from "./check-design.js";
+
+// The a11y/token scanners are line scanners over component sources — markup or
+// raw values mentioned in comments/docstrings are documentation, not rendered
+// UI, and must not produce findings (real case: a commented
+// `<input type="datetime-local">` example flagged as an unlabeled input).
+
+describe("stripComments", () => {
+  it("blanks block comments (incl. JSX-wrapped) while preserving line numbers", () => {
+    const src = `a\n{/* <input type="text"> */}\n/* one\ntwo */\nb`;
+    const out = stripComments(src);
+    assert.equal(out.split("\n").length, src.split("\n").length);
+    assert.ok(!out.includes("<input"));
+    assert.ok(!out.includes("two"));
+    assert.ok(out.includes("a") && out.includes("b"));
+  });
+
+  it("blanks HTML comments (astro/vue templates)", () => {
+    const out = stripComments(`x\n<!-- <img src="a.png"> -->\ny`);
+    assert.ok(!out.includes("<img"));
+    assert.equal(out.split("\n").length, 3);
+  });
+
+  it("blanks // line comments but keeps URLs", () => {
+    const out = stripComments(`const u = "https://ex.com/p"; // #fff example\n<a href="x">`);
+    assert.ok(out.includes("https://ex.com/p"), "URL must survive");
+    assert.ok(!out.includes("#fff"), "comment tail must be blanked");
+    assert.ok(out.includes(`<a href="x">`));
+  });
+});
+
+describe("checkDesign comment awareness", () => {
+  let tempDir: string;
+  let originalCwd: string;
+
+  before(async () => {
+    originalCwd = process.cwd();
+    tempDir = await mkdtemp(join(tmpdir(), "kit-design-"));
+    await mkdir(join(tempDir, "src"), { recursive: true });
+    process.chdir(tempDir);
+  });
+
+  after(async () => {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("ignores markup and raw values inside comments; still flags the real thing", async () => {
+    await writeFile(
+      join(tempDir, "src", "form.tsx"),
+      [
+        "/**",
+        ' * Docstring example: <input type="datetime-local"> — documentation only.',
+        " */",
+        "// commented style: color: #abcdef;",
+        "export const Form = () => (",
+        "  <form>",
+        '    <input type="text" />', // the ONE real finding
+        "  </form>",
+        ");",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const results = await checkDesign({ srcRoots: ["src"] });
+    const a11y = results.find((r) => r.name.startsWith("a11y"))!;
+    const tokens = results.find((r) => r.name.startsWith("design-token"))!;
+
+    // Exactly one a11y finding — the rendered unlabeled input on line 7, not
+    // the docstring example on line 2.
+    assert.equal(a11y.status, "warn");
+    assert.match(a11y.detail, /1 new a11y finding/);
+    assert.ok(
+      a11y.files?.some((f) => f.includes("form.tsx:7")),
+      `wrong line: ${a11y.files}`,
+    );
+
+    // The commented-out hex is prose, not a token bypass.
+    assert.equal(tokens.status, "pass", `commented hex flagged: ${tokens.detail}`);
+  });
+});

--- a/src/check-design.ts
+++ b/src/check-design.ts
@@ -51,6 +51,28 @@ function walkSources(root: string, exts: string[]): string[] {
   });
 }
 
+/**
+ * Blank out comment interiors — slash-star block comments (which also covers
+ * the JSX-wrapped form), HTML comments (`<!-- … -->`, astro/vue templates),
+ * and `//` line comments (SCSS/TS) — while preserving every newline so finding
+ * line numbers stay stable. Markup mentioned in a comment or docstring is
+ * documentation, not rendered UI, and must not trip the a11y/token scanners
+ * (real case: a commented `<input type="datetime-local">` example flagged as
+ * an unlabeled input).
+ *
+ * Deterministic heuristic, not a parser: `//` preceded by `:` is kept so
+ * `https://…` URLs survive, and comment markers inside string literals are
+ * treated as comments — an accepted precision trade-off for a zero-dependency
+ * line scanner.
+ */
+export function stripComments(source: string): string {
+  const blank = (s: string) => s.replace(/[^\n]/g, " ");
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, blank)
+    .replace(/<!--[\s\S]*?-->/g, blank)
+    .replace(/(^|[^:])\/\/[^\n]*/g, (m, keep: string) => keep + " ".repeat(m.length - keep.length));
+}
+
 interface A11yFinding {
   file: string;
   line: number;
@@ -97,7 +119,8 @@ async function scanA11y(srcRoots: string[]): Promise<A11yFinding[]> {
       } catch {
         continue;
       }
-      const lines = content.split("\n");
+      // Comments/docstrings are documentation, not rendered UI — strip before matching.
+      const lines = stripComments(content).split("\n");
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
         for (const rule of A11Y_RULES) {
@@ -137,7 +160,9 @@ async function scanTokenBypass(srcRoots: string[], tokenFiles: string[]): Promis
       } catch {
         continue;
       }
-      const lines = content.split("\n");
+      // Same comment-stripping as the a11y scan: a hex/px value in a comment
+      // is prose, not a token bypass.
+      const lines = stripComments(content).split("\n");
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
         const hex = line.match(/#[0-9a-f]{3,8}\b/i);

--- a/src/check-security.test.ts
+++ b/src/check-security.test.ts
@@ -12,6 +12,7 @@ import {
   findJvmProject,
   checkMemoryHooksLiveness,
   checkDeviceIdOverride,
+  unpinnedNodeDeps,
   LOCKFILE_ECOSYSTEMS,
   type SecurityCheckResult,
 } from "./check-security.js";
@@ -529,5 +530,55 @@ describe("lockfile ecosystem coverage (#353)", () => {
     for (const e of LOCKFILE_ECOSYSTEMS) {
       assert.ok(e.manifests.length > 0 && e.lockfiles.length > 0, `${e.name} malformed`);
     }
+  });
+});
+
+// Workspace-aware pinning: internal monorepo packages resolve to the local
+// tree, never the registry — "@repo/x": "*" is npm-workspaces convention, not
+// a floating range, and "pinning" it would actually be wrong (real false
+// positive from a Turborepo user).
+describe("unpinnedNodeDeps", () => {
+  const noMembers = () => false;
+
+  it("flags registry ranges and floating versions", () => {
+    assert.deepStrictEqual(
+      unpinnedNodeDeps({ a: "^1.2.3", b: "~2.0.0", c: ">=3", d: "*", e: "4.x" }, noMembers),
+      ["a@^1.2.3", "b@~2.0.0", "c@>=3", "d@*", "e@4.x"],
+    );
+  });
+
+  it("passes exact versions", () => {
+    assert.deepStrictEqual(unpinnedNodeDeps({ a: "1.2.3", b: "0.0.1-rc.2" }, noMembers), []);
+  });
+
+  it("skips workspace/file/link/portal/catalog protocol refs — local, not floating", () => {
+    assert.deepStrictEqual(
+      unpinnedNodeDeps(
+        {
+          a: "workspace:*",
+          b: "workspace:^",
+          c: "file:../local",
+          d: "link:../local",
+          e: "portal:../local",
+          f: "catalog:default",
+        },
+        noMembers,
+      ),
+      [],
+    );
+  });
+
+  it('skips "*" on internal workspace members but still flags external "*"', () => {
+    const members = new Set(["@repo/ui", "@repo/config"]);
+    assert.deepStrictEqual(
+      unpinnedNodeDeps({ "@repo/ui": "*", "@repo/config": "*", "left-pad": "*" }, (n) =>
+        members.has(n),
+      ),
+      ["left-pad@*"],
+    );
+  });
+
+  it("handles a missing dep map", () => {
+    assert.deepStrictEqual(unpinnedNodeDeps(undefined, noMembers), []);
   });
 });

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { homedir } from "node:os";
 import { execFileNoThrow } from "./utils/execFileNoThrow.js";
+import { resolveWorkspaceRoots } from "./workspaces.js";
 import { resolveToolBin } from "./utils/resolveTool.js";
 import { classifyGuardDog } from "./guarddog.js";
 import { depsHashFor, loadGuardDogCache, saveGuardDogCache } from "./guarddog-cache.js";
@@ -727,6 +728,55 @@ async function checkServiceExposure(): Promise<SecurityCheckResult[]> {
   return results;
 }
 
+/** Version specifiers that are local/protocol refs (workspace:, file:, link:,
+ *  portal:, catalog:) — resolved outside the registry, so "floating" is
+ *  meaningless for them. */
+const LOCAL_PROTOCOL_REF = /^(workspace|file|link|portal|catalog):/;
+
+/**
+ * The unpinned rows of one dependency map. Workspace-aware: internal monorepo
+ * packages (declared `"@repo/x": "*"` per npm-workspaces convention, or via the
+ * workspace:/file: protocols) resolve to the local tree, never the registry —
+ * flagging them as "unpinned" was a false positive, and "pinning" them would
+ * actually be wrong. Exported for tests.
+ */
+export function unpinnedNodeDeps(
+  deps: Record<string, string> | undefined,
+  isWorkspaceMember: (name: string) => boolean,
+): string[] {
+  if (!deps) return [];
+  const unpinned: string[] = [];
+  for (const [name, version] of Object.entries(deps)) {
+    if (LOCAL_PROTOCOL_REF.test(version)) continue;
+    if (isWorkspaceMember(name)) continue;
+    // Range specifiers: ^, ~, >, <, >=, <=, *, x
+    if (/^[~^><=*x]|[*x]$/.test(version)) {
+      unpinned.push(`${name}@${version}`);
+    }
+  }
+  return unpinned;
+}
+
+/** Names of this repo's workspace member packages (empty set when none / on error). */
+function workspaceMemberNames(cwd: string): Set<string> {
+  const names = new Set<string>();
+  try {
+    for (const root of resolveWorkspaceRoots(cwd)) {
+      try {
+        const pkg = JSON.parse(readFileSync(resolve(cwd, root, "package.json"), "utf-8")) as {
+          name?: string;
+        };
+        if (pkg.name) names.add(pkg.name);
+      } catch {
+        // unreadable member package.json — skip it, never fail the check
+      }
+    }
+  } catch {
+    // workspace resolution is best-effort; no workspaces ⇒ empty set
+  }
+  return names;
+}
+
 /**
  * Check if dependencies use pinned versions
  */
@@ -737,19 +787,13 @@ async function checkPinnedVersions(): Promise<SecurityCheckResult> {
   try {
     const packageJsonContent = await readFile(resolve(process.cwd(), "package.json"), "utf-8");
     const packageJson = JSON.parse(packageJsonContent);
+    const members = workspaceMemberNames(process.cwd());
+    const isMember = (name: string) => members.has(name);
 
-    const checkDeps = (deps: Record<string, string> | undefined) => {
-      if (!deps) return;
-      for (const [name, version] of Object.entries(deps)) {
-        // Check for range specifiers: ^, ~, >, <, >=, <=, *, x
-        if (/^[~^><=*x]|[*x]$/.test(version)) {
-          unpinned.push(`${name}@${version}`);
-        }
-      }
-    };
-
-    checkDeps(packageJson.dependencies);
-    checkDeps(packageJson.devDependencies);
+    unpinned.push(
+      ...unpinnedNodeDeps(packageJson.dependencies, isMember),
+      ...unpinnedNodeDeps(packageJson.devDependencies, isMember),
+    );
   } catch {
     // No package.json or parse error
   }


### PR DESCRIPTION
## What

Two scanner-precision fixes from a Turborepo user's false-positive report. Same discipline as #405: sharpen the matching, never loosen the gates.

### 1. Comment-aware a11y/token scanning (`check-design.ts`)

A commented `<input type="datetime-local">` example inside a docstring was flagged as an unlabeled input. Markup mentioned in a comment is documentation, not rendered UI.

`stripComments` blanks comment interiors — slash-star block comments (covers the JSX-wrapped form), HTML comments (astro/vue), and `//` line comments — **newline-preserving**, so finding line numbers stay stable. `https://…` URLs survive (`//` preceded by `:` is kept). Applied to both the a11y scan and the raw-hex/px token scan (a hex in a comment is prose, not a token bypass).

Deterministic heuristic, not a parser — comment markers inside string literals are treated as comments, a documented trade-off for a zero-dependency line scanner. Stripping can only *reduce* findings, so existing baselines stay valid (a baseline only suppresses).

### 2. Workspace-aware dependency pinning (`check-security.ts`)

`"@repo/ui": "*"` (npm-workspaces convention) was reported as an unpinned dependency — but internal workspace packages resolve to the local tree, never the registry, and "pinning" them would actually be wrong.

The pinned-versions check now skips:
- `workspace:` / `file:` / `link:` / `portal:` / `catalog:` protocol refs (local, not floating)
- `*` on names that are actual workspace members (resolved via `resolveWorkspaceRoots` + member `package.json` names, fail-soft)

External `*` and registry ranges (`^`, `~`, `>=`, `4.x`) still flag exactly as before. The core is extracted as pure `unpinnedNodeDeps` and exported for tests.

## Verification

- 3253/3253 tests — 9 new: `stripComments` units, a `checkDesign` integration proving the docstring case produces zero findings while the real unlabeled input still flags **with the correct line number**, and `unpinnedNodeDeps` covering ranges/exact/protocol-refs/member-`*`-vs-external-`*`
- lint 0 errors, prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
