### PR TITLE
fix(bumblebee): bump pin to 0.1.2 — and correct the 5.22.0 claim it changes no intel (5.23.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.23.0] - 2026-07-27
+
+### Changed
+
+- **bumblebee pin bumped 0.1.1 → 0.1.2, with the digests verified by download rather than
+  copied.** All four release tarballs were fetched and their SHA-256 recomputed against the
+  release's `checksums.txt` (4/4 match); v0.1.1's published checksums were also confirmed to
+  equal the digests already embedded here, cross-validating the source.
+  - **Threat intel: 6 → 11 catalogs**, newest authoring date 2026-05-18 → 2026-06-18
+    (65 → 38 days, under the 60-day staleness threshold, so the advisory clears). Adds
+    `glassworm`, `trapdoor-crypto-stealer`, `mastra-2026-06-17`, `laravel-lang-2026-05-23`,
+    `mini-shai-hulud-redhat-cloud-services`.
+  - **Inventory coverage** widens into kit's own domain: an `agent-skill` ecosystem
+    (skills.sh / vercel-labs lock files, including the project-local `skills-lock.json` kit
+    already manages), `homebrew` install receipts, and `~/.claude.json` MCP parsing for
+    Claude Code's user- and project-scoped servers.
+
+### Fixed
+
+- **Corrected the 5.22.0 claim that a newer bumblebee release brings no fresher threat
+  intel.** It does here. The error was methodological and is now recorded in
+  `bumblebee-update.ts` so it is not repeated: the six pre-existing catalogs *are*
+  byte-identical across the two tags, and `raw.githubusercontent.com` cannot list a
+  directory — so comparing only the filenames already known makes five ADDED catalogs
+  invisible and looks like "nothing changed". Compare the release tarball, not a guessed
+  file list. The suggestion text no longer asserts either direction: whether a bump
+  refreshes the catalogs depends on the release, so it points at the evidence instead.
+
+
 ## [5.22.0] - 2026-07-27
 
 ### Added

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -1099,7 +1099,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.22.0"
+    "version": "5.23.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "5.22.0",
+  "version": "5.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "5.22.0",
+      "version": "5.23.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.22.0",
+  "version": "5.23.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/bumblebee-update.ts
+++ b/src/bumblebee-update.ts
@@ -23,14 +23,23 @@
  * decision (air-gap / CI / opt-out), a 3s timeout, a cached result, and every failure
  * path returning null. A notice must never slow down, break, or leak out of a run.
  *
- * MEASURED CAVEAT (2026-07-27, upstream v0.1.1 vs v0.1.2): a newer release does NOT
- * imply newer threat intel. All six threat_intel/*.json catalogs are byte-identical
- * across those two tags; what v0.1.2 adds is inventory COVERAGE (an `agent-skill`
- * ecosystem for skills.sh / vercel-labs lock files, `homebrew`, and `~/.claude.json`
- * MCP parsing). So this module reports "a newer release exists", never "your catalogs
- * will get fresher" — the catalog age can be upstream's own, not a lagging pin. Also
- * note a *tag* is not a *release*: the notice reads the releases API and skips
- * drafts/prereleases, so a tagged-but-unreleased version correctly produces silence.
+ * MEASURED (2026-07-27, upstream v0.1.1 → v0.1.2): a bump moved the catalogs from 6 to
+ * 11 files and the newest authoring date from 2026-05-18 to 2026-06-18 (65 → 38 days),
+ * adding glassworm, trapdoor-crypto-stealer, mastra-2026-06-17, laravel-lang-2026-05-23
+ * and mini-shai-hulud-redhat-cloud-services. It also widened inventory COVERAGE: an
+ * `agent-skill` ecosystem (skills.sh / vercel-labs lock files), `homebrew` receipts, and
+ * `~/.claude.json` MCP parsing.
+ *
+ * Method note worth keeping, because getting it wrong once cost a wrong conclusion: the
+ * six pre-existing catalogs are byte-identical across those tags, so comparing only the
+ * filenames you already know looks like "nothing changed". `raw.githubusercontent.com`
+ * cannot list a directory — the ADDED files are invisible that way. Compare the actual
+ * release tarball, not a guessed file list.
+ *
+ * So the notice reports "a newer release exists" and leaves whether it ships fresher
+ * catalogs to be checked rather than assumed — sometimes it does, sometimes the age is
+ * upstream's own. Note also that a *tag* is not a *release*: this reads the releases API
+ * and skips drafts/prereleases, so a tagged-but-unreleased version produces silence.
  */
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { readFileSync } from "node:fs";

