### PR TITLE
feat(statusline): adoption nudge — say what to DO, not just the score

### DIFF
--- a/src/statusline.test.ts
+++ b/src/statusline.test.ts
@@ -36,4 +36,35 @@ describe("formatStatusline", () => {
     assert.equal(formatStatusline({ update: "2.0.0" }), "⬆2.0.0");
     assert.equal(formatStatusline({ pal: 3 }), "⚠3");
   });
+
+  // The adoption nudge: a bare "kit:full 1/6" is true but actionless — the line
+  // must say what to DO next, exactly once, and only while incomplete.
+  it("appends the next-step nudge when the score is incomplete", () => {
+    assert.equal(
+      formatStatusline({ mode: "full", score: { done: 1, total: 6 }, next: "kit init" }),
+      "kit:full 1/6 → kit init",
+    );
+  });
+
+  it("nudge rides AFTER the other segments", () => {
+    assert.equal(
+      formatStatusline({
+        mode: "full",
+        score: { done: 2, total: 6 },
+        update: "9.9.9",
+        pal: 1,
+        next: "kit install",
+      }),
+      "kit:full 2/6 · ⬆9.9.9 · ⚠1 → kit install",
+    );
+  });
+
+  it("no nudge when complete, when no score shows, or when next is absent", () => {
+    assert.equal(
+      formatStatusline({ mode: "full", score: { done: 6, total: 6 }, next: "kit init" }),
+      "kit:full 6/6",
+    );
+    assert.equal(formatStatusline({ next: "kit init" }), "");
+    assert.equal(formatStatusline({ mode: "full", score: { done: 1, total: 6 } }), "kit:full 1/6");
+  });
 });

--- a/src/statusline.ts
+++ b/src/statusline.ts
@@ -25,12 +25,17 @@ export interface StatuslineParts {
   update?: string | null;
   /** open PAL ("blocked on you") count */
   pal?: number;
+  /** The ONE next setup command when adoption is incomplete (e.g. "kit init").
+   *  A bare "kit:full 1/6" is true but actionless — the score says something is
+   *  missing without saying what to DO, which is how a new repo stays un-kitted. */
+  next?: string;
 }
 
 /**
- * Render the compact line, e.g. `kit:full 6/6 · ⬆1.34.0 · ⚠2`. Segments are omitted
- * when empty so an up-to-date repo with no PAL items shows just the score (or
- * nothing). Plain ASCII + two glyphs only — safe in any terminal/harness bar.
+ * Render the compact line, e.g. `kit:full 6/6 · ⬆1.34.0 · ⚠2` — or, in an
+ * un-adopted repo, `kit:full 1/6 → kit init`. Segments are omitted when empty so
+ * an up-to-date repo with no PAL items shows just the score (or nothing).
+ * Plain ASCII + three glyphs only — safe in any terminal/harness bar.
  */
 export function formatStatusline(p: StatuslineParts): string {
   const seg: string[] = [];
@@ -45,7 +50,12 @@ export function formatStatusline(p: StatuslineParts): string {
   }
   if (p.update) seg.push(`⬆${p.update}`);
   if (typeof p.pal === "number" && p.pal > 0) seg.push(`⚠${p.pal}`);
-  return seg.join(" · ");
+  const line = seg.join(" · ");
+  // The nudge rides the score segment: only when a score is showing AND incomplete.
+  if (p.next && p.score && p.score.total > 0 && p.score.done < p.score.total) {
+    return `${line} → ${p.next}`;
+  }
+  return line;
 }
 
 /** Cheap, read-only subsystem presence (file-existence only — no shell/network), for
@@ -125,12 +135,15 @@ export async function buildStatuslineText(
     /* no/invalid .kit.toml — statusline still works (mode=full default) */
   }
   const { profile } = resolveMode(opts.modeFlag, config.setup?.mode);
-  const { done, total } = modeScore(profile, quickSubsystems(cwd));
+  const { done, total, gaps } = modeScore(profile, quickSubsystems(cwd));
   const update = readCachedUpdateSync(getKitVersionSync());
   return formatStatusline({
     mode: profile.mode,
     score: { done, total },
     update: update?.latest ?? null,
     pal: await quickPalCount(cwd),
+    // First gap in subsystem order = the natural next step (config → "kit init"
+    // first, so a repo with no .kit.toml is told how to START, not just scored).
+    next: gaps[0]?.next,
   });
 }


### PR DESCRIPTION
An un-kitted repo's statusline said `kit:full 1/6` — true but actionless. It now appends the one next step from the first subsystem gap: `kit:full 1/6 → kit init` (then `→ kit install`, `→ kit secrets`, … as adoption progresses). Complete score keeps today's output. Since the memory SessionStart hook injects this same line, every harness session in a new repo now opens with the reminder.

Verified live in a fresh repo fixture; 3 new formatter tests pin the nudge contract (incomplete-only, rides last, absent when complete/no score).

Local suite note: 3281/3282 — the one red is self-audit's cloud-sync rule catching iCloud conflict copies spawning in gitignored dist/ during the run (this machine's repo lives under iCloud-synced ~/Documents). Honest environmental finding; clean CI runner is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)