### PR TITLE
fix(release): 6.3.1 — repository metadata the provenance check requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [6.3.1] - 2026-08-03
+
+### Fixed
+
+- **The 6.3.0 first-publish of the adapter SDK and plugins failed provenance
+  validation.** npm's sigstore check requires each workspace `package.json` to
+  carry a `repository.url` matching the provenance source
+  (`https://github.com/sandstream/kit`); the field was empty, so the registry
+  rejected `sandstream-kit-adapter-sdk` with E422 and the eleven plugins never
+  ran (the CLI itself published). All thirteen manifests now declare
+  `repository` (with the monorepo `directory` field); the publish step is
+  idempotent, so this tag completes the set the 6.3.0 tag started.
+
 ## [6.3.0] - 2026-08-01
 
 ### Security

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -1131,7 +1131,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "6.3.0"
+    "version": "6.3.1"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/packages/adapter-sdk/package.json
+++ b/packages/adapter-sdk/package.json
@@ -20,5 +20,10 @@
   },
   "devDependencies": {
     "typescript": "5.9.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sandstream/kit.git",
+    "directory": "packages/adapter-sdk"
   }
 }

--- a/packages/kit-plugin-cloudflare/package.json
+++ b/packages/kit-plugin-cloudflare/package.json
@@ -5,12 +5,19 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc"
   },
   "devDependencies": {
     "@types/node": "22.19.15",
     "typescript": "5.9.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sandstream/kit.git",
+    "directory": "packages/kit-plugin-cloudflare"
   }
 }

--- a/packages/kit-plugin-fly/package.json
+++ b/packages/kit-plugin-fly/package.json
@@ -5,12 +5,19 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc"
   },
   "devDependencies": {
     "@types/node": "22.19.15",
     "typescript": "5.9.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sandstream/kit.git",
+    "directory": "packages/kit-plugin-fly"
   }
 }

--- a/packages/kit-plugin-github/package.json
+++ b/packages/kit-plugin-github/package.json
@@ -24,5 +24,10 @@
   "devDependencies": {
     "sandstream-kit-adapter-sdk": "*",
     "typescript": "5.9.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sandstream/kit.git",
+    "directory": "packages/kit-plugin-github"
   }
 }

--- a/packages/kit-plugin-railway/package.json
+++ b/packages/kit-plugin-railway/package.json
@@ -24,5 +24,10 @@
   "devDependencies": {
     "sandstream-kit-adapter-sdk": "*",
     "typescript": "5.9.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sandstream/kit.git",
+    "directory": "packages/kit-plugin-railway"
   }
 }

--- a/packages/kit-plugin-sentrux/package.json
+++ b/packages/kit-plugin-sentrux/package.json
@@ -5,12 +5,19 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc"
   },
   "devDependencies": {
     "@types/node": "22.19.15",
     "typescript": "5.9.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sandstream/kit.git",
+    "directory": "packages/kit-plugin-sentrux"
   }
 }

--- a/packages/kit-plugin-sentry/package.json
+++ b/packages/kit-plugin-sentry/package.json
@@ -1,16 +1,23 @@
 {
   "name": "sandstream-kit-plugin-sentry",
   "version": "0.1.0",
-  "description": "Sentry REST API client for kit — issue triage, release tagging, project introspection.",
+  "description": "Sentry REST API client for kit \u2014 issue triage, release tagging, project introspection.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc"
   },
   "devDependencies": {
     "@types/node": "22.19.15",
     "typescript": "5.9.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sandstream/kit.git",
+    "directory": "packages/kit-plugin-sentry"
   }
 }

--- a/packages/kit-plugin-snyk/package.json
+++ b/packages/kit-plugin-snyk/package.json
@@ -5,12 +5,19 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc"
   },
   "devDependencies": {
     "@types/node": "22.19.15",
     "typescript": "5.9.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sandstream/kit.git",
+    "directory": "packages/kit-plugin-snyk"
   }
 }

--- a/packages/kit-plugin-stripe/package.json
+++ b/packages/kit-plugin-stripe/package.json
@@ -5,12 +5,19 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc"
   },
   "devDependencies": {
     "@types/node": "22.19.15",
     "typescript": "5.9.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sandstream/kit.git",
+    "directory": "packages/kit-plugin-stripe"
   }
 }

--- a/packages/kit-plugin-supabase/package.json
+++ b/packages/kit-plugin-supabase/package.json
@@ -24,5 +24,10 @@
   "devDependencies": {
     "sandstream-kit-adapter-sdk": "*",
     "typescript": "5.9.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sandstream/kit.git",
+    "directory": "packages/kit-plugin-supabase"
   }
 }

--- a/packages/kit-plugin-vercel/package.json
+++ b/packages/kit-plugin-vercel/package.json
@@ -24,5 +24,10 @@
   "devDependencies": {
     "sandstream-kit-adapter-sdk": "*",
     "typescript": "5.9.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sandstream/kit.git",
+    "directory": "packages/kit-plugin-vercel"
   }
 }

--- a/packages/kit-plugin-wiz/package.json
+++ b/packages/kit-plugin-wiz/package.json
@@ -5,12 +5,19 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc"
   },
   "devDependencies": {
     "@types/node": "22.19.15",
     "typescript": "5.9.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sandstream/kit.git",
+    "directory": "packages/kit-plugin-wiz"
   }
 }


### PR DESCRIPTION
v6.3.0's first-publish of the workspaces failed npm's sigstore provenance validation: `repository.url` was empty in every workspace manifest (E422 on adapter-sdk; the 11 plugins never ran; the CLI published fine). All 13 manifests now declare `repository` with the monorepo `directory` field. Publish is idempotent — the v6.3.1 tag completes the set.

Full suite green, changelog gate renders 742 bytes, contracts regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)