### PR TITLE
chore(release): 5.25.0 — the managed block bootstraps itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.25.0] - 2026-07-28
+
+### Added
+
+- **The managed block carries its own bootstrap line.** The README one-liner
+  tells an agent how to install kit — but `kit init` replaces it with the
+  managed rules block, which said "Start: `kit check`" and nothing about a
+  missing binary. The teammate who cloned a kit-managed repo got the block,
+  not the line, and their agent met `command not found` and had to guess.
+  The block now opens with: if `kit` is missing (fresh clone/machine),
+  install it, then continue. The docs↔block drift gate shipped in 5.24.0
+  fired on this change exactly as designed and forced the README example to
+  follow; kit-public's own CLAUDE.md updated with it (dogfood). Existing
+  repos pick the line up on their next `kit agent-config` / `kit init` run
+  (the block is idempotent — only the marker-delimited region updates).
+
 ## [5.24.0] - 2026-07-28
 
 The adoption release — three pieces that close the "new project, nothing set

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -1099,7 +1099,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.24.0"
+    "version": "5.25.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.24.0",
+  "version": "5.25.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
Version bump + CHANGELOG for #421 (bootstrap line in the managed block — the fresh-clone dead end closed). Local verification: 3283/3283 tests, lint 0 errors, prettier clean, self-audit 0 fail 0 warn, changelog gate renders 985 bytes, opencli regenerated.

After merge: signed tag `v5.25.0` on main (owner signs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)