### PR TITLE
chore(release): 5.26.0 — review scoping (stages + category)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [5.26.0] - 2026-07-28
+
+### Added
+
+- **`kit review` scopes: `--stages` + `--category`.** `collectReview` (and
+  therefore both surfaces — `kit review --stages check,standards --category
+  general` and the `kit_review` MCP tool's `stages`/`category` params) can run
+  a subset of the four gates, canonical order kept regardless of input order.
+  Enum-validated: an unknown stage is a refusal with the valid list, never a
+  silent full run. `stages: ["standards"]` is the fast, read-only lint loop —
+  seconds instead of the full audit's security scan per iteration — and it is
+  the migration path that survives `kit_standards`' 6.0 removal (the
+  deprecation text now names it). The report stays honest under scoping: `ok`
+  covers exactly the stages that ran, and the `stages` array shows the scope.
+
 ## [5.25.0] - 2026-07-28
 
 ### Added

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -1099,7 +1099,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "5.25.0"
+    "version": "5.26.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "5.25.0",
+  "version": "5.26.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
Version bump + CHANGELOG for #423. Local verification: 3287/3287 tests, lint 0 errors, prettier clean, self-audit 0 fail 0 warn, changelog gate renders 935 bytes, opencli regenerated.

After merge: signed tag `v5.26.0` on main (owner signs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)