### PR TITLE
feat!(mcp): 6.0 surface — the six deprecated tools leave (16 → 10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -957,12 +957,6 @@ For Cline, add the same config to your `cline_mcp_settings.json`.
 | `kit_context`   | Gather project context (stack, services, env status)                                            |
 | `kit_map`       | Repo map: import-neighborhood slice around seed paths                                           |
 | `kit_init`      | Detect the stack and generate `.kit.toml` (dry-run supported)                                   |
-| `kit_standards` | _Deprecated (leaves in 6.0)_ — `kit_review` runs this gate as its standards stage               |
-| `kit_env`       | _Deprecated (leaves in 6.0)_ — inspect `.env.local` key status; prefer `kit_context`            |
-| `kit_ci`        | _Deprecated (leaves in 6.0)_ — CI runners have a shell; run `kit ci` there                      |
-| `kit_install`   | _Deprecated (leaves in 6.0)_ — setup-time provisioning; use `kit install` or `kit_run`          |
-| `kit_login`     | _Deprecated (leaves in 6.0)_ — interactive service auth; use `kit login` in a shell             |
-| `kit_add`       | _Deprecated (leaves in 6.0)_ — service provisioning; use `kit add` or `kit_run`                 |
 
 Full reference: [docs/MCP_TOOLS_REFERENCE.md](docs/MCP_TOOLS_REFERENCE.md) · usage guide: [docs/MCP_TOOLS_GUIDE.md](docs/MCP_TOOLS_GUIDE.md)
 

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -5,7 +5,7 @@
       "summary": "Provision a service (kit add --list to see all adapters)",
       "x-kit-args-modeled": false,
       "x-kit-audience": "human",
-      "x-kit-mcp": true,
+      "x-kit-mcp": false,
       "x-kit-stability": "stable"
     },
     "adr": {
@@ -207,7 +207,7 @@
       "summary": "CI-native check: GitHub Actions annotations, GitLab JUnit, JSON (--init gitlab|bitbucket scaffolds a pipeline)",
       "x-kit-args-modeled": false,
       "x-kit-audience": "all",
-      "x-kit-mcp": true,
+      "x-kit-mcp": false,
       "x-kit-stability": "stable"
     },
     "clone": {
@@ -333,7 +333,7 @@
       "summary": "Show current environment info",
       "x-kit-args-modeled": false,
       "x-kit-audience": "all",
-      "x-kit-mcp": true,
+      "x-kit-mcp": false,
       "x-kit-stability": "stable"
     },
     "escalate": {
@@ -487,7 +487,7 @@
       "summary": "Install missing tools via mise",
       "x-kit-args-modeled": false,
       "x-kit-audience": "human",
-      "x-kit-mcp": true,
+      "x-kit-mcp": false,
       "x-kit-stability": "stable"
     },
     "login": {
@@ -505,7 +505,7 @@
       "summary": "Guided login to all configured services",
       "x-kit-args-modeled": false,
       "x-kit-audience": "human",
-      "x-kit-mcp": true,
+      "x-kit-mcp": false,
       "x-kit-stability": "stable"
     },
     "map": {
@@ -1043,7 +1043,7 @@
       "summary": "Dev-standards gate: general metrics + per-language linters + user plugins vs the baseline (--category general|specific|plugins|<lang>, --enforce fails CI)",
       "x-kit-args-modeled": false,
       "x-kit-audience": "all",
-      "x-kit-mcp": true,
+      "x-kit-mcp": false,
       "x-kit-stability": "stable"
     },
     "status": {

--- a/contracts/public-surface.json
+++ b/contracts/public-surface.json
@@ -251,21 +251,15 @@
     "whoami"
   ],
   "mcpTools": [
-    "kit_add",
     "kit_check",
-    "kit_ci",
     "kit_context",
-    "kit_env",
     "kit_fix",
     "kit_init",
-    "kit_install",
-    "kit_login",
     "kit_map",
     "kit_memory",
     "kit_review",
     "kit_run",
     "kit_secrets",
-    "kit_standards",
     "kit_triage"
   ]
 }

--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -65,17 +65,18 @@ kit_run     → escape hatch: any other kit command
 - **Secrets never round-trip.** `kit_secrets` returns key names and statuses,
   never values.
 
-## Deprecations
+## The 6.0 surface
 
-`kit_ci`, `kit_install`, `kit_login`, `kit_add`, `kit_env`, and
-`kit_standards` are marked deprecated and leave the MCP surface in kit 6.0
-(the stability policy requires notice before removal). Their descriptions say
-so and point to the replacement (`kit_review` subsumes `kit_standards` as its
-standards stage); `kit_run` remains the escape hatch for all of them. Rationale:
-CI runners and setup-time provisioning are shell contexts by definition — a
-shell-less MCP client is never the thing running CI or provisioning services;
-and one audit tool that runs every gate beats a per-gate tool per stage
-(surface economy — each standing tool costs every client context).
+kit 6.0 completed the deprecation cycle announced in the 5.x line and removed
+the six setup-time/CI tools from the MCP surface (their CLI commands are
+unchanged — only the MCP exposure ended, after notice via deprecation markers
+and docs). Rationale: CI runners and setup-time provisioning are shell
+contexts by definition — a shell-less MCP client is never the thing running CI
+or provisioning services; and one audit tool that runs every gate beats a
+per-gate tool per stage (surface economy — each standing tool costs every
+client context). Migrations: `kit_review` (with `stages`/`category`) covers
+the standards gate; `kit_context` covers env inspection; `kit_run` remains the
+escape hatch for everything else.
 
 ## Drift guarantees
 
