### PR TITLE
feat(review): stages + category scoping — the migration path 6.0 needs

### DIFF
--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -770,7 +770,7 @@
     },
     "review": {
       "kind": "command",
-      "summary": "Full repo audit — runs check + design + standards + adr in one gate (for agents / PR checks; --json emits one structured report)",
+      "summary": "Full repo audit — runs check + design + standards + adr in one gate (for agents / PR checks; --json emits one structured report; --stages check,standards scopes the run, --category scopes the standards stage)",
       "x-kit-args-modeled": false,
       "x-kit-audience": "all",
       "x-kit-mcp": true,

--- a/docs/MCP_TOOLS_REFERENCE.md
+++ b/docs/MCP_TOOLS_REFERENCE.md
@@ -26,7 +26,7 @@ governance floor (revocation, budget, permissions, expired-secret block).
 | Tool | Kind | Purpose |
 | --- | --- | --- |
 | `kit_check` | read | Run all checks — tools, services, secrets, skills, hooks, security, tests, locks — and return the same verdict `kit check` computes. |
-| `kit_review` | read | Full repo audit in one shot — the check, design, standards, and ADR gates as one structured report (`{ ok, failed, stages }`), from the same core `kit review` renders. `concise: true` omits pass/skip rows (per-stage counts stay). |
+| `kit_review` | read | Full repo audit in one shot — the check, design, standards, and ADR gates as one structured report (`{ ok, failed, stages }`), from the same core `kit review` renders. `stages: ["standards"]` scopes to named gates (the fast, read-only lint loop — no full security scan), `category` scopes the standards stage, `concise: true` omits pass/skip rows (per-stage counts stay). |
 | `kit_fix` | write | Auto-fix what `kit_check` found: install missing tools, generate missing lock files. Returns actions taken. |
 | `kit_triage` | write | Security-triage a dependency **before** installing it (`type`: npm/pip/docker/brew/repo/skill + `target`). A PASS is recorded in the triage log the install gates read, so an MCP-run triage satisfies them identically to a CLI-run one. Refuses in read-only mode — an unrecordable pass could not satisfy the gates anyway. |
 | `kit_memory` | read | Search cross-session conversation memory plus the repo's curated shared decisions (`query`, `limit?`, `global?`). Search-only by design: writes stay on the CLI/indexer path so an MCP client can never inject text into the trusted store. Quarantined rows excluded. A missing store returns empty — it is never created by a read. |
@@ -35,7 +35,7 @@ governance floor (revocation, budget, permissions, expired-secret block).
 | `kit_context` | read | Gather project context (stack, services, env status) for the agent. |
 | `kit_map` | read | Repo map: import-neighborhood slice around seed paths (`paths`, `depth?`, `budget?`, `co_change?`). |
 | `kit_init` | write | Detect the stack and generate `.kit.toml` for a project that has none (`dryRun` to preview). |
-| `kit_standards` | read | **Deprecated — removed from the MCP surface in kit 6.0.** `kit_review` runs this gate as its standards stage; a scoped run (`--category`) goes via `kit_run`. |
+| `kit_standards` | read | **Deprecated — removed from the MCP surface in kit 6.0.** Use `kit_review` with `stages: ["standards"]` (+ `category` for scoping) — same gate, same read-only posture, one tool. |
 | `kit_env` | read | **Deprecated — removed from the MCP surface in kit 6.0.** Inspect `.env.local` key status (values redacted). Prefer `kit_context`. |
 | `kit_ci` | read | **Deprecated — removed in kit 6.0.** CI runners always have a shell; run `kit ci` there. |
 | `kit_install` | write | **Deprecated — removed in kit 6.0.** Setup-time provisioning happens in a shell (`kit install`), or via `kit_run`. |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -724,7 +724,7 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
   review: {
     handler: cmdReview,
     stability: "stable",
-    help: "Full repo audit — runs check + design + standards + adr in one gate (for agents / PR checks; --json emits one structured report)",
+    help: "Full repo audit — runs check + design + standards + adr in one gate (for agents / PR checks; --json emits one structured report; --stages check,standards scopes the run, --category scopes the standards stage)",
     // MCP-exposed: THE one-shot audit for shell-less agents (kit_review),
     // superseding kit_standards on that surface (deprecated, leaves in 6.0).
     mcp: true,

--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -69,4 +69,26 @@ describe("collectReview", () => {
     assert.equal(design.ok, true);
     assert.ok(design.findings.every((f) => f.status !== "fail"));
   });
+
+  it("stages scopes the run — only the requested gates appear, canonical order kept", async () => {
+    const scoped = await collectReview({ cwd: process.cwd(), stages: ["adr", "standards"] });
+    assert.deepEqual(
+      scoped.stages.map((s) => s.stage),
+      ["standards", "adr"],
+      "canonical order regardless of input order",
+    );
+    assert.equal(
+      scoped.ok,
+      scoped.stages.every((s) => s.ok),
+      "a scoped ok covers exactly the stages that ran",
+    );
+  });
+
+  it("a standards-only run is the fast lint loop — no check/security stage at all", async () => {
+    const scoped = await collectReview({ cwd: process.cwd(), stages: ["standards"] });
+    assert.deepEqual(
+      scoped.stages.map((s) => s.stage),
+      ["standards"],
+    );
+  });
 });

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -12,7 +12,7 @@
  * `kit check`'s own CLI extras. `kit review` is the gate, not the fixer.
  */
 import { c } from "../utils/colors.js";
