### PR TITLE
fix(deps): MCP SDK 1.30.0 — clears the @hono/node-server path traversal (GHSA-frvp-7c67-39w9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-## [6.3.1] - 2026-08-03
+### Security
+
+- **`@modelcontextprotocol/sdk` 1.29.0 → 1.30.0, pulling the transitive
+  `@hono/node-server` from 1.19.14 to 2.0.12.** The 1.x line carries
+  GHSA-frvp-7c67-39w9 (CVSS 5.9): on Windows hosts an encoded backslash
+  (`%5C`) in a request path decodes to `\`, which the Windows path resolver
+  treats as a separator, letting `serve-static` escape its root. Kit's MCP
+  server runs over stdio and never serves static files, so no kit code path
+  was exploitable — but the lockfile pin kept `osv-scanner` red on every
+  `kit check`. The fix only exists in the 2.x line, and SDK 1.30.0 is the
+  first release whose range (`^1.19.9 || ^2.0.5`) admits it.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `kit check`. The fix only exists in the 2.x line, and SDK 1.30.0 is the
   first release whose range (`^1.19.9 || ^2.0.5`) admits it.
 
+## [6.3.1] - 2026-08-03
+
 ### Fixed
 
 - **The 6.3.0 first-publish of the adapter SDK and plugins failed provenance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "sandstream-kit",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.29.0",
+        "@modelcontextprotocol/sdk": "1.30.0",
         "@upstash/redis": "1.37.0",
         "smol-toml": "1.6.1",
         "zod": "4.3.6"
@@ -608,10 +608,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -684,10 +686,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "format:check": "prettier --check \"**/*.ts\""
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.29.0",
+    "@modelcontextprotocol/sdk": "1.30.0",
     "@upstash/redis": "1.37.0",
     "smol-toml": "1.6.1",
     "zod": "4.3.6"


### PR DESCRIPTION
## What

Bumps `@modelcontextprotocol/sdk` 1.29.0 → 1.30.0, which pulls the transitive `@hono/node-server` from 1.19.14 to 2.0.12.

## Why

`@hono/node-server` 1.x carries [GHSA-frvp-7c67-39w9](https://osv.dev/GHSA-frvp-7c67-39w9) (CVSS 5.9): on Windows hosts an encoded backslash (`%5C`) in a request path decodes to `\`, which the Windows path resolver treats as a separator, letting `serve-static` escape its root.

Kit's MCP server is stdio-only and serves no static files, so no kit code path was exploitable — but the lockfile pin kept `osv-scanner` red on every `kit check`. The fix only exists in the 2.x line, and SDK 1.30.0 is the first release whose range (`^1.19.9 || ^2.0.5`) admits it.

## Verification

- 3797 tests pass, 0 fail
- `osv-scanner -r .` — no issues found
- `npm audit` — 0 vulnerabilities
- `kit check --category security` — 22/23 (the remaining warn is the known secrets-history baseline)

## Follow-up (not this PR)

SDK 1.30 deprecates the `server.tool()` overload `mcp-server.ts` uses (9 call sites). Warnings only — migration to `registerTool()` deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)