### PR TITLE
feat(hints): three stack-aware rules — gha-audit, baseline freeze, memory index

### DIFF
--- a/src/hints.test.ts
+++ b/src/hints.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { collectHints } from "./hints.js";
@@ -8,29 +8,35 @@ import { collectHints } from "./hints.js";
 // Isolate every external surface the detectors read so a test never depends on
 // what's installed / present on the host: markers + identity + anchor store all
 // point at fresh temp dirs.
-function withEnv(fn: (repo: string) => void | Promise<void>): Promise<void> {
+function withEnv(fn: (repo: string, claudeDir: string) => void | Promise<void>): Promise<void> {
   const repo = mkdtempSync(join(tmpdir(), "kit-hints-repo-"));
   const home = mkdtempSync(join(tmpdir(), "kit-hints-home-"));
   const anchor = mkdtempSync(join(tmpdir(), "kit-hints-anchor-"));
   const ident = mkdtempSync(join(tmpdir(), "kit-hints-id-"));
+  const claude = mkdtempSync(join(tmpdir(), "kit-hints-claude-"));
   const saved = {
     KIT_MEMORY_DIR: process.env.KIT_MEMORY_DIR,
+    KIT_MEMORY_DB: process.env.KIT_MEMORY_DB,
     KIT_AUDIT_ANCHOR_DIR: process.env.KIT_AUDIT_ANCHOR_DIR,
     KIT_IDENTITY_DIR: process.env.KIT_IDENTITY_DIR,
+    KIT_CLAUDE_DIR: process.env.KIT_CLAUDE_DIR,
     KIT_NO_HINTS: process.env.KIT_NO_HINTS,
     KIT_GUARDDOG: process.env.KIT_GUARDDOG,
   };
   process.env.KIT_MEMORY_DIR = home;
   process.env.KIT_AUDIT_ANCHOR_DIR = anchor;
   process.env.KIT_IDENTITY_DIR = ident; // empty → no identity → policy-init won't fire
+  process.env.KIT_CLAUDE_DIR = claude; // empty → no transcripts → memory-unindexed won't fire
+  delete process.env.KIT_MEMORY_DB;
   delete process.env.KIT_NO_HINTS;
   delete process.env.KIT_GUARDDOG;
-  return Promise.resolve(fn(repo)).finally(() => {
+  return Promise.resolve(fn(repo, claude)).finally(() => {
     for (const [k, v] of Object.entries(saved)) {
       if (v === undefined) delete process.env[k];
       else process.env[k] = v;
     }
-    for (const d of [repo, home, anchor, ident]) rmSync(d, { recursive: true, force: true });
+    for (const d of [repo, home, anchor, ident, claude])
+      rmSync(d, { recursive: true, force: true });
   });
 }
 
@@ -92,5 +98,45 @@ describe("hints — deterministic contextual tips", () => {
       assert.ok(ids(a).includes("policy-unsigned"));
       const b = await collectHints(repo, { max: 5, markSeen: false });
       assert.ok(ids(b).includes("policy-unsigned"), "without markSeen it stays collectable");
+    }));
+
+  // ── stack-aware rules: surface an existing kit capability at the moment the
+  // repo's own state makes it relevant ─────────────────────────────────────────
+
+  it("fires `gha-unaudited` when workflows exist; not for an empty workflows dir", () =>
+    withEnv(async (repo) => {
+      mkdirSync(join(repo, ".github", "workflows"), { recursive: true });
+      assert.deepEqual(await collectHints(repo, { max: 5 }), [], "empty dir must not fire");
+      writeFileSync(join(repo, ".github", "workflows", "ci.yml"), "on: push\n");
+      const hs = await collectHints(repo, { max: 5 });
+      assert.ok(ids(hs).includes("gha-unaudited"), `expected gha-unaudited, got ${ids(hs)}`);
+    }));
+
+  it("fires `baseline-unfrozen` only for a kit-managed repo with sources and no baseline", () =>
+    withEnv(async (repo) => {
+      mkdirSync(join(repo, "src"), { recursive: true });
+      assert.deepEqual(await collectHints(repo, { max: 5 }), [], "no .kit.toml ⇒ no hint");
+      writeFileSync(join(repo, ".kit.toml"), "# kit\n");
+      const hs = await collectHints(repo, { max: 5, markSeen: false });
+      assert.ok(
+        ids(hs).includes("baseline-unfrozen"),
+        `expected baseline-unfrozen, got ${ids(hs)}`,
+      );
+      writeFileSync(join(repo, ".kit-baseline.json"), "{}\n");
+      assert.deepEqual(
+        await collectHints(repo, { max: 5 }),
+        [],
+        "existing baseline must silence it",
+      );
+    }));
+
+  it("fires `memory-unindexed` when transcripts exist but no store; store silences it", () =>
+    withEnv(async (repo, claudeDir) => {
+      mkdirSync(join(claudeDir, "projects", "-Users-x-proj"), { recursive: true });
+      const hs = await collectHints(repo, { max: 5, markSeen: false });
+      assert.ok(ids(hs).includes("memory-unindexed"), `expected memory-unindexed, got ${ids(hs)}`);
+      // a memory store at the resolved db path silences the rule
+      writeFileSync(join(process.env.KIT_MEMORY_DIR!, "memory.db"), "");
+      assert.deepEqual(await collectHints(repo, { max: 5 }), []);
     }));
 });