-import { hasFlag, envTruthy } from "../utils/flags.js";
+import { hasFlag, flagValue, envTruthy } from "../utils/flags.js";
 import { loadConfig, type kitConfig } from "../config.js";
 import { resolveConfigPath } from "../cli-shared.js";
 import { withGovernance } from "../governance-middleware.js";
@@ -42,6 +42,8 @@ export interface ReviewReport {
   stages: ReviewStageReport[];
 }
 
+export const REVIEW_STAGES: readonly ReviewStageName[] = ["check", "design", "standards", "adr"];
+
 export interface CollectReviewOptions {
   cwd?: string;
   /** Preloaded config for the check stage (the CLI already has one for governance). */
@@ -52,6 +54,15 @@ export interface CollectReviewOptions {
   enforceTests?: boolean;
   /** Security gate posture (lenient / fail-on-warning) for the check stage. */
   gate?: GateOpts;
+  /** Run only these stages (canonical order is kept regardless of input order).
+   *  THE scoped, read-only path: an agent iterating on standards findings runs
+   *  `stages: ["standards"]` in seconds instead of paying the full audit's
+   *  security scan per loop — and it survives kit_standards' 6.0 removal.
+   *  Undefined ⇒ all four. */
+  stages?: ReviewStageName[];
+  /** Standards-stage scope (general | specific | plugins | platform | <language>),
+   *  passed through to the standards gate — parity with `kit standards --category`. */
+  category?: string;
 }
 
 function summarize(findings: JsonCheck[]): ReviewStageReport["summary"] {
@@ -118,26 +129,42 @@ function adrFindings(adr: Awaited<ReturnType<typeof runAdrGate>>): JsonCheck[] {
 }
 
 /**
- * Run every review stage and return the structured report. Read-only; stages run
- * in the order the CLI always ran them (check → design → standards → adr).
+ * Run the requested review stages (default: all four) and return the structured
+ * report. Read-only; stages run in the order the CLI always ran them
+ * (check → design → standards → adr) regardless of the input order. The report
+ * covers exactly the stages that ran — a scoped run's `ok` says nothing about
+ * the stages it skipped, and the `stages` array shows the scope honestly.
  */
 export async function collectReview(opts: CollectReviewOptions = {}): Promise<ReviewReport> {
-  const check = await runCheckGate({
-    cwd: opts.cwd,
-    config: opts.config,
-    enforceTests: opts.enforceTests,
-    gate: opts.gate,
-  });
-  const design = await runDesignGate({ cwd: opts.cwd, enforce: opts.enforce });
-  const standards = await runStandardsGate({ cwd: opts.cwd, enforce: opts.enforce });
-  const adr = await runAdrGate(opts.cwd ?? process.cwd());
+  const wanted = new Set<ReviewStageName>(opts.stages ?? REVIEW_STAGES);
+  const stages: ReviewStageReport[] = [];
 
-  const stages: ReviewStageReport[] = [
-    stageReport("check", check.ok, checkRunToJsonChecks(check)),
-    stageReport("design", design.ok, design.checks),
-    stageReport("standards", standards.ok, standards.checks),
-    stageReport("adr", adr.ok, adrFindings(adr)),
-  ];
+  if (wanted.has("check")) {
+    const check = await runCheckGate({
+      cwd: opts.cwd,
+      config: opts.config,
+      enforceTests: opts.enforceTests,
+      gate: opts.gate,
+    });
+    stages.push(stageReport("check", check.ok, checkRunToJsonChecks(check)));
+  }
+  if (wanted.has("design")) {
+    const design = await runDesignGate({ cwd: opts.cwd, enforce: opts.enforce });
+    stages.push(stageReport("design", design.ok, design.checks));
+  }
+  if (wanted.has("standards")) {
+    const standards = await runStandardsGate({
+      cwd: opts.cwd,
+      enforce: opts.enforce,
+      category: opts.category,
+    });
+    stages.push(stageReport("standards", standards.ok, standards.checks));
+  }
+  if (wanted.has("adr")) {
+    const adr = await runAdrGate(opts.cwd ?? process.cwd());
+    stages.push(stageReport("adr", adr.ok, adrFindings(adr)));
+  }
+
   const failed = stages.filter((s) => !s.ok).map((s) => s.stage);
   return { ok: failed.length === 0, failed, stages };
 }
@@ -158,6 +185,25 @@ export async function cmdReview(): Promise<boolean> {
     hasFlag(process.argv, "--fail-on-warning") ||
     hasFlag(process.argv, "--strict") ||
     envTruthy(process.env.KIT_CI_STRICT);
+  // --stages check,standards — scoped run (same semantics as the MCP tool's
+  // `stages` param). An unknown name is a refusal, not a silent full run.
+  const stagesFlag = flagValue(process.argv, "--stages");
+  let stages: ReviewStageName[] | undefined;
+  if (stagesFlag) {
+    const parsed = stagesFlag
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const bad = parsed.filter((s) => !REVIEW_STAGES.includes(s as ReviewStageName));
+    if (bad.length > 0) {
+      console.error(
+        `${c.red}✗ unknown stage(s): ${bad.join(", ")}${c.reset}  ${c.dim}(valid: ${REVIEW_STAGES.join(", ")})${c.reset}`,
+      );
+      return false;
+    }
+    stages = parsed as ReviewStageName[];
+  }
+  const category = flagValue(process.argv, "--category");
   const config = await loadConfig(resolveConfigPath());
 
   return await withGovernance(
@@ -170,6 +216,8 @@ export async function cmdReview(): Promise<boolean> {
         enforce,
         enforceTests,
         gate: { lenient, failOnWarning },
+        stages,
+        category,
       });
 
       if (jsonMode) {

--- a/src/mcp-server.test.ts
+++ b/src/mcp-server.test.ts
@@ -238,6 +238,39 @@ describe("kit_review", () => {
     }
   });
 
+  it('stages: ["standards"] runs ONLY that gate — the fast read-only lint loop', async () => {
+    const { client, cleanup } = await createTestClient();
+    try {
+      const result = await client.callTool({
+        name: "kit_review",
+        arguments: { cwd: tempDir, stages: ["standards"] },
+      });
+      const data = parseResult(result) as { stages: Array<{ stage: string }> };
+      assert.deepEqual(
+        data.stages.map((s) => s.stage),
+        ["standards"],
+        "no check/design/adr stage may run on a scoped call",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rejects an unknown stage name at the schema layer", async () => {
+    const { client, cleanup } = await createTestClient();
+    try {
+      const result = await client.callTool({
+        name: "kit_review",
+        arguments: { cwd: tempDir, stages: ["lint"] },
+      });
+      assert.equal(result.isError, true);
+      const content = result.content as Array<{ type: string; text: string }>;
+      assert.match(content[0].text, /invalid|enum/i);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("concise:true strips pass/skip rows but keeps the per-stage counts honest", async () => {
     const { client, cleanup } = await createTestClient();
     try {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -221,13 +221,24 @@ function register_kit_review(server: McpServer): void {
   // Read-only: no writes, so no governance/read-only gating.
   server.tool(
     "kit_review",
-    "Full repo audit in one shot — runs the check, design, standards, and ADR gates and returns one structured report ({ ok, failed, stages }). The same core `kit review` renders, so the surfaces cannot disagree. Read-only. Use concise:true to omit pass/skip rows (per-stage counts stay).",
+    'Full repo audit in one shot — runs the check, design, standards, and ADR gates and returns one structured report ({ ok, failed, stages }). The same core `kit review` renders, so the surfaces cannot disagree. Read-only. Use stages to scope (e.g. ["standards"] for a fast lint loop — no full security scan), category to scope the standards stage, and concise:true to omit pass/skip rows (per-stage counts stay).',
     {
       cwd: z.string().optional().describe("Working directory (defaults to process.cwd())"),
       enforce: z
         .boolean()
         .optional()
         .describe("Fail on net-new design/standards findings AND setup gaps (CI posture)"),
+      stages: z
+        .array(z.enum(["check", "design", "standards", "adr"]))
+        .nonempty()
+        .optional()
+        .describe(
+          'Run only these stages (canonical order kept). Omit for the full audit. ["standards"] is the fast, read-only lint loop',
+        ),
+      category: z
+        .string()
+        .optional()
+        .describe("Standards-stage scope: general | specific | plugins | platform | <language>"),
       concise: z
         .boolean()
         .optional()
@@ -235,10 +246,10 @@ function register_kit_review(server: McpServer): void {
           "Return only fail/warn findings; per-stage summary counts still cover everything",
         ),
     },
-    async ({ cwd, enforce, concise }) => {
+    async ({ cwd, enforce, stages, category, concise }) => {
       try {
         const { collectReview } = await import("./commands/review.js");
-        const report = await collectReview({ cwd, enforce });
+        const report = await collectReview({ cwd, enforce, stages, category });
         const payload = concise
           ? {
               ...report,
@@ -269,7 +280,7 @@ function register_kit_standards(server: McpServer): void {
   // kit_run for the rare scoped call), so a second standalone tool is surface bloat.
   server.tool(
     "kit_standards",
-    `${DEPRECATED_6_0}; kit_review runs this gate as its standards stage — prefer it (or kit_run with \`kit standards --category …\` for a scoped run). Run kit standards (deterministic dev-standards gate: complexity/duplication/size + per-language linters + user plugins + container) and return structured findings. Read-only.`,
+    `${DEPRECATED_6_0}; use kit_review with stages: ["standards"] (+ category for scoping) — same gate, same read-only posture, one tool. Run kit standards (deterministic dev-standards gate: complexity/duplication/size + per-language linters + user plugins + container) and return structured findings. Read-only.`,
     {
       cwd: z.string().optional().describe("Working directory (defaults to process.cwd())"),
       enforce: z


### PR DESCRIPTION
The open build-item from the 6.0 checklist: `collectReview` now takes `stages` (canonical order kept) and `category`, on both surfaces — `kit review --stages check,standards --category general` and the `kit_review` MCP params (enum-validated; unknown stage = schema refusal).

Why before 6.0: removing `kit_standards` without this left a read-only hole (`kit_run` refuses under `KIT_READ_ONLY`, so a scoped standards run would cost the full audit's security scan per lint-loop iteration). `stages: ["standards"]` is seconds, read-only, and survives the removal — the deprecation text now names it as the migration path.

Report honesty under scoping: `ok` covers exactly the stages that ran; the `stages` array shows the scope.

Verified: CLI smoke both ways, 3287/3287 tests (4 new), lint 0 errors, opencli regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)