### PR TITLE
refactor(mcp): migrate server.tool() to registerTool() (MCP SDK ≥1.30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`mcp-server.ts` migrated from the deprecated `server.tool()` overload to
+  `server.registerTool()` (MCP SDK ≥ 1.30).** All ten registrations now pass
+  `{ description, inputSchema }` config objects; the tool surface (names,
+  descriptions, input schemas) is unchanged, verified by a live client
+  round-trip. The R8 self-audit extractor recognizes both registration forms
+  so a tool added through either API can never dodge read-only-guard
+  classification. Closes the TS6387 deprecation warnings introduced by the
+  SDK 1.30.0 bump (#437).
+
 ### Security
 
 - **`@modelcontextprotocol/sdk` 1.29.0 → 1.30.0, pulling the transitive

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -200,16 +200,19 @@ function register_kit_check(server: McpServer): void {
   // kit_check — run all checks, return structured JSON. Collection + verdict come
   // from the shared core (check-run.ts) — the SAME path `kit check` runs, so the
   // two surfaces can never disagree on what runs or what "green" means.
-  server.tool(
+  server.registerTool(
     "kit_check",
-    "Run kit check and return structured status for all tools, services, secrets, and security checks.",
     {
-      cwd: z
-        .string()
-        .optional()
-        .describe(
-          "Working directory. Must equal the server process's own cwd (or be omitted): the check dimensions resolve paths from the process, so a different value is REFUSED rather than answered for the wrong project.",
-        ),
+      description:
+        "Run kit check and return structured status for all tools, services, secrets, and security checks.",
+      inputSchema: {
+        cwd: z
+          .string()
+          .optional()
+          .describe(
+            "Working directory. Must equal the server process's own cwd (or be omitted): the check dimensions resolve paths from the process, so a different value is REFUSED rather than answered for the wrong project.",
+          ),
+      },
     },
     async ({ cwd }) => {
       const scoped = crossProjectRefusal(cwd, "kit_check");
@@ -256,32 +259,35 @@ function register_kit_review(server: McpServer): void {
   // structured report, via the same collectReview core `kit review` renders.
   // Replaces kit_standards on the MCP surface (that stage is one of its four).
   // Read-only: no writes, so no governance/read-only gating.
-  server.tool(
+  server.registerTool(
     "kit_review",
-    'Full repo audit in one shot — runs the check, design, standards, and ADR gates and returns one structured report ({ ok, failed, stages }). The same core `kit review` renders, so the surfaces cannot disagree. Read-only. Use stages to scope (e.g. ["standards"] for a fast lint loop — no full security scan), category to scope the standards stage, and concise:true to omit pass/skip rows (per-stage counts stay).',
     {
-      cwd: z.string().optional().describe("Working directory (defaults to process.cwd())"),
-      enforce: z
-        .boolean()
-        .optional()
-        .describe("Fail on net-new design/standards findings AND setup gaps (CI posture)"),
-      stages: z
-        .array(z.enum(["check", "design", "standards", "adr"]))
-        .nonempty()
-        .optional()
-        .describe(
-          'Run only these stages (canonical order kept). Omit for the full audit. ["standards"] is the fast, read-only lint loop',
-        ),
-      category: z
-        .string()
-        .optional()
-        .describe("Standards-stage scope: general | specific | plugins | platform | <language>"),
-      concise: z
-        .boolean()
-        .optional()
-        .describe(
-          "Return only fail/warn findings; per-stage summary counts still cover everything",
-        ),
+      description:
+        'Full repo audit in one shot — runs the check, design, standards, and ADR gates and returns one structured report ({ ok, failed, stages }). The same core `kit review` renders, so the surfaces cannot disagree. Read-only. Use stages to scope (e.g. ["standards"] for a fast lint loop — no full security scan), category to scope the standards stage, and concise:true to omit pass/skip rows (per-stage counts stay).',
+      inputSchema: {
+        cwd: z.string().optional().describe("Working directory (defaults to process.cwd())"),
+        enforce: z
+          .boolean()
+          .optional()
+          .describe("Fail on net-new design/standards findings AND setup gaps (CI posture)"),
+        stages: z
+          .array(z.enum(["check", "design", "standards", "adr"]))
+          .nonempty()
+          .optional()
+          .describe(
+            'Run only these stages (canonical order kept). Omit for the full audit. ["standards"] is the fast, read-only lint loop',
+          ),
+        category: z
+          .string()
+          .optional()
+          .describe("Standards-stage scope: general | specific | plugins | platform | <language>"),
+        concise: z
+          .boolean()
+          .optional()
+          .describe(
+            "Return only fail/warn findings; per-stage summary counts still cover everything",
+          ),
+      },
     },
     async ({ cwd, enforce, stages, category, concise }) => {
       const scoped = crossProjectRefusal(cwd, "kit_review");
@@ -313,10 +319,13 @@ function register_kit_review(server: McpServer): void {
 
 function register_kit_secrets(server: McpServer): void {
   // kit_secrets — generate .env.local from config
-  server.tool(
+  server.registerTool(
     "kit_secrets",
-    "Generate .env.local by resolving secrets defined in .kit.toml. Returns the list of written keys.",
-    { cwd: z.string().optional().describe("Working directory") },
+    {
+      description:
+        "Generate .env.local by resolving secrets defined in .kit.toml. Returns the list of written keys.",
+      inputSchema: { cwd: z.string().optional().describe("Working directory") },
+    },
     async ({ cwd }) => {
       if (isReadOnlyMode()) return readOnlyRefusal("kit_secrets");
       try {
@@ -381,16 +390,19 @@ function register_kit_secrets(server: McpServer): void {
 
 function register_kit_fix(server: McpServer): void {
   // kit_fix — auto-fix issues (generate lock files, install tools)
-  server.tool(
+  server.registerTool(
     "kit_fix",
-    "Auto-fix issues found by kit check (install missing tools, generate missing lock files). Returns actions taken.",
     {
-      cwd: z
-        .string()
-        .optional()
-        .describe(
-          "Working directory. Must equal the server process's own cwd (or be omitted): the lock-file writes resolve paths from the process, so a different value is REFUSED rather than written into the wrong project.",
-        ),
+      description:
+        "Auto-fix issues found by kit check (install missing tools, generate missing lock files). Returns actions taken.",
+      inputSchema: {
+        cwd: z
+          .string()
+          .optional()
+          .describe(
+            "Working directory. Must equal the server process's own cwd (or be omitted): the lock-file writes resolve paths from the process, so a different value is REFUSED rather than written into the wrong project.",
+          ),
+      },
     },
     async ({ cwd }) => {
       if (isReadOnlyMode()) return readOnlyRefusal("kit_fix");
@@ -494,15 +506,18 @@ function register_kit_fix(server: McpServer): void {
 
 function register_kit_init(server: McpServer): void {
   // kit_init — detect stack, generate .kit.toml, optionally write it
-  server.tool(
+  server.registerTool(
     "kit_init",
-    "Detect project stack and generate .kit.toml for a project that does not yet have one. Use dryRun:true to preview without writing.",
     {
-      cwd: z.string().optional().describe("Project directory (defaults to process.cwd())"),
-      dry_run: z
-        .boolean()
-        .optional()
-        .describe("Return generated config without writing to disk (default: false)"),
+      description:
+        "Detect project stack and generate .kit.toml for a project that does not yet have one. Use dryRun:true to preview without writing.",
+      inputSchema: {
+        cwd: z.string().optional().describe("Project directory (defaults to process.cwd())"),
+        dry_run: z
+          .boolean()
+          .optional()
+          .describe("Return generated config without writing to disk (default: false)"),
+      },
     },
     async ({ cwd, dry_run }) => {
       // dry_run is a read-only preview; a real write is refused in read-only mode.
@@ -574,14 +589,17 @@ function register_kit_init(server: McpServer): void {
 
 function register_kit_run(server: McpServer): void {
   // kit_run — execute a command with project env vars loaded
-  server.tool(
+  server.registerTool(
     "kit_run",
-    "Execute a command with project environment variables loaded from .env.local. Useful for running tests, scripts, and build commands with proper secrets and config in scope.",
     {
-      command: z
-        .string()
-        .describe("Command to execute (with arguments, e.g., 'pnpm test --watch')"),
-      cwd: z.string().optional().describe("Working directory (defaults to process.cwd())"),
+      description:
+        "Execute a command with project environment variables loaded from .env.local. Useful for running tests, scripts, and build commands with proper secrets and config in scope.",
+      inputSchema: {
+        command: z
+          .string()
+          .describe("Command to execute (with arguments, e.g., 'pnpm test --watch')"),
+        cwd: z.string().optional().describe("Working directory (defaults to process.cwd())"),
+      },
     },
     async ({ command, cwd }) => {
       if (isReadOnlyMode()) return readOnlyRefusal("kit_run");
@@ -662,10 +680,15 @@ function register_kit_run(server: McpServer): void {
 
 function register_kit_context(server: McpServer): void {
   // kit_context — gather structured project context for agents
-  server.tool(
+  server.registerTool(
     "kit_context",
-    "Gather comprehensive project context: detected stack, configured tools, services, secrets, and environment. Use this to understand project architecture at a glance.",
-    { cwd: z.string().optional().describe("Project directory (defaults to process.cwd())") },
+    {
+      description:
+        "Gather comprehensive project context: detected stack, configured tools, services, secrets, and environment. Use this to understand project architecture at a glance.",
+      inputSchema: {
+        cwd: z.string().optional().describe("Project directory (defaults to process.cwd())"),
+      },
+    },
     async ({ cwd }) => {
       try {
         const workDir = cwd ?? process.cwd();
@@ -695,26 +718,29 @@ function register_kit_context(server: McpServer): void {
 function register_kit_map(server: McpServer): void {
   // kit_map — deterministic repo-map: the relevant slice around a seed file (read-only). Shares the
   // exact core (mapReport) with the `kit map` CLI, so the two surfaces can't disagree.
-  server.tool(
+  server.registerTool(
     "kit_map",
-    "Deterministic, zero-LLM repo-map: given seed file path(s), return the relevant SLICE of the codebase — files connected within N import hops (both directions) + external packages, each attributed to its owner (CODEOWNERS or git-blame). Optionally budget the slice to the N nearest files and add historical co-change coupling. Use it to load only the part of a growing repo that matters to a task, instead of the whole tree.",
     {
-      paths: z
-        .array(z.string())
-        .min(1)
-        .describe("Seed file path(s) to map around (repo-relative or absolute)"),
-      depth: z.number().int().min(0).optional().describe("Import hops from the seed (default 1)"),
-      budget: z
-        .number()
-        .int()
-        .min(0)
-        .optional()
-        .describe("Keep only the N nearest-to-seed files (0 = unbounded); drops are reported"),
-      co_change: z
-        .boolean()
-        .optional()
-        .describe("Add files that historically change WITH each seed (git history)"),
-      cwd: z.string().optional().describe("Working directory (defaults to process.cwd())"),
+      description:
+        "Deterministic, zero-LLM repo-map: given seed file path(s), return the relevant SLICE of the codebase — files connected within N import hops (both directions) + external packages, each attributed to its owner (CODEOWNERS or git-blame). Optionally budget the slice to the N nearest files and add historical co-change coupling. Use it to load only the part of a growing repo that matters to a task, instead of the whole tree.",
+      inputSchema: {
+        paths: z
+          .array(z.string())
+          .min(1)
+          .describe("Seed file path(s) to map around (repo-relative or absolute)"),
+        depth: z.number().int().min(0).optional().describe("Import hops from the seed (default 1)"),
+        budget: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe("Keep only the N nearest-to-seed files (0 = unbounded); drops are reported"),
+        co_change: z
+          .boolean()
+          .optional()
+          .describe("Add files that historically change WITH each seed (git history)"),
+        cwd: z.string().optional().describe("Working directory (defaults to process.cwd())"),
+      },
     },
     async ({ paths, depth, budget, co_change, cwd }) => {
       try {
@@ -743,22 +769,25 @@ function register_kit_triage(server: McpServer): void {
   // MCP client could not previously follow. A PASS is recorded through the SAME
   // triage-log path the CLI uses, so the pre-commit and install gates recognize
   // an MCP-run triage identically.
-  server.tool(
+  server.registerTool(
     "kit_triage",
-    "Security-triage a dependency BEFORE installing it (registry reputation, repo health, known-compromise catalogs). Required by kit's install gate for anything it has not already cleared. A pass is recorded in the triage log the gates read. Deterministic, zero-LLM.",
     {
-      type: z
-        .enum(["npm", "pip", "docker", "brew", "repo", "skill"])
-        .describe(
-          "Target kind: npm/pip package, docker image, brew formula, GitHub repo, or agent skill",
-        ),
-      target: z.string().describe("Package name, image ref, owner/repo, or skill path"),
-      cwd: z
-        .string()
-        .optional()
-        .describe(
-          "Working directory (defaults to process.cwd()) — where the triage log is written",
-        ),
+      description:
+        "Security-triage a dependency BEFORE installing it (registry reputation, repo health, known-compromise catalogs). Required by kit's install gate for anything it has not already cleared. A pass is recorded in the triage log the gates read. Deterministic, zero-LLM.",
+      inputSchema: {
+        type: z
+          .enum(["npm", "pip", "docker", "brew", "repo", "skill"])
+          .describe(
+            "Target kind: npm/pip package, docker image, brew formula, GitHub repo, or agent skill",
+          ),
+        target: z.string().describe("Package name, image ref, owner/repo, or skill path"),
+        cwd: z
+          .string()
+          .optional()
+          .describe(
+            "Working directory (defaults to process.cwd()) — where the triage log is written",
+          ),
+      },
     },
     async ({ type, target, cwd }) => {
       // Appends to .kit-triage.jsonl on PASS, so read-only mode refuses it —
@@ -806,17 +835,20 @@ function register_kit_memory(server: McpServer): void {
   // the trusted store stay on the CLI/indexer path, so an MCP client can never
   // inject foreign text into recall. Quarantined (injection-flagged) rows are
   // excluded, matching the CLI default.
-  server.tool(
+  server.registerTool(
     "kit_memory",
-    "Search kit's local cross-session conversation memory plus the repo's curated shared decisions. Use before answering project-specific questions to recall what was actually said/decided. Read-only search; quarantined rows excluded.",
     {
-      query: z.string().describe("Search terms"),
-      limit: z.number().int().min(1).max(100).optional().describe("Max raw hits (default 20)"),
-      global: z
-        .boolean()
-        .optional()
-        .describe("Search across all projects instead of only the current one"),
-      cwd: z.string().optional().describe("Project directory (defaults to process.cwd())"),
+      description:
+        "Search kit's local cross-session conversation memory plus the repo's curated shared decisions. Use before answering project-specific questions to recall what was actually said/decided. Read-only search; quarantined rows excluded.",
+      inputSchema: {
+        query: z.string().describe("Search terms"),
+        limit: z.number().int().min(1).max(100).optional().describe("Max raw hits (default 20)"),
+        global: z
+          .boolean()
+          .optional()
+          .describe("Search across all projects instead of only the current one"),
+        cwd: z.string().optional().describe("Project directory (defaults to process.cwd())"),
+      },
     },
     async ({ query, limit, global: searchGlobal, cwd }) => {
       try {

--- a/src/self-audit.test.ts
+++ b/src/self-audit.test.ts
@@ -327,6 +327,26 @@ describe("R8-readonly-guard", () => {
     assert.ok(countStatus(res, "warn") >= 1);
   });
 
+  it("fires on the registerTool form too (SDK ≥1.30 registration)", () => {
+    // Same fail-open shape as above, but registered through the non-deprecated
+    // registerTool API — the extractor must classify both forms.
+    const pre = `function register(server: any) {
+  server.registerTool(
+    "kit_install",
+    {
+      description: "desc",
+      inputSchema: {},
+    },
+    async ({ cwd }) => {
+      const config = await loadConfig(configPath(cwd));
+      return installTools(config);
+    },
+  );
+}`;
+    const res = ruleById("R8-readonly-guard").run(ctxFromText(pre, "mcp-server.ts"));
+    assert.ok(countStatus(res, "warn") >= 1);
+  });
+
   it("does NOT fire on a no-op stub (no side-effect) even if not allowlisted", () => {
     const stub = `function register(server: any) {
   server.tool(

--- a/src/self-audit.ts
+++ b/src/self-audit.ts
@@ -76,7 +76,7 @@ interface FnWindow {
 
 // A "function start" heuristic that covers kit's style: top-level `function`,
 // `export function`, `async function`, arrow consts assigned a function, and
-// `server.tool(` handler arrows. We don't need exact scoping — we need a bounded
+// `server.registerTool(` handler arrows. We don't need exact scoping — we need a bounded
 // window per logical function so "validator BEFORE sink" / "guard NEAR handler"
 // checks compare lines that actually belong together. Brace-depth tracking from a
 // function-start line until depth returns to its starting level closes the window.
@@ -678,16 +678,19 @@ const GUARD_WINDOW = 12;
 // with none of these (a JSON-assembling stub) is not a mutation risk.
 const MCP_SIDE_EFFECT_RE =
   /\b(?:writeFile|writeFileSync|appendFile|appendFileSync|mkdir|mkdirSync|generateSecrets|loginServices|provisionService|installTools|executeCommand|execFileSync|execFile|execSync|spawnSync|spawn|exec)\s*\(/;
-// Registration of a kit_* MCP tool: `server.tool("kit_...",` (name on the next line).
+// Registration of a kit_* MCP tool: `server.registerTool("kit_...",` (name on the
+// next line). The deprecated `server.tool(` overload is still matched so a tool
+// added through it can never dodge classification (fail-closed).
 const KIT_TOOL_REG_RE = /["'](kit_[a-z_]+)["']/;
 
 /** Every kit_* tool registered in mcp-server.ts, with the line of its registration. */
 export function extractKitTools(file: SourceFile): { name: string; regIdx: number }[] {
   const tools: { name: string; regIdx: number }[] = [];
   for (let i = 0; i < file.lines.length; i++) {
-    // Anchor on the `server.tool(` call, then read the tool name from the next
-    // non-empty line (kit's style puts the name on its own line).
-    if (!/server\.tool\s*\(/.test(file.lines[i])) continue;
+    // Anchor on the `server.registerTool(` call (or the deprecated `server.tool(`),
+    // then read the tool name from the next non-empty line (kit's style puts the
+    // name on its own line).
+    if (!/server\.(?:registerTool|tool)\s*\(/.test(file.lines[i])) continue;
     for (let j = i; j < Math.min(file.lines.length, i + 3); j++) {
       const m = KIT_TOOL_REG_RE.exec(file.lines[j]);
       if (m) {


### PR DESCRIPTION
Closes #438.

SDK 1.30.0 (bumped in #437) deprecates the `server.tool(name, description, paramsSchema, cb)` overload — TS6387 on every call site. This migrates all registrations in `mcp-server.ts` to `server.registerTool(name, { description, inputSchema }, cb)`.

## What changed

- **`src/mcp-server.ts`** — all **10** call sites rewritten (the issue said 9; grep says 10). Mechanical transform via a TS-AST codemod, so descriptions and zod shapes are byte-identical — only the wrapping changed.
- **`src/self-audit.ts`** — the R8 (`readonly-guard`) extractor anchored on `server.tool(` and found **zero** tools after the migration; its own completeness test (`expected >= 10 kit_* tools, found 0`) caught it. The anchor now matches both `registerTool(` and the deprecated `tool(`, fail-closed: a tool added through either API can never dodge classification.
- **`src/self-audit.test.ts`** — new fixture test: an unguarded mutating tool registered via `registerTool` still fires R8. The old-form fixtures stay as regression coverage for the dual matcher.
- **`CHANGELOG.md`** — entry under Unreleased → Changed.

## Verification

- `tsc --noEmit` clean; the 10 TS6387 diagnostics are gone (no `server.tool` call sites remain).
- Full suite: **3798/3798 pass** (was 3796/3797 with the R8 completeness failure mid-migration).
- Live smoke: real MCP client over `InMemoryTransport` against the built server — `listTools` returns all 10 tools, each with a non-empty description and object input schema, and a real `kit_map` call round-trips green.
- `kit check --category security`: no new findings (the pre-existing git-history secrets warn is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)