@@ -83,8 +84,8 @@ Three tests keep this surface honest:
 
 - `KIT_MCP_TOOLS` ↔ actually-registered tools ↔ the CLI registry's `mcp`
   flags (CLI = MCP, `mcp-server.test.ts`);
-- `x-kit-audience`: a human/harness command is never MCP-exposed, modulo the
-  pinned 6.0 deprecations (`opencli.test.ts`);
+- `x-kit-audience`: a human/harness command is never MCP-exposed, no
+  exceptions (`opencli.test.ts`);
 - this documentation ↔ `KIT_MCP_TOOLS`, in both directions
   (`docs-mcp-sync.test.ts`) — every real tool documented, no fictional tool
   documentable.

--- a/docs/MCP_TOOLS_REFERENCE.md
+++ b/docs/MCP_TOOLS_REFERENCE.md
@@ -35,12 +35,6 @@ governance floor (revocation, budget, permissions, expired-secret block).
 | `kit_context` | read | Gather project context (stack, services, env status) for the agent. |
 | `kit_map` | read | Repo map: import-neighborhood slice around seed paths (`paths`, `depth?`, `budget?`, `co_change?`). |
 | `kit_init` | write | Detect the stack and generate `.kit.toml` for a project that has none (`dryRun` to preview). |
-| `kit_standards` | read | **Deprecated — removed from the MCP surface in kit 6.0.** Use `kit_review` with `stages: ["standards"]` (+ `category` for scoping) — same gate, same read-only posture, one tool. |
-| `kit_env` | read | **Deprecated — removed from the MCP surface in kit 6.0.** Inspect `.env.local` key status (values redacted). Prefer `kit_context`. |
-| `kit_ci` | read | **Deprecated — removed in kit 6.0.** CI runners always have a shell; run `kit ci` there. |
-| `kit_install` | write | **Deprecated — removed in kit 6.0.** Setup-time provisioning happens in a shell (`kit install`), or via `kit_run`. |
-| `kit_login` | write | **Deprecated — removed in kit 6.0.** Service auth is interactive/setup-time; use `kit login` in a shell. |
-| `kit_add` | write | **Deprecated — removed in kit 6.0.** Provision a service integration; use `kit add` in a shell, or `kit_run`. |
 
 ## Server instructions
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -543,13 +543,11 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
     handler: cmdInstall,
     stability: "stable",
     help: "Install missing tools via mise",
-    mcp: true,
   },
   login: {
     handler: cmdLogin,
     stability: "stable",
     help: "Guided login to all configured services",
-    mcp: true,
   },
   secrets: {
     handler: cmdSecrets,
@@ -585,7 +583,6 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
     handler: cmdAdd,
     stability: "stable",
     help: "Provision a service (kit add --list to see all adapters)",
-    mcp: true,
   },
   audit: { handler: cmdAudit, stability: "stable", help: "View audit log of kit operations" },
   auth: {
@@ -598,7 +595,7 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
     stability: "stable",
     help: "MCP server over stdio (Claude Code/Cursor/Codex); 'kit mcp list|auth|set-token|clear' manages declared servers",
   },