--- a/src/bumblebee.ts
+++ b/src/bumblebee.ts
@@ -52,7 +52,7 @@ export interface EnsureResult {
  * Pinned bumblebee release. Bump deliberately, and update TARBALL_CHECKSUMS to
  * match the release's checksums.txt — the two MUST move together.
  */
-export const BUMBLEBEE_VERSION = "0.1.1";
+export const BUMBLEBEE_VERSION = "0.1.2";
 
 const RELEASE_BASE_URL = "https://github.com/perplexityai/bumblebee/releases/download";
 
@@ -64,14 +64,14 @@ const RELEASE_BASE_URL = "https://github.com/perplexityai/bumblebee/releases/dow
  * kit package itself.
  */
 export const TARBALL_CHECKSUMS: Record<string, string> = {
-  "bumblebee_0.1.1_darwin_amd64.tar.gz":
-    "dd3b2573a974a2786f58215483420fa11cf62b39ff4032693f1440575940dc25",
-  "bumblebee_0.1.1_darwin_arm64.tar.gz":
-    "dc0a620e54e85f998c2280b0323763c342973a25eda475d8036d16b01820a2bf",
-  "bumblebee_0.1.1_linux_amd64.tar.gz":
-    "0ef1c56c85a67c10f7211883c0eb5fb902de705cc30bbca0bc6f4d60941547da",
-  "bumblebee_0.1.1_linux_arm64.tar.gz":
-    "41aad0296bb6c88e746b237ed32eaa3b9b93c48770a51cd66f736f8a4d07a7d1",
+  "bumblebee_0.1.2_darwin_amd64.tar.gz":
+    "ea7f0ea303f712f3073ddb0f9fc0b368692ec1eee581b9a5d069ed986db2b433",
+  "bumblebee_0.1.2_darwin_arm64.tar.gz":
+    "0535aefeb6d1bdc2b4f44e393c5da385c95ac63c7c8f0bcee01b054d688bdab5",
+  "bumblebee_0.1.2_linux_amd64.tar.gz":
+    "53b080cf3ddb692b0c4e5492ef4785b4c54daf1624fcd0fcba3958116a0be8d9",
+  "bumblebee_0.1.2_linux_arm64.tar.gz":
+    "cb641a1023b12cd7b1411ebef5c7d426f7ecd81770a15a85873c5334a0e6b74d",
 };
 
 export interface PlatformTarget {

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -2009,13 +2009,12 @@ async function checkBumblebee(): Promise<SecurityCheckResult> {
       // cache is populated by the post-command notice in cli.ts.
       const { readCachedBumblebeeUpdateSync } = await import("./bumblebee-update.js");
       const upd = readCachedBumblebeeUpdateSync(BUMBLEBEE_VERSION);
-      // Neither branch promises that a bump yields FRESHER catalogs. Measured against
-      // upstream: every threat_intel catalog is byte-identical between v0.1.1 and
-      // v0.1.2, so the age can be upstream's own data age rather than a lagging pin —
-      // and "bump to refresh the catalogs" would then be a false promise.
+      // Neither branch ASSERTS that a bump refreshes the catalogs — it depends on the
+      // release. (v0.1.1 → v0.1.2 did: 6 → 11 catalogs, 65 → 38 days. But the six
+      // pre-existing files were byte-identical, so a bump can also change nothing.)
       const suggestion = upd
-        ? `bumblebee ${upd.latest} is available (pinned ${upd.pinned}). Moving BUMBLEBEE_VERSION + TARBALL_CHECKSUMS together in src/bumblebee.ts is the only way to change the bundled catalogs — check the release actually ships newer ones before assuming a bump refreshes them.`
-        : "No newer bumblebee release is known here (the check is cached, suppressed, or upstream has published none), so the age may be upstream's own rather than a lagging pin — a bump only helps if a newer release ships fresher catalogs.";
+        ? `bumblebee ${upd.latest} is available (pinned ${upd.pinned}). Moving BUMBLEBEE_VERSION + TARBALL_CHECKSUMS together in src/bumblebee.ts is the only way to change the bundled catalogs — compare the release tarball's threat_intel/ to see what it actually adds.`
+        : "No newer bumblebee release is known here (the check is cached, suppressed, or upstream has published none), so this age may be upstream's own rather than a lagging pin.";
       return {
         category,
         name,


### PR DESCRIPTION
## The pin moves, and the digests were verified rather than copied

All four v0.1.2 tarballs were downloaded and their SHA-256 recomputed against the release's `checksums.txt` — **4/4 match**. As a cross-check on the source, v0.1.1's published checksums were confirmed identical to the digests already embedded in `bumblebee.ts`, which proves the file being read is the one the existing pin came from.

```
✓ bumblebee_0.1.2_darwin_amd64.tar.gz
✓ bumblebee_0.1.2_darwin_arm64.tar.gz
✓ bumblebee_0.1.2_linux_amd64.tar.gz
✓ bumblebee_0.1.2_linux_arm64.tar.gz
→ verified=4 failed=0
```

## What the bump actually brings

**Threat intel: 6 → 11 catalogs.** Newest authoring date 2026-05-18 → 2026-06-18, i.e. **65 → 38 days** — under the 60-day threshold, so the staleness advisory clears. New: `glassworm`, `trapdoor-crypto-stealer`, `mastra-2026-06-17`, `laravel-lang-2026-05-23`, `mini-shai-hulud-redhat-cloud-services`.

**Inventory coverage, straight into kit's own domain:**

- `agent-skill` ecosystem — skills.sh / vercel-labs lock files, including the project-local `skills-lock.json` kit already manages in `src/skills.ts`
- `homebrew` — formula `INSTALL_RECEIPT.json` and cask `.metadata` markers
- MCP now parses `~/.claude.json` — Claude Code's user- and project-scoped `mcpServers`

## Correcting 5.22.0

5.22.0 stated that a newer release brings **no** fresher threat intel, and wrote that into the docblock, the suggestion text, and the CHANGELOG. **That was wrong**, and the error is worth recording because the failure mode is subtle:

- The six **pre-existing** catalogs *are* byte-identical across v0.1.1 and v0.1.2 — that part was correct.
- `raw.githubusercontent.com` **cannot list a directory**. Comparing only the filenames already known therefore makes the five **added** catalogs invisible, and the result reads as "nothing changed".
- Probing for guessed new filenames found nothing, which felt like confirmation. It was not evidence.

The fix that mattered was comparing the **release tarball**, not a file list. That method note now lives in `bumblebee-update.ts` so the next reader does not re-derive it.

The suggestion text no longer asserts either direction — whether a bump refreshes the catalogs depends on the release, so it points at the evidence instead of promising an outcome.

## Verification

Full suite **3270 tests, 0 fail**. `tsc --noEmit`, `prettier --check` clean, contracts regenerated. The notice path was also exercised live against the real releases API, which independently identified 0.1.2 as the newest non-draft, non-prerelease release; at the new pin it is correctly silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