--- a/src/hints.ts
+++ b/src/hints.ts
@@ -13,9 +13,10 @@
  * Every detector is fail-safe: a thrown error means "don't hint", never a crash —
  * a tip must never break `kit check` or a session.
  */
-import { existsSync, statSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, statSync, writeFileSync, mkdirSync, readdirSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { getMemoryDir } from "./memory/db.js";
+import { getMemoryDir, getMemoryDbPath } from "./memory/db.js";
+import { getClaudeProjectsDir } from "./memory/parser.js";
 import { resolveToolBin } from "./utils/resolveTool.js";
 import { loadPolicy, verifyPolicy } from "./policy-doc.js";
 import { tryLoadIdentity } from "./identity.js";
@@ -114,6 +115,33 @@ const RULES: HintRule[] = [
       hasAny(root, ["package.json", "requirements.txt", "pyproject.toml"]) &&
       !(await guarddogEnabled(root)) &&
       !!(await resolveToolBin("semgrep")), // only suggest when it can actually run
+  },
+  {
+    id: "gha-unaudited",
+    tip: "you have GitHub Actions workflows — `kit gha-audit` lints them for unpinned actions and pwn-request patterns",
+    detect: (root) => {
+      const dir = resolve(root, ".github", "workflows");
+      if (!existsSync(dir)) return false;
+      return readdirSync(dir).some((f) => f.endsWith(".yml") || f.endsWith(".yaml"));
+    },
+  },
+  {
+    id: "baseline-unfrozen",
+    tip: "no findings baseline yet — `kit baseline freeze` snapshots today's findings so the review/standards gates trip only on NET-NEW ones",
+    detect: (root) =>
+      // Only in a kit-managed repo with source to scan — not any stray folder.
+      existsSync(resolve(root, ".kit.toml")) &&
+      hasAny(root, ["src", "app", "components"]) &&
+      !existsSync(resolve(root, ".kit-baseline.json")),
+  },
+  {
+    id: "memory-unindexed",
+    tip: "agent transcripts found but no cross-session memory — `kit memory index` builds local recall (then `kit memory search`)",
+    detect: () => {
+      if (existsSync(getMemoryDbPath())) return false;
+      const projects = getClaudeProjectsDir();
+      return existsSync(projects) && readdirSync(projects).length > 0;
+    },
   },
   {
     id: "policy-init",


### PR DESCRIPTION
Extends the deterministic hint engine with three stack-aware rules that surface an existing kit capability at the moment the repo's state makes it relevant: workflows present but never gha-audited, kit-managed sources without a findings baseline, agent transcripts without a memory store. Same contract as the existing five rules: plain state checks, one tip per run, marker-gated shown-once, fail-safe detectors, zero LLM.

Test isolation hardened: the hints test env now pins KIT_CLAUDE_DIR and clears KIT_MEMORY_DB so no test sees the host's real transcripts or store.

Verified: 3256/3256 tests (3 new), lint 0 errors, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)