### PR TITLE
feat(agent-config): the managed block carries its own bootstrap line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@
 
 This repo is managed by [kit](https://github.com/sandstream/kit) (env, secrets, security gates). Hooks enforce the hard rules; what you need to know:
 
+- If `kit` is missing (fresh clone/machine): `npm i -g sandstream-kit`, then continue below.
 - Start: `kit check` — on `fail`, run `kit fix`, then re-check.
 - Prior decisions: `kit memory search "<query>"` (cross-session, cross-agent).
 - Secrets: `kit secrets` (vault-backed); placeholders go in `.env.example`, never plaintext in `.env*`.

--- a/README.md
+++ b/README.md
@@ -861,6 +861,7 @@ idempotent — re-runs update only the region between them):
 
 This repo is managed by [kit](https://github.com/sandstream/kit) (env, secrets, security gates). Hooks enforce the hard rules; what you need to know:
 
+- If `kit` is missing (fresh clone/machine): `npm i -g sandstream-kit`, then continue below.
 - Start: `kit check` — on `fail`, run `kit fix`, then re-check.
 - Prior decisions: `kit memory search "<query>"` (cross-session, cross-agent).
 - Secrets: `kit secrets` (vault-backed); placeholders go in `.env.example`, never plaintext in `.env*`.

--- a/src/agent-config.ts
+++ b/src/agent-config.ts
@@ -43,6 +43,7 @@ export const KIT_INSTRUCTION = `## kit
 
 This repo is managed by [kit](https://github.com/sandstream/kit) (env, secrets, security gates). Hooks enforce the hard rules; what you need to know:
 
+- If \`kit\` is missing (fresh clone/machine): \`npm i -g sandstream-kit\`, then continue below.
 - Start: \`kit check\` — on \`fail\`, run \`kit fix\`, then re-check.
 - Prior decisions: \`kit memory search "<query>"\` (cross-session, cross-agent).
 - Secrets: \`kit secrets\` (vault-backed); placeholders go in \`.env.example\`, never plaintext in \`.env*\`.


### PR DESCRIPTION
Closes the fresh-clone dead end found while tracing "what happens with no kit installed at all": the managed block (which replaces the README one-liner after `kit init`) never said what to do when the binary is missing — a teammate cloning a kit-managed repo got `command not found` and a guessing agent. One line in `KIT_INSTRUCTION` fixes it; the new docs-agent-block-sync drift gate fired on the change exactly as designed and forced the README example to follow. kit-public's own CLAUDE.md updated (dogfood).

3283/3283 tests, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
