### PR TITLE
docs(readme): transparent end state for the bootstrap line — pinned by a drift gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,6 +850,31 @@ own bootstrap. Releases carry SLSA provenance and cosign-signed images; see
 [docs/VERIFY.md](docs/VERIFY.md) to verify before you paste the line into an
 org-wide template.
 
+**Transparent end state** — you should know exactly what a line you paste
+will turn into. When the bootstrap completes, your rules file contains this
+managed block and nothing else has been touched (visible BEGIN/END markers,
+idempotent — re-runs update only the region between them):
+
+```markdown
+<!-- BEGIN kit (managed block — edit outside the markers, not inside) -->
+## kit
+
+This repo is managed by [kit](https://github.com/sandstream/kit) (env, secrets, security gates). Hooks enforce the hard rules; what you need to know:
+
+- Start: `kit check` — on `fail`, run `kit fix`, then re-check.
+- Prior decisions: `kit memory search "<query>"` (cross-session, cross-agent).
+- Secrets: `kit secrets` (vault-backed); placeholders go in `.env.example`, never plaintext in `.env*`.
+- Deps the install gate hasn't covered (git repos, URLs, vendored code): `kit triage repo <target>` first.
+- After a batch of edits: `kit check --category security`; halt and surface findings on `fail`.
+- Everything else: `kit --help` — the commands are self-documenting.
+<!-- END kit -->
+```
+
+The block is an index, not an encyclopedia — every agent turn pays for these
+tokens, so anything a hook already enforces deterministically carries zero
+prose here. A drift test pins this README example to the `KIT_INSTRUCTION`
+the code actually writes, so the promise can't rot.
+
 kit exposes its capabilities as an MCP server, making it usable directly by Claude Code, Cursor, Windsurf, Cline, and any other MCP-compatible AI assistant. Once registered, assistants can call `kit_check`, `kit_fix`, `kit_triage`, and other tools without leaving their context. (An agent **with shell access** should prefer the CLI — zero standing context cost, and `kit <command> --help` self-documents; the MCP surface exists for shell-less clients. The server's `instructions` field tells clients exactly this.)
 
 ### Claude Code

--- a/src/docs-agent-block-sync.test.ts
+++ b/src/docs-agent-block-sync.test.ts
@@ -1,0 +1,30 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { KIT_BLOCK_BEGIN, KIT_BLOCK_END, KIT_INSTRUCTION } from "./agent-config.js";
+
+/**
+ * README ↔ managed-block drift gate.
+ *
+ * The bootstrap section shows users the EXACT managed block the one-liner will
+ * turn into — the whole point is transparency, so a stale example is worse
+ * than none (it promises one thing and writes another). This pins the README's
+ * quoted block to the KIT_INSTRUCTION the code actually writes; change either
+ * side and the build says so.
+ */
+describe("README bootstrap section ↔ KIT_INSTRUCTION", () => {
+  const readme = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "..", "README.md"),
+    "utf8",
+  );
+
+  it("quotes the real managed block, markers included, verbatim", () => {
+    const expected = `${KIT_BLOCK_BEGIN}\n${KIT_INSTRUCTION}\n${KIT_BLOCK_END}`;
+    assert.ok(
+      readme.includes(expected),
+      "README's transparent-end-state example drifted from the KIT_INSTRUCTION the code writes — update the README block (or, if the instruction changed deliberately, the README example) so the promise stays true",
+    );
+  });
+});


### PR DESCRIPTION
Follow-up to #418 from today's discussion: show users the exact managed block the one-liner turns into (verbatim, markers included) plus the idempotence contract. A new drift test (`docs-agent-block-sync.test.ts`) pins the README example to the `KIT_INSTRUCTION` the code writes — the transparency promise can't rot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)