### PR TITLE
feat(notice): pinned-scanner release notice + advisories reach the PAL ledger (5.22.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.22.0] - 2026-07-27
+
+### Added
+
+- **Pinned-scanner release notice, and out-of-verdict advisories now reach the PAL ledger.**
+  kit reported that bumblebee's threat-intel catalogs were N days old but never whether a
+  newer release existed to bump *to* — half a sentence. The other half is now there.
+
+  - **The binary pin stays.** `BUMBLEBEE_VERSION` + `TARBALL_CHECKSUMS` are never
+    auto-updated: fetching an executable whose checksum cannot be verified in advance is
+    the supply-chain attack kit exists to catch. This is a **notice**, and the bump remains
+    a deliberate commit where the two constants move together.
+  - **The real defect it exposes** is that the `threat_intel/` catalogs ship *inside* the
+    pinned tarball, coupling data with a days-scale half-life to a binary with a
+    months-scale one. The notice makes that coupling visible instead of silent.
+  - **Not part of any verdict.** Whether upstream cut a release depends on the network and
+    someone else's schedule, so letting it move pass/fail would make `kit ci --strict`
+    non-deterministic for an unchanged repo — the same reasoning that already keeps catalog
+    *age* out of the verdict. The security check reads a **cache only** and never makes a
+    network call.
+  - **`SecurityCheckResult.advisory`** — a new optional `{ key, title, detail }` for
+    signals that must not move the verdict but must still reach a human. Advisories mostly
+    ride on `pass` results, which is exactly why `actionableFindings` (fail/warn only)
+    could never see them. `advisoryFindings()` bridges them into PAL under their own `adv`
+    source tag, so they reconcile independently of `sec` findings — folding them together
+    would have made each sync close the other's rows every run. The dedup key deliberately
+    excludes the day count, so a climbing age keeps **one** open row instead of opening a
+    new one daily, and the row auto-closes once the advisory stops being emitted.
+  - **Delivery is the point:** a printed line scrolls out of the terminal, so the signal
+    also lands in PAL — persistent, cross-session, and counted in the `kit statusline` ⚠
+    badge the session-start hook injects.
+  - Network posture mirrors kit's own update check exactly, via a now-shared
+    `isAirGapPosture()` so air-gap cannot be honored on one notice path and punched
+    through on another: 3s timeout, 24h cache, and every failure path (suppressed,
+    offline, rate-limited, malformed JSON, unparseable tag) returning null. `KIT_NO_UPDATE_CHECK`,
+    `CI`, `GITHUB_ACTIONS`, `GITLAB_CI` and air-gap all suppress it; the notice prints to
+    **stderr** so it cannot corrupt piped stdout.
+
+
 ## [5.21.0] - 2026-07-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   - **Delivery is the point:** a printed line scrolls out of the terminal, so the signal
     also lands in PAL — persistent, cross-session, and counted in the `kit statusline` ⚠
     badge the session-start hook injects.