-  env: { handler: cmdEnv, stability: "stable", help: "Show current environment info", mcp: true },
+  env: { handler: cmdEnv, stability: "stable", help: "Show current environment info" },
   doctor: {
     handler: cmdDoctor,
     stability: "stable",
@@ -628,7 +625,6 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
     handler: cmdCi,
     stability: "stable",
     help: "CI-native check: GitHub Actions annotations, GitLab JUnit, JSON (--init gitlab|bitbucket scaffolds a pipeline)",
-    mcp: true,
   },
   "self-audit": {
     handler: cmdSelfAudit,
@@ -721,7 +717,6 @@ const COMMAND_REGISTRY: Record<string, CommandDescriptor> = {
     handler: cmdStandards,
     stability: "stable",
     help: "Dev-standards gate: general metrics + per-language linters + user plugins vs the baseline (--category general|specific|plugins|<lang>, --enforce fails CI)",
-    mcp: true,
   },
   review: {
     handler: cmdReview,

--- a/src/docs-mcp-sync.test.ts
+++ b/src/docs-mcp-sync.test.ts
@@ -61,17 +61,10 @@ describe("docs ↔ MCP surface", () => {
   });
 
   it("the reference marks exactly the deprecated tools as deprecated", () => {
-    // The six 6.0 removals must carry a deprecation marker in the reference,
-    // and no non-deprecated tool may. When 6.0 removes them, the first
-    // assertion's tool list shrinks and this stays green by construction.
-    const DEPRECATED = [
-      "kit_env",
-      "kit_ci",
-      "kit_install",
-      "kit_login",
-      "kit_add",
-      "kit_standards",
-    ];
+    // 6.0 removed the six deprecated tools, so the set is empty: no row may
+    // carry a deprecation marker. When a future removal cycle starts, list the
+    // newly-deprecated tools here again.
+    const DEPRECATED: string[] = [];
     const ref = DOCS[0].text;
     const rows = ref.split("\n").filter((l) => l.startsWith("| `kit_"));
     for (const row of rows) {

--- a/src/mcp-server.test.ts
+++ b/src/mcp-server.test.ts
@@ -26,11 +26,6 @@ const FIXTURE_MISSING_ENV_SECRET = `
 MISSING_VAR = { source = "env" }
 `;
 
-const FIXTURE_NODE_TOOL = `
-[tools]
-node = "latest"
-`;
-
 /**
  * Create a connected Client + McpServer pair using in-memory transport.
  * Returns the client (already connected) and a cleanup function.
@@ -70,21 +65,15 @@ describe("MCP server tool registration", () => {
       const names = tools.map((t) => t.name);
       assert.ok(names.includes("kit_check"), "kit_check missing");
       assert.ok(names.includes("kit_review"), "kit_review missing");
-      assert.ok(names.includes("kit_standards"), "kit_standards missing");
-      assert.ok(names.includes("kit_install"), "kit_install missing");
-      assert.ok(names.includes("kit_login"), "kit_login missing");
       assert.ok(names.includes("kit_secrets"), "kit_secrets missing");
       assert.ok(names.includes("kit_fix"), "kit_fix missing");
-      assert.ok(names.includes("kit_add"), "kit_add missing");
-      assert.ok(names.includes("kit_env"), "kit_env missing");
       assert.ok(names.includes("kit_init"), "kit_init missing");
-      assert.ok(names.includes("kit_ci"), "kit_ci missing");
       assert.ok(names.includes("kit_run"), "kit_run missing");
       assert.ok(names.includes("kit_context"), "kit_context missing");
       assert.ok(names.includes("kit_map"), "kit_map missing");
       assert.ok(names.includes("kit_triage"), "kit_triage missing");
       assert.ok(names.includes("kit_memory"), "kit_memory missing");
-      assert.equal(tools.length, 16);
+      assert.equal(tools.length, 10);
     } finally {
       await cleanup();
     }
@@ -358,79 +347,6 @@ describe("kit_fix", () => {
   });
 });
 
-// ─── kit_add ───────────────────────────────────────────────────────────────
-
-describe("kit_add", () => {
-  let tempDir: string;
-
-  before(async () => {
-    tempDir = await mkdtemp(join(tmpdir(), "kit-mcp-add-"));
-    await writeFile(join(tempDir, ".kit.toml"), FIXTURE_EMPTY, "utf-8");
-  });
-
-  after(async () => {
-    await rm(tempDir, { recursive: true, force: true });
-  });
-
-  it("returns success:false and error for unknown service", async () => {
-    const { client, cleanup } = await createTestClient();
-    try {
-      const result = await client.callTool({
-        name: "kit_add",
-        arguments: { service: "nonexistent-service-xyz", cwd: tempDir },
-      });
-      const data = parseResult(result) as { success: boolean; error?: string };
-      assert.equal(data.success, false);
-      assert.ok(
-        data.error?.includes("Unknown service"),
-        `Expected unknown service error, got: ${data.error}`,
-      );
-    } finally {
-      await cleanup();
-    }
-  });
-});
-
-// ─── kit_login ─────────────────────────────────────────────────────────────
-
-describe("kit_login", () => {
-  let tempDir: string;
-
-  before(async () => {
-    tempDir = await mkdtemp(join(tmpdir(), "kit-mcp-login-"));
-  });
-
-  after(async () => {
-    await rm(tempDir, { recursive: true, force: true });
-    delete process.env.KIT_NON_INTERACTIVE;
-  });
-
-  it("returns no results when no services configured", async () => {
-    await writeFile(join(tempDir, ".kit.toml"), FIXTURE_EMPTY, "utf-8");
-    const { client, cleanup } = await createTestClient();
-    try {
-      const result = await client.callTool({ name: "kit_login", arguments: { cwd: tempDir } });
-      const data = parseResult(result) as { results: unknown[]; message: string };
-      assert.equal(data.results.length, 0);
-      assert.ok(data.message.includes("No services"));
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("sets KIT_NON_INTERACTIVE to prevent TTY hang", async () => {
-    delete process.env.KIT_NON_INTERACTIVE;
-    await writeFile(join(tempDir, ".kit.toml"), FIXTURE_EMPTY, "utf-8");
-    const { client, cleanup } = await createTestClient();
-    try {
-      await client.callTool({ name: "kit_login", arguments: { cwd: tempDir } });
-      assert.equal(process.env.KIT_NON_INTERACTIVE, "1");
-    } finally {
-      await cleanup();
-    }
-  });
-});
-
 // ─── kit_secrets ──────────────────────────────────────────────────────────
 
 describe("kit_secrets", () => {
@@ -613,151 +529,6 @@ describe("kit_run + signed-scope egress mediation", () => {
       const text = (result.content as Array<{ text: string }>)[0].text;
       assert.match(text, /hello/);
     } finally {
-      await cleanup();
-    }
-  });
-});
-
-// ─── kit_install ───────────────────────────────────────────────────────────
-
-describe("kit_install", () => {
-  let tempDir: string;
-
-  before(async () => {
-    tempDir = await mkdtemp(join(tmpdir(), "kit-mcp-install-"));
-    await writeFile(join(tempDir, ".gitignore"), GITIGNORE, "utf-8");
-  });
-
-  after(async () => {
-    await rm(tempDir, { recursive: true, force: true });
-  });
-
-  it("returns no-op message when no tools configured", async () => {
-    await writeFile(join(tempDir, ".kit.toml"), FIXTURE_EMPTY, "utf-8");
-    const { client, cleanup } = await createTestClient();
-    try {
-      const result = await client.callTool({ name: "kit_install", arguments: { cwd: tempDir } });
-      const data = parseResult(result) as { message: string };
-      assert.ok(data.message.includes("No tools"));
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("returns ok:true when node is already installed at latest", async () => {
-    await writeFile(join(tempDir, ".kit.toml"), FIXTURE_NODE_TOOL, "utf-8");
-    const { client, cleanup } = await createTestClient();
-    try {
-      const result = await client.callTool({ name: "kit_install", arguments: { cwd: tempDir } });
-      const data = parseResult(result) as {
-        ok: boolean;
-        results: Array<{ name: string; action: string }>;
-      };
-      assert.equal(data.ok, true);
-      const node = data.results.find((r) => r.name === "node");
-      assert.ok(node, "node not in results");
-      assert.equal(node.action, "already_ok");
-    } finally {
-      await cleanup();
-    }
-  });
-});
-
-// ─── kit_env ───────────────────────────────────────────────────────────────
-
-describe("kit_env", () => {
-  let tempDir: string;
-
-  before(async () => {
-    tempDir = await mkdtemp(join(tmpdir(), "kit-mcp-env-"));
-    await writeFile(join(tempDir, ".gitignore"), GITIGNORE, "utf-8");
-    await writeFile(join(tempDir, ".kit.toml"), FIXTURE_EMPTY, "utf-8");
-  });
-
-  after(async () => {
-    await rm(tempDir, { recursive: true, force: true });
-  });
-
-  it("returns envLocalExists=false when .env.local is missing", async () => {
-    const { client, cleanup } = await createTestClient();
-    try {
-      const result = await client.callTool({ name: "kit_env", arguments: { cwd: tempDir } });
-      const data = parseResult(result) as { ok: boolean; keys: unknown[]; envLocalExists: boolean };
-      assert.equal(data.envLocalExists, false);
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("returns keys from .env.local with redacted values", async () => {
-    await writeFile(join(tempDir, ".env.local"), "SECRET=sk-abcdefghij\n", "utf-8");
-    const { client, cleanup } = await createTestClient();
-    try {
-      const result = await client.callTool({ name: "kit_env", arguments: { cwd: tempDir } });
-      const data = parseResult(result) as {
-        ok: boolean;
-        keys: Array<{ name: string; set: boolean; redacted?: string; value?: string }>;
-        envLocalExists: boolean;
-      };
-      assert.equal(data.envLocalExists, true);
-      const key = data.keys.find((k) => k.name === "SECRET");
-      assert.ok(key, "SECRET key not found");
-      assert.equal(key.set, true);
-      assert.ok(key.redacted, "value should be redacted by default");
-      assert.equal(key.value, undefined, "raw value should not be exposed by default");
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("returns actual value when show_values=true", async () => {
-    const { client, cleanup } = await createTestClient();
-    try {
-      const result = await client.callTool({
-        name: "kit_env",
-        arguments: { cwd: tempDir, show_values: true },
-      });
-      const data = parseResult(result) as {
-        keys: Array<{ name: string; value?: string }>;
-      };
-      const key = data.keys.find((k) => k.name === "SECRET");
-      assert.ok(key, "SECRET key not found");
-      assert.equal(key.value, "sk-abcdefghij");
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("returns only missing keys when missing_only=true", async () => {
-    const configWithMissing = `
-[secrets.keys]
-SECRET = { source = "env" }
-MISSING_KEY = { source = "env" }
-`;
-    await writeFile(join(tempDir, ".kit.toml"), configWithMissing, "utf-8");
-    const { client, cleanup } = await createTestClient();
-    try {
-      const result = await client.callTool({
-        name: "kit_env",
-        arguments: { cwd: tempDir, missing_only: true },
-      });
-      const data = parseResult(result) as {
-        keys: Array<{ name: string; set: boolean }>;
-      };
-      assert.ok(
-        data.keys.every((k) => !k.set),
-        "missing_only should only return unset keys",
-      );
-      assert.ok(
-        data.keys.some((k) => k.name === "MISSING_KEY"),
-        "MISSING_KEY should be in result",
-      );
-      assert.ok(
-        !data.keys.some((k) => k.name === "SECRET"),
-        "SECRET is set — should not appear with missing_only",
-      );
-    } finally {
-      await writeFile(join(tempDir, ".kit.toml"), FIXTURE_EMPTY, "utf-8");
       await cleanup();
     }
   });

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -4,14 +4,8 @@ import { z } from "zod";
 import { resolve, join, relative } from "node:path";
 import { loadConfig } from "./config.js";
 import { checkTools } from "./check-tools.js";
-import { checkServices } from "./check-services.js";
-import { checkSecrets } from "./check-secrets.js";
-import { checkSecurity } from "./check-security.js";
-import { checkSkills } from "./check-skills.js";
-import { checkLockFiles } from "./check-lock.js";
 import { runCheckGate } from "./check-run.js";
 import { installTools } from "./install.js";
-import { loginServices } from "./login.js";
 import { generateSecrets } from "./secrets.js";
 import {
   readSkillsLock,
@@ -20,8 +14,6 @@ import {
   updateCliLock,
   readkitMeta,
 } from "./lock.js";
-import { provisionService, listAvailableServices } from "./provision.js";
-import { inspectEnv } from "./env-inspect.js";
 import { detectStack } from "./stack-detector.js";
 import { generateToml } from "./toml-generator.js";
 import { writeFile, access } from "node:fs/promises";
@@ -29,7 +21,6 @@ import { executeCommand } from "./run.js";
 import { gatherProjectContext } from "./context.js";
 import { mapReport } from "./commands/repomap.js";
 import { isReadOnlyMode } from "./read-only-mode.js";
-import { escapeWorkflowCmd } from "./utils/ci-escape.js";
 import { runGovernedBrokered } from "./governance-middleware.js";
 import type { kitConfig } from "./config.js";
 import { runTriage, type TriageType } from "./triage.js";
@@ -49,15 +40,9 @@ const KIT_FILE = ".kit.toml";
 export const KIT_MCP_TOOLS: readonly string[] = [
   "kit_check",
   "kit_review",
-  "kit_standards",
-  "kit_install",
-  "kit_login",
   "kit_secrets",
   "kit_fix",
-  "kit_add",
-  "kit_env",
   "kit_init",
-  "kit_ci",
   "kit_run",
   "kit_context",
   "kit_map",
@@ -78,14 +63,6 @@ const KIT_MCP_INSTRUCTIONS = `kit is a deterministic, local-first dev-environmen
 If you have shell access, prefer running \`kit <command>\` directly — the CLI covers far more than these tools and \`kit <command> --help\` documents everything. These MCP tools exist for shell-less clients.
 
 Typical loop: kit_check (verify env + security) → kit_fix (auto-repair) → kit_triage (REQUIRED before installing any package kit's gate has not already cleared — the gate blocks untriaged installs) → kit_memory (recall prior cross-session decisions before answering project-specific questions) → kit_review (full audit — check + design + standards + ADR — before merging) → kit_run (escape hatch for any other kit command).`;
-
-// Deprecation prefix for tools scheduled for removal from the MCP surface in
-// kit 6.0 (the MCP surface is "Evolving" per docs/API_STABILITY_AND_VERSIONING.md
-// — removal requires notice, so they are marked, not dropped). Rationale: setup-
-// time and CI commands are shell contexts by definition; a shell-less MCP client
-// is never the thing provisioning services or running CI. kit_run remains the
-// escape hatch for all of them.
-const DEPRECATED_6_0 = "DEPRECATED — scheduled for removal from the MCP surface in kit 6.0";
 
 function configPath(cwd?: string): string {
   return resolve(cwd ?? process.cwd(), KIT_FILE);
@@ -144,15 +121,9 @@ export function createMcpServer(): McpServer {
   // function). Each register_* attaches its tool to the server.
   register_kit_check(server);
   register_kit_review(server);
-  register_kit_standards(server);
-  register_kit_install(server);
-  register_kit_login(server);
   register_kit_secrets(server);
   register_kit_fix(server);
-  register_kit_add(server);
-  register_kit_env(server);
   register_kit_init(server);
-  register_kit_ci(server);
   register_kit_run(server);
   register_kit_context(server);
   register_kit_map(server);
@@ -261,150 +232,6 @@ function register_kit_review(server: McpServer): void {
           : report;
         return {
           content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
-        };
-      } catch (err) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
-          isError: true,
-        };
-      }
-    },
-  );
-}
-
-function register_kit_standards(server: McpServer): void {
-  // kit_standards — run the dev-standards gate (general + per-language + plugins +
-  // platform) and return the SAME { ok, checks, summary } envelope as `kit standards`.
-  // Read-only: no writes, so no governance/read-only gating. Deprecated for 6.0:
-  // kit_review runs this gate as its standards stage (with --category parity via
-  // kit_run for the rare scoped call), so a second standalone tool is surface bloat.
-  server.tool(
-    "kit_standards",
-    `${DEPRECATED_6_0}; use kit_review with stages: ["standards"] (+ category for scoping) — same gate, same read-only posture, one tool. Run kit standards (deterministic dev-standards gate: complexity/duplication/size + per-language linters + user plugins + container) and return structured findings. Read-only.`,
-    {
-      cwd: z.string().optional().describe("Working directory (defaults to process.cwd())"),
-      enforce: z
-        .boolean()
-        .optional()
-        .describe("Fail on net-new findings AND setup gaps (CI posture)"),
-      category: z
-        .string()
-        .optional()
-        .describe("Scope: general | specific | plugins | platform | <language>"),
-    },
-    async ({ cwd, enforce, category }) => {
-      try {
-        const { runStandardsGate } = await import("./standards-run.js");
-        const { ok, checks, summary, baselineIgnored } = await runStandardsGate({
-          cwd,
-          enforce,
-          category,
-        });
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({ ok, checks, summary, baselineIgnored }, null, 2),
-            },
-          ],
-        };
-      } catch (err) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
-          isError: true,
-        };
-      }
-    },
-  );
-}
-
-function register_kit_install(server: McpServer): void {
-  // kit_install — install missing tools via mise
-  server.tool(
-    "kit_install",
-    `${DEPRECATED_6_0}; setup-time provisioning happens in a shell — use \`kit install\` there, or kit_run. Install missing tools defined in .kit.toml using mise.`,
-    { cwd: z.string().optional().describe("Working directory") },
-    async ({ cwd }) => {
-      if (isReadOnlyMode()) return readOnlyRefusal("kit_install");
-      try {
-        const config = await loadConfig(configPath(cwd));
-        if (!config.tools || Object.keys(config.tools).length === 0) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: JSON.stringify({ installed: [], message: "No tools configured" }),
-              },
-            ],
-          };
-        }
-
-        const gov = await runGovernedBrokered(
-          config,
-          {
-            operation: "tools.install",
-            operationType: "write",
-            metadata: { tools: Object.keys(config.tools) },
-            // Infrastructure: mise installs to $HOME + fetches from tool hosts by design — not an
-            // agent project action the [scope] RoE governs. Allowed but audited as an exemption.
-            infrastructure: true,
-          },
-          () => installTools(config.tools!),
-          { cwd: cwd ?? process.cwd() },
-        );
-        if (!gov.ok) return governanceRefusal(gov.reason ?? "denied");
-        const results = gov.result!;
-        const ok = results.every((r) => r.action !== "failed");
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({ ok, results }, null, 2),
-            },
-          ],
-        };
-      } catch (err) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
-          isError: true,
-        };
-      }
-    },
-  );
-}
-
-function register_kit_login(server: McpServer): void {
-  // kit_login — attempt service logins (non-interactive)
-  server.tool(
-    "kit_login",
-    `${DEPRECATED_6_0}; service auth is interactive/setup-time — use \`kit login\` in a shell. Attempt to log in to services defined in .kit.toml. Runs in non-interactive mode — services requiring interactive auth will be skipped.`,
-    { cwd: z.string().optional().describe("Working directory") },
-    async ({ cwd }) => {
-      if (isReadOnlyMode()) return readOnlyRefusal("kit_login");
-      try {
-        // Force non-interactive for MCP context
-        process.env.KIT_NON_INTERACTIVE = "1";
-        const config = await loadConfig(configPath(cwd));
-        if (!config.services || Object.keys(config.services).length === 0) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: JSON.stringify({ results: [], message: "No services configured" }),
-              },
-            ],
-          };
-        }
-
-        const results = await loginServices(config.services);
-        const ok = results.every((r) => r.action !== "failed");
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({ ok, results }, null, 2),
-            },
-          ],
         };
       } catch (err) {
         return {
@@ -585,110 +412,6 @@ function register_kit_fix(server: McpServer): void {
   );
 }
 
-function register_kit_add(server: McpServer): void {
-  // kit_add — provision a service (stripe, supabase, etc.)
-  server.tool(
-    "kit_add",
-    `${DEPRECATED_6_0}; provisioning is setup-time shell work — use \`kit add\` there, or kit_run. Provision a service integration for the project. Available services: ${listAvailableServices().join(", ")}. Writes generated secrets to .env.local and returns provisioning result.`,
-    {
-      service: z
-        .string()
-        .describe(`Service adapter name (e.g. ${listAvailableServices().slice(0, 3).join(", ")})`),
-      project_name: z
-        .string()
-        .optional()
-        .describe("Project name (used by some adapters for resource naming)"),
-      cwd: z.string().optional().describe("Working directory"),
-    },
-    async ({ service, project_name, cwd }) => {
-      if (isReadOnlyMode()) return readOnlyRefusal("kit_add");
-      try {
-        const workDir = cwd ?? process.cwd();
-        const result = await provisionService(service, workDir, project_name);
-
-        const secretsWritten = result.secrets ? Object.keys(result.secrets) : [];
-        // Extract manual steps from message when provisioning fails due to missing requirements
-        const manualSteps = !result.success && result.message ? [result.message] : [];
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(
-                {
-                  success: result.success,
-                  secrets_written: secretsWritten,
-                  manual_steps: manualSteps,
-                  message: result.message,
-                  ...(result.error && { error: result.error }),
-                },
-                null,
-                2,
-              ),
-            },
-          ],
-          ...(result.error && { isError: true }),
-        };
-      } catch (err) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
-          isError: true,
-        };
-      }
-    },
-  );
-}
-
-function register_kit_env(server: McpServer): void {
-  // kit_env — inspect environment variables loaded from .env.local
-  server.tool(
-    "kit_env",
-    `${DEPRECATED_6_0}; kit_context includes environment status — prefer it. Inspect environment variables from .env.local. Returns each key's set/missing status. Values are redacted by default.`,
-    {
-      show_values: z
-        .boolean()
-        .optional()
-        .describe("Return actual values (default: false, values are redacted)"),
-      missing_only: z
-        .boolean()
-        .optional()
-        .describe("Return only keys that are not set in .env.local"),
-      cwd: z.string().optional().describe("Working directory"),
-    },
-    async ({ show_values, missing_only, cwd }) => {
-      try {
-        const workDir = cwd ?? process.cwd();
-        let config = {};
-        try {
-          config = await loadConfig(configPath(workDir));
-        } catch {
-          // Works without .kit.toml
-        }
-
-        const result = await inspectEnv(config, {
-          showValues: show_values,
-          missingOnly: missing_only,
-          cwd: workDir,
-        });
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
-      } catch (err) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
-          isError: true,
-        };
-      }
-    },
-  );
-}
-
 function register_kit_init(server: McpServer): void {
   // kit_init — detect stack, generate .kit.toml, optionally write it
   server.tool(
@@ -758,147 +481,6 @@ function register_kit_init(server: McpServer): void {
               ),
             },
           ],
-        };
-      } catch (err) {
-        return {
-          content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
-          isError: true,
-        };
-      }
-    },
-  );
-}
-
-function register_kit_ci(server: McpServer): void {
-  server.tool(
-    "kit_ci",
-    `${DEPRECATED_6_0}; CI runners always have a shell — run \`kit ci\` there. Run kit CI checks and return structured results. Use before deploying or merging to validate the environment is correctly configured. Returns pass/fail/warn status for tools, services, secrets, lock files, and security.`,
-    {
-      cwd: z.string().optional().describe("Project directory (defaults to process.cwd())"),
-      format: z
-        .enum(["json", "github", "text"])
-        .optional()
-        .describe("Output format: json (default), github (annotations), text"),
-      fail_on_warning: z
-        .boolean()
-        .optional()
-        .describe("Treat warnings as failures (default: false)"),
-    },
-    async ({ cwd, format = "json", fail_on_warning = false }) => {
-      try {
-        const workDir = cwd ?? process.cwd();
-        const cfgPath = resolve(workDir, ".kit.toml");
-        const config = await loadConfig(cfgPath);
-
-        const toolResults = config.tools ? await checkTools(config.tools) : [];
-        const serviceResults = config.services ? await checkServices(config.services) : [];
-        const secretResults = config.secrets
-          ? await checkSecrets(config.secrets)
-          : { templateExists: null, keys: [] };
-        const skillResults = config.skills ? await checkSkills(config.skills) : [];
-        const securityResults = await checkSecurity();
-        const lockResults = await checkLockFiles(config);
-
-        interface CiCheck {
-          name: string;
-          status: "pass" | "fail" | "warn" | "skip";
-          detail: string;
-          category: string;
-        }
-
-        const checks: CiCheck[] = [
-          ...toolResults.map((t) => ({
-            name: t.name,
-            status: (t.ok ? "pass" : "fail") as CiCheck["status"],
-            detail: t.installed ? `installed ${t.installed}` : "not installed",
-            category: "tools",
-          })),
-          ...serviceResults.map((s) => ({
-            name: s.name,
-            status: (s.authenticated ? "pass" : "fail") as CiCheck["status"],
-            detail: s.output ?? (s.authenticated ? "authenticated" : "not authenticated"),
-            category: "services",
-          })),
-          ...secretResults.keys.map((s) => ({
-            name: s.name,
-            status: (s.available ? "pass" : "fail") as CiCheck["status"],
-            detail: s.detail ?? (s.available ? "available" : "missing"),
-            category: "secrets",
-          })),
-          ...skillResults.map((s) => ({
-            name: s.name,
-            status: (s.installed ? "pass" : s.required ? "fail" : "warn") as CiCheck["status"],
-            detail: s.installed ? "installed" : "not installed",
-            category: "skills",
-          })),
-          ...lockResults.map((l) => ({
-            name: l.category === "skills-lock" ? "skills-lock.json" : "cli-lock.json",
-            status: (l.inSync ? "pass" : l.exists ? "warn" : "fail") as CiCheck["status"],
-            detail: l.detail,
-            category: "lock",
-          })),
-          ...securityResults.map((s) => ({
-            name: s.name,
-            status: s.status as CiCheck["status"],
-            detail: s.detail,
-            category: `security/${s.category}`,
-          })),
-        ];
-
-        const summary = checks.reduce(
-          (acc, c) => {
-            if (c.status === "pass") acc.passed++;
-            else if (c.status === "fail") acc.failed++;
-            else if (c.status === "warn") acc.warnings++;
-            else acc.skipped++;
-            return acc;
-          },
-          { passed: 0, failed: 0, warnings: 0, skipped: 0 },
-        );
-
-        const ok = summary.failed === 0 && (!fail_on_warning || summary.warnings === 0);
-        const result = { ok, checks, summary };
-
-        let text: string;
-        if (format === "github") {
-          const lines: string[] = [];
-          for (const c of checks) {
-            // Escape config-controlled category/name/detail before interpolating into
-            // a GitHub workflow command — raw CR/LF would let a crafted detail string
-            // forge or hide annotation lines (same class escapeWorkflowCmd prevents).
-            const msg = escapeWorkflowCmd(`${c.category}/${c.name}: ${c.detail}`);
-            if (c.status === "fail") lines.push(`::error::${msg}`);
-            else if (c.status === "warn") lines.push(`::warning::${msg}`);
-          }
-          lines.push(
-            `kit ci: ${summary.passed} passed, ${summary.failed} failed, ${summary.warnings} warnings`,
-          );
-          text = lines.join("\n");
-        } else if (format === "text") {
-          const failures = checks.filter((c) => c.status === "fail");
-          const warnings = checks.filter((c) => c.status === "warn");
-          const lines: string[] = [];
-          if (failures.length)
-            lines.push(
-              "FAILURES:",
-              ...failures.map((f) => `  ✗ [${f.category}] ${f.name}: ${f.detail}`),
-            );
-          if (warnings.length)
-            lines.push(
-              "WARNINGS:",
-              ...warnings.map((w) => `  ! [${w.category}] ${w.name}: ${w.detail}`),
-            );
-          lines.push(
-            `kit ci: ${summary.passed} passed, ${summary.failed} failed, ${summary.warnings} warnings`,
-          );
-          text = lines.join("\n");
-        } else {
-          text = JSON.stringify(result, null, 2);
-        }
-
-        return {
-          content: [{ type: "text" as const, text }],
-          isError: !ok,
         };
       } catch (err) {
         return {

--- a/src/opencli.test.ts
+++ b/src/opencli.test.ts
@@ -88,33 +88,17 @@ describe("OpenCLI document shape", () => {
   // Audience ↔ MCP consistency: the exposure layer must respect the audience
   // annotation. "human" commands are interactive/setup surfaces — they do not
   // belong on the MCP surface; "harness" commands are hook stdin protocols —
-  // they belong on NO discovery surface. The only tolerated human∩MCP overlap
-  // is the trio already deprecated on the MCP surface, which leaves in kit 6.0
-  // — at which point this exception list empties and gets deleted.
-  it("audience: human/harness commands are never MCP-exposed (modulo the 6.0 deprecations)", () => {
-    const DEPRECATED_MCP_UNTIL_6_0 = new Set(["add", "install", "login"]);
+  // they belong on NO discovery surface. 6.0 removed the last tolerated
+  // overlap (the deprecated setup-time tools), so this is now exception-free.
+  it("audience: human/harness commands are never MCP-exposed", () => {
     const offenders: string[] = [];
     for (const [name, c] of Object.entries(doc.commands)) {
       const audience = c["x-kit-audience"];
       if ((audience === "human" || audience === "harness") && c["x-kit-mcp"]) {
-        if (audience === "human" && DEPRECATED_MCP_UNTIL_6_0.has(name)) continue;
         offenders.push(`${name} (${audience})`);
       }
     }
     assert.deepEqual(offenders, [], "human/harness-audience commands must not be MCP-exposed");
-    // The exception list must not rot: every entry must still be a real,
-    // MCP-exposed, human-audience command. When 6.0 removes the tools, this
-    // fails and the list (and eventually the whole exception) gets deleted.
-    for (const name of DEPRECATED_MCP_UNTIL_6_0) {
-      const c = doc.commands[name];
-      assert.ok(c, `${name} vanished from the command surface — update the exception list`);
-      assert.equal(
-        c["x-kit-mcp"],
-        true,
-        `${name} is no longer MCP-exposed — remove it from the exception list`,
-      );
-      assert.equal(c["x-kit-audience"], "human");
-    }
   });
 
   it("every command carries a valid audience", () => {

--- a/src/self-audit.test.ts
+++ b/src/self-audit.test.ts
@@ -359,7 +359,9 @@ describe("R8-readonly-guard", () => {
     // fail-open hole; this asserts the allowlist stays in sync with mcp-server.ts.
     const post = realSource("src/mcp-server.ts");
     const tools = extractKitTools(post);
-    assert.ok(tools.length >= 12, `expected >= 12 kit_* tools, found ${tools.length}`);
+    // Sanity floor = the 6.0 surface (10 tools after the deprecated six left).
+    // If this trips low, the extractor rotted — not the surface.
+    assert.ok(tools.length >= 10, `expected >= 10 kit_* tools, found ${tools.length}`);
 
     const unclassified: string[] = [];
     for (const t of tools) {

--- a/src/self-audit.ts
+++ b/src/self-audit.ts
@@ -664,10 +664,10 @@ const R7: SelfAuditRule = {
 // test in self-audit.test.ts.
 export const READ_ONLY_SAFE = new Set<string>([
   "kit_check",
-  "kit_standards",
-  "kit_env",
-  "kit_ci",
+  "kit_review",
   "kit_context",
+  "kit_map",
+  "kit_memory",
 ]);
 const GUARD_WINDOW = 12;
 // Real side-effects in an MCP handler body: filesystem writes, process exec, secret

--- a/src/standards-run.ts
+++ b/src/standards-run.ts
@@ -1,7 +1,7 @@
 /**
  * kit standards — the orchestrator shared by the CLI (`kit standards`) and the MCP
- * surface (`kit_standards`), so the two can never disagree on what the gate does or
- * what "green" means (the same CLI-vs-MCP parity discipline as `kit check`).
+ * surface (kit_review's standards stage), so the two can never disagree on what the
+ * gate does or what "green" means (the same CLI-vs-MCP parity discipline as `kit check`).
  *
  * Runs the requested dimensions — general (P1), specific/per-language (P2),
  * plugins (P3), platform (P4) — against the fail-closed baseline and config, and


### PR DESCRIPTION
The deletion release's content, exactly as tracked since 5.16: the six deprecated MCP tools are removed (CLI commands unchanged), the audience exception list is deleted, the docs purged of the six names by the fiction gate, contracts regenerated, and the read-only allowlist corrected to the 6.0 truth. Migrations shipped beforehand: `kit_review` (stages/category), `kit_context`, `kit_fix`, `kit_run`.

Verified on a real stdio server: exactly 10 tools, zero deprecation markers. 3288/3288 tests, lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)