### PR TITLE
fix(skill): parse a block-scalar description — a false "description missing" in a gate (6.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [6.1.1] - 2026-07-31
+
+### Fixed
+
+- **`kit skill test` no longer reports "description missing" for a description written as a
+  YAML block scalar.** `description: >` (folded) and `description: |` (literal) are the common
+  real-world shape — it is the longest frontmatter field — and the parser read only the
+  same-line value, so a skill that declared a perfectly good description failed both the
+  `contract` and `trigger` checks. That is a **false finding in a gate**, which erodes trust in
+  the verdict exactly as a missed finding does.
+
+  Found by running `kit skill test` against a **real published `SKILL.md`** (a 10.4k-star
+  OSINT project shipping an agent skill), not by reading the parser. Chomping indicators
+  (`>-`, `|+`, …) are handled, the block correctly ends at the next key rather than swallowing
+  it, and an empty block yields an empty string rather than the literal indicator character.
+
+
 ## [6.1.0] - 2026-07-31
 
 ### Added

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -1123,7 +1123,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "6.1.0"
+    "version": "6.1.1"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/skill/test.test.ts
+++ b/src/skill/test.test.ts
@@ -40,6 +40,63 @@ describe("parseSkillManifest", () => {
     assert.ok(m.body.includes("## Intent"));
   });
 
+  // Regression: a description written as a YAML block scalar is the common real-world
+  // shape (it is the longest field). Reading only the same-line value reported
+  // "description missing" for a skill that declared one — a false finding in a gate.
+  // Found by running `kit skill test` against a real published SKILL.md.
+  it("parses a FOLDED (>) block-scalar description", () => {
+    const m = parseSkillManifest(`---
+name: shadowbroker
+description: >
+  Query the OSINT platform for real-time geospatial intelligence,
+  place pins on the map, and generate reports.
+allowed-tools: [Read]
+---
+body`);
+    assert.equal(m.name, "shadowbroker");
+    assert.equal(
+      m.description,
+      "Query the OSINT platform for real-time geospatial intelligence, place pins on the map, and generate reports.",
+      "folded lines join with a space, no leading indent",
+    );
+    assert.deepEqual(m.allowedTools, ["Read"], "the key AFTER the block still parses");
+  });
+
+  it("parses a LITERAL (|) block-scalar description, and chomping indicators", () => {
+    for (const ind of ["|", "|-", ">-", ">+", "|+"]) {
+      const m = parseSkillManifest(`---
+name: x
+description: ${ind}
+  First line.
+  Second line.
+---
+body`);
+      assert.equal(m.description, "First line. Second line.", `indicator ${ind}`);
+    }
+  });
+
+  it("a block scalar ends at the next key, not at the end of frontmatter", () => {
+    const m = parseSkillManifest(`---
+description: >
+  Only this belongs to the description.
+name: after-the-block
+allowed-tools: [Read]
+---
+body`);
+    assert.equal(m.description, "Only this belongs to the description.");
+    assert.equal(m.name, "after-the-block", "a later key is not swallowed by the block");
+  });
+
+  it("an empty block scalar stays absent-ish rather than becoming a bogus description", () => {
+    const m = parseSkillManifest(`---
+name: x
+description: >
+allowed-tools: [Read]
+---
+body`);
+    assert.equal(m.description, "", 'empty, not the literal ">" indicator');
+  });
+
   it("parses a YAML block-list allowed-tools", () => {
     const m = parseSkillManifest(`---
 name: x

--- a/src/skill/test.ts
+++ b/src/skill/test.ts
@@ -88,11 +88,38 @@ function unquote(v: string): string {
   return v.trim().replace(/^["']|["']$/g, "");
 }
 
+/** True for a YAML block-scalar indicator (`>`, `|`, with optional chomping: `>-`, `|+`). */
+function isBlockScalar(value: string): boolean {
+  return /^\s*[>|][+-]?\s*$/.test(value);
+}
+
 /**
- * Minimal, dependency-free `SKILL.md` parser. Handles a leading `---` frontmatter block
- * with `key: value` scalars and `allowed-tools` in inline (`[a, b]` / `a, b`) or YAML
- * block-list (`- item`) form. Pure. Never throws — malformed input yields a manifest with
- * `hasFrontmatter: false` and the whole text as the body.
+ * Join the indented lines following a block-scalar indicator at `start` into one string.
+ * Folded (`>`) and literal (`|`) both collapse to a single line here: this text is only ever
+ * length-checked and shown to a human, so preserving literal newlines would buy nothing and
+ * risks a spurious "too short" on the first line alone.
+ */
+function readBlockScalar(lines: string[], start: number): string {
+  const out: string[] = [];
+  for (let j = start + 1; j < lines.length; j++) {
+    const l = lines[j];
+    if (l.trim() === "") {
+      out.push("");
+      continue;
+    }
+    // The block ends at the first line that is not indented (i.e. the next key).
+    if (!/^\s/.test(l)) break;
+    out.push(l.trim());
+  }
+  return out.join(" ").trim();
+}
+
+/**
+ * Minimal, dependency-free `SKILL.md` parser. Handles a leading `---` frontmatter block with
+ * `key: value` scalars, `description` in inline OR YAML block-scalar (`>` / `|`) form, and
+ * `allowed-tools` in inline (`[a, b]` / `a, b`) or block-list (`- item`) form. Pure. Never
+ * throws — malformed input yields a manifest with `hasFrontmatter: false` and the whole text
+ * as the body.
  */
 export function parseSkillManifest(raw: string): SkillManifest {
   const text = raw.replace(/\r\n/g, "\n");
@@ -113,7 +140,12 @@ export function parseSkillManifest(raw: string): SkillManifest {
     const value = kv[2];
 
     if (key === "name") manifest.name = unquote(value);
-    else if (key === "description") manifest.description = unquote(value);
+    else if (key === "description")
+      // A description is routinely written as a YAML block scalar (`description: >` folded,
+      // or `|` literal) because it is the longest field. Reading only the same-line value
+      // reported "description missing" for a skill that declared a perfectly good one —
+      // a FALSE finding in a gate, which erodes trust exactly like a missed one.
+      manifest.description = isBlockScalar(value) ? readBlockScalar(lines, i) : unquote(value);
     else if (key === "user-invokable" || key === "user_invokable")
       manifest.userInvokable = parseBool(value);
     else if (key === "disable-model-invocation" || key === "disable_model_invocation")


### PR DESCRIPTION
## A false finding in a gate

`kit skill test` reported **"description missing or too short"** for a skill whose description was right there — written as a YAML **block scalar**:

```yaml
description: >
  Query the ShadowBroker OSINT intelligence platform for real-time geospatial
  intelligence, place AI intel pins on the map, manage autonomous monitoring…
```

The parser read only the same-line value, so any description in folded (`>`) or literal (`|`) form read as absent. That failed **two** checks for the wrong reason:

```
✗ contract    description missing or too short to declare when/why the skill applies
✗ trigger     no description — nothing declares when the skill triggers
```

`description` is the **longest** frontmatter field, so a block scalar is the most natural thing an author reaches for. This would hit them for writing correct YAML.

A false finding erodes trust in a verdict exactly as a missed finding does — arguably worse here, because the author has no way to tell they are being told something untrue.

## Isolated before fixing

Three fixtures, same content, three YAML shapes:

```
t-inline     ✓ contract    name + description + body declared
t-folded     ✗ contract    description missing or too short…
t-literal    ✗ contract    description missing or too short…
```

After the fix all three pass — and the real-world skill's remaining failure is the **correct** one:

```
✓ contract    name + description + body declared (shadowbroker)
✓ trigger     trigger declared, no collision across 3 sibling skill(s)
✗ scope       no allowed-tools declared — skill implicitly claims ALL tools (not least-privilege)
```

## The fix

Block-scalar support for `description`: folded and literal, chomping indicators (`>-`, `|+`, …), the block **terminates at the next key** rather than swallowing it, and an empty block yields an empty string rather than the literal indicator character. Folded and literal both collapse to one line — this text is only length-checked and shown to a human, and preserving newlines would risk a spurious "too short" on the first line alone.

`allowed-tools` already had block-**list** support; the parser simply had no block-**scalar** path.

## How it was found

Not by reviewing the parser. By running `kit skill test` against a **real published `SKILL.md`** from a 10.4k-star project shipping an agent skill.

Same discovery mode that surfaced the dropped `severity` field in 6.1.0: build or run against real input, and the defects present themselves. Reviewing your own parser tends to confirm the shapes you already imagined.

## Verification

4 new regression tests (folded, literal + all chomping indicators, termination at the next key, empty block). Full suite **3308 tests, 0 fail**. `tsc --noEmit` and `prettier --check` clean; contracts regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DbF4MFePXWNCd4dxBQvqH2)_