+  - **Measured against upstream, and the wording follows the measurement:** a newer
+    release does NOT imply newer threat intel. All six `threat_intel/*.json` catalogs are
+    byte-identical between upstream v0.1.1 and v0.1.2; what v0.1.2 adds is inventory
+    *coverage* (an `agent-skill` ecosystem for skills.sh / vercel-labs lock files,
+    `homebrew`, and `~/.claude.json` MCP parsing). So neither branch of the suggestion
+    promises a bump will refresh the catalogs — the age can be upstream's own data age
+    rather than a lagging pin, and the previous "bump to refresh the exposure catalogs"
+    wording was a false promise. A *tag* is also not a *release*: the notice reads the
+    releases API and skips drafts/prereleases, so a tagged-but-unreleased version
+    correctly produces silence.
   - Network posture mirrors kit's own update check exactly, via a now-shared
     `isAirGapPosture()` so air-gap cannot be honored on one notice path and punched
     through on another: 3s timeout, 24h cache, and every failure path (suppressed,

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -1099,7 +1099,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.21.0"
+    "version": "5.22.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "5.15.0",
+  "version": "5.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "5.15.0",
+      "version": "5.22.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.21.0",
+  "version": "5.22.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/bumblebee-update.test.ts
+++ b/src/bumblebee-update.test.ts
@@ -1,0 +1,165 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseReleaseTag,
+  pickLatestStableRelease,
+  bumblebeeUpdateFrom,
+  formatBumblebeeNotice,
+  checkForBumblebeeUpdate,
+} from "./bumblebee-update.js";
+import { advisoryFindings } from "./findings-track.js";
+import type { SecurityCheckResult } from "./check-security.js";
+
+describe("parseReleaseTag", () => {
+  it("strips a leading v and accepts a plain version", () => {
+    assert.equal(parseReleaseTag("v0.2.0"), "0.2.0");
+    assert.equal(parseReleaseTag("0.2.0"), "0.2.0");
+    assert.equal(parseReleaseTag("  V1.10.3 "), "1.10.3");
+  });
+
+  it("returns null for anything we cannot compare — no notice beats a wrong one", () => {
+    for (const t of ["nightly", "release-20260721.0", "", "v", null, undefined, 3, {}, []])
+      assert.equal(parseReleaseTag(t), null, `must reject ${JSON.stringify(t)}`);
+  });
+});
+
+describe("pickLatestStableRelease", () => {
+  it("takes the highest version, not the first array entry", () => {
+    const payload = [{ tag_name: "v0.1.1" }, { tag_name: "v0.3.0" }, { tag_name: "v0.2.5" }];
+    assert.equal(pickLatestStableRelease(payload), "0.3.0");
+  });
+
+  it("skips drafts and prereleases", () => {
+    const payload = [
+      { tag_name: "v0.9.0", draft: true },
+      { tag_name: "v0.8.0", prerelease: true },
+      { tag_name: "v0.2.0" },
+    ];
+    assert.equal(pickLatestStableRelease(payload), "0.2.0");
+  });
+
+  it("accepts a single release object (the /releases/latest shape)", () => {
+    assert.equal(pickLatestStableRelease({ tag_name: "v0.4.0" }), "0.4.0");
+  });
+
+  it("returns null for junk, an empty list, or all-unparseable tags", () => {
+    assert.equal(pickLatestStableRelease([]), null);
+    assert.equal(pickLatestStableRelease(null), null);
+    assert.equal(pickLatestStableRelease("nope"), null);
+    assert.equal(pickLatestStableRelease([{ tag_name: "nightly" }]), null);
+    assert.equal(pickLatestStableRelease({ message: "API rate limit exceeded" }), null);
+  });
+});
+
+describe("bumblebeeUpdateFrom", () => {
+  it("reports only a genuinely newer upstream release", () => {
+    assert.deepEqual(bumblebeeUpdateFrom("0.1.1", "0.2.0"), { pinned: "0.1.1", latest: "0.2.0" });
+    assert.equal(bumblebeeUpdateFrom("0.2.0", "0.2.0"), null);
+    assert.equal(bumblebeeUpdateFrom("0.3.0", "0.2.0"), null, "never suggests a downgrade");
+  });
+
+  it("fails closed on malformed versions (no notice)", () => {
+    assert.equal(bumblebeeUpdateFrom("0.1.1", "garbage"), null);
+    assert.equal(bumblebeeUpdateFrom("", "0.2.0"), null);
+  });
+});
+
+describe("checkForBumblebeeUpdate — suppression posture", () => {
+  /** Run `fn` with env vars applied, restoring the previous values after. */
+  async function withEnv(vars: Record<string, string>, fn: () => Promise<void>): Promise<void> {
+    const prev = new Map(Object.keys(vars).map((k) => [k, process.env[k]]));
+    Object.assign(process.env, vars);
+    try {
+      await fn();
+    } finally {
+      for (const [k, v] of prev) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    }
+  }
+
+  it("makes no outbound call under air-gap, CI, or the explicit opt-out", async () => {
+    // The point is the POSTURE, not the network: patch fetch to fail loudly if called.
+    const realFetch = globalThis.fetch;
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      throw new Error("fetch must not be called under a suppressed posture");
+    }) as typeof fetch;
+    try {
+      const postures: Record<string, string>[] = [
+        { KIT_AIRGAP: "1" },
+        { CI: "true" },
+        { GITHUB_ACTIONS: "true" },
+        { GITLAB_CI: "true" },
+        { KIT_NO_UPDATE_CHECK: "1" },
+      ];
+      for (const vars of postures) {
+        await withEnv(vars, async () => {
+          assert.equal(await checkForBumblebeeUpdate("0.1.1"), null);
+        });
+        assert.equal(called, false, `fetch called despite ${JSON.stringify(vars)}`);
+      }
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it("never throws when the network fails", async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new Error("ENOTFOUND");
+    }) as typeof fetch;
+    try {
+      await withEnv(
+        { KIT_AIRGAP: "", CI: "", GITHUB_ACTIONS: "", GITLAB_CI: "", KIT_NO_UPDATE_CHECK: "" },
+        async () => {
+          // Either null (fetch failed) or a cached answer — the contract is "no throw".
+          await checkForBumblebeeUpdate("0.1.1");
+        },
+      );
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});
+
+describe("formatBumblebeeNotice", () => {
+  it("names both versions and says the two pins move together", () => {
+    const s = formatBumblebeeNotice({ pinned: "0.1.1", latest: "0.2.0" });
+    assert.match(s, /0\.1\.1/);
+    assert.match(s, /0\.2\.0/);
+    assert.match(s, /BUMBLEBEE_VERSION/);
+    assert.match(s, /TARBALL_CHECKSUMS/);
+  });
+});
+
+describe("advisoryFindings — the PAL bridge", () => {
+  const base: SecurityCheckResult = {
+    category: "supply-chain",
+    name: "bumblebee (supply-chain)",
+    status: "pass",
+    detail: "no known exposures",
+  };
+
+  it("carries an advisory off a PASS result — invisible to the fail/warn filter", () => {
+    const out = advisoryFindings([{ ...base, advisory: { key: "k1", title: "t1", detail: "d1" } }]);
+    assert.deepEqual(out, [{ dedupKey: "k1", title: "t1", detail: "d1" }]);
+  });
+
+  it("ignores results with no advisory", () => {
+    assert.deepEqual(advisoryFindings([base, { ...base, status: "fail" }]), []);
+  });
+
+  it("keys on the advisory key, so a climbing day count does not open a new row daily", () => {
+    const day1 = advisoryFindings([
+      { ...base, advisory: { key: "bumblebee-catalogs-stale", title: "65 days old", detail: "d" } },
+    ]);
+    const day2 = advisoryFindings([
+      { ...base, advisory: { key: "bumblebee-catalogs-stale", title: "66 days old", detail: "d" } },
+    ]);
+    assert.equal(day1[0].dedupKey, day2[0].dedupKey);
+    assert.notEqual(day1[0].title, day2[0].title, "the title still tells the truth about age");
+  });
+});

--- a/src/bumblebee-update.ts
+++ b/src/bumblebee-update.ts
@@ -22,6 +22,15 @@
  * Network posture mirrors the kit self-update check exactly: one shared suppression
  * decision (air-gap / CI / opt-out), a 3s timeout, a cached result, and every failure
  * path returning null. A notice must never slow down, break, or leak out of a run.
+ *
+ * MEASURED CAVEAT (2026-07-27, upstream v0.1.1 vs v0.1.2): a newer release does NOT
+ * imply newer threat intel. All six threat_intel/*.json catalogs are byte-identical
+ * across those two tags; what v0.1.2 adds is inventory COVERAGE (an `agent-skill`
+ * ecosystem for skills.sh / vercel-labs lock files, `homebrew`, and `~/.claude.json`
+ * MCP parsing). So this module reports "a newer release exists", never "your catalogs
+ * will get fresher" — the catalog age can be upstream's own, not a lagging pin. Also
+ * note a *tag* is not a *release*: the notice reads the releases API and skips
+ * drafts/prereleases, so a tagged-but-unreleased version correctly produces silence.
  */
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { readFileSync } from "node:fs";

--- a/src/bumblebee-update.ts
+++ b/src/bumblebee-update.ts
@@ -1,0 +1,177 @@
+/**
+ * Bumblebee release notice — "your pinned scanner is behind upstream".
+ *
+ * `src/bumblebee.ts` pins BUMBLEBEE_VERSION + TARBALL_CHECKSUMS deliberately: an
+ * executable whose checksum we cannot verify in advance is exactly the supply-chain
+ * attack kit exists to catch, so the binary is NEVER auto-updated. But the
+ * threat_intel/ exposure catalogs ship INSIDE that pinned tarball, which couples data
+ * with a days-scale half-life to a binary with a months-scale one. That coupling is
+ * why the catalogs go stale, and kit already reports the age honestly (advisory, not
+ * gated — see check-security.ts).
+ *
+ * What was missing is the other half of the sentence: kit knew the catalogs were old
+ * but never whether a newer release exists to bump TO. This module closes that, as a
+ * NOTICE only — it tells you a bump is available and leaves the bump a deliberate,
+ * reviewed commit where VERSION and CHECKSUMS move together.
+ *
+ * Deliberately NOT part of any verdict. Whether upstream has cut a release depends on
+ * the network and someone else's schedule, so letting it touch pass/fail would make
+ * `kit ci --strict` non-deterministic for an unchanged repo — the same reasoning that
+ * keeps catalog AGE out of the verdict.
+ *
+ * Network posture mirrors the kit self-update check exactly: one shared suppression
+ * decision (air-gap / CI / opt-out), a 3s timeout, a cached result, and every failure
+ * path returning null. A notice must never slow down, break, or leak out of a run.
+ */
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { isNewer, isValidVersion, isAirGapPosture } from "./update-check.js";
+
+/** GitHub releases API for the upstream repo the pinned tarballs come from. */
+const RELEASES_URL = "https://api.github.com/repos/perplexityai/bumblebee/releases";
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const CACHE_DIR = join(homedir(), ".kit");
+const CACHE_FILE = join(CACHE_DIR, "last-bumblebee-release-check.json");
+const FETCH_TIMEOUT_MS = 3_000;
+
+export interface BumblebeeUpdateInfo {
+  /** The version pinned in src/bumblebee.ts. */
+  pinned: string;
+  /** Newest stable upstream release. */
+  latest: string;
+}
+
+interface ReleaseCheckCache {
+  checkedAt: number;
+  latestVersion: string;
+}
+
+/**
+ * Normalize a GitHub release tag to a bare version (`v0.2.0` → `0.2.0`).
+ * Returns null for anything that is not a plain version — a tag we cannot parse is
+ * never compared, so a weird upstream tagging scheme produces no notice rather than
+ * a wrong one.
+ */
+export function parseReleaseTag(tag: unknown): string | null {
+  if (typeof tag !== "string") return null;
+  const bare = tag.trim().replace(/^v/i, "");
+  return isValidVersion(bare) ? bare : null;
+}
+
+/** One entry of the releases payload, as much of it as we care about. */
+interface ReleaseEntry {
+  tag_name?: unknown;
+  draft?: unknown;
+  prerelease?: unknown;
+}
+
+/**
+ * Highest stable version in a GitHub releases payload. Drafts and prereleases are
+ * skipped (kit pins releases people can actually download), and the maximum is taken
+ * by version order rather than trusting the array order.
+ */
+export function pickLatestStableRelease(payload: unknown): string | null {
+  const list: unknown[] = Array.isArray(payload) ? payload : [payload];
+  let best: string | null = null;
+  for (const raw of list) {
+    if (!raw || typeof raw !== "object") continue;
+    const r = raw as ReleaseEntry;
+    if (r.draft === true || r.prerelease === true) continue;
+    const v = parseReleaseTag(r.tag_name);
+    if (v && (best === null || isNewer(v, best))) best = v;
+  }
+  return best;
+}
+
+/**
+ * Pure comparison: an update to report, or null when the pin is current (or the
+ * comparison is not decidable). `isNewer` fails closed on malformed input, so garbage
+ * in the cache or the payload silently yields no notice.
+ */
+export function bumblebeeUpdateFrom(pinned: string, latest: string): BumblebeeUpdateInfo | null {
+  return isNewer(latest, pinned) ? { pinned, latest } : null;
+}
+
+/** True when kit must not make the outbound release check. */
+async function checkSuppressed(): Promise<boolean> {
+  return (
+    process.env.KIT_NO_UPDATE_CHECK === "1" ||
+    process.env.CI === "true" ||
+    process.env.GITHUB_ACTIONS === "true" ||
+    process.env.GITLAB_CI === "true" ||
+    (await isAirGapPosture())
+  );
+}
+
+/**
+ * Check upstream for a newer bumblebee release, honoring the cache and the shared
+ * suppression posture. Never throws and never rejects: every failure — suppressed,
+ * offline, timeout, rate-limited, malformed JSON — returns null.
+ */
+export async function checkForBumblebeeUpdate(
+  pinnedVersion: string,
+): Promise<BumblebeeUpdateInfo | null> {
+  try {
+    if (await checkSuppressed()) return null;
+
+    let cache: ReleaseCheckCache | null = null;
+    try {
+      cache = JSON.parse(await readFile(CACHE_FILE, "utf8")) as ReleaseCheckCache;
+    } catch {
+      /* no cache yet */
+    }
+
+    const now = Date.now();
+    if (cache && now - cache.checkedAt < CHECK_INTERVAL_MS) {
+      return bumblebeeUpdateFrom(pinnedVersion, cache.latestVersion);
+    }
+
+    const resp = await fetch(`${RELEASES_URL}?per_page=10`, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!resp.ok) return null;
+
+    const latest = pickLatestStableRelease(await resp.json());
+    // Only a version we successfully parsed is cached, so the cache can never hold a
+    // value that would later be compared as garbage.
+    if (!latest) return null;
+
+    try {
+      await mkdir(CACHE_DIR, { recursive: true });
+      await writeFile(
+        CACHE_FILE,
+        JSON.stringify({ checkedAt: now, latestVersion: latest }),
+        "utf8",
+      );
+    } catch {
+      /* cache write failure is non-fatal */
+    }
+
+    return bumblebeeUpdateFrom(pinnedVersion, latest);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Cached-only, synchronous read for paths that must not touch the network — notably
+ * the security check, which stays offline so its output does not depend on whether a
+ * GitHub request happened to succeed. Returns null when there is no usable cache.
+ */
+export function readCachedBumblebeeUpdateSync(pinnedVersion: string): BumblebeeUpdateInfo | null {
+  try {
+    const cache = JSON.parse(readFileSync(CACHE_FILE, "utf8")) as ReleaseCheckCache;
+    if (!cache || typeof cache.latestVersion !== "string") return null;
+    return bumblebeeUpdateFrom(pinnedVersion, cache.latestVersion);
+  } catch {
+    return null;
+  }
+}
+
+/** One-line notice text. Kept pure so the wording is testable without any I/O. */
+export function formatBumblebeeNotice(info: BumblebeeUpdateInfo): string {
+  return `bumblebee ${info.pinned} pinned · ${info.latest} available upstream — bump BUMBLEBEE_VERSION + TARBALL_CHECKSUMS together in src/bumblebee.ts`;
+}

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -2009,9 +2009,13 @@ async function checkBumblebee(): Promise<SecurityCheckResult> {
       // cache is populated by the post-command notice in cli.ts.
       const { readCachedBumblebeeUpdateSync } = await import("./bumblebee-update.js");
       const upd = readCachedBumblebeeUpdateSync(BUMBLEBEE_VERSION);
+      // Neither branch promises that a bump yields FRESHER catalogs. Measured against
+      // upstream: every threat_intel catalog is byte-identical between v0.1.1 and
+      // v0.1.2, so the age can be upstream's own data age rather than a lagging pin —
+      // and "bump to refresh the catalogs" would then be a false promise.
       const suggestion = upd
-        ? `Bump BUMBLEBEE_VERSION to ${upd.latest} (and TARBALL_CHECKSUMS to match its checksums.txt) in src/bumblebee.ts — the two MUST move together.`
-        : "Bump BUMBLEBEE_VERSION (and TARBALL_CHECKSUMS) in src/bumblebee.ts to refresh the exposure catalogs.";
+        ? `bumblebee ${upd.latest} is available (pinned ${upd.pinned}). Moving BUMBLEBEE_VERSION + TARBALL_CHECKSUMS together in src/bumblebee.ts is the only way to change the bundled catalogs — check the release actually ships newer ones before assuming a bump refreshes them.`
+        : "No newer bumblebee release is known here (the check is cached, suppressed, or upstream has published none), so the age may be upstream's own rather than a lagging pin — a bump only helps if a newer release ships fresher catalogs.";
       return {
         category,
         name,

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -17,6 +17,7 @@ import {
   maxSeverity,
   newestCatalogMtime,
   isCatalogStale,
+  BUMBLEBEE_VERSION,
   type BumblebeeFinding,
 } from "./bumblebee.js";
 
@@ -67,6 +68,16 @@ export interface SecurityCheckResult {
    * didNotRun — it is an honest skip.
    */
   didNotRun?: boolean;
+  /**
+   * An out-of-verdict advisory riding on this result. Some signals must NOT move
+   * pass/fail — catalog age is a function of the wall clock, an upstream release is a
+   * function of someone else's schedule — but they still need to reach a human. A
+   * printed line scrolls out of the terminal; this carries the signal to the PAL
+   * ledger (persistent, cross-session, counted in the statusline) without any
+   * consumer having to string-match the `detail` text. `key` is the stable dedup
+   * identity, so the ledger row auto-closes once the advisory stops being emitted.
+   */
+  advisory?: { key: string; title: string; detail: string };
   /**
    * The self-audit rule id (e.g. "R2-secret-argv") that produced this result.
    * Lets consumers (kit coverage --verify) bind evidence by the stable rule id
@@ -1992,13 +2003,35 @@ async function checkBumblebee(): Promise<SecurityCheckResult> {
   if (newest !== null) {
     const { stale, ageDays } = isCatalogStale(newest, Date.now());
     if (stale) {
+      // Cached-only lookup: whether a newer release EXISTS is the other half of "your
+      // catalogs are old", but it must not put a network call in the check path — the
+      // check's output would then depend on whether a GitHub request succeeded. The
+      // cache is populated by the post-command notice in cli.ts.
+      const { readCachedBumblebeeUpdateSync } = await import("./bumblebee-update.js");
+      const upd = readCachedBumblebeeUpdateSync(BUMBLEBEE_VERSION);
+      const suggestion = upd
+        ? `Bump BUMBLEBEE_VERSION to ${upd.latest} (and TARBALL_CHECKSUMS to match its checksums.txt) in src/bumblebee.ts — the two MUST move together.`
+        : "Bump BUMBLEBEE_VERSION (and TARBALL_CHECKSUMS) in src/bumblebee.ts to refresh the exposure catalogs.";
       return {
         category,
         name,
         status: "pass",
-        detail: `no known exposures (${outcome.packagesScanned} packages); note: threat-intel catalogs are ${ageDays} days old (advisory — not gated)`,
-        suggestion:
-          "Bump BUMBLEBEE_VERSION (and TARBALL_CHECKSUMS) in src/bumblebee.ts to refresh the exposure catalogs.",
+        detail:
+          `no known exposures (${outcome.packagesScanned} packages); note: threat-intel catalogs are ${ageDays} days old (advisory — not gated)` +
+          (upd ? `; bumblebee ${upd.latest} is available upstream (pinned ${upd.pinned})` : ""),
+        suggestion,
+        // Dedup identity excludes ageDays on purpose: the age climbs every single day,
+        // so keying on it would open a NEW ledger row per day instead of keeping one
+        // open item. It does include whether an upstream bump is known, so the row is
+        // replaced (not silently kept stale) when "old catalogs" becomes "old catalogs,
+        // and here is the version to bump to".
+        advisory: {
+          key: upd ? `bumblebee-catalogs-stale:${upd.latest}` : "bumblebee-catalogs-stale",
+          title: upd
+            ? `bumblebee ${upd.latest} available (pinned ${upd.pinned}, catalogs ${ageDays}d old)`
+            : `bumblebee threat-intel catalogs ${ageDays} days old`,
+          detail: suggestion,
+        },
       };
     }
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -388,6 +388,18 @@ async function main(): Promise<void> {
           if (info) printUpdateNotice(info);
         })
         .catch(() => {}); // never fail
+
+      // Pinned-scanner release notice. Same posture as the self-update check (shared
+      // suppression, 3s timeout, cached, never throws) and deliberately NOT a verdict:
+      // it only refreshes the cache the security check reads, and prints when a bump
+      // exists. Never auto-installs — the binary pin is a supply-chain control.
+      import("./bumblebee-update.js")
+        .then(async ({ checkForBumblebeeUpdate, formatBumblebeeNotice }) => {
+          const { BUMBLEBEE_VERSION } = await import("./bumblebee.js");
+          const info = await checkForBumblebeeUpdate(BUMBLEBEE_VERSION);
+          if (info) console.error(`  ${c.dim}╰─${c.reset} ${formatBumblebeeNotice(info)}`);
+        })
+        .catch(() => {}); // never fail
     }
   } catch (err: unknown) {
     const code =

--- a/src/findings-track.ts
+++ b/src/findings-track.ts
@@ -30,6 +30,25 @@ export function securityFindingToSync(r: SecurityCheckResult): SyncFinding {
 }
 
 /**
+ * Out-of-verdict advisories carried by results of ANY status — including `pass`, which
+ * is where they mostly live, since an advisory that moved the verdict would make the
+ * gate depend on the wall clock or on someone else's release schedule. That is exactly
+ * why `actionableFindings` cannot see them: it filters on fail/warn.
+ */
+export function advisoryFindings(results: SecurityCheckResult[]): SyncFinding[] {
+  return results
+    .filter(
+      (r): r is SecurityCheckResult & { advisory: NonNullable<SecurityCheckResult["advisory"]> } =>
+        r.advisory !== undefined,
+    ) // prettier-ignore
+    .map((r) => ({
+      dedupKey: r.advisory.key,
+      title: r.advisory.title,
+      detail: r.advisory.detail,
+    }));
+}
+
+/**
  * Sync security findings into the PAL ledger (track + auto-close cleared ones).
  * Fail-open: returns the sync counts, or null if the store is unavailable —
  * tracking must never break the calling command.
@@ -47,9 +66,18 @@ export async function syncSecurityFindings(
     const scope = getCurrentProjectRoot();
     const db = openMemoryDb();
     try {
-      return palSyncFindings(db, "sec", actionableFindings(results).map(securityFindingToSync), {
+      const r = palSyncFindings(db, "sec", actionableFindings(results).map(securityFindingToSync), {
         scope,
       });
+      // Advisories reconcile under their OWN source tag. palSyncFindings closes every
+      // row of its tag that is absent from the batch, so folding advisories into "sec"
+      // would make each sync close the other's items on every run.
+      const a = palSyncFindings(db, "adv", advisoryFindings(results), { scope });
+      return {
+        added: r.added + a.added,
+        reopened: r.reopened + a.reopened,
+        closed: [...r.closed, ...a.closed],
+      };
     } finally {
       db.close();
     }

--- a/src/knobs.ts
+++ b/src/knobs.ts
@@ -136,7 +136,7 @@ export const KNOBS: KnobGroup[] = [
       {
         name: "KIT_NO_UPDATE_CHECK",
         kind: "env",
-        desc: "disable the npm update check (reproducible/offline CI)",
+        desc: "disable the outbound version notices — kit's own npm check and the pinned-scanner release check (reproducible/offline CI)",
       },
       {
         name: "KIT_AIRGAP",

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -35,7 +35,7 @@ export interface UpdateInfo {
  * exported would otherwise let the npm update beacon punch through. Best-effort:
  * a missing/invalid config falls back to the env-only signal.
  */
-async function isAirGapPosture(): Promise<boolean> {
+export async function isAirGapPosture(): Promise<boolean> {
   if (isAirGap()) return true;
   try {
     const [{ loadConfig }, { resolveAirGap }] = await Promise.all([


### PR DESCRIPTION
## Half a sentence

kit told you the bumblebee threat-intel catalogs were 65 days old. It never told you whether there was a newer release to bump **to**. This adds the other half — as a *notice*.

## What is deliberately NOT changed

**The binary pin stays.** `BUMBLEBEE_VERSION` + `TARBALL_CHECKSUMS` are never auto-updated. Fetching an executable whose checksum cannot be verified in advance is precisely the supply-chain attack kit exists to catch, and `IntegrityError` in `bumblebee.ts` exists for that case. The bump remains a deliberate, reviewed commit where the two constants move together — which the code already demands in capitals.

**No verdict moves.** Whether upstream cut a release depends on the network and someone else's release schedule. Letting that touch pass/fail would make `kit ci --strict` return a different answer for an unchanged repo — exactly the reasoning already written into `check-security.ts` for why catalog *age* is advisory. The security check therefore reads a **cache only** and makes no network call; the cache is refreshed by the post-command notice.

## The real defect it surfaces

The `threat_intel/` catalogs ship **inside** the pinned tarball. That couples data with a days-scale half-life to a binary with a months-scale one — which is *why* the catalogs go stale, and why there is no way to refresh them without moving the pin. The notice makes that coupling visible instead of silent.

## Advisories now reach PAL

New optional field:

```ts
advisory?: { key: string; title: string; detail: string }
```

Signals that must not move the verdict but must still reach a human. These ride mostly on **`pass`** results — which is exactly why `actionableFindings` (fail/warn only) could never see them. That was the delivery gap: a printed line scrolls out of the terminal and is gone.

`advisoryFindings()` bridges them into the PAL ledger under their own **`adv`** source tag:

- **Separate tag, deliberately.** `palSyncFindings` closes every row of its tag absent from the batch, so folding advisories into `sec` would make each sync close the other's rows on every run.
- **Dedup key excludes the day count.** Keying on "65 days old" would open a *new* ledger row every single day. One row stays open, with its title refreshed to tell the truth about the current age.
- **Auto-closes** once the advisory stops being emitted (catalogs refreshed).
- Lands in the `kit statusline` ⚠ badge the session-start hook injects — persistent and cross-session.

## Notice robustness

Audited the existing self-update notice and mirrored it, extracting `isAirGapPosture()` so **one** decision governs both outbound notice paths — air-gap cannot be honored on one and punched through on another. Per check: 3s `AbortSignal.timeout`, 24h cache, and every failure path returning null (suppressed / offline / rate-limited / malformed JSON / unparseable tag / cache write failure). Only a successfully parsed version is ever cached, so the cache cannot hold a value that later compares as garbage.

Suppressed by `KIT_NO_UPDATE_CHECK`, `CI`, `GITHUB_ACTIONS`, `GITLAB_CI`, and air-gap. `kit knobs` updated to say so.

The notice prints to **stderr**, so it cannot corrupt piped stdout.

## Verification

- 14 new unit tests: tag parsing (rejects `nightly`, `release-20260721.0`, non-strings), highest-stable selection (skips drafts/prereleases, ignores array order, handles a rate-limit error object), never suggesting a downgrade, and a suppression test that **patches `fetch` to throw if called** — proving the posture, not just the return value.
- End-to-end against a real SQLite store: a `pass`-carried advisory lands in PAL, stays **one** row across a climbing day count with the title refreshed, auto-closes when it clears, coexists with `sec` findings without either closing the other, and is visible through the *scoped* read the statusline uses with no cross-repo bleed.
- Full suite **3270 tests, 0 fail**. `tsc --noEmit`, `prettier --check`, eslint all clean. Contracts regenerated.

## One thing I did not change

The existing self-update notice still prints to **stdout**, which is why it has to be skipped in `--json` mode. stderr would be structurally correct and make that workaround unnecessary — but it would change what an existing `kit … | grep` sees, so it is flagged here rather than changed silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
