### PR TITLE
fix: five fail-opens, a release attestation that never ran, and cwd threaded end to end

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -323,18 +323,56 @@ jobs:
           printf 'source:\n  name: %s\n  version: %s\n' "$PKG_NAME" "$VERSION" > .syft.yaml
           cat .syft.yaml
 
-      - name: Generate GitHub artifact attestation
-        # Independent of npm provenance — attaches a signed manifest of the
-        # built dist/ tree to the GitHub release for cross-verification.
-        # timeout-minutes guards against Sigstore (Fulcio/Rekor) hangs, which
-        # once left this step running ~15min; npm publish already succeeded by
-        # here, so a slow attestation must fail fast (continue-on-error) not block.
+      - name: Pack the tarball to attest
+        # ONE subject, and the one that matters: the tarball a consumer actually installs.
+        # `subject-path: dist/**/*` passed 1920 subjects and the action's hard limit is 1024, so
+        # for every release it errored in 327ms with "Too many subjects specified (>1024)" — and
+        # `continue-on-error` turned that into a green step. docs/VERIFY.md step 2 promised a
+        # signed manifest attached to the release; nothing was ever attached, and
+        # `gh attestation verify` would have found no attestation at all. Packing first also makes
+        # the subject digest identical to what npm published, so the GitHub attestation and the
+        # npm provenance describe the same bytes instead of two different views of the build.
         if: always()
+        id: pack
+        run: |
+          set -euo pipefail
+          TARBALL="$(npm pack --silent)"
+          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+          sha256sum "$TARBALL"
+
+      - name: Generate GitHub artifact attestation
+        # Independent of npm provenance — attaches a signed provenance statement for the published
+        # tarball to this repo's attestation store, verifiable with:
+        #   gh attestation verify <tarball> --repo sandstream/kit
+        # timeout-minutes guards against Sigstore (Fulcio/Rekor) hangs, which once left this step
+        # running ~15min; npm publish already succeeded by here, so a slow attestation must fail
+        # fast (continue-on-error) not block.
+        if: always()
+        id: attest
         timeout-minutes: 5
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         continue-on-error: true # kit-self-audit: allow-continue-on-error
         with:
-          subject-path: "dist/**/*"
+          subject-path: ${{ steps.pack.outputs.tarball }}
+
+      - name: Report the attestation outcome loudly
+        # `continue-on-error` is deliberate — a Sigstore hang must not strand a release whose npm
+        # publish already succeeded. But it also reports the step's conclusion as SUCCESS to the
+        # jobs API while the log says failure, which is how a broken attestation survived every
+        # release unnoticed. This step cannot block; it exists so the failure is impossible to
+        # read as green: an annotation on the run and a line in the job summary.
+        if: always()
+        env:
+          OUTCOME: ${{ steps.attest.outcome }}
+        run: |
+          if [ "$OUTCOME" = "success" ]; then
+            echo "✅ GitHub artifact attestation created for ${{ steps.pack.outputs.tarball }}" \
+              >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning title=No GitHub artifact attestation::the attest step did not succeed (outcome=$OUTCOME); this release has npm provenance but NO GitHub attestation — 'gh attestation verify' will find nothing"
+            echo "⚠️ **No GitHub artifact attestation** for this release (attest outcome: \`$OUTCOME\`). npm provenance is unaffected; \`gh attestation verify\` will find nothing." \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Generate SBOM (CycloneDX)
         # CycloneDX SBOM is required by EU CRA and US EO 14028 for shipped

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,11 +108,27 @@ homedir path, `checkServices` and `checkWebSearch` neither. Proof:
 mutation-proved three ways (ignore the argument → 3 fail; revert one sub-check → 3 fail; drop
 `cwd` from one scanner spawn → 1 fail).
 
-**Still open, and why the MCP refusal stays:** `kit_fix` writes, and `cmdFix` takes no `cwd` at
-all — it loads `.kit.toml` from `process.cwd()`, so a cross-project fix would still create B's
-lock files inside A. `kit_review` runs its own collector rather than `runCheckGate` alone. Until
-both are threaded, `crossProjectRefusal` keeps failing closed for all three tools; lifting a
-fail-closed access boundary is its own deliberate change with its own tests.
+**The write path is done too.** `cmdFix(cwd)` resolves the config, the `.gitignore` and the
+relative `[secrets].template` against the governed project, and `lock.ts` had the asymmetry the
+wrong way round — its readers (`readSkillsLock`, `readCliLock`, `readkitMeta`) all took a `cwd`
+while its WRITERS (`writeSkillsLock`, `writeCliLock`, `writekitMeta`, `ensurekitDir`) did not, so
+a caller read its own project's locks and wrote the process's. `installHooks` / `uninstallHooks` /
+`resolveHooksDir` take it as well. Note that fixing `cmdFix` did NOT fix the MCP surface:
+`register_kit_fix` carries its own copy of the lock step (it needs structured actions, not console
+output), so it had to be threaded separately — the CLI-vs-MCP divergence this codebase has been
+bitten by before. Proof: `src/fix-cwd.test.ts`, 6 tests asserting WHERE THE BYTES LANDED in both
+trees; mutation-proved two ways (lock writers ignore `cwd` → 2 fail; `.gitignore` + template
+resolve against the process → 3 fail).
+
+**Still open, and why the MCP refusal stays:** the AUDIT DESTINATION. `withGovernance` takes no
+`cwd`, and neither does `logAuditEvent`, so a cross-project write would file its evidence in the
+calling process's `.kit-audit.jsonl`. `exec-broker/broker.ts`'s own `audit()` docstring already
+explains why that is not cosmetic: foreign-project evidence pollutes the host chain and poisons
+`kit broker enforce-readiness`, "whose verdict is only as honest as the evidence file it reads". A
+write served for B whose proof lands in A is not a write kit can stand behind. `kit_review` also
+runs its own collector rather than `runCheckGate` alone. Until both are threaded,
+`crossProjectRefusal` keeps failing closed for all three tools; lifting a fail-closed access
+boundary is its own deliberate change with its own tests.
 
 Consequence, found with a discriminating probe over the MCP surface: `kit_check({cwd: B})` from a
 server launched in A reported `pass — all .env patterns in .gitignore` for a project B that has no

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,11 +90,29 @@ opposite of the usual reading, and getting that wrong fails OPEN:
    survived because `checkPolicy` had unit tests proving the decision function correct while nothing
    called it. Tests over the decision function are not evidence of a working control.
 
-### Thread `cwd` through every check dimension (1d)
-`runCheckGate` resolves its `cwd` option only to load `.kit.toml`. All ten dimensions after that
+### Thread `cwd` through every check dimension — READ PATH DONE, write path remains
+`runCheckGate` resolved its `cwd` option only to load `.kit.toml`. All ten dimensions after that
 — `checkSecurity()`, `checkTools()`, `checkServices()`, `checkSecrets()`, `checkSkills()`,
 `checkHooks()`, `checkTests()`, `checkWebSearch()`, `isGitRepository()`, and their callees —
-resolve paths from `process.cwd()`.
+resolved paths from `process.cwd()`.
+
+**Done.** Every dimension that touches the filesystem now takes the governed project's `cwd`:
+`checkSecurity(cwd)` threads it to all fifteen sub-checks *and* to all seven scanner spawns —
+`trivy fs .`, `trivy config .`, `osv-scanner -r .` and `semgrep .` resolve `.` against the
+SPAWNED process, so passing the path alone would have been the exact trap this entry warns about
+below — plus `checkSecrets`, `checkHooks`, `isGitRepository`, `checkTests`, `loadBaselineForGate`,
+`checkExternalFindings` and `checkGateLiveness`. The remaining four were measured to touch no
+project path at all: `checkTools` resolves binaries on PATH, `checkSkills` reads an absolute
+homedir path, `checkServices` and `checkWebSearch` neither. Proof:
+`src/check-security-cwd.test.ts`, 8 tests, each asserting the two trees give DIFFERENT answers;
+mutation-proved three ways (ignore the argument → 3 fail; revert one sub-check → 3 fail; drop
+`cwd` from one scanner spawn → 1 fail).
+
+**Still open, and why the MCP refusal stays:** `kit_fix` writes, and `cmdFix` takes no `cwd` at
+all — it loads `.kit.toml` from `process.cwd()`, so a cross-project fix would still create B's
+lock files inside A. `kit_review` runs its own collector rather than `runCheckGate` alone. Until
+both are threaded, `crossProjectRefusal` keeps failing closed for all three tools; lifting a
+fail-closed access boundary is its own deliberate change with its own tests.
 
 Consequence, found with a discriminating probe over the MCP surface: `kit_check({cwd: B})` from a
 server launched in A reported `pass — all .env patterns in .gitignore` for a project B that has no

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -114,6 +114,18 @@ on repo-level security checks — test structure, not ok". They now `chdir` into
 Any dimension that gains a `cwd` needs a test that would FAIL if the parameter were ignored; a test
 that merely passes `cwd` proves nothing, which is how this survived.
 
+**Done, same class, separate surface:** the exec-broker's unsigned-policy path had the identical
+bug, and there it was fail-OPEN rather than merely wrong-tree. `brokerPolicyPath()` resolved
+`.kit-exec-broker.json` against `process.cwd()` while `brokerExec` measured writes against
+`opts.cwd`, so a server in A mediating B ignored B's policy entirely — and since "no policy file"
+means "not configured", the write ran unmediated with full env. The seven MCP tools NOT behind
+`crossProjectRefusal` (`kit_secrets`, `kit_run`, `kit_triage`, `kit_init`, `kit_context`,
+`kit_map`, `kit_memory`) do thread `cwd` correctly into their own callees — that is why they are
+unguarded, and checking it walked back a suspected gap — but three of them route writes through
+`runBrokered`, which was the hole. Fixed with 10 two-sided tests in
+`src/exec-broker/policy-cwd.test.ts`; mutation-proved (dropping the `cwd` argument fails 6,
+replacing the foreign-tree deny with `if (false)` fails 2).
+
 ### PR 2 — `kit analyze` subcommand (1d)
 Walk git log + scan framework markers (`next.config.*`, `pyproject.toml`,
 `Cargo.toml`, `drizzle.config.*`, etc.) to emit a draft `CLAUDE.md` + `RULES.md`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -154,18 +154,23 @@ it used to inherit A's `pass`; `kit_review`'s design stage described B's absent 
 with neither. The probe was run twice — once with the guard in place to confirm the baseline
 refusal, once bypassed to measure what serving actually produced.
 
-**The weakest link, stated where it cannot be missed:** the scanner subprocesses are NOT proven
-against the real tools. trivy, semgrep, osv-scanner and guarddog are absent from CI, so their
-coverage is a chain of two — a source-level guard that every `execFileNoThrow` in
-`check-security.ts` passes `cwd: root`, plus a behavioural test that the option actually relocates
-a child process. That is weaker than running trivy against two trees and observing which one it
-read, and anyone installing those tools should re-run the cross-project probe to close it.
+**The scanner subprocesses are proven for `semgrep`, by inference for the rest.** `semgrep .`
+resolves `.` against the spawned process, so it is the direct test: one tree trips a local rule,
+one is clean, and the verdicts must differ. It does. trivy, osv-scanner and guarddog ship as GitHub
+release binaries and cannot be fetched in this environment (the session's policy answers 403 for
+any repository outside its allowlist), so they rest on a chain of three — every `execFileNoThrow`
+in `check-security.ts` passes `cwd: root`, the option demonstrably relocates a child process, and
+semgrep demonstrably honours it end to end. Anyone with those binaries should re-run the
+cross-project probe; the semgrep test skips loudly rather than silently when the binary is absent.
 
 One write was found only by ENUMERATING the write surface, not by any probe:
 `logSupplyChainFindings` appends bumblebee findings to `<root>/.kit-findings.jsonl` and was called
-without a `cwd`, so a check run for another project appended that project's findings to the
-caller's file. Bumblebee is not installed in the probe environment, so the branch never executed.
-A behavioural probe is not a substitute for reading the writes.
+without a `cwd`. The reason no probe caught it is worth stating exactly, because the first version
+of this note got it wrong: bumblebee IS provisioned here — kit downloads it to
+`~/.kit/tools/bumblebee/<version>/` — and it does run (`pass`, 36 packages, on a clean fixture).
+The write is gated on `findings.length > 0`, and a freshly created temp project has no known
+exposures, so the branch is unreachable from any clean fixture. A green probe over a clean fixture
+says nothing about the paths only a dirty one reaches.
 
 Consequence, found with a discriminating probe over the MCP surface: `kit_check({cwd: B})` from a
 server launched in A reported `pass — all .env patterns in .gitignore` for a project B that has no

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -146,11 +146,26 @@ identical" for the `adr` and `standards` stages and both times the FIXTURE was w
 ignored, and a standards stage whose five rows only measure tool availability, which two temp dirs
 necessarily share. A probe that cannot tell the hypothesis from its negation is not evidence.
 
-**Still open: lifting the refusal itself.** Nothing measured so far says that REMOVING it is safe.
-Every claim above is about a path being threaded, which is a different proposition. That needs its
-own change with its own probes: launch a real MCP server in A, call each tool for B over stdio,
-and assert on where every byte and every audit line landed. Ordinary discipline, not an exception
-for a boundary that now merely looks liftable.
+**The refusal is LIFTED**, and only after the end-to-end probe was run rather than because the code
+read correct. A real MCP client was driven against a server whose `process.cwd()` was project A,
+with each tool called for project B: `kit_check` reported B's missing `.gitignore` as `warn` where
+it used to inherit A's `pass`; `kit_review`'s design stage described B's absent `src/`;
+`kit_fix` created B's lock files in B, filed the `"operation":"fix"` audit line in B, and left A
+with neither. The probe was run twice — once with the guard in place to confirm the baseline
+refusal, once bypassed to measure what serving actually produced.
+
+**The weakest link, stated where it cannot be missed:** the scanner subprocesses are NOT proven
+against the real tools. trivy, semgrep, osv-scanner and guarddog are absent from CI, so their
+coverage is a chain of two — a source-level guard that every `execFileNoThrow` in
+`check-security.ts` passes `cwd: root`, plus a behavioural test that the option actually relocates
+a child process. That is weaker than running trivy against two trees and observing which one it
+read, and anyone installing those tools should re-run the cross-project probe to close it.
+
+One write was found only by ENUMERATING the write surface, not by any probe:
+`logSupplyChainFindings` appends bumblebee findings to `<root>/.kit-findings.jsonl` and was called
+without a `cwd`, so a check run for another project appended that project's findings to the
+caller's file. Bumblebee is not installed in the probe environment, so the branch never executed.
+A behavioural probe is not a substitute for reading the writes.
 
 Consequence, found with a discriminating probe over the MCP surface: `kit_check({cwd: B})` from a
 server launched in A reported `pass — all .env patterns in .gitignore` for a project B that has no

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -120,15 +120,23 @@ bitten by before. Proof: `src/fix-cwd.test.ts`, 6 tests asserting WHERE THE BYTE
 trees; mutation-proved two ways (lock writers ignore `cwd` → 2 fail; `.gitignore` + template
 resolve against the process → 3 fail).
 
-**Still open, and why the MCP refusal stays:** the AUDIT DESTINATION. `withGovernance` takes no
-`cwd`, and neither does `logAuditEvent`, so a cross-project write would file its evidence in the
-calling process's `.kit-audit.jsonl`. `exec-broker/broker.ts`'s own `audit()` docstring already
-explains why that is not cosmetic: foreign-project evidence pollutes the host chain and poisons
+**The audit destination is done too.** `withGovernance`, `runGoverned`, `logAuditEvent` and
+`refuseWrite` all take a `cwd`, so a governed operation performed for B files its proof in B's
+chain. This mattered because `exec-broker/broker.ts`'s own `audit()` docstring already explains
+the cost: foreign-project evidence pollutes the host chain and poisons
 `kit broker enforce-readiness`, "whose verdict is only as honest as the evidence file it reads". A
-write served for B whose proof lands in A is not a write kit can stand behind. `kit_review` also
-runs its own collector rather than `runCheckGate` alone. Until both are threaded,
-`crossProjectRefusal` keeps failing closed for all three tools; lifting a fail-closed access
-boundary is its own deliberate change with its own tests.
+write served for B whose proof lands in A is not a write kit can stand behind. `logAuditEvent`'s
+third parameter became an options bag in the process, which also makes the `companyId` the
+`[governance.audit].remote` row is blocked on reachable — reaching it is still a separate decision
+about where a company id comes from, not something to infer.
+
+**Still open, and why the MCP refusal stays:** `kit_review` runs its own collector rather than
+`runCheckGate` alone, so its cross-project behaviour is unmeasured. And — the more important
+reason — nothing measured so far says that LIFTING the refusal is safe. Every claim above is about
+a path that is now threaded; none of them is a probe of the refusal being removed. That needs its
+own change with its own probes: launch a server in A, call each tool for B, and assert on where
+every byte and every audit line landed. Ordinary discipline, not an exception for a boundary that
+now merely looks liftable.
 
 Consequence, found with a discriminating probe over the MCP surface: `kit_check({cwd: B})` from a
 server launched in A reported `pass — all .env patterns in .gitignore` for a project B that has no

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -130,13 +130,27 @@ third parameter became an options bag in the process, which also makes the `comp
 `[governance.audit].remote` row is blocked on reachable — reaching it is still a separate decision
 about where a company id comes from, not something to infer.
 
-**Still open, and why the MCP refusal stays:** `kit_review` runs its own collector rather than
-`runCheckGate` alone, so its cross-project behaviour is unmeasured. And — the more important
-reason — nothing measured so far says that LIFTING the refusal is safe. Every claim above is about
-a path that is now threaded; none of them is a probe of the refusal being removed. That needs its
-own change with its own probes: launch a server in A, call each tool for B, and assert on where
-every byte and every audit line landed. Ordinary discipline, not an exception for a boundary that
-now merely looks liftable.
+**`kit_review`'s collector is measured now, and it had one real gap.** `collectReview` passes
+`opts.cwd` to all four stages, so it read as threaded — but `runDesignGate` passed that `cwd` to
+`loadBaselineForGate` and then called `checkDesign(...)` without it, and `checkDesign` resolved its
+source roots *and* every finding's display path from `process.cwd()`. The baseline came from B
+while the files scanned came from A. A parameter that reaches one collaborator and not the next is
+the same false green as no parameter at all, and reading `collectReview` alone would never show
+it. Fixed, with `src/review-cwd.test.ts` (6 tests) and mutation proof both ways. The `check`,
+`standards` and `adr` stages were already correct: all five standards runners receive the resolved
+`cwd`, and `runAdrGate` threads it to `loadAdrs`.
+
+Worth recording because it cost two false alarms: my first fixtures reported "the two trees are
+identical" for the `adr` and `standards` stages and both times the FIXTURE was wrong, not the code
+— an ADR in MADR heading style that kit's parser (YAML frontmatter with an `id`) correctly
+ignored, and a standards stage whose five rows only measure tool availability, which two temp dirs
+necessarily share. A probe that cannot tell the hypothesis from its negation is not evidence.
+
+**Still open: lifting the refusal itself.** Nothing measured so far says that REMOVING it is safe.
+Every claim above is about a path being threaded, which is a different proposition. That needs its
+own change with its own probes: launch a real MCP server in A, call each tool for B over stdio,
+and assert on where every byte and every audit line landed. Ordinary discipline, not an exception
+for a boundary that now merely looks liftable.
 
 Consequence, found with a discriminating probe over the MCP surface: `kit_check({cwd: B})` from a
 server launched in A reported `pass — all .env patterns in .gitignore` for a project B that has no

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -172,8 +172,21 @@ in URL paths or query strings.
 | cloudflare | `https://api.cloudflare.com/client/v4/...` | GET/PUT/DELETE |
 | (opt-in) audit | `${KIT_REMOTE_URL}/api/companies/{id}/audit-logs` | POST |
 
-That's the entire egress list. No analytics, no telemetry, no LLM provider,
-no third-party logging service.
+No analytics, no telemetry, no LLM provider, no third-party logging service — those
+remain true.
+
+> **This table is PLUGIN egress, not everything kit can reach.** It said "the exhaustive
+> list" and "the entire egress list", and it is not: kit's own scanner provisioning
+> fetches `https://api.github.com/repos/perplexityai/bumblebee/releases`
+> (`bumblebee-update.ts:51`) and downloads from
+> `https://github.com/perplexityai/bumblebee/releases/download` (`bumblebee.ts:57`) —
+> neither is in the table, and the release-download host is not the `api.github.com`
+> path the github plugin row describes. A reviewer who used this table as an allow-list
+> for an egress-filtered or air-gapped deployment would find `kit check --category
+> security` attempting an undocumented download. Set `KIT_NO_DOWNLOAD` (or supply
+> `KIT_BUMBLEBEE_BIN`) to keep provisioning offline. Treat the table as complete for
+> plugin traffic and incomplete for kit's own toolchain until each provisioning path is
+> enumerated here.
 
 ## File-system writes
 

--- a/docs/OWASP_2025.md
+++ b/docs/OWASP_2025.md
@@ -24,7 +24,7 @@ Per memory `feedback_owasp_2025`, security reviews target the **2025** Top 10
 |---|---|
 | Token store `~/.kit/mcp-tokens.json` atomic write + mode 0o600 on create | ✅ fixed (security-review caught race window — `edb29f7`) |
 | Parent dir `~/.kit/` chmod 0o700 | ⚠️ **not on every path** — measured 2026-08-03: with `kit identity init` as the FIRST command the dir lands at **0755**. The files inside are 0600, so no secret is world-READABLE, but the directory is world-traversable, which matters on a shared runner. Reproduce: `HOME=$(mktemp -d) kit identity init && stat -c '%a' $HOME/.kit`. |
-| Secret values never echoed in error messages (`safeStatusLine()` truncation + `redactSecrets()`) | ✅ shipped |
+| Secret values redacted in error messages (`safeStatusLine()` truncation + `redactSecrets()`) | ✅ shipped, for **26 recognised vendor shapes** (`utils/redactSecrets.ts`). It is a pattern list, not a universal filter: a Postgres/MySQL password, a self-hosted Sentry or Vault token, or an HTTP basic-auth secret matches none of them and would pass through. "Never echoed" was too strong; the truncation in `safeStatusLine()` is the backstop that does not depend on recognising the shape. |
 | TOTP secret at `~/.kit/totp-secret` chmod 0o600 | ✅ shipped (`elevation.ts:enrollTotp`) |
 | Tokens never persisted in plugin code — read from vault per-call | ✅ shipped (every sandstream-kit-plugin-* follows this pattern) |
 | TLS: every fetch uses HTTPS to vendor APIs; no custom `Agent` with `rejectUnauthorized:false` | ✅ verified in P0 audit |
@@ -82,7 +82,7 @@ Per memory `feedback_owasp_2025`, security reviews target the **2025** Top 10
 | `KIT_ELEVATED=1` CI escape hatch emits loud stderr warning + audit event | ✅ shipped |
 | `KIT_PROD_OK=1` warning at the read site (not the consumer site) | ✅ shipped (P0.2) |
 | `KIT_NON_INTERACTIVE=1` emits one-time stderr warning + audit | ⚠️ **TTY-conditional, so silent in the case it exists for** — `environment.ts:137,142` guard the warning with `if (process.stdout.isTTY)`. A CI job or agent harness that sets the flag and captures stdout gets no warning and no audit event; only a human at a terminal sees it. Backwards from the intent. |
-| MCP token store separate from raw vault — short-lived bearer not long-term refresh | ✅ shipped (P1.2) |
+| MCP token store separate from raw vault — bearer with vendor-supplied expiry, not a refresh token | ✅ shipped (P1.2), with the limit named: `McpToken.expiresAt` is **optional and best-effort** (`mcp-orchestrator.ts:41`). When the vendor supplies it, kit honours it and `kit mcp status` reports `expired … — re-authorize` (lines 130-138). When the vendor does not, the stored bearer has no lifetime and kit neither mints nor enforces one. "Short-lived" describes the intended token class, not a property kit guarantees. |
 
 ## A08 — Software & Data Integrity Failures
 
@@ -103,7 +103,7 @@ Per memory `feedback_owasp_2025`, security reviews target the **2025** Top 10
 | `.kit-skipped-commits.jsonl` records `git commit --no-verify` events | ✅ shipped |
 | `.kit-scan-results.jsonl` INGESTION contract — kit reads external findings into the verdict | ✅ shipped (`external-findings.ts`: "a tool appends one JSON object per line"; `check-security.ts:2139` folds it in, can only escalate). The Snyk and Wiz plugins emit it. **Nothing in kit writes Bumblebee findings there** — that half was a claim about a producer kit does not control. |
 | `appendAuditEventDirect` fail-closed (caller refuses if audit-log write fails) | ✅ shipped |
-| `[governance.audit].remote = true` opt-in for centralized log shipping with retry-queue | ✅ shipped |
+| `[governance.audit].remote = true` opt-in for centralized log shipping with retry-queue | ⚠️ **the transport exists; nothing reaches it** — `logAuditEvent` guards the remote branch with `if (companyId && …)` and `companyId` is an OPTIONAL third argument that **all 11 production callers omit** (governance-middleware ×7, doctor, memory, broker, gate). So setting the flag ships nothing, in either direction. The POST path, retry queue and tmp+rename parking are implemented and unreachable. Verify: `grep -rn 'logAuditEvent(' src --include=*.ts \| grep -v test`. |
 | Sentry integration (`sandstream-kit-plugin-sentry`) for issue triage + release tagging | ✅ shipped (P1.1) |
 | Cost-monitor anomaly detection with rolling baseline (EMA) | ⚠️ **algorithm only, not wired** — `detectCostAnomalies` (cost-monitor.ts) has **0 callers** outside its own tests, and no command produces `.kit-cost-baseline.json`. Verify: `grep -rn detectCostAnomalies src --include=*.ts \| grep -v test \| grep -v cost-monitor.ts`. |
 

--- a/docs/OWASP_2025.md
+++ b/docs/OWASP_2025.md
@@ -23,7 +23,7 @@ Per memory `feedback_owasp_2025`, security reviews target the **2025** Top 10
 | kit control | Status |
 |---|---|
 | Token store `~/.kit/mcp-tokens.json` atomic write + mode 0o600 on create | ✅ fixed (security-review caught race window — `edb29f7`) |
-| Parent dir `~/.kit/` chmod 0o700 | ✅ shipped |
+| Parent dir `~/.kit/` chmod 0o700 | ⚠️ **not on every path** — measured 2026-08-03: with `kit identity init` as the FIRST command the dir lands at **0755**. The files inside are 0600, so no secret is world-READABLE, but the directory is world-traversable, which matters on a shared runner. Reproduce: `HOME=$(mktemp -d) kit identity init && stat -c '%a' $HOME/.kit`. |
 | Secret values never echoed in error messages (`safeStatusLine()` truncation + `redactSecrets()`) | ✅ shipped |
 | TOTP secret at `~/.kit/totp-secret` chmod 0o600 | ✅ shipped (`elevation.ts:enrollTotp`) |
 | Tokens never persisted in plugin code — read from vault per-call | ✅ shipped (every sandstream-kit-plugin-* follows this pattern) |
@@ -40,7 +40,7 @@ Per memory `feedback_owasp_2025`, security reviews target the **2025** Top 10
 | GitHub artifact attestation cross-verification | ✅ shipped (`actions/attest-build-provenance` in publish.yml) |
 | CycloneDX + SPDX SBOM published per release | ✅ shipped |
 | GPG-signed tags required by publish.yml | ✅ shipped (T.5) |
-| `sandstream-kit-plugin-snyk` + `sandstream-kit-plugin-wiz` — read-only scanner-result ingestion | ✅ shipped (T.6) |
+| `sandstream-kit-plugin-snyk` + `sandstream-kit-plugin-wiz` — read-only scanner-result ingestion | ✅ shipped (T.6) — **and installable since 6.3.1**: both are on npm (HTTP 200, checked 2026-08-03), alongside `sandstream-kit-adapter-sdk@1.0.0`. Before that release the code existed only in this monorepo, so the control was unreachable to anyone who had not cloned it. |
 | `docs/VERIFY.md` documents the operator-side verification flow | ✅ shipped |
 
 ## A04 — Insecure Design
@@ -81,7 +81,7 @@ Per memory `feedback_owasp_2025`, security reviews target the **2025** Top 10
 | 15-minute default elevation TTL; one-shot scopes for jwt-secret-roll / purge-history / onecli-register | ✅ shipped |
 | `KIT_ELEVATED=1` CI escape hatch emits loud stderr warning + audit event | ✅ shipped |
 | `KIT_PROD_OK=1` warning at the read site (not the consumer site) | ✅ shipped (P0.2) |
-| `KIT_NON_INTERACTIVE=1` emits one-time stderr warning + audit | ✅ shipped (P1.8) |
+| `KIT_NON_INTERACTIVE=1` emits one-time stderr warning + audit | ⚠️ **TTY-conditional, so silent in the case it exists for** — `environment.ts:137,142` guard the warning with `if (process.stdout.isTTY)`. A CI job or agent harness that sets the flag and captures stdout gets no warning and no audit event; only a human at a terminal sees it. Backwards from the intent. |
 | MCP token store separate from raw vault — short-lived bearer not long-term refresh | ✅ shipped (P1.2) |
 
 ## A08 — Software & Data Integrity Failures
@@ -92,7 +92,7 @@ Per memory `feedback_owasp_2025`, security reviews target the **2025** Top 10
 | Signed git tags required to publish | ✅ shipped (T.5) |
 | Pre-commit hook sentinel + post-commit detector log `--no-verify` skips | ✅ shipped (P0.4) |
 | `kit security verify-pull` post-merge audit: new deps, gitignore drops, introduced secrets | ✅ shipped |
-| Audit-log atomic write (tmp + rename) prevents half-written entries | ✅ shipped |
+| Audit-log atomic write (tmp + rename) | ⚠️ **describes the remote QUEUE, not the log** — `audit.ts:436` does tmp+rename for the retry queue; the log line itself is a plain `appendFile` (`audit.ts:93`). A single small append under O_APPEND does not interleave in practice, but two concurrent kit processes can still both read the same tail hash, and "tmp + rename" is not what protects the log. |
 | Vercel `upsertEnvVar` atomic (PATCH fast-path; create-then-delete fallback) | ✅ shipped (P2.4 earlier) |
 
 ## A09 — Security Logging & Monitoring Failures
@@ -101,11 +101,11 @@ Per memory `feedback_owasp_2025`, security reviews target the **2025** Top 10
 |---|---|
 | `.kit-audit.jsonl` append-only; every destructive op logged | ✅ shipped |
 | `.kit-skipped-commits.jsonl` records `git commit --no-verify` events | ✅ shipped |
-| `.kit-scan-results.jsonl` consolidates Bumblebee + Snyk + Wiz findings | ✅ shipped (T.6) |
+| `.kit-scan-results.jsonl` INGESTION contract — kit reads external findings into the verdict | ✅ shipped (`external-findings.ts`: "a tool appends one JSON object per line"; `check-security.ts:2139` folds it in, can only escalate). The Snyk and Wiz plugins emit it. **Nothing in kit writes Bumblebee findings there** — that half was a claim about a producer kit does not control. |
 | `appendAuditEventDirect` fail-closed (caller refuses if audit-log write fails) | ✅ shipped |
 | `[governance.audit].remote = true` opt-in for centralized log shipping with retry-queue | ✅ shipped |
 | Sentry integration (`sandstream-kit-plugin-sentry`) for issue triage + release tagging | ✅ shipped (P1.1) |
-| Cost-monitor anomaly detection with rolling baseline (EMA) | ✅ shipped (P3.1) |
+| Cost-monitor anomaly detection with rolling baseline (EMA) | ⚠️ **algorithm only, not wired** — `detectCostAnomalies` (cost-monitor.ts) has **0 callers** outside its own tests, and no command produces `.kit-cost-baseline.json`. Verify: `grep -rn detectCostAnomalies src --include=*.ts \| grep -v test \| grep -v cost-monitor.ts`. |
 
 ## A10 — Exceptional Conditions (NEW in 2025)
 

--- a/docs/VERIFY.md
+++ b/docs/VERIFY.md
@@ -12,8 +12,10 @@ When `v<N>.<N>.<N>` is tagged on `main`:
    `npm publish --provenance`. A SLSA build-provenance attestation is
    automatically generated, signed by the GitHub Actions OIDC identity, and
    uploaded to Sigstore's public transparency log.
-2. **GitHub artifact attestation** — independent of npm provenance, attaches
-   a signed manifest of the built `dist/` tree to the GitHub release.
+2. **GitHub artifact attestation** — independent of npm provenance, attaches a
+   signed provenance statement for the published tarball to this repo's
+   attestation store. **Not present on releases up to and including 6.3.1** —
+   see the note below before relying on it.
 3. **CycloneDX SBOM** (`sbom.cyclonedx.json`) — full dependency-tree
    inventory in the format US EO 14028 / EU CRA expect.
 4. **SPDX SBOM** (`sbom.spdx.json`) — same, in the SPDX 2.3 format some
@@ -56,6 +58,25 @@ gh attestation verify \
 step in `.github/workflows/publish.yml`. If the binary's hash differs from
 what the workflow built, the command fails.
 
+> **This returns "no attestations found" for every release up to and including
+> 6.3.1, and that is our bug, not a tampering signal.** The step passed
+> `subject-path: dist/**/*` — 1920 files against the action's hard limit of 1024 —
+> so it errored in 327ms with `Too many subjects specified (>1024)` on every
+> release. `continue-on-error: true` (there to stop a Sigstore hang from
+> stranding an already-published release) then reported the step as SUCCESS to
+> the jobs API while the log said failure, so nothing surfaced it. Measured in
+> run `30804371457`, step 20.
+>
+> Fixed for the next release: the step now attests the packed tarball — one
+> subject, and the same bytes npm published — and a following step annotates the
+> run and the job summary whenever the attestation did not happen, so a
+> swallowed failure can no longer read as green.
+>
+> Until then, verify 6.3.1 with the **npm provenance** above (that one is real:
+> its attestation carries a `slsa.dev/provenance/v1` statement with the GitHub
+> Actions workflow buildType) plus the **signed git tag**. Two independent
+> checks, not three.
+
 ### Verify the signed git tag
 
 ```bash
@@ -96,7 +117,7 @@ artifact you scan against.
 | Verification | Catches |
 |---|---|
 | `npm audit signatures` | Tarball tampering after publish; registry compromise |
-| `gh attestation verify` | Cross-checks against the GitHub build — catches divergence between npm-side and source-of-truth |
+| `gh attestation verify` | Cross-checks against the GitHub build — catches divergence between npm-side and source-of-truth. **Nothing to check on ≤6.3.1** (see the note above) |
 | `git tag -v` | Tag-rewrite attacks; ensures the commit you check out is what the maintainer published |
 | SBOM scan | Known-vulnerable transitive deps; license-policy violations |
 
@@ -134,20 +155,29 @@ For organizations that pin kit in CI:
 
 ```yaml
 # .github/workflows/kit-pin.yml
-- name: Verify kit attestation
+- name: Verify kit before installing
   env:
     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   run: |
-    npm pack sandstream-kit@$KIT_VERSION
+    set -euo pipefail
+    npm pack "sandstream-kit@$KIT_VERSION"
+    # Gate 1 — npm provenance. Present on every release; blocking.
+    npm audit signatures
+    # Gate 2 — GitHub attestation. Absent on <=6.3.1 (see the note above), so it
+    # ADVISES rather than blocks; make it blocking once you pin a later version.
     gh attestation verify \
       --owner sandstream \
       --repo kit \
-      sandstream-kit-$KIT_VERSION.tgz
-    npm install -g ./sandstream-kit-$KIT_VERSION.tgz
+      "sandstream-kit-$KIT_VERSION.tgz" \
+      || echo "::warning::no GitHub attestation for $KIT_VERSION — npm provenance still verified above"
+    npm install -g "./sandstream-kit-$KIT_VERSION.tgz"
 ```
 
-This ensures the CI runner only installs versions that pass attestation
-verification — refusing tarballs that don't match the published build.
+The npm-provenance gate is the blocking one: the runner installs only a tarball
+whose signature matches the published build. The attestation gate is written
+non-blocking on purpose — pointing a hard gate at something kit did not ship
+until after 6.3.1 would fail every pinned build for a reason that has nothing to
+do with the artifact. Flip the `||` away once your pinned version has one.
 
 ## Reporting verification problems
 

--- a/docs/VERIFY.md
+++ b/docs/VERIFY.md
@@ -9,7 +9,7 @@ production-adjacent workflow. Every step is reproducible from public data.
 When `v<N>.<N>.<N>` is tagged on `main`:
 
 1. **npm tarball** — published to `npmjs.com/package/sandstream-kit` with
-   `npm publish --provenance`. SLSA Level 3 build provenance attestation is
+   `npm publish --provenance`. A SLSA build-provenance attestation is
    automatically generated, signed by the GitHub Actions OIDC identity, and
    uploaded to Sigstore's public transparency log.
 2. **GitHub artifact attestation** — independent of npm provenance, attaches
@@ -100,9 +100,23 @@ artifact you scan against.
 | `git tag -v` | Tag-rewrite attacks; ensures the commit you check out is what the maintainer published |
 | SBOM scan | Known-vulnerable transitive deps; license-policy violations |
 
-All four together = SLSA Level 3 supply-chain guarantee. The build is
-reproducible from source, the build platform is signed, and the artifact is
-attested at multiple independent points.
+What these four do NOT add up to is a SLSA level. SLSA levels are defined on the
+build/provenance track: L3 asks for a hardened build platform producing
+non-falsifiable provenance, which `npm publish --provenance` from a GitHub-hosted
+runner does supply — verified for 6.3.1, whose npm attestation carries a
+`slsa.dev/provenance/v1` statement with the GitHub Actions workflow buildType. The
+other three rows are CONSUMER-side verifications. They are worth running, and they
+do not raise a level.
+
+And this paragraph previously claimed "the build is reproducible from source". It is
+not, and SLSA does not ask for it at any level (reproducible builds are explicitly out
+of scope in SLSA v1.0). kit has no reproducible-build proof — no build-timestamp
+normalisation, no rebuild-and-compare in CI. Do not cite kit as reproducible.
+
+Honest summary of what the four buy you: the artifact you install is the one that was
+published (signatures), it was built by this repo's workflow from a signed tag
+(provenance + `git tag -v`), and its dependency tree is enumerated for scanning (SBOM).
+That is a strong chain. It is not a reproducibility claim and not a certified level.
 
 ## What kit explicitly does NOT do
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1102,9 +1102,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1619,9 +1619,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1910,7 +1910,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -459,8 +459,9 @@ async function sendToRemoteAPI(event: AuditEvent, companyId: string): Promise<vo
 export async function logAuditEvent(
   config: Required<GovernanceConfig>,
   event: Omit<AuditEvent, "timestamp" | "agent_id" | "agent_name">,
-  companyId?: string,
+  opts: { companyId?: string; cwd?: string } = {},
 ): Promise<boolean> {
+  const { companyId, cwd } = opts;
   // Audit disabled by config → nothing to write, nothing to gate on.
   if (!config.audit.enabled) {
     return true;
@@ -493,8 +494,14 @@ export async function logAuditEvent(
   // Write to local JSONL file (hash-chained for tamper-evidence). The boolean
   // return lets fail-closed callers (e.g. destructive ops in withGovernance)
   // refuse to proceed when the local audit append fails.
+  // The GOVERNED project's directory, not the calling process's. A governed operation performed
+  // FOR another tree must file its evidence in that tree: `appendAuditEventDirect` has taken a
+  // `cwd` all along and `exec-broker/broker.ts`'s `audit()` explains why — foreign-project
+  // records pollute the host repo's chain and poison `kit broker enforce-readiness`, "whose
+  // verdict is only as honest as the evidence file it reads". A write served for B whose proof
+  // lands in A is not a write kit can stand behind. An absolute `log_file` still wins, as before.
   const logFile = config.audit.log_file || ".kit-audit.jsonl";
-  const logPath = resolve(process.cwd(), logFile);
+  const logPath = resolve(cwd ?? process.cwd(), logFile);
 
   let wroteLocal = false;
   try {

--- a/src/check-design.ts
+++ b/src/check-design.ts
@@ -107,7 +107,7 @@ const A11Y_RULES: Array<{ id: string; pattern: RegExp; description: string }> = 
   },
 ];
 
-async function scanA11y(srcRoots: string[]): Promise<A11yFinding[]> {
+async function scanA11y(srcRoots: string[], root: string): Promise<A11yFinding[]> {
   const findings: A11yFinding[] = [];
   for (const root of srcRoots) {
     if (!(await pathExists(root))) continue;
@@ -126,7 +126,7 @@ async function scanA11y(srcRoots: string[]): Promise<A11yFinding[]> {
         for (const rule of A11Y_RULES) {
           if (rule.pattern.test(line)) {
             findings.push({
-              file: relative(process.cwd(), file),
+              file: relative(root, file),
               line: i + 1,
               rule: rule.id,
               snippet: line.trim().slice(0, 120),
@@ -146,7 +146,11 @@ interface TokenBypass {
   match: string;
 }
 
-async function scanTokenBypass(srcRoots: string[], tokenFiles: string[]): Promise<TokenBypass[]> {
+async function scanTokenBypass(
+  srcRoots: string[],
+  tokenFiles: string[],
+  root: string,
+): Promise<TokenBypass[]> {
   const findings: TokenBypass[] = [];
   for (const root of srcRoots) {
     if (!(await pathExists(root))) continue;
@@ -168,7 +172,7 @@ async function scanTokenBypass(srcRoots: string[], tokenFiles: string[]): Promis
         const hex = line.match(/#[0-9a-f]{3,8}\b/i);
         if (hex) {
           findings.push({
-            file: relative(process.cwd(), file),
+            file: relative(root, file),
             line: i + 1,
             kind: "raw-hex",
             match: hex[0],
@@ -177,7 +181,7 @@ async function scanTokenBypass(srcRoots: string[], tokenFiles: string[]): Promis
         const px = line.match(/\b\d{2,}px\b/);
         if (px && !line.includes("border")) {
           findings.push({
-            file: relative(process.cwd(), file),
+            file: relative(root, file),
             line: i + 1,
             kind: "raw-px",
             match: px[0],
@@ -195,13 +199,19 @@ export async function checkDesign(
     tokenFiles?: string[];
     enforce?: boolean;
     baseline?: { a11y?: string[]; tokens?: string[] };
+    cwd?: string;
   } = {},
 ): Promise<DesignCheckResult[]> {
+  // The GOVERNED project's root. `runDesignGate` accepted a `cwd`, passed it to the baseline
+  // loader, and then called this function without it — so the baseline came from B while the
+  // files scanned came from A. A parameter that reaches one collaborator and not the next is the
+  // same false green as no parameter at all.
+  const root = opts.cwd ?? process.cwd();
   // Monorepo (#249): also scan each workspace's src/app/components — a Turborepo
   // full of tsx under apps/* must not read as "no components found".
   const rootDirs = opts.srcRoots ?? ["src", "app", "components"];
-  const wsDirs = opts.srcRoots ? [] : workspaceSourceDirs(process.cwd(), rootDirs);
-  const srcRoots = [...rootDirs, ...wsDirs].map((d) => resolve(process.cwd(), d));
+  const wsDirs = opts.srcRoots ? [] : workspaceSourceDirs(root, rootDirs);
+  const srcRoots = [...rootDirs, ...wsDirs].map((d) => resolve(root, d));
   const tokenFiles = opts.tokenFiles ?? ["design-tokens", "tokens.ts", "theme.ts"];
   const enforce = opts.enforce ?? false;
   const results: DesignCheckResult[] = [];
@@ -231,7 +241,7 @@ export async function checkDesign(
   }
 
   // A11y
-  const a11y = await scanA11y(srcRoots);
+  const a11y = await scanA11y(srcRoots, root);
   const a11yBaseline = new Set(opts.baseline?.a11y ?? []);
   const newA11y = a11y.filter((f) => !a11yBaseline.has(`${f.file}:${f.rule}`));
 
@@ -262,7 +272,7 @@ export async function checkDesign(
   }
 
   // Design tokens
-  const tokenFindings = await scanTokenBypass(srcRoots, tokenFiles);
+  const tokenFindings = await scanTokenBypass(srcRoots, tokenFiles, root);
   const tokenBaseline = new Set(opts.baseline?.tokens ?? []);
   const newTokens = tokenFindings.filter(
     (f) => !tokenBaseline.has(`${f.file}:${f.kind}:${f.match}`),
@@ -298,10 +308,12 @@ export async function checkDesign(
 }
 
 /** Exposed so `kit baseline freeze` can snapshot these into .kit-baseline.json. */
-export async function collectDesignKeys(): Promise<{ a11y: string[]; tokens: string[] }> {
-  const srcRoots = ["src", "app", "components"].map((d) => resolve(process.cwd(), d));
-  const a11y = await scanA11y(srcRoots);
-  const tokens = await scanTokenBypass(srcRoots, ["design-tokens", "tokens.ts", "theme.ts"]);
+export async function collectDesignKeys(
+  cwd: string = process.cwd(),
+): Promise<{ a11y: string[]; tokens: string[] }> {
+  const srcRoots = ["src", "app", "components"].map((d) => resolve(cwd, d));
+  const a11y = await scanA11y(srcRoots, cwd);
+  const tokens = await scanTokenBypass(srcRoots, ["design-tokens", "tokens.ts", "theme.ts"], cwd);
   return {
     a11y: a11y.map((f) => `${f.file}:${f.rule}`),
     tokens: tokens.map((f) => `${f.file}:${f.kind}:${f.match}`),

--- a/src/check-hooks.ts
+++ b/src/check-hooks.ts
@@ -13,9 +13,13 @@ export interface HookCheckResult {
 /**
  * Check if git hooks are installed and up-to-date
  */
-export async function checkHooks(config: HooksConfig, gitDir = ".git"): Promise<HookCheckResult[]> {
+export async function checkHooks(
+  config: HooksConfig,
+  gitDir = ".git",
+  cwd = process.cwd(),
+): Promise<HookCheckResult[]> {
   const results: HookCheckResult[] = [];
-  const hooksDir = resolve(process.cwd(), gitDir, "hooks");
+  const hooksDir = resolve(cwd, gitDir, "hooks");
 
   for (const [hookName, commands] of Object.entries(config)) {
     if (!commands || commands.length === 0) {
@@ -85,7 +89,7 @@ async function checkHook(
 /**
  * Check if git directory exists
  */
-export function isGitRepository(gitDir = ".git"): boolean {
-  const gitPath = resolve(process.cwd(), gitDir);
+export function isGitRepository(gitDir = ".git", cwd = process.cwd()): boolean {
+  const gitPath = resolve(cwd, gitDir);
   return existsSync(gitPath);
 }

--- a/src/check-run.ts
+++ b/src/check-run.ts
@@ -134,26 +134,26 @@ export async function runCheckGate(opts: RunCheckOptions = {}): Promise<CheckRun
       : [];
   const secrets =
     wants("secrets") && config.secrets
-      ? await step("secrets", () => checkSecrets(config.secrets!))
+      ? await step("secrets", () => checkSecrets(config.secrets!, cwd))
       : { templateExists: null, keys: [] };
   const skills =
     wants("skills") && config.skills ? await step("skills", () => checkSkills(config.skills!)) : [];
   const hooks =
-    wants("hooks") && config.hooks && isGitRepository()
-      ? await step("git hooks", () => checkHooks(config.hooks!))
+    wants("hooks") && config.hooks && isGitRepository(".git", cwd)
+      ? await step("git hooks", () => checkHooks(config.hooks!, ".git", cwd))
       : [];
   const webSearch =
     wants("web") && config.web?.search
       ? await step("web search", () => checkWebSearch(config.web!.search!))
       : null;
-  const security = wants("security") ? await step("security scan", () => checkSecurity()) : [];
+  const security = wants("security") ? await step("security scan", () => checkSecurity(cwd)) : [];
   const locks = wants("locks") ? await step("lock files", () => checkLockFiles(config, cwd)) : [];
 
   // Test-coverage is part of the verdict on every surface (omitting it on one
   // was half of the historical CLI-vs-MCP divergence). Baseline-aware; a
   // corrupt/tampered baseline is ignored (nothing suppressed) and surfaced as a
   // finding — fail-closed + visible, never a crash of the gate.
-  const { baseline, ignored: baselineIgnored } = await loadBaselineForGate();
+  const { baseline, ignored: baselineIgnored } = await loadBaselineForGate(cwd);
   if (baselineIgnored && wants("security")) {
     security.push({
       category: "secrets",
@@ -166,6 +166,10 @@ export async function runCheckGate(opts: RunCheckOptions = {}): Promise<CheckRun
   const tests = wants("tests")
     ? await step("test coverage", () =>
         checkTests({
+          // `checkTests` already accepted a `cwd` and defaulted it to `process.cwd()`; this call
+          // simply never passed one, so the coverage dimension measured the calling process's
+          // tree while every other dimension was being fixed to measure the governed one.
+          cwd,
           enforce: opts.enforceTests,
           baseline: baselineGet(baseline, "tests", "untested_files"),
         }),

--- a/src/check-secrets.ts
+++ b/src/check-secrets.ts
@@ -1,4 +1,5 @@
 import { access } from "node:fs/promises";
+import { resolve } from "node:path";
 import type { SecretsConfig, SecretKeyConfig, InfisicalConfig } from "./config.js";
 import { check1PasswordStatus } from "./onepassword.js";
 import { exec } from "./utils/exec.js";
@@ -333,11 +334,15 @@ async function checkAzureSecret(
 
 export async function checkSecrets(
   secrets: SecretsConfig,
+  cwd = process.cwd(),
 ): Promise<{ templateExists: boolean | null; keys: SecretStatus[] }> {
   let templateExists: boolean | null = null;
   if (secrets.template) {
     try {
-      await access(secrets.template);
+      // `template` is a repo-relative path in .kit.toml, so it must resolve against the
+      // GOVERNED project. Bare `access(secrets.template)` resolved it against the calling
+      // process and reported the caller's .env.template as the target's.
+      await access(resolve(cwd, secrets.template));
       templateExists = true;
     } catch {
       templateExists = false;

--- a/src/check-security-cwd.test.ts
+++ b/src/check-security-cwd.test.ts
@@ -1,0 +1,274 @@
+/**
+ * `checkSecurity(cwd)` must describe the tree it was given, not the tree the process happens to
+ * sit in.
+ *
+ * All fifteen sub-checks resolved paths from `process.cwd()`, and none of the seven scanner
+ * spawns passed a `cwd`. Measured over the MCP surface: `kit_check({cwd: B})` from a server
+ * launched in A answered `pass — all .env patterns in .gitignore` for a project B that has no
+ * `.gitignore` at all. The config came from B and the verdict came from A — a green earned by
+ * the wrong tree, which is the worst shape a gate can fail in.
+ *
+ * The tests below are DISCRIMINATING by construction, per the warning in ROADMAP.md: "Any
+ * dimension that gains a `cwd` needs a test that would FAIL if the parameter were ignored; a
+ * test that merely passes `cwd` proves nothing, which is how this survived." So A is given a
+ * COMPLETE `.gitignore` and B none, and each test asserts the two answers DIFFER. A build that
+ * drops the parameter makes them agree and fails the pair.
+ *
+ * Only checks that are deterministic without external tooling are asserted on: `.env gitignored`
+ * and `lockfiles committed` read files directly. The scanner-backed checks (trivy, semgrep, osv,
+ * guarddog) skip when the binary is absent, so they cannot carry a portable assertion — their
+ * `cwd` threading is covered by the source-level guard at the end of this file, which is
+ * mechanical but is the only thing that can fail when a tool is not installed.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { checkSecurity } from "./check-security.js";
+
+/** A project whose .gitignore covers every .env spelling the check looks for. */
+function projectWithGitignore(): string {
+  const dir = mkdtempSync(join(tmpdir(), "kit-sec-A-"));
+  writeFileSync(join(dir, ".kit.toml"), "version = 1\n");
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name: "a", version: "1.0.0", private: true }) + "\n",
+  );
+  writeFileSync(join(dir, ".gitignore"), ".env\n.env.local\n.env.*.local\nnode_modules\n");
+  return dir;
+}
+
+/** A project with NO .gitignore at all — the check must not pass here. */
+function projectWithout(): string {
+  const dir = mkdtempSync(join(tmpdir(), "kit-sec-B-"));
+  writeFileSync(join(dir, ".kit.toml"), "version = 1\n");
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name: "b", version: "1.0.0", private: true }) + "\n",
+  );
+  return dir;
+}
+
+/** Run `fn` with the process sitting in `dir`, restoring cwd afterwards. */
+async function inCwd<T>(dir: string, fn: () => Promise<T>): Promise<T> {
+  const prev = process.cwd();
+  process.chdir(dir);
+  try {
+    return await fn();
+  } finally {
+    process.chdir(prev);
+  }
+}
+
+function statusOf(results: Awaited<ReturnType<typeof checkSecurity>>, name: string): string {
+  const hit = results.find((r) => r.name === name);
+  return hit ? hit.status : "absent";
+}
+
+describe("checkSecurity honours the cwd it is given", () => {
+  it("the .env gitignore verdict follows the GOVERNED tree, not the process's", async () => {
+    const A = projectWithGitignore();
+    const B = projectWithout();
+    try {
+      // Process sits in A (complete .gitignore) and asks about B (none).
+      const aboutB = await inCwd(A, () => checkSecurity(B));
+      const aboutA = await inCwd(A, () => checkSecurity(A));
+
+      const bStatus = statusOf(aboutB, ".env gitignored");
+      const aStatus = statusOf(aboutA, ".env gitignored");
+
+      // The pair IS the assertion. Ignoring `cwd` makes both answers A's answer.
+      assert.notEqual(
+        bStatus,
+        aStatus,
+        `a project with no .gitignore must not get A's verdict (both were "${bStatus}")`,
+      );
+      assert.equal(aStatus, "pass", "A has a complete .gitignore and must pass");
+      assert.notEqual(bStatus, "pass", "B has no .gitignore at all and must not pass");
+    } finally {
+      rmSync(A, { recursive: true, force: true });
+      rmSync(B, { recursive: true, force: true });
+    }
+  });
+
+  it("the mirror image holds: a process in B still answers correctly about A", async () => {
+    const A = projectWithGitignore();
+    const B = projectWithout();
+    try {
+      // Swapping which tree the process occupies must not swap the answers. A guard that
+      // merely refused, or a threading that only worked one way, fails here.
+      const aboutA = await inCwd(B, () => checkSecurity(A));
+      const aboutB = await inCwd(B, () => checkSecurity(B));
+
+      assert.equal(statusOf(aboutA, ".env gitignored"), "pass");
+      assert.notEqual(statusOf(aboutB, ".env gitignored"), "pass");
+    } finally {
+      rmSync(A, { recursive: true, force: true });
+      rmSync(B, { recursive: true, force: true });
+    }
+  });
+
+  it("omitting cwd is identical to passing process.cwd()", async () => {
+    const A = projectWithGitignore();
+    try {
+      const omitted = await inCwd(A, () => checkSecurity());
+      const explicit = await inCwd(A, () => checkSecurity(A));
+      // The backwards-compatibility guarantee, asserted rather than asserted in prose: every
+      // existing caller passes nothing, and must keep seeing exactly what it saw before.
+      assert.equal(
+        statusOf(omitted, ".env gitignored"),
+        statusOf(explicit, ".env gitignored"),
+        "the default must resolve to the process's own tree",
+      );
+    } finally {
+      rmSync(A, { recursive: true, force: true });
+    }
+  });
+
+  it("the lockfile verdict follows the governed tree too", async () => {
+    const withLock = mkdtempSync(join(tmpdir(), "kit-sec-lock-"));
+    const without = mkdtempSync(join(tmpdir(), "kit-sec-nolock-"));
+    try {
+      for (const d of [withLock, without]) {
+        writeFileSync(join(d, ".kit.toml"), "version = 1\n");
+        writeFileSync(
+          join(d, "package.json"),
+          JSON.stringify({ name: "l", version: "1.0.0", private: true }) + "\n",
+        );
+      }
+      writeFileSync(join(withLock, "package-lock.json"), '{"lockfileVersion":3}\n');
+
+      const aboutWithout = await inCwd(withLock, () => checkSecurity(without));
+      const aboutWith = await inCwd(withLock, () => checkSecurity(withLock));
+
+      // A second dimension of the same bug: `checkLockfilesCommitted` probed for the lock file
+      // under `process.cwd()`, so it reported the CALLER's lock state as the target's.
+      const names = new Set(aboutWith.map((r) => r.name));
+      assert.equal(
+        names.size > 0,
+        true,
+        "sanity: the security dimension must produce named results",
+      );
+      assert.notDeepEqual(
+        aboutWithout.map((r) => `${r.name}:${r.status}`),
+        aboutWith.map((r) => `${r.name}:${r.status}`),
+        "two different trees must not produce an identical result vector",
+      );
+    } finally {
+      rmSync(withLock, { recursive: true, force: true });
+      rmSync(without, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("no scanner spawn may inherit the caller's cwd", () => {
+  // Mechanical, and the only check that still works when trivy/semgrep/osv are not installed.
+  // `trivy fs .`, `trivy config .`, `osv-scanner -r .` and `semgrep .` all resolve "." against
+  // the SPAWNED process's directory, so threading the path parameter without pinning `cwd` on
+  // the exec would have left the scanners reading the caller's tree while the signature looked
+  // threaded — the precise failure ROADMAP warned about.
+  it("every execFileNoThrow in check-security.ts passes a cwd", () => {
+    const src = readFileSync(
+      resolve(import.meta.dirname, "..", "src", "check-security.ts"),
+      "utf8",
+    );
+    // Each spawn's options object ends the call; capture from the call to its closing paren.
+    const calls = src.split("execFileNoThrow(").slice(1);
+    const missing: string[] = [];
+    for (const call of calls) {
+      const body = call.slice(0, 900);
+      // `--version` probes are liveness checks for the binary itself and touch no project file.
+      if (body.includes('"--version"')) continue;
+      if (!/cwd:\s*root/.test(body)) missing.push(body.split("\n")[0].trim());
+    }
+    assert.deepEqual(missing, [], `these scanner spawns would read the caller's tree: ${missing}`);
+  });
+
+  it("check-security.ts reads no path from process.cwd() outside a parameter default", () => {
+    const src = readFileSync(
+      resolve(import.meta.dirname, "..", "src", "check-security.ts"),
+      "utf8",
+    );
+    const offenders = src
+      .split("\n")
+      .map((line, i) => ({ line: line.trim(), n: i + 1 }))
+      .filter(({ line }) => line.includes("process.cwd()"))
+      // Comments explaining the bug are not the bug. Filtering these out is what makes the
+      // remaining match a real read rather than prose about one.
+      .filter(({ line }) => !line.startsWith("//") && !line.startsWith("*"))
+      // Two spellings of the documented fallback are legitimate and must not be flagged:
+      // a parameter default (`cwd: string = process.cwd()`) and the single resolution at the
+      // top of `checkSecurity` (`const root = cwd ?? process.cwd()`). Anything else is a
+      // sub-check reaching past its `root` argument.
+      .filter(({ line }) => !/(=|\?\?)\s*process\.cwd\(\)/.test(line));
+    assert.deepEqual(
+      offenders,
+      [],
+      `direct process.cwd() reads defeat the cwd parameter: ${JSON.stringify(offenders)}`,
+    );
+  });
+});
+
+describe("runCheckGate threads cwd to the dimensions that read the filesystem", () => {
+  // The end-to-end form of the ROADMAP probe. `runCheckGate` always resolved `cwd` for
+  // `.kit.toml` and then handed the dimensions nothing, so the config came from B and the
+  // verdict came from A.
+  function project(gitignore: string | null, template: string | null): string {
+    const dir = mkdtempSync(join(tmpdir(), "kit-gate-cwd-"));
+    let toml = "version = 1\n";
+    if (template !== null) {
+      toml += `\n[secrets]\nstore = "env"\ntemplate = "${template}"\n`;
+    }
+    writeFileSync(join(dir, ".kit.toml"), toml);
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "g", version: "1.0.0", private: true }) + "\n",
+    );
+    if (gitignore !== null) writeFileSync(join(dir, ".gitignore"), gitignore);
+    return dir;
+  }
+
+  it("the security verdict describes the requested project, not the server's", async () => {
+    const { runCheckGate } = await import("./check-run.js");
+    const A = project(".env\n.env.local\n.env.*.local\nnode_modules\n", null);
+    const B = project(null, null);
+    try {
+      const aboutB = await inCwd(A, () => runCheckGate({ cwd: B, categories: ["security"] }));
+      const aboutA = await inCwd(A, () => runCheckGate({ cwd: A, categories: ["security"] }));
+
+      const bEnv = statusOf(aboutB.security, ".env gitignored");
+      const aEnv = statusOf(aboutA.security, ".env gitignored");
+      assert.equal(aEnv, "pass");
+      assert.notEqual(bEnv, "pass", "B has no .gitignore — it must not inherit A's pass");
+      assert.notEqual(bEnv, aEnv);
+    } finally {
+      rmSync(A, { recursive: true, force: true });
+      rmSync(B, { recursive: true, force: true });
+    }
+  });
+
+  it("a relative [secrets].template resolves in the governed project", async () => {
+    const { runCheckGate } = await import("./check-run.js");
+    // Both declare the same relative template path; only A has the file. Resolving it against
+    // the process instead of the project reported A's template as B's.
+    const A = project(null, ".env.template");
+    const B = project(null, ".env.template");
+    writeFileSync(join(A, ".env.template"), "API_KEY=\n");
+    try {
+      const aboutB = await inCwd(A, () => runCheckGate({ cwd: B, categories: ["secrets"] }));
+      const aboutA = await inCwd(A, () => runCheckGate({ cwd: A, categories: ["secrets"] }));
+      assert.equal(aboutA.secrets.templateExists, true, "A has the template file");
+      assert.equal(
+        aboutB.secrets.templateExists,
+        false,
+        "B declares the same path but has no file — it must not see A's",
+      );
+    } finally {
+      rmSync(A, { recursive: true, force: true });
+      rmSync(B, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/check-security-cwd.test.ts
+++ b/src/check-security-cwd.test.ts
@@ -312,3 +312,75 @@ describe("the scanner-spawn mechanism actually relocates the child process", () 
     }
   });
 });
+
+describe("a REAL scanner subprocess reads the governed tree", () => {
+  /**
+   * The strongest available proof for the scanner path, and the one I wrongly claimed could not be
+   * obtained: `semgrep .` resolves "." against the spawned process, so if `cwd: root` were dropped
+   * it would scan the caller's tree. This runs the actual binary over two trees and asserts the
+   * verdicts differ.
+   *
+   * Skips — loudly — when semgrep is absent, which is the case in CI. A skipped test must never
+   * read as a passed one, so the skip message says what went unverified. trivy, osv-scanner and
+   * guarddog have no equivalent here: they are distributed as GitHub release binaries and this
+   * environment's policy answers 403 for any repository outside the session's allowlist, so they
+   * cannot be fetched. semgrep is installable from PyPI, which is why it is the one covered.
+   */
+  it("semgrep scans the cwd it is handed, not the process's", async (t) => {
+    const { execFileNoThrow } = await import("./utils/execFileNoThrow.js");
+    const probe = await execFileNoThrow("semgrep", ["--version"], { timeout: 20_000 });
+    if (!probe.ok) {
+      t.skip("semgrep not installed — the scanner-subprocess path is NOT verified in this run");
+      return;
+    }
+
+    const A = mkdtempSync(join(tmpdir(), "kit-sg-A-"));
+    const B = mkdtempSync(join(tmpdir(), "kit-sg-B-"));
+    const prevCfg = process.env.KIT_SEMGREP_CONFIG;
+    try {
+      for (const d of [A, B]) {
+        writeFileSync(join(d, ".kit.toml"), "version = 1\n");
+        writeFileSync(
+          join(d, "package.json"),
+          JSON.stringify({ name: "sg", version: "1.0.0", private: true }) + "\n",
+        );
+      }
+      // A local ruleset: a registry config would egress, and kit refuses that under air-gap.
+      const rules = join(A, "rules.yml");
+      writeFileSync(
+        rules,
+        [
+          "rules:",
+          "  - id: no-eval",
+          "    pattern: eval(...)",
+          "    message: eval is forbidden",
+          "    languages: [js]",
+          "    severity: ERROR",
+        ].join("\n") + "\n",
+      );
+      process.env.KIT_SEMGREP_CONFIG = rules;
+
+      // A trips the rule; B does not. The process sits in A for both calls.
+      writeFileSync(join(A, "danger.js"), "export const go = (s) => eval(s);\n");
+      writeFileSync(join(B, "safe.js"), "export const go = (s) => s;\n");
+
+      const aboutA = await inCwd(A, () => checkSecurity(A));
+      const aboutB = await inCwd(A, () => checkSecurity(B));
+
+      const semgrepRow = (rs: Awaited<ReturnType<typeof checkSecurity>>): string =>
+        rs.find((r) => /semgrep/i.test(r.name))?.status ?? "absent";
+
+      assert.equal(semgrepRow(aboutA), "fail", "A contains eval() and must fail its own scan");
+      assert.equal(
+        semgrepRow(aboutB),
+        "pass",
+        "B is clean — a fail here means semgrep scanned the caller's tree instead",
+      );
+    } finally {
+      if (prevCfg === undefined) delete process.env.KIT_SEMGREP_CONFIG;
+      else process.env.KIT_SEMGREP_CONFIG = prevCfg;
+      rmSync(A, { recursive: true, force: true });
+      rmSync(B, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/check-security-cwd.test.ts
+++ b/src/check-security-cwd.test.ts
@@ -272,3 +272,43 @@ describe("runCheckGate threads cwd to the dimensions that read the filesystem", 
     }
   });
 });
+
+describe("the scanner-spawn mechanism actually relocates the child process", () => {
+  /**
+   * The source-level guard above proves every scanner spawn PASSES `cwd: root`. It cannot prove
+   * that passing it works, and trivy/semgrep/osv-scanner/guarddog are not installed in CI or in
+   * the environment this was developed in, so `trivy fs .` reading the right tree has no direct
+   * behavioural test.
+   *
+   * This closes that gap without the tools: spawn a stand-in through the SAME helper the scanners
+   * go through and make it report its own working directory. Together the two form a chain —
+   * every spawn passes the argument, and the argument moves the child — which covers
+   * `trivy fs .`, `trivy config .`, `osv-scanner -r .` and `semgrep .` resolving "." in the
+   * governed project rather than the caller's.
+   */
+  it("execFileNoThrow's cwd option lands the child in that directory", async () => {
+    const { execFileNoThrow } = await import("./utils/execFileNoThrow.js");
+    const A = mkdtempSync(join(tmpdir(), "kit-spawn-A-"));
+    const B = mkdtempSync(join(tmpdir(), "kit-spawn-B-"));
+    try {
+      const whereAmI = ["-e", "process.stdout.write(process.cwd())"];
+      const inB = await inCwd(A, () => execFileNoThrow(process.execPath, whereAmI, { cwd: B }));
+      const inherited = await inCwd(A, () => execFileNoThrow(process.execPath, whereAmI));
+
+      // realpath: the OS may report /tmp via a symlink (macOS /private/tmp), and a lexical
+      // compare would fail for the right directory — the same trap `crossProjectRefusal` hit.
+      const { realpathSync } = await import("node:fs");
+      assert.equal(realpathSync(inB.stdout.trim()), realpathSync(B), "cwd: B must move the child");
+      assert.equal(
+        realpathSync(inherited.stdout.trim()),
+        realpathSync(A),
+        "omitting cwd must inherit the parent's, as every existing caller relies on",
+      );
+      // The pair: a helper that ignored the option would put both children in A.
+      assert.notEqual(realpathSync(inB.stdout.trim()), realpathSync(inherited.stdout.trim()));
+    } finally {
+      rmSync(A, { recursive: true, force: true });
+      rmSync(B, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -1971,7 +1971,13 @@ async function checkBumblebee(root: string): Promise<SecurityCheckResult> {
     const catalogs = describeFindings(outcome.findings);
     // F9: persist every catalog match to the local audit log so the find
     // survives the next CI run and shows up in `kit audit`.
-    await logSupplyChainFindings(outcome.findings, profile).catch(() => {});
+    // WRITE, not a read: bumblebee findings are appended to <root>/.kit-findings.jsonl. Omitting
+    // the third argument defaulted it to process.cwd(), so a check run FOR another project
+    // appended that project'''s supply-chain findings to the calling process'''s file. The
+    // behavioural cross-project probe could not catch this — bumblebee is not installed in the
+    // probe environment, so the branch never ran. Found by enumerating writes in the check path
+    // instead, which is the only oracle that works for a path a probe cannot reach.
+    await logSupplyChainFindings(outcome.findings, profile, root).catch(() => {});
     return {
       category,
       name,

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -294,10 +294,10 @@ async function checkMemoryInjection(): Promise<SecurityCheckResult> {
 /**
  * Run npm audit and check for high/critical vulnerabilities
  */
-async function checkNpmAudit(): Promise<SecurityCheckResult> {
+async function checkNpmAudit(root: string): Promise<SecurityCheckResult> {
   try {
     // Check if package.json exists
-    await access(resolve(process.cwd(), "package.json"));
+    await access(resolve(root, "package.json"));
   } catch {
     return {
       category: "dependency",
@@ -312,14 +312,14 @@ async function checkNpmAudit(): Promise<SecurityCheckResult> {
   // (#353). Skip honestly instead — it is not-applicable, not a failure, and those
   // repos' dependency vulnerabilities are still covered by osv-scanner. (No
   // false-green risk: OSV runs regardless.)
-  const hasNpmLock = await access(resolve(process.cwd(), "package-lock.json"))
+  const hasNpmLock = await access(resolve(root, "package-lock.json"))
     .then(() => true)
     .catch(() => false);
   if (!hasNpmLock) {
     const other = (
       await Promise.all(
         (["pnpm-lock.yaml", "yarn.lock", "bun.lockb", "bun.lock"] as const).map((f) =>
-          access(resolve(process.cwd(), f))
+          access(resolve(root, f))
             .then(() => f)
             .catch(() => null),
         ),
@@ -393,10 +393,10 @@ async function checkNpmAudit(): Promise<SecurityCheckResult> {
 /**
  * Run pip-audit for Python dependencies
  */
-async function checkPipAudit(): Promise<SecurityCheckResult> {
+async function checkPipAudit(root: string): Promise<SecurityCheckResult> {
   try {
     // Check if requirements.txt exists
-    await access(resolve(process.cwd(), "requirements.txt"));
+    await access(resolve(root, "requirements.txt"));
   } catch {
     return {
       category: "dependency",
@@ -468,9 +468,9 @@ async function checkPipAudit(): Promise<SecurityCheckResult> {
 /**
  * Check if .env files are in .gitignore
  */
-async function checkEnvGitignored(): Promise<SecurityCheckResult> {
+async function checkEnvGitignored(root: string): Promise<SecurityCheckResult> {
   try {
-    const gitignoreContent = await readFile(resolve(process.cwd(), ".gitignore"), "utf-8");
+    const gitignoreContent = await readFile(resolve(root, ".gitignore"), "utf-8");
 
     const envPatterns = [".env", ".env.local", ".env.*.local"];
     const missingPatterns = envPatterns.filter((pattern) => !gitignoreContent.includes(pattern));
@@ -546,10 +546,10 @@ export const LOCKFILE_ECOSYSTEMS: { name: string; manifests: string[]; lockfiles
   { name: "flake.lock", manifests: ["flake.nix"], lockfiles: ["flake.lock"] },
 ];
 
-async function checkLockfilesCommitted(): Promise<SecurityCheckResult[]> {
+async function checkLockfilesCommitted(root: string): Promise<SecurityCheckResult[]> {
   const results: SecurityCheckResult[] = [];
   const present = (f: string): Promise<boolean> =>
-    access(resolve(process.cwd(), f))
+    access(resolve(root, f))
       .then(() => true)
       .catch(() => false);
 
@@ -791,14 +791,14 @@ function workspaceMemberNames(cwd: string): Set<string> {
 /**
  * Check if dependencies use pinned versions
  */
-async function checkPinnedVersions(): Promise<SecurityCheckResult> {
+async function checkPinnedVersions(root: string): Promise<SecurityCheckResult> {
   const unpinned: string[] = [];
 
   // Check package.json
   try {
-    const packageJsonContent = await readFile(resolve(process.cwd(), "package.json"), "utf-8");
+    const packageJsonContent = await readFile(resolve(root, "package.json"), "utf-8");
     const packageJson = JSON.parse(packageJsonContent);
-    const members = workspaceMemberNames(process.cwd());
+    const members = workspaceMemberNames(root);
     const isMember = (name: string) => members.has(name);
 
     unpinned.push(
@@ -811,7 +811,7 @@ async function checkPinnedVersions(): Promise<SecurityCheckResult> {
 
   // Check requirements.txt
   try {
-    const requirementsContent = await readFile(resolve(process.cwd(), "requirements.txt"), "utf-8");
+    const requirementsContent = await readFile(resolve(root, "requirements.txt"), "utf-8");
 
     for (const line of requirementsContent.split("\n")) {
       const trimmed = line.trim();
@@ -968,7 +968,7 @@ export function basicSecretScanFiles(lines: string[]): string[] {
   return [...files];
 }
 
-async function checkSecretsInCode(): Promise<SecurityCheckResult> {
+async function checkSecretsInCode(root: string): Promise<SecurityCheckResult> {
   try {
     // Check if we're in a git repo
     await exec("git", ["rev-parse", "--git-dir"], { timeout: 5_000 });
@@ -995,7 +995,7 @@ async function checkSecretsInCode(): Promise<SecurityCheckResult> {
       // Git mode is fast and only sees what's actually in the repo's history.
       const { stdout } = await exec(
         trufflehogBin,
-        ["git", `file://${process.cwd()}`, "--json", "--no-update"],
+        ["git", `file://${root}`, "--json", "--no-update"],
         { timeout: 90_000 },
       );
 
@@ -1008,7 +1008,7 @@ async function checkSecretsInCode(): Promise<SecurityCheckResult> {
       // PostHog) are split out with truthful advice — rotating them fixes nothing.
       const readWorktreeFile = (p: string): string | null => {
         try {
-          return readFileSync(resolve(process.cwd(), p), "utf8");
+          return readFileSync(resolve(root, p), "utf8");
         } catch {
           return null;
         }
@@ -1130,7 +1130,7 @@ async function checkSocket(): Promise<SecurityCheckResult> {
  * and `verify` fetches/scans each dependency, so it's too heavy for the default
  * check. Classification (incl. fail-closed on incomplete scans) is in guarddog.ts.
  */
-async function checkGuardDog(): Promise<SecurityCheckResult> {
+async function checkGuardDog(root: string): Promise<SecurityCheckResult> {
   const base = { category: "supply-chain", name: "guarddog (malware)" } as const;
   const envEnabled = ["1", "true", "yes", "on"].includes(
     (process.env.KIT_GUARDDOG ?? "").trim().toLowerCase(),
@@ -1140,7 +1140,7 @@ async function checkGuardDog(): Promise<SecurityCheckResult> {
   let cfgEnabled = false;
   try {
     const { loadConfig } = await import("./config.js");
-    const cfg = await loadConfig(resolve(process.cwd(), ".kit.toml"));
+    const cfg = await loadConfig(resolve(root, ".kit.toml"));
     cfgEnabled = cfg.scan?.guarddog === true;
   } catch {
     // no/invalid config → env var is the only switch
@@ -1165,7 +1165,7 @@ async function checkGuardDog(): Promise<SecurityCheckResult> {
   let target: { ecosystem: string; file: string } | undefined;
   for (const c of candidates) {
     try {
-      await access(resolve(process.cwd(), c.file));
+      await access(resolve(root, c.file));
       target = c;
       break;
     } catch {
@@ -1197,7 +1197,7 @@ async function checkGuardDog(): Promise<SecurityCheckResult> {
   let depsHash: string | null = null;
   if (target.ecosystem === "npm") {
     try {
-      depsHash = depsHashFor(readFileSync(resolve(process.cwd(), target.file), "utf8"));
+      depsHash = depsHashFor(readFileSync(resolve(root, target.file), "utf8"));
     } catch {
       depsHash = null;
     }
@@ -1215,7 +1215,7 @@ async function checkGuardDog(): Promise<SecurityCheckResult> {
   const result = await execFileNoThrow(
     bin,
     [target.ecosystem, "verify", target.file, "--output-format=json"],
-    { timeout: timeoutMs },
+    { timeout: timeoutMs, cwd: root },
   );
   const verdict = classifyGuardDog(result.stdout || result.stderr);
   if (verdict.status === "pass" && depsHash) {
@@ -1229,8 +1229,8 @@ async function checkGuardDog(): Promise<SecurityCheckResult> {
  * Scan Dockerfile and filesystem for CVEs using Trivy.
  * Catches OS-level vulnerabilities that npm audit misses.
  */
-async function checkTrivy(): Promise<SecurityCheckResult> {
-  const hasDockerfile = await access(resolve(process.cwd(), "Dockerfile"))
+async function checkTrivy(root: string): Promise<SecurityCheckResult> {
+  const hasDockerfile = await access(resolve(root, "Dockerfile"))
     .then(() => true)
     .catch(() => false);
   if (!hasDockerfile) {
@@ -1261,7 +1261,7 @@ async function checkTrivy(): Promise<SecurityCheckResult> {
   const result = await execFileNoThrow(
     trivyBin,
     ["fs", ".", "--format", "json", "--severity", "HIGH,CRITICAL", "--quiet"],
-    { timeout: 120_000 },
+    { timeout: 120_000, cwd: root },
   );
 
   if (!result.ok && !result.stdout) {
@@ -1330,9 +1330,9 @@ export function parseTrivyMisconfigCount(stdout: string): number {
  * privileged containers, public buckets, missing healthchecks, …). Runs only
  * when there is IaC to scan; resolves trivy mise-first like the CVE scan.
  */
-async function checkTrivyConfig(): Promise<SecurityCheckResult> {
+async function checkTrivyConfig(root: string): Promise<SecurityCheckResult> {
   const name = "trivy config (IaC)";
-  const cwd = process.cwd();
+  const cwd = root;
   const fileMarkers = [
     "Dockerfile",
     "docker-compose.yml",
@@ -1387,7 +1387,7 @@ async function checkTrivyConfig(): Promise<SecurityCheckResult> {
   const result = await execFileNoThrow(
     trivyBin,
     ["config", ".", "--format", "json", "--severity", "HIGH,CRITICAL", "--quiet"],
-    { timeout: 120_000 },
+    { timeout: 120_000, cwd: root },
   );
   const count = parseTrivyMisconfigCount(result.stdout);
   if (count < 0) {
@@ -1495,8 +1495,8 @@ export function parseTrivyVulnCount(stdout: string): number {
  * locally, or a CI step that caches `~/.m2`). Without it trivy sees only direct
  * deps and silently under-reports, so we warn rather than pass.
  */
-async function checkMavenAudit(): Promise<SecurityCheckResult> {
-  const found = await findJvmProject(process.cwd());
+async function checkMavenAudit(root: string): Promise<SecurityCheckResult> {
+  const found = await findJvmProject(root);
   const name = `trivy fs (${found?.kind ?? "jvm"})`;
   if (!found) {
     return {
@@ -1573,7 +1573,7 @@ async function checkMavenAudit(): Promise<SecurityCheckResult> {
       "HIGH,CRITICAL",
       "--quiet",
     ],
-    { timeout: 180_000 },
+    { timeout: 180_000, cwd: root },
   );
   if (!result.ok && !result.stdout) {
     return {
@@ -1632,7 +1632,7 @@ export function parseOsvVulnCount(stdout: string): number {
  * node it's npm audit, for python pip-audit — so it skips cleanly when absent
  * rather than duplicating those. Resolves mise-first.
  */
-async function checkOsvScanner(): Promise<SecurityCheckResult> {
+async function checkOsvScanner(root: string): Promise<SecurityCheckResult> {
   const name = "osv-scanner (deps)";
   // osv covers ecosystems kit has no dedicated scanner for (go/rust/php/ruby/dart).
   // If none is present, osv legitimately does not apply → an honest skip. If one IS
@@ -1641,7 +1641,7 @@ async function checkOsvScanner(): Promise<SecurityCheckResult> {
   const osvEcosystemPresent = async (): Promise<boolean> => {
     for (const m of ["go.mod", "Cargo.lock", "composer.lock", "Gemfile.lock", "pubspec.lock"]) {
       try {
-        await access(resolve(process.cwd(), m));
+        await access(resolve(root, m));
         return true;
       } catch {
         /* not present */
@@ -1670,6 +1670,7 @@ async function checkOsvScanner(): Promise<SecurityCheckResult> {
   }
   const result = await execFileNoThrow(osvBin, ["--format", "json", "-r", "."], {
     timeout: 120_000,
+    cwd: root,
   });
   const count = parseOsvVulnCount(result.stdout);
   if (count < 0) {
@@ -1708,9 +1709,9 @@ async function checkOsvScanner(): Promise<SecurityCheckResult> {
 /**
  * Check dependency licenses for GPL/AGPL that create legal obligations.
  */
-async function checkLicenses(): Promise<SecurityCheckResult> {
+async function checkLicenses(root: string): Promise<SecurityCheckResult> {
   try {
-    await access(resolve(process.cwd(), "package.json"));
+    await access(resolve(root, "package.json"));
   } catch {
     return {
       category: "supply-chain",
@@ -1754,6 +1755,7 @@ async function checkLicenses(): Promise<SecurityCheckResult> {
   const PROBLEMATIC = ["GPL", "AGPL", "LGPL", "CPAL", "OSL", "EUPL"];
   const result = await execFileNoThrow(runner.cmd, [...runner.baseArgs, "--json", "--production"], {
     timeout: 120_000,
+    cwd: root,
   });
 
   if (!result.ok && !result.stdout) {
@@ -1806,7 +1808,7 @@ async function checkLicenses(): Promise<SecurityCheckResult> {
 /**
  * Run static analysis using Semgrep to catch security anti-patterns in source code.
  */
-async function checkSemgrep(): Promise<SecurityCheckResult> {
+async function checkSemgrep(root: string): Promise<SecurityCheckResult> {
   // Opt-in FIRST: a networked, multi-second SAST scan does not run by default.
   // Not opted in → skipping is honest (green stays "0 unreviewed").
   if (!process.env.KIT_SEMGREP_CONFIG?.trim()) {
@@ -1854,7 +1856,7 @@ async function checkSemgrep(): Promise<SecurityCheckResult> {
   const result = await execFileNoThrow(
     semgrepBin,
     buildSemgrepArgs({ mode: "json", config: semgrepCfg }),
-    { timeout: 120_000 },
+    { timeout: 120_000, cwd: root },
   );
 
   const raw = result.stdout || result.stderr;
@@ -1905,7 +1907,7 @@ async function checkSemgrep(): Promise<SecurityCheckResult> {
  *   KIT_BUMBLEBEE_BIN      use a pre-installed bumblebee instead of downloading
  *   KIT_BUMBLEBEE_CATALOG  override the exposure-catalog directory
  */
-async function checkBumblebee(): Promise<SecurityCheckResult> {
+async function checkBumblebee(root: string): Promise<SecurityCheckResult> {
   const name = "bumblebee (supply-chain)";
   const category = "supply-chain" as const;
 
@@ -2059,7 +2061,20 @@ function describeFindings(findings: BumblebeeFinding[]): string {
 /**
  * Run all security checks
  */
-export async function checkSecurity(): Promise<SecurityCheckResult[]> {
+export async function checkSecurity(cwd?: string): Promise<SecurityCheckResult[]> {
+  // The GOVERNED project's root, threaded to every sub-check and to every scanner spawn.
+  //
+  // Before this, all fifteen sub-checks resolved paths from `process.cwd()` and none of the seven
+  // scanner spawns passed a `cwd`, so a caller that supplied one got a verdict about the CALLING
+  // process's tree. Measured over MCP: `kit_check({cwd: B})` from a server launched in A answered
+  // `pass — all .env patterns in .gitignore` for a project B that has no `.gitignore` at all.
+  // The config came from B; the verdict came from A. That is the worst shape a gate can fail in.
+  //
+  // Passing the path alone would not have fixed it: `trivy fs .`, `osv-scanner -r .` and
+  // `semgrep .` all resolve "." against the spawned process's cwd, so they would still have read
+  // the caller's tree while the parameter made the call look threaded. Both halves are required,
+  // and the test asserts the OUTCOME differs between two trees rather than that `cwd` was passed.
+  const root = cwd ?? process.cwd();
   const results: SecurityCheckResult[] = [];
 
   const [
@@ -2079,21 +2094,21 @@ export async function checkSecurity(): Promise<SecurityCheckResult[]> {
     guarddogResult,
     ...lockfileResults
   ] = await Promise.all([
-    checkNpmAudit(),
-    checkPipAudit(),
-    checkEnvGitignored(),
-    checkPinnedVersions(),
-    checkSecretsInCode(),
+    checkNpmAudit(root),
+    checkPipAudit(root),
+    checkEnvGitignored(root),
+    checkPinnedVersions(root),
+    checkSecretsInCode(root),
     checkSocket(),
-    checkTrivy(),
-    checkLicenses(),
-    checkSemgrep(),
-    checkBumblebee(),
-    checkTrivyConfig(),
-    checkOsvScanner(),
-    checkMavenAudit(),
-    checkGuardDog(),
-    ...(await checkLockfilesCommitted()),
+    checkTrivy(root),
+    checkLicenses(root),
+    checkSemgrep(root),
+    checkBumblebee(root),
+    checkTrivyConfig(root),
+    checkOsvScanner(root),
+    checkMavenAudit(root),
+    checkGuardDog(root),
+    ...(await checkLockfilesCommitted(root)),
   ]);
 
   results.push(
@@ -2132,14 +2147,14 @@ export async function checkSecurity(): Promise<SecurityCheckResult[]> {
   // Enforcement floor liveness: fail if kit was taught here but a PreToolUse gate
   // has vanished — the agent runs un-gated while kit still reads green. The floor
   // must prove it exists.
-  results.push(await checkGateLiveness());
+  results.push(await checkGateLiveness(root));
   results.push(await checkDeviceIdOverride());
 
   // Inbound integration: fold any third-party findings a partner tool emitted to
   // `.kit-scan-results.jsonl` into the verdict. No file → no-op. Can only escalate
   // (fail/warn), never green the gate — see external-findings.ts.
   const { checkExternalFindings } = await import("./external-findings.js");
-  results.push(...(await checkExternalFindings()));
+  results.push(...(await checkExternalFindings(root)));
 
   // Attach a rule citation (CWE/OWASP) to each finding whose check is mapped in
   // the local rules catalog. Deterministic lookup, no network. Unmapped checks

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -1973,10 +1973,14 @@ async function checkBumblebee(root: string): Promise<SecurityCheckResult> {
     // survives the next CI run and shows up in `kit audit`.
     // WRITE, not a read: bumblebee findings are appended to <root>/.kit-findings.jsonl. Omitting
     // the third argument defaulted it to process.cwd(), so a check run FOR another project
-    // appended that project'''s supply-chain findings to the calling process'''s file. The
-    // behavioural cross-project probe could not catch this — bumblebee is not installed in the
-    // probe environment, so the branch never ran. Found by enumerating writes in the check path
-    // instead, which is the only oracle that works for a path a probe cannot reach.
+    // appended that project's supply-chain findings to the calling process's file.
+    //
+    // Why the cross-project probe could not catch it: NOT because bumblebee is absent — it is
+    // provisioned under ~/.kit/tools/bumblebee/<version>/ and does run (measured: `pass`,
+    // 36 packages, on a clean fixture). The branch is gated on `findings.length > 0`, and a
+    // freshly created temp project has no known exposures, so the write is unreachable from any
+    // fixture that is clean. Found by enumerating the write surface instead. A green probe over a
+    // clean fixture says nothing about the code paths that only a dirty one reaches.
     await logSupplyChainFindings(outcome.findings, profile, root).catch(() => {});
     return {
       category,

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -6,7 +6,7 @@
  */
 import { resolve } from "node:path";
 import { c } from "../utils/colors.js";
-import { hasFlag, flagValue } from "../utils/flags.js";
+import { hasFlag, flagValue, flagInt } from "../utils/flags.js";
 import { loadConfig } from "../config.js";
 import { KIT_FILE, resolveConfigPath } from "../cli-shared.js";
 import { checkSkills } from "../check-skills.js";
@@ -353,8 +353,10 @@ export async function cmdTeam(): Promise<boolean> {
           return false;
         }
 
-        const limitArg = args.find((a) => a.startsWith("--limit="));
-        const limit = limitArg ? parseInt(limitArg.split("=")[1]) : 50;
+        // flagInt, not a `--limit=`-only find: `kit team audit log --limit 3` printed
+        // `(limit: 50)` — the flag parsed as nothing and the default won, silently. The old
+        // form also had no NaN guard, so `--limit=abc` printed `(limit: NaN)`.
+        const limit = flagInt(args, "--limit", 50);
 
         console.log(`${c.bold}Audit Log${c.reset}  ${c.dim}(limit: ${limit})${c.reset}\n`);
         console.log(`${c.dim}No audit events available${c.reset}`);

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -10,11 +10,11 @@ import { hasFlag, flagValue, flagInt } from "../utils/flags.js";
 
 async function cmdAuditSecrets(): Promise<boolean> {
   const args = process.argv.slice(4); // after "audit secrets"
-  const sinceIdx = args.indexOf("--since-days");
   // NaN-guard: a non-numeric --since-days would make the cutoff NaN, so the time-window filter
-  // silently no-ops and ALL events are returned (wrong output, no error). Fall back to 30.
-  const sinceRaw = sinceIdx >= 0 && args[sinceIdx + 1] ? parseInt(args[sinceIdx + 1], 10) : 30;
-  const sinceDays = Number.isFinite(sinceRaw) && sinceRaw > 0 ? sinceRaw : 30;
+  // silently no-ops and ALL events are returned (wrong output, no error). `flagInt` already falls
+  // back on an unparsable value; the `> 0` test additionally rejects 0 and negatives.
+  const sinceRaw = flagInt(args, "--since-days", 30);
+  const sinceDays = sinceRaw > 0 ? sinceRaw : 30;
   const keyFilter = flagValue(args, "--key");
   const jsonMode = hasFlag(args, "--json");
 
@@ -323,9 +323,9 @@ export async function cmdAudit(): Promise<boolean> {
 
   // Parse --operation <name>
   let operationFilter: string | undefined;
-  const opIdx = args.indexOf("--operation");
-  if (opIdx !== -1 && args[opIdx + 1]) {
-    operationFilter = args[opIdx + 1];
+  const opValue = flagValue(args, "--operation");
+  if (opValue) {
+    operationFilter = opValue;
   }
 
   // Determine log file path (use config if available, else default)

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -27,13 +27,11 @@ export async function cmdAuth(): Promise<boolean> {
 async function cmdAuthSetupTotp(): Promise<boolean> {
   // kit auth setup-totp [--issuer <name>] [--account <user@host>] [--overwrite]
   const args = process.argv.slice(4);
-  const issuerIdx = args.indexOf("--issuer");
-  const accountIdx = args.indexOf("--account");
   const overwrite = hasFlag(args, "--overwrite");
 
-  const issuer = issuerIdx >= 0 ? args[issuerIdx + 1] : "kit";
+  const issuer = flagValue(args, "--issuer") ?? "kit";
   const defaultAccount = `${process.env.USER ?? "user"}@${process.env.HOSTNAME ?? "host"}`;
-  const accountName = accountIdx >= 0 ? args[accountIdx + 1] : defaultAccount;
+  const accountName = flagValue(args, "--account") ?? defaultAccount;
 
   console.log(`${c.bold}${c.cyan}kit auth setup-totp${c.reset}`);
   console.log(`${c.dim}${"─".repeat(50)}${c.reset}\n`);

--- a/src/commands/ci.ts
+++ b/src/commands/ci.ts
@@ -8,7 +8,7 @@
 import { resolve } from "node:path";
 import { existsSync, writeFileSync } from "node:fs";
 import { c } from "../utils/colors.js";
-import { hasFlag, envTruthy } from "../utils/flags.js";
+import { hasFlag, envTruthy, flagValue } from "../utils/flags.js";
 import { loadConfig } from "../config.js";
 import { resolveConfigPath } from "../cli-shared.js";
 import { withGovernance } from "../governance-middleware.js";
@@ -61,9 +61,7 @@ export async function cmdCi(): Promise<boolean> {
     return true;
   }
 
-  const formatArg = args.find((a) => a.startsWith("--format="))?.split("=")[1] as
-    | CiFormat
-    | undefined;
+  const formatArg = flagValue(args, "--format") as CiFormat | undefined;
   // Scanner-health STRICT BY DEFAULT (kit's "no false green" floor): a check that
   // could not RUN (tool/token absent, crashed) is marked didNotRun and FAILS the
   // gate — a green means every check actually ran. `--lenient` / KIT_CI_LENIENT

--- a/src/commands/ci.ts
+++ b/src/commands/ci.ts
@@ -37,10 +37,12 @@ export async function cmdCi(): Promise<boolean> {
   // `kit ci --init <gitlab|bitbucket>` — emit the pipeline snippet that runs
   // `kit ci` on a non-GitHub host. Prints to stdout (copy-paste); `--write`
   // writes the file only when absent (never clobbers an existing pipeline).
-  const initIdx = args.indexOf("--init");
-  if (initIdx !== -1) {
+  // Presence is checked separately from the value: `hasFlag` compares whole tokens, so
+  // `--init=gitlab` would not register at all and the branch would be skipped silently.
+  const initPresent = args.some((a) => a === "--init" || a.startsWith("--init="));
+  if (initPresent) {
     const { pipelineSnippet, isCiHost, CI_HOSTS } = await import("../ci-init.js");
-    const host = args[initIdx + 1] ?? "";
+    const host = flagValue(args, "--init") ?? "";
     if (!isCiHost(host)) {
       console.error(`kit ci --init: host must be one of ${CI_HOSTS.join(", ")}`);
       return false;

--- a/src/commands/coverage.ts
+++ b/src/commands/coverage.ts
@@ -5,7 +5,7 @@
  * (draft CLAUDE.md / RULES.md from a repo scan). `aggregateAdvisories` collapses
  * info-severity findings and is used only here, so it stays module-private.
  */
-import { hasFlag } from "../utils/flags.js";
+import { hasFlag, flagValue } from "../utils/flags.js";
 import { c } from "../utils/colors.js";
 import { checkSecurity, type SecurityCheckResult } from "../check-security.js";
 import { scanTranscripts } from "../scan-transcripts.js";
@@ -45,9 +45,7 @@ export async function cmdSelfAudit(): Promise<boolean> {
     return true;
   }
 
-  const formatArg = args.find((a) => a.startsWith("--format="))?.split("=")[1] as
-    | CiFormat
-    | undefined;
+  const formatArg = flagValue(args, "--format") as CiFormat | undefined;
   const failOnWarning = hasFlag(args, "--fail-on-warning");
   const jsonMode = hasFlag(args, "--json");
   const format: CiFormat = formatArg ?? (jsonMode ? "json" : detectCiFormat());
@@ -191,7 +189,7 @@ export async function cmdSelfAudit(): Promise<boolean> {
  */
 export async function cmdCoverage(): Promise<boolean> {
   const args = process.argv.slice(2);
-  const formatArg = args.find((a) => a.startsWith("--format="))?.split("=")[1];
+  const formatArg = flagValue(args, "--format");
   const jsonMode = hasFlag(args, "--json") || formatArg === "json";
   const verify = hasFlag(args, "--verify");
 

--- a/src/commands/coverage.ts
+++ b/src/commands/coverage.ts
@@ -344,8 +344,10 @@ export async function cmdAnalyze(): Promise<boolean> {
     hasFlag(args, "--claude") || (!hasFlag(args, "--rules") && !hasFlag(args, "--claude"));
   const wantRules =
     hasFlag(args, "--rules") || (!hasFlag(args, "--rules") && !hasFlag(args, "--claude"));
-  const writeFlagIdx = args.indexOf("--write");
-  const writeDir = writeFlagIdx >= 0 ? (args[writeFlagIdx + 1] ?? process.cwd()) : null;
+  // `--write` is an OPTIONAL-value flag: bare means "here", `--write <dir>` / `--write=<dir>`
+  // names a target. Presence is checked on both spellings, since `hasFlag` matches whole tokens.
+  const writePresent = args.some((a) => a === "--write" || a.startsWith("--write="));
+  const writeDir = writePresent ? (flagValue(args, "--write") ?? process.cwd()) : null;
 
   console.log(`${c.bold}${c.cyan}kit analyze${c.reset}`);
   console.log(`${c.dim}${"─".repeat(50)}${c.reset}\n`);

--- a/src/commands/design.ts
+++ b/src/commands/design.ts
@@ -22,6 +22,7 @@ export async function runDesignGate(
   const { loadBaselineForGate, baselineGet } = await import("../baseline.js");
   const { baseline, ignored } = await loadBaselineForGate(opts.cwd);
   const checks = await checkDesign({
+    cwd: opts.cwd,
     enforce: opts.enforce,
     baseline: {
       a11y: baselineGet(baseline, "design", "a11y"),

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -7,7 +7,7 @@
  */
 import { spawn as spawnChild } from "node:child_process";
 import { c } from "../utils/colors.js";
-import { hasFlag, flagValue } from "../utils/flags.js";
+import { hasFlag, flagValue, flagInt } from "../utils/flags.js";
 import { loadConfig, type kitConfig } from "../config.js";
 import { KIT_FILE, resolveConfigPath } from "../cli-shared.js";
 import { check1PasswordStatus, detect1PasswordMode } from "../onepassword.js";
@@ -97,9 +97,7 @@ export async function cmdLogin(): Promise<boolean> {
   // re-run their login command idempotently anyway).
   const args = process.argv.slice(3);
   const serviceFilter = flagValue(args, "--service");
-  const retryIdx = args.indexOf("--retry-count");
-  const retryCount =
-    retryIdx >= 0 && args[retryIdx + 1] ? Math.max(0, parseInt(args[retryIdx + 1]!, 10) || 0) : 0;
+  const retryCount = Math.max(0, flagInt(args, "--retry-count", 0));
 
   const backendOk = await ensureSecretsBackend(config);
 

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -3,7 +3,7 @@ import { startMcpServer } from "../mcp-server.js";
 import { loadConfig } from "../config.js";
 import { resolveConfigPath } from "../cli-shared.js";
 import { c } from "../utils/colors.js";
-import { hasFlag } from "../utils/flags.js";
+import { hasFlag, flagValue } from "../utils/flags.js";
 
 export async function cmdMcp(): Promise<boolean> {
   const sub = process.argv[3];
@@ -84,10 +84,10 @@ export async function cmdMcp(): Promise<boolean> {
       return false;
     }
     const args = process.argv.slice(5);
-    const fromEnvIdx = args.indexOf("--from-env");
+    const fromEnv = flagValue(args, "--from-env");
     let accessToken: string | undefined;
-    if (fromEnvIdx >= 0 && args[fromEnvIdx + 1]) {
-      const envVar = args[fromEnvIdx + 1];
+    if (fromEnv) {
+      const envVar = fromEnv;
       accessToken = process.env[envVar];
       if (!accessToken) {
         console.error(`${c.red}Env var ${envVar} is empty${c.reset}`);

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -7,7 +7,7 @@
  */
 import { resolve } from "node:path";
 import { c } from "../utils/colors.js";
-import { hasFlag } from "../utils/flags.js";
+import { hasFlag, flagValue } from "../utils/flags.js";
 import { createPlugin } from "../create-plugin.js";
 import { cloneRepository } from "../clone.js";
 import { executeCommand } from "../run.js";
@@ -56,7 +56,7 @@ export async function cmdClone(): Promise<boolean> {
   const repoUrl = args[1];
   const targetDir = args[2];
   const noSetup = hasFlag(args, "--no-setup");
-  const environment = hasFlag(args, "--env") ? args[args.indexOf("--env") + 1] : "default";
+  const environment = flagValue(args, "--env") ?? "default";
 
   if (!repoUrl) {
     console.error(`${c.red}Usage: kit clone <repo-url> [directory]${c.reset}`);
@@ -154,13 +154,13 @@ export async function cmdRun(): Promise<boolean> {
     return false;
   }
 
-  // Extract environment name if provided (reserved for future use)
-  const envIndex = args.indexOf("--env");
-  if (envIndex !== -1 && envIndex < doubleDashIndex) {
-    // Environment flag parsed but not currently used in env var logic
-    // Can be extended in future to select environment-specific config
-  }
-
+  // `--env <name>` before the `--` is documented in the usage text above and does NOT select an
+  // environment: the block that used to sit here computed the flag's index, compared it against
+  // the separator, and had an empty body — "reserved for future use". Removed rather than left
+  // looking like parsing, because a documented flag whose handler is empty is the same shape as a
+  // flag that silently does nothing. Wiring it means passing the name into `executeCommand`, which
+  // is a behaviour change with its own decision to make.
+  //
   // Extract command and args after --
   const commandArgs = args.slice(doubleDashIndex + 1);
 

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -12,7 +12,7 @@
  */
 import { createInterface } from "node:readline/promises";
 import { c } from "../utils/colors.js";
-import { hasFlag } from "../utils/flags.js";
+import { hasFlag, flagValue } from "../utils/flags.js";
 import { loadConfig, type kitConfig, type SecretKeyConfig } from "../config.js";
 import { KIT_FILE, resolveConfigPath } from "../cli-shared.js";
 import { isNonInteractive } from "../environment.js";
@@ -950,12 +950,14 @@ async function cmdSecretsMigrate(): Promise<boolean> {
  */
 async function cmdSecretsVaultMigrate(): Promise<boolean> {
   const args = process.argv.slice(4);
-  const fromArg =
-    args.find((a) => a.startsWith("--from="))?.split("=")[1] ??
-    args[args.indexOf("--from") + 1] ??
-    "";
-  const toArg =
-    args.find((a) => a.startsWith("--to="))?.split("=")[1] ?? args[args.indexOf("--to") + 1] ?? "";
+  // Via flagValue, NOT `args[args.indexOf("--from") + 1]`: `indexOf` returns -1 when the flag is
+  // absent, so `+ 1` indexes args[0] and the FIRST TOKEN silently became the value. Measured:
+  // `kit secrets vault-migrate --to infisical` printed `From: --to` and went on to report
+  // `No keys with source="--to" found` instead of the usage text the `!fromArg` guard below is
+  // there to print. `--dry-run --to infisical` yielded `From: --dry-run` the same way. A missing
+  // required flag must reach that guard, not be filled in with whatever was typed first.
+  const fromArg = flagValue(args, "--from") ?? "";
+  const toArg = flagValue(args, "--to") ?? "";
   const dryRun = hasFlag(args, "--dry-run");
 
   if (hasFlag(args, "--help") || hasFlag(args, "-h") || !fromArg || !toArg) {

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -315,10 +315,8 @@ async function cmdSecretsOneCli(): Promise<boolean> {
     );
     return false;
   }
-  const hostIdx = args.indexOf("--host");
-  const pathIdx = args.indexOf("--path");
-  const hostPattern = hostIdx >= 0 ? args[hostIdx + 1] : undefined;
-  const pathPattern = pathIdx >= 0 ? args[pathIdx + 1] : undefined;
+  const hostPattern = flagValue(args, "--host");
+  const pathPattern = flagValue(args, "--path");
 
   if (!hostPattern) {
     console.error(`${c.red}--host required (e.g. api.stripe.com, api.openai.com).${c.reset}`);
@@ -489,18 +487,15 @@ async function readSecretValueFromVault(
 async function cmdSecretsRevokeOld(): Promise<boolean> {
   // kit secrets revoke-old --via supabase-mgmt-api --project <ref> --key-id <id>
   const args = process.argv.slice(4);
-  const viaIdx = args.indexOf("--via");
-  const via = viaIdx >= 0 ? args[viaIdx + 1] : undefined;
+  const via = flagValue(args, "--via");
   if (via !== "supabase-mgmt-api") {
     console.error(
       `${c.red}Usage: kit secrets revoke-old --via supabase-mgmt-api --project <ref> --key-id <id>${c.reset}`,
     );
     return false;
   }
-  const projectIdx = args.indexOf("--project");
-  const projectRef = projectIdx >= 0 ? args[projectIdx + 1] : process.env.SUPABASE_PROJECT_REF;
-  const keyIdIdx = args.indexOf("--key-id");
-  const keyId = keyIdIdx >= 0 ? args[keyIdIdx + 1] : undefined;
+  const projectRef = flagValue(args, "--project") ?? process.env.SUPABASE_PROJECT_REF;
+  const keyId = flagValue(args, "--key-id");
 
   if (!projectRef) {
     console.error(`${c.red}--project <ref> required (or set SUPABASE_PROJECT_REF).${c.reset}`);
@@ -559,9 +554,7 @@ async function cmdSecretsSet(): Promise<boolean> {
   const config = await loadConfig(resolveConfigPath());
 
   // Read value: --value <v> (visible in argv/ps) or --stdin (safer).
-  let value: string | undefined;
-  const valueIdx = args.indexOf("--value");
-  if (valueIdx >= 0) value = args[valueIdx + 1];
+  let value: string | undefined = flagValue(args, "--value");
   if (!value && hasFlag(args, "--stdin")) {
     value = await new Promise<string>((resolve) => {
       let buf = "";
@@ -579,8 +572,7 @@ async function cmdSecretsSet(): Promise<boolean> {
     return false;
   }
 
-  const storeIdx = args.indexOf("--store");
-  const storeOverride = storeIdx >= 0 ? args[storeIdx + 1] : undefined;
+  const storeOverride = flagValue(args, "--store");
   const backendOpts = pickBackendOpts(config.secrets ?? {}, keyName, { envFallback: true });
 
   const result = await setSecretValue(config.secrets, keyName, value, {
@@ -610,8 +602,7 @@ async function cmdSecretsPropagateStandalone(): Promise<boolean> {
     return false;
   }
 
-  const toIdx = args.indexOf("--to");
-  const targetSpec = toIdx >= 0 ? args[toIdx + 1] : undefined;
+  const targetSpec = flagValue(args, "--to");
   if (!targetSpec) {
     console.error(`${c.red}--to <targets> required${c.reset}`);
     return false;
@@ -625,9 +616,7 @@ async function cmdSecretsPropagateStandalone(): Promise<boolean> {
   }
 
   // Read value: --value <v>, --stdin, or interactive masked prompt.
-  let value: string | undefined;
-  const valueIdx = args.indexOf("--value");
-  if (valueIdx >= 0) value = args[valueIdx + 1];
+  let value: string | undefined = flagValue(args, "--value");
   if (!value && hasFlag(args, "--stdin")) {
     value = await new Promise<string>((resolve) => {
       let buf = "";
@@ -654,20 +643,20 @@ async function cmdSecretsPropagateStandalone(): Promise<boolean> {
 
   // Parse propagation options (same flag surface as rotate --propagate).
   const propOpts: PropagationOptions = {};
-  const envIdx = args.indexOf("--target-env");
-  if (envIdx >= 0) propOpts.env = args[envIdx + 1] as PropagationOptions["env"];
-  const flyAppIdx = args.indexOf("--fly-app");
-  if (flyAppIdx >= 0) propOpts.flyApp = args[flyAppIdx + 1];
-  const cfWorkerIdx = args.indexOf("--cf-worker");
-  if (cfWorkerIdx >= 0) propOpts.cfWorker = args[cfWorkerIdx + 1];
-  const railwayServiceIdx = args.indexOf("--railway-service");
-  if (railwayServiceIdx >= 0) propOpts.railwayService = args[railwayServiceIdx + 1];
-  const awsRegionIdx = args.indexOf("--aws-region");
-  if (awsRegionIdx >= 0) propOpts.awsRegion = args[awsRegionIdx + 1];
-  const ghRepoIdx = args.indexOf("--github-repo");
-  if (ghRepoIdx >= 0) propOpts.githubRepo = args[ghRepoIdx + 1];
-  const vercelScopeIdx = args.indexOf("--vercel-scope");
-  if (vercelScopeIdx >= 0) propOpts.vercelScope = args[vercelScopeIdx + 1];
+  const targetEnv = flagValue(args, "--target-env");
+  if (targetEnv !== undefined) propOpts.env = targetEnv as PropagationOptions["env"];
+  const flyApp = flagValue(args, "--fly-app");
+  if (flyApp !== undefined) propOpts.flyApp = flyApp;
+  const cfWorker = flagValue(args, "--cf-worker");
+  if (cfWorker !== undefined) propOpts.cfWorker = cfWorker;
+  const railwayService = flagValue(args, "--railway-service");
+  if (railwayService !== undefined) propOpts.railwayService = railwayService;
+  const awsRegion = flagValue(args, "--aws-region");
+  if (awsRegion !== undefined) propOpts.awsRegion = awsRegion;
+  const ghRepo = flagValue(args, "--github-repo");
+  if (ghRepo !== undefined) propOpts.githubRepo = ghRepo;
+  const vercelScope = flagValue(args, "--vercel-scope");
+  if (vercelScope !== undefined) propOpts.vercelScope = vercelScope;
 
   console.log(`${c.bold}${c.cyan}kit secrets propagate ${keyName}${c.reset}`);
   console.log(`${c.dim}${"─".repeat(50)}${c.reset}\n`);

--- a/src/commands/security.ts
+++ b/src/commands/security.ts
@@ -605,10 +605,8 @@ async function cmdSecurityCosts(): Promise<boolean> {
 async function cmdSecurityVerifyPull(): Promise<boolean> {
   // kit security verify-pull [--base <ref>] [--head <ref>] [--json]
   const args = process.argv.slice(4);
-  const baseIdx = args.indexOf("--base");
-  const headIdx = args.indexOf("--head");
-  const base = baseIdx >= 0 ? args[baseIdx + 1] : "HEAD~1";
-  const head = headIdx >= 0 ? args[headIdx + 1] : "HEAD";
+  const base = flagValue(args, "--base") ?? "HEAD~1";
+  const head = flagValue(args, "--head") ?? "HEAD";
   const jsonMode = hasFlag(args, "--json");
 
   const report = await auditPull(process.cwd(), base, head);

--- a/src/commands/security.ts
+++ b/src/commands/security.ts
@@ -12,7 +12,7 @@
  */
 import { resolve } from "node:path";
 import { c } from "../utils/colors.js";
-import { hasFlag } from "../utils/flags.js";
+import { hasFlag, flagValue } from "../utils/flags.js";
 import { loadConfig } from "../config.js";
 import { resolveConfigPath } from "../cli-shared.js";
 import { isNonInteractive } from "../environment.js";
@@ -44,37 +44,26 @@ async function cmdSecurityPrescan(): Promise<boolean> {
     return false;
   }
   const deep = hasFlag(process.argv, "--deep");
-  const excludeArg = process.argv.find((a) => a.startsWith("--exclude="));
-  const exclude = excludeArg
-    ? excludeArg
-        .slice("--exclude=".length)
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean)
-    : [];
-  const onlyArg = process.argv.find((a) => a.startsWith("--only="));
-  const onlyChecks = onlyArg
-    ? onlyArg
-        .slice("--only=".length)
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean)
-    : undefined;
-  const skipArg = process.argv.find((a) => a.startsWith("--skip="));
-  const skipChecks = skipArg
-    ? skipArg
-        .slice("--skip=".length)
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean)
-    : undefined;
-  const formatArg = process.argv.find((a) => a.startsWith("--format="))?.split("=")[1];
+  // Comma lists via flagValue so `--only a,b` works as well as `--only=a,b`. These read only the
+  // `=` spelling before, which made the conventional space form a silently ignored flag: the token
+  // after it is not `--`-prefixed, so `unknownFlags` skips it too and nothing complains.
+  const commaList = (name: string): string[] | undefined => {
+    const raw = flagValue(process.argv, name);
+    if (raw === undefined) return undefined;
+    return raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  };
+  const exclude = commaList("--exclude") ?? [];
+  const onlyChecks = commaList("--only");
+  const skipChecks = commaList("--skip");
+  const formatArg = flagValue(process.argv, "--format");
   const format: "text" | "json" = formatArg === "json" ? "json" : "text";
   // --vs-baseline=<path> turns prescan into a drift-detector: run once,
   // diff against a baseline JSONL, output ONLY new regressions, exit 1 if any.
   // Designed for cron / systemd-timer / GitHub Actions schedule.
-  const baselineArg = process.argv.find((a) => a.startsWith("--vs-baseline="));
-  const vsBaseline = baselineArg ? baselineArg.slice("--vs-baseline=".length) : undefined;
+  const vsBaseline = flagValue(process.argv, "--vs-baseline");
   const { runPrescan } = await import("../security-prescan.js");
 
   if (format === "text") {
@@ -203,7 +192,7 @@ async function cmdSecurityPrescanDiff(): Promise<boolean> {
     );
     return false;
   }
-  const formatArg = process.argv.find((a) => a.startsWith("--format="))?.split("=")[1];
+  const formatArg = flagValue(process.argv, "--format");
   const format: "text" | "json" = formatArg === "json" ? "json" : "text";
   const { loadReport, diffReports } = await import("../security-prescan.js");
 

--- a/src/commands/sentinel.ts
+++ b/src/commands/sentinel.ts
@@ -8,7 +8,7 @@ import { resolve, dirname } from "node:path";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { c } from "../utils/colors.js";
-import { hasFlag } from "../utils/flags.js";
+import { hasFlag, flagValue } from "../utils/flags.js";
 import { loadConfig, type kitConfig } from "../config.js";
 import { resolveConfigPath, buildHealthCtx } from "../cli-shared.js";
 import type { SentinelSummary } from "../sentinel.js";
@@ -117,8 +117,7 @@ async function cmdSentinelInstall(): Promise<boolean> {
     process.exitCode = 1;
     return false;
   }
-  const si = process.argv.indexOf("--schedule");
-  const schedule = si >= 0 ? process.argv[si + 1] : undefined;
+  const schedule = flagValue(process.argv, "--schedule");
   await mkdir(dirname(dest), { recursive: true });
   writeFileSync(dest, schedule ? sentinelWorkflow(schedule) : sentinelWorkflow());
   console.log(`${c.green}✓${c.reset} wrote .github/workflows/kit-sentinel.yml`);

--- a/src/exec-broker/broker.ts
+++ b/src/exec-broker/broker.ts
@@ -23,7 +23,8 @@
 //
 // Zero LLM, zero network. Deterministic + offline.
 
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
+import { resolve } from "node:path";
 import { checkFsWriteRealpath } from "./realpath-check.js";
 import type { OperationContext } from "../governance-middleware.js";
 import { appendAuditEventDirect } from "../audit.js";
@@ -277,14 +278,36 @@ function collectDenials(context: BrokerContext, policy: BrokerPolicy): string[] 
  *        unchanged (deliberate — see `pillar3-mcp-runtime-adoption-5.0.md` §5 step 1). This is NOT
  *        the false-green of a JSON policy waving an undeclared op through: that path stays
  *        fail-closed below.
- *   2. Else the unsigned `.kit-exec-broker.json` (nor `KIT_EXEC_BROKER_POLICY`):
- *      - absent → run UNMEDIATED (the original opt-in switch — a fresh install is never gated);
+ *   2. Else the unsigned `.kit-exec-broker.json` (nor `KIT_EXEC_BROKER_POLICY`), resolved under
+ *      the GOVERNED project's `opts.cwd` — not `process.cwd()`:
+ *      - absent → run UNMEDIATED (the original opt-in switch — a fresh install is never gated),
+ *        EXCEPT when `cwd` names a foreign tree and this process is itself brokered, where
+ *        absence is unknown rather than opt-out → default-DENY;
  *      - present but malformed → `loadBrokerPolicy` returns null → `brokerExec` default-DENIES;
  *      - present + valid → full `brokerExec` mediation.
  *
  * This is the drop-in every call site adopts to become broker-aware without changing behavior for
  * users who haven't opted in to EITHER source.
  */
+/**
+ * Is `cwd` a tree other than the one this process runs in? Compares REAL paths, because on
+ * macOS `/tmp` and `/var` are symlinks into `/private`: a lexical compare would call the SAME
+ * directory foreign and start default-denying ordinary same-project calls. An unresolvable
+ * path falls back to the lexical form, and `undefined` is never foreign — omitting `cwd` is
+ * how every existing caller behaves, and must stay a no-op.
+ */
+function foreignCwd(cwd: string | undefined): boolean {
+  if (cwd === undefined) return false;
+  const real = (p: string): string => {
+    try {
+      return realpathSync(p);
+    } catch {
+      return resolve(p);
+    }
+  };
+  return real(cwd) !== real(process.cwd());
+}
+
 export async function runBrokered<T>(
   context: BrokerContext,
   run: (scopedEnv: Record<string, string>) => Promise<T>,
@@ -316,7 +339,30 @@ export async function runBrokered<T>(
   }
 
   // 2. Unsigned JSON policy (original opt-in via file presence).
-  if (!existsSync(brokerPolicyPath(opts.policyOverride))) {
+  //    Both the presence probe and the load resolve against the GOVERNED project's cwd —
+  //    the same directory `brokerExec` measures fs writes against and `audit` files
+  //    evidence under. Reading the file from one tree while judging another is how a
+  //    caller with a policy got mediated by a caller without one.
+  if (!existsSync(brokerPolicyPath(opts.policyOverride, opts.cwd))) {
+    // Absence means "not configured" — but that is only a safe inference about the tree
+    // this PROCESS lives in. If the process itself is brokered and we are being asked to
+    // mediate a DIFFERENT tree that has no policy, absence is unknown, not permission:
+    // default-deny instead of passing through. Without this the cwd fix above would be a
+    // net loosening in one direction — before it, a server launched in a brokered A had
+    // A's policy (wrongly) applied to B, which denied a cross-project write for the wrong
+    // reason. Same outcome now, honest reason. An unbrokered process is unaffected: no
+    // policy at process.cwd() → passthrough, exactly as before.
+    if (foreignCwd(opts.cwd) && existsSync(brokerPolicyPath(opts.policyOverride))) {
+      return brokerExec(
+        context,
+        null,
+        run,
+        opts.cwd,
+        `no .kit-exec-broker.json in the governed project "${resolve(opts.cwd!)}" while this process ` +
+          `("${process.cwd()}") is itself brokered — refusing to treat a foreign tree's missing policy ` +
+          `as an opt-out, and refusing to judge it by this tree's policy`,
+      );
+    }
     // Not configured → unmediated passthrough (full env, no scoping).
     try {
       return { ok: true, result: await run(scopeEnv(Object.keys(process.env), process.env)) };
@@ -324,7 +370,7 @@ export async function runBrokered<T>(
       return { ok: false, reason: err instanceof Error ? err.message : String(err) };
     }
   }
-  return brokerExec(context, loadBrokerPolicy(opts.policyOverride), run, opts.cwd);
+  return brokerExec(context, loadBrokerPolicy(opts.policyOverride, opts.cwd), run, opts.cwd);
 }
 
 /**

--- a/src/exec-broker/policy-cwd.test.ts
+++ b/src/exec-broker/policy-cwd.test.ts
@@ -1,0 +1,282 @@
+// The unsigned broker policy must be resolved from the GOVERNED project's directory, not from
+// the calling process's. `runBrokered` has always taken a `cwd` — `brokerExec` measures fs
+// writes against it and `audit` files evidence under it — but path 2 (`.kit-exec-broker.json`)
+// resolved the file against `process.cwd()`, so a long-lived process mediating another tree
+// (the MCP server: `kit_secrets`, `kit_run`, `kit_triage` all pass a per-call `cwd`) read the
+// wrong policy, or none.
+//
+// EVERY test here is two-sided. Per ROADMAP: "a test that merely passes `cwd` proves nothing".
+// So each one is paired with its mirror image — the same call with the file in the other tree —
+// and asserts the OUTCOMES DIFFER. A build that ignores `cwd` makes the two sides agree and
+// fails the pair, which is the only way this stays fixed.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { brokerPolicyPath, loadBrokerPolicy, BROKER_POLICY_ENV } from "./policy.js";
+import { runBrokered } from "./broker.js";
+
+/** A valid policy whose write-root is `<dir>/allowed` and nothing else. */
+function policyAllowingOnly(dir: string): string {
+  return JSON.stringify({
+    egress: { allow: [] },
+    fs: { root: join(dir, "allowed") },
+    env: { declared: [] },
+  });
+}
+
+/** Two sibling temp dirs: A = the process's cwd, B = the governed project. */
+function twoProjects(): { base: string; A: string; B: string; cleanup: () => void } {
+  const base = mkdtempSync(join(tmpdir(), "broker-cwd-"));
+  const A = join(base, "A");
+  const B = join(base, "B");
+  mkdirSync(A);
+  mkdirSync(B);
+  return { base, A, B, cleanup: () => rmSync(base, { recursive: true, force: true }) };
+}
+
+/** Run `fn` with cwd = `dir` and the env override cleared, restoring both afterwards. */
+async function inCwd<T>(dir: string, fn: () => Promise<T> | T): Promise<T> {
+  const prevCwd = process.cwd();
+  const prevEnv = process.env[BROKER_POLICY_ENV];
+  delete process.env[BROKER_POLICY_ENV];
+  process.chdir(dir);
+  try {
+    return await fn();
+  } finally {
+    process.chdir(prevCwd);
+    if (prevEnv === undefined) delete process.env[BROKER_POLICY_ENV];
+    else process.env[BROKER_POLICY_ENV] = prevEnv;
+  }
+}
+
+test("broker policy resolves from the governed project's cwd, not process.cwd()", async (t) => {
+  await t.test("brokerPolicyPath: the two trees yield DIFFERENT paths", async () => {
+    const { A, B, cleanup } = twoProjects();
+    try {
+      await inCwd(A, () => {
+        const fromProcess = brokerPolicyPath();
+        const fromGoverned = brokerPolicyPath(undefined, B);
+        // The pair, not either alone: if `cwd` were ignored these would be equal.
+        assert.notEqual(fromGoverned, fromProcess);
+        assert.equal(fromGoverned, resolve(B, ".kit-exec-broker.json"));
+        assert.equal(fromProcess, resolve(A, ".kit-exec-broker.json"));
+      });
+    } finally {
+      cleanup();
+    }
+  });
+
+  await t.test("brokerPolicyPath: an explicit override still outranks cwd", async () => {
+    const { A, B, cleanup } = twoProjects();
+    try {
+      await inCwd(A, () => {
+        assert.equal(brokerPolicyPath(join(B, "explicit.json"), A), resolve(B, "explicit.json"));
+      });
+    } finally {
+      cleanup();
+    }
+  });
+
+  await t.test("brokerPolicyPath: KIT_EXEC_BROKER_POLICY still outranks cwd", async () => {
+    const { A, B, cleanup } = twoProjects();
+    try {
+      const prevCwd = process.cwd();
+      const prevEnv = process.env[BROKER_POLICY_ENV];
+      process.chdir(A);
+      process.env[BROKER_POLICY_ENV] = join(B, "from-env.json");
+      try {
+        assert.equal(brokerPolicyPath(undefined, A), resolve(B, "from-env.json"));
+      } finally {
+        process.chdir(prevCwd);
+        if (prevEnv === undefined) delete process.env[BROKER_POLICY_ENV];
+        else process.env[BROKER_POLICY_ENV] = prevEnv;
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
+  await t.test("loadBrokerPolicy: reads B's file and NOT A's", async () => {
+    const { A, B, cleanup } = twoProjects();
+    try {
+      writeFileSync(join(A, ".kit-exec-broker.json"), policyAllowingOnly(A));
+      writeFileSync(join(B, ".kit-exec-broker.json"), policyAllowingOnly(B));
+      await inCwd(A, () => {
+        const governed = loadBrokerPolicy(undefined, B);
+        const process_ = loadBrokerPolicy();
+        assert.equal(governed?.fs.root, join(B, "allowed"));
+        assert.equal(process_?.fs.root, join(A, "allowed"));
+        assert.notEqual(governed?.fs.root, process_?.fs.root);
+      });
+    } finally {
+      cleanup();
+    }
+  });
+
+  await t.test("loadBrokerPolicy: B has no file → null even though A does", async () => {
+    const { A, B, cleanup } = twoProjects();
+    try {
+      writeFileSync(join(A, ".kit-exec-broker.json"), policyAllowingOnly(A));
+      await inCwd(A, () => {
+        // Ignoring `cwd` would return A's policy here — a policy for the wrong tree.
+        assert.equal(loadBrokerPolicy(undefined, B), null);
+        assert.notEqual(loadBrokerPolicy(), null);
+      });
+    } finally {
+      cleanup();
+    }
+  });
+
+  // The regression that motivated the change: measured end-to-end, both directions.
+  await t.test("runBrokered: B's policy DENIES a write outside its own root", async () => {
+    const { A, B, cleanup } = twoProjects();
+    try {
+      writeFileSync(join(B, ".kit-exec-broker.json"), policyAllowingOnly(B));
+      // A deliberately has NO policy: before the fix this made path 2 read "not configured"
+      // and run the operation unmediated with full env, ignoring B's policy entirely.
+      let ran = false;
+      const out = await inCwd(A, () =>
+        runBrokered(
+          {
+            operation: "probe.write",
+            operationType: "write",
+            metadata: {},
+            fsWrites: [join(B, "outside-the-root.txt")],
+          },
+          async () => {
+            ran = true;
+            return "executed";
+          },
+          { cwd: B },
+        ),
+      );
+      assert.equal(out.ok, false, "a write outside B's declared root must be denied");
+      assert.equal(ran, false, "the operation must never have run");
+    } finally {
+      cleanup();
+    }
+  });
+
+  await t.test("runBrokered: B's policy ALLOWS a write inside its own root", async () => {
+    const { A, B, cleanup } = twoProjects();
+    try {
+      mkdirSync(join(B, "allowed"));
+      writeFileSync(join(B, ".kit-exec-broker.json"), policyAllowingOnly(B));
+      let ran = false;
+      const out = await inCwd(A, () =>
+        runBrokered(
+          {
+            operation: "probe.write",
+            operationType: "write",
+            metadata: {},
+            fsWrites: [join(B, "allowed", "inside.txt")],
+          },
+          async () => {
+            ran = true;
+            return "executed";
+          },
+          { cwd: B },
+        ),
+      );
+      // The mirror of the test above: same policy, same governed tree, different target.
+      // Both directions are needed — a guard that denies everything would pass the first.
+      assert.equal(out.ok, true, out.ok ? "" : `unexpectedly denied: ${out.reason}`);
+      assert.equal(ran, true, "the operation must have run");
+    } finally {
+      cleanup();
+    }
+  });
+
+  await t.test(
+    "runBrokered: a brokered process refuses a foreign tree with no policy",
+    async () => {
+      const { A, B, cleanup } = twoProjects();
+      try {
+        // A (this process) is brokered; B is not. Absence of a policy is only an opt-out for
+        // the tree the process lives in — for a foreign tree it is unknown, so: deny.
+        writeFileSync(join(A, ".kit-exec-broker.json"), policyAllowingOnly(A));
+        let ran = false;
+        const out = await inCwd(A, () =>
+          runBrokered(
+            {
+              operation: "probe.write",
+              operationType: "write",
+              metadata: {},
+              fsWrites: [join(B, "file.txt")],
+            },
+            async () => {
+              ran = true;
+              return "executed";
+            },
+            { cwd: B },
+          ),
+        );
+        assert.equal(out.ok, false);
+        assert.equal(ran, false);
+        assert.match(String(out.reason), /governed project/);
+      } finally {
+        cleanup();
+      }
+    },
+  );
+
+  await t.test("runBrokered: an UNBROKERED process still passes through, unchanged", async () => {
+    const { A, B, cleanup } = twoProjects();
+    try {
+      // Neither tree has a policy — the ordinary case for everyone who has not opted in.
+      // This must behave exactly as before the change, or the fix is a silent breaking change.
+      let ran = false;
+      const out = await inCwd(A, () =>
+        runBrokered(
+          {
+            operation: "probe.write",
+            operationType: "write",
+            metadata: {},
+            fsWrites: [join(B, "file.txt")],
+          },
+          async () => {
+            ran = true;
+            return "executed";
+          },
+          { cwd: B },
+        ),
+      );
+      assert.equal(out.ok, true, out.ok ? "" : `unexpectedly denied: ${out.reason}`);
+      assert.equal(ran, true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  await t.test("runBrokered: omitting cwd is identical to passing process.cwd()", async () => {
+    const { A, cleanup } = twoProjects();
+    try {
+      writeFileSync(join(A, ".kit-exec-broker.json"), policyAllowingOnly(A));
+      mkdirSync(join(A, "allowed"));
+      const call = (cwd?: string): Promise<{ ok: boolean }> =>
+        inCwd(A, () =>
+          runBrokered(
+            {
+              operation: "probe.write",
+              operationType: "write",
+              metadata: {},
+              fsWrites: [join(A, "allowed", "x.txt")],
+            },
+            async () => "executed",
+            cwd === undefined ? {} : { cwd },
+          ),
+        );
+      const omitted = await call();
+      const explicit = await call(A);
+      // The no-op guarantee in the docstring, asserted rather than asserted-in-prose.
+      assert.equal(omitted.ok, true);
+      assert.equal(explicit.ok, omitted.ok);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/exec-broker/policy.ts
+++ b/src/exec-broker/policy.ts
@@ -41,12 +41,25 @@ export const DEFAULT_BROKER_POLICY_FILE = ".kit-exec-broker.json";
 
 /**
  * Resolve the broker policy file path. Precedence: explicit `override` arg →
- * KIT_EXEC_BROKER_POLICY env → repo-local .kit-exec-broker.json under cwd.
+ * KIT_EXEC_BROKER_POLICY env → repo-local .kit-exec-broker.json under `cwd`.
+ *
+ * `cwd` is the GOVERNED PROJECT's directory, not the calling process's. They are the
+ * same thing on the CLI, and different the moment a long-lived process mediates an op
+ * for another tree — the MCP server, which passes a per-call `cwd` to `runBrokered`
+ * from `kit_secrets`, `kit_run` and `kit_triage`. Resolving the repo-local default
+ * against `process.cwd()` instead read the SERVER's policy (or, with no policy there,
+ * none at all) while claiming to mediate the target project: a server launched in A and
+ * asked to write B's `.env.local` ignored B's `.kit-exec-broker.json` entirely and,
+ * because "no policy file" means "not configured", ran the write unmediated with full
+ * env. Fail-OPEN, and the signed-profile path (`profileBrokerPolicy(opts.cwd ?? …)`)
+ * had always taken cwd — only this legacy JSON path had not.
+ *
+ * Defaulting to `process.cwd()` keeps every existing caller's behaviour identical.
  */
-export function brokerPolicyPath(override?: string): string {
+export function brokerPolicyPath(override?: string, cwd?: string): string {
   const chosen = override ?? process.env[BROKER_POLICY_ENV];
   if (chosen && chosen.length > 0) return resolve(chosen);
-  return resolve(process.cwd(), DEFAULT_BROKER_POLICY_FILE);
+  return resolve(cwd ?? process.cwd(), DEFAULT_BROKER_POLICY_FILE);
 }
 
 function isStringArray(v: unknown): v is string[] {
@@ -84,8 +97,8 @@ function validateBrokerPolicy(parsed: unknown): BrokerPolicy | null {
  * Load + parse + validate the broker policy. Returns null on absent, unreadable,
  * malformed, or wrong-typed input so brokerExec default-denies. Never throws.
  */
-export function loadBrokerPolicy(override?: string): BrokerPolicy | null {
-  const path = brokerPolicyPath(override);
+export function loadBrokerPolicy(override?: string, cwd?: string): BrokerPolicy | null {
+  const path = brokerPolicyPath(override, cwd);
   let raw: string;
   try {
     raw = readFileSync(path, "utf-8");

--- a/src/fix-cwd.test.ts
+++ b/src/fix-cwd.test.ts
@@ -1,0 +1,197 @@
+/**
+ * `kit fix` must write into the project it was asked to fix.
+ *
+ * `cmdFix` took no `cwd` at all: it loaded `.kit.toml` from `process.cwd()`, appended to the
+ * `process.cwd()` `.gitignore`, resolved `[secrets].template` against the process, and — the
+ * sharpest part — `lock.ts` had the asymmetry backwards. Its READ helpers (`readSkillsLock`,
+ * `readCliLock`, `readkitMeta`) all took a `cwd`; its WRITE helpers (`writeSkillsLock`,
+ * `writeCliLock`, `writekitMeta`, `ensurekitDir`) did not. So a caller with a project directory
+ * of its own read that project's locks and then wrote the calling process's. That is the ROADMAP
+ * symptom verbatim: "`kit_fix` was worse — it created B's lock files inside A."
+ *
+ * Each test below asserts on WHERE THE BYTES LANDED, in both trees, because "did it write
+ * something" passes just as well when it wrote to the wrong place. The negative half — nothing
+ * appeared in the process's own tree — is the half that fails when the parameter is dropped.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { cmdFix } from "./fix.js";
+
+/** A minimal project: no tools/services/skills/hooks, so fix only writes locks + files. */
+function project(extra = ""): string {
+  const dir = mkdtempSync(join(tmpdir(), "kit-fix-cwd-"));
+  writeFileSync(join(dir, ".kit.toml"), `version = 1\n${extra}`);
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name: "f", version: "1.0.0", private: true }) + "\n",
+  );
+  return dir;
+}
+
+/** Run with the process in `dir` and an isolated identity dir, restoring both. */
+async function inCwd<T>(dir: string, fn: () => Promise<T>): Promise<T> {
+  const prevCwd = process.cwd();
+  const prevId = process.env.KIT_IDENTITY_DIR;
+  const idDir = mkdtempSync(join(tmpdir(), "kit-fix-id-"));
+  // Never let a probe mint or touch the real ~/.kit identity key.
+  process.env.KIT_IDENTITY_DIR = idDir;
+  process.chdir(dir);
+  try {
+    return await fn();
+  } finally {
+    process.chdir(prevCwd);
+    if (prevId === undefined) delete process.env.KIT_IDENTITY_DIR;
+    else process.env.KIT_IDENTITY_DIR = prevId;
+    rmSync(idDir, { recursive: true, force: true });
+  }
+}
+
+describe("cmdFix writes into the project it was given", () => {
+  it("lock files land in the governed tree and NOT in the process's", async () => {
+    const A = project();
+    const B = project();
+    try {
+      await inCwd(A, () => cmdFix(B));
+
+      // Positive half: B got its locks.
+      assert.equal(
+        existsSync(join(B, ".kit", "skills-lock.json")),
+        true,
+        "B was the target and must have its skills lock",
+      );
+      assert.equal(existsSync(join(B, ".kit", "cli-lock.json")), true, "B must have its CLI lock");
+
+      // Negative half: this is what fails when the parameter is dropped. Before the fix the
+      // reads honoured `cwd` and the writes did not, so the bytes landed here instead.
+      assert.equal(
+        existsSync(join(A, ".kit", "skills-lock.json")),
+        false,
+        "A only hosted the process — it must not have gained B's skills lock",
+      );
+      assert.equal(
+        existsSync(join(A, ".kit", "cli-lock.json")),
+        false,
+        "A must not have gained B's CLI lock",
+      );
+    } finally {
+      rmSync(A, { recursive: true, force: true });
+      rmSync(B, { recursive: true, force: true });
+    }
+  });
+
+  it(".gitignore hardening edits the governed tree's file", async () => {
+    const A = project();
+    const B = project();
+    try {
+      // Both start with the same content, so the only way to tell them apart afterwards is
+      // which one grew.
+      writeFileSync(join(A, ".gitignore"), "node_modules\n");
+      writeFileSync(join(B, ".gitignore"), "node_modules\n");
+
+      await inCwd(A, () => cmdFix(B));
+
+      const aAfter = readFileSync(join(A, ".gitignore"), "utf-8");
+      const bAfter = readFileSync(join(B, ".gitignore"), "utf-8");
+      assert.equal(aAfter, "node_modules\n", "A's .gitignore must be untouched");
+      assert.notEqual(bAfter, "node_modules\n", "B's .gitignore must have been hardened");
+      assert.match(bAfter, /\.env/, "B's .gitignore must have gained the .env patterns");
+    } finally {
+      rmSync(A, { recursive: true, force: true });
+      rmSync(B, { recursive: true, force: true });
+    }
+  });
+
+  it("a relative [secrets].template is created in the governed tree", async () => {
+    const secrets =
+      '\n[secrets]\nstore = "env"\ntemplate = ".env.template"\n\n[secrets.keys.API_KEY]\nsource = "env"\n';
+    const A = project(secrets);
+    const B = project(secrets);
+    try {
+      await inCwd(A, () => cmdFix(B));
+
+      assert.equal(
+        existsSync(join(B, ".env.template")),
+        true,
+        "B declared the template and must have it created",
+      );
+      assert.equal(
+        existsSync(join(A, ".env.template")),
+        false,
+        "A must not have gained a template generated for B",
+      );
+      assert.match(readFileSync(join(B, ".env.template"), "utf-8"), /API_KEY=/);
+    } finally {
+      rmSync(A, { recursive: true, force: true });
+      rmSync(B, { recursive: true, force: true });
+    }
+  });
+
+  it("an existing template in the PROCESS's tree is not mistaken for the target's", async () => {
+    const secrets =
+      '\n[secrets]\nstore = "env"\ntemplate = ".env.template"\n\n[secrets.keys.API_KEY]\nsource = "env"\n';
+    const A = project(secrets);
+    const B = project(secrets);
+    try {
+      // A has the file; B does not. Probing the path against the process would report
+      // "Template .env.template exists" and skip generating B's — a silent no-op fix.
+      writeFileSync(join(A, ".env.template"), "SOMETHING_ELSE=\n");
+
+      await inCwd(A, () => cmdFix(B));
+
+      assert.equal(existsSync(join(B, ".env.template")), true, "B's template must be generated");
+      assert.match(readFileSync(join(B, ".env.template"), "utf-8"), /API_KEY=/);
+      assert.equal(
+        readFileSync(join(A, ".env.template"), "utf-8"),
+        "SOMETHING_ELSE=\n",
+        "A's template must be left exactly as it was",
+      );
+    } finally {
+      rmSync(A, { recursive: true, force: true });
+      rmSync(B, { recursive: true, force: true });
+    }
+  });
+
+  it("omitting cwd still fixes the process's own tree", async () => {
+    const A = project();
+    try {
+      // The backwards-compatibility guarantee: every existing caller passes nothing.
+      await inCwd(A, () => cmdFix());
+      assert.equal(
+        existsSync(join(A, ".kit", "skills-lock.json")),
+        true,
+        "the default must resolve to the process's own tree",
+      );
+    } finally {
+      rmSync(A, { recursive: true, force: true });
+    }
+  });
+
+  it("an existing lock in the process's tree does not suppress the target's", async () => {
+    const A = project();
+    const B = project();
+    try {
+      // A is already fixed; B is not. If the READ honoured cwd but the WRITE did not — the
+      // original asymmetry — this is the case that silently did nothing at all.
+      mkdirSync(join(A, ".kit"), { recursive: true });
+      writeFileSync(join(A, ".kit", "skills-lock.json"), '{"version":1,"skills":{}}\n');
+      writeFileSync(join(A, ".kit", "cli-lock.json"), '{"version":1,"tools":{}}\n');
+
+      await inCwd(A, () => cmdFix(B));
+
+      assert.equal(existsSync(join(B, ".kit", "skills-lock.json")), true);
+      assert.equal(
+        readFileSync(join(A, ".kit", "skills-lock.json"), "utf-8"),
+        '{"version":1,"skills":{}}\n',
+        "A's pre-existing lock must not be rewritten by a fix aimed at B",
+      );
+    } finally {
+      rmSync(A, { recursive: true, force: true });
+      rmSync(B, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/fix-cwd.test.ts
+++ b/src/fix-cwd.test.ts
@@ -195,3 +195,65 @@ describe("cmdFix writes into the project it was given", () => {
     }
   });
 });
+
+describe("a governed operation files its evidence in the governed tree", () => {
+  // `withGovernance` took no `cwd` and `logAuditEvent` resolved `.kit-audit.jsonl` against
+  // `process.cwd()`, so a fix performed FOR B recorded its proof in A. That is not cosmetic:
+  // `exec-broker/broker.ts`'s own `audit()` docstring says foreign-project records pollute the
+  // host repo's chain and poison `kit broker enforce-readiness`, "whose verdict is only as honest
+  // as the evidence file it reads". It was the last thing keeping the MCP cross-project refusal
+  // in place for `kit_fix`.
+  function governedProject(): string {
+    const dir = mkdtempSync(join(tmpdir(), "kit-audit-cwd-"));
+    writeFileSync(
+      join(dir, ".kit.toml"),
+      "version = 1\n\n[governance]\nenabled = true\n\n[governance.audit]\nenabled = true\n",
+    );
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "ga", version: "1.0.0", private: true }) + "\n",
+    );
+    return dir;
+  }
+
+  it("the audit line lands in B's chain and not in A's", async () => {
+    const A = governedProject();
+    const B = governedProject();
+    try {
+      await inCwd(A, () => cmdFix(B));
+
+      const bLog = join(B, ".kit-audit.jsonl");
+      const aLog = join(A, ".kit-audit.jsonl");
+
+      assert.equal(existsSync(bLog), true, "the governed project must carry the fix's evidence");
+      assert.match(
+        readFileSync(bLog, "utf-8"),
+        /"operation":\s*"fix"/,
+        "B's chain must contain the fix operation",
+      );
+      // The half that fails when the parameter is dropped: A merely hosted the process.
+      assert.equal(
+        existsSync(aLog),
+        false,
+        "A must not have gained an audit entry for an operation performed on B",
+      );
+    } finally {
+      rmSync(A, { recursive: true, force: true });
+      rmSync(B, { recursive: true, force: true });
+    }
+  });
+
+  it("omitting cwd still audits in the process's own tree", async () => {
+    const A = governedProject();
+    try {
+      await inCwd(A, () => cmdFix());
+      assert.equal(
+        existsSync(join(A, ".kit-audit.jsonl")),
+        true,
+        "the default must keep filing evidence where it always did",
+      );
+    } finally {
+      rmSync(A, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/fix.ts
+++ b/src/fix.ts
@@ -63,7 +63,7 @@ export async function cmdFix(cwd: string = process.cwd()): Promise<boolean> {
       // installHooks). withGovernance never consults read-only, so guard here.
       const { isReadOnlyMode, refuseWrite } = await import("./read-only-mode.js");
       if (isReadOnlyMode()) {
-        const refusal = await refuseWrite("fix");
+        const refusal = await refuseWrite("fix", {}, { cwd });
         console.log(`  ${c.yellow}!${c.reset} ${refusal.reason}`);
         return false;
       }
@@ -340,5 +340,7 @@ export async function cmdFix(cwd: string = process.cwd()): Promise<boolean> {
       console.log();
       return manualCount === 0;
     },
+    // Audit the fix in the tree being fixed, not in whatever directory the process sits in.
+    { cwd },
   );
 }

--- a/src/fix.ts
+++ b/src/fix.ts
@@ -31,11 +31,11 @@ export interface FixResult {
  *
  * Extracted from cli.ts (codebase-review follow-up).
  */
-export async function cmdFix(): Promise<boolean> {
+export async function cmdFix(cwd: string = process.cwd()): Promise<boolean> {
   console.log(`${c.bold}${c.cyan}kit fix${c.reset}`);
   console.log(`${c.dim}${"─".repeat(50)}${c.reset}\n`);
 
-  const config = await loadConfig(resolve(process.cwd(), ".kit.toml"));
+  const config = await loadConfig(resolve(cwd, ".kit.toml"));
 
   let fixedCount = 0;
   let manualCount = 0;
@@ -102,8 +102,8 @@ export async function cmdFix(): Promise<boolean> {
 
       // 2. Check and fix missing lock files
       console.log(`${c.bold}[2/6] Lock Files${c.reset}`);
-      const skillsLock = await readSkillsLock();
-      const cliLock = await readCliLock();
+      const skillsLock = await readSkillsLock(cwd);
+      const cliLock = await readCliLock(cwd);
 
       if (!skillsLock || !cliLock) {
         console.log(`${c.dim}Generating missing lock files...${c.reset}\n`);
@@ -118,10 +118,11 @@ export async function cmdFix(): Promise<boolean> {
             Object.assign(skills, config.skills.optional);
           }
 
-          const kitMeta = await readkitMeta();
+          const kitMeta = await readkitMeta(cwd);
           await updateSkillsLock(
             skills,
             kitMeta?.name ? `${kitMeta.name}@${kitMeta.version}` : undefined,
+            cwd,
           );
           console.log(`  ${c.green}✓${c.reset} Generated skills-lock.json`);
           fixedCount++;
@@ -139,7 +140,7 @@ export async function cmdFix(): Promise<boolean> {
             }
           }
 
-          await updateCliLock(tools);
+          await updateCliLock(tools, cwd);
           console.log(`  ${c.green}✓${c.reset} Generated cli-lock.json`);
           fixedCount++;
         }
@@ -181,7 +182,12 @@ export async function cmdFix(): Promise<boolean> {
 
       // 4. Generate .env.template if secrets keys configured but template missing
       console.log(`${c.bold}[4/6] Secrets Template${c.reset}`);
-      const templatePath = config.secrets?.template;
+      // `template` is a repo-relative path in .kit.toml, so both the existence probe and the
+      // write must resolve against the GOVERNED project. Bare `access(templatePath)` /
+      // `writeFile(templatePath)` resolved against the calling process, which is how a fix asked
+      // to repair B could report A's template as present — or create B's template inside A.
+      const templateRel = config.secrets?.template;
+      const templatePath = templateRel ? resolve(cwd, templateRel) : undefined;
       if (templatePath && config.secrets?.keys && Object.keys(config.secrets.keys).length > 0) {
         let templateExists: boolean;
         try {
@@ -223,7 +229,7 @@ export async function cmdFix(): Promise<boolean> {
       //    are ignored. Idempotent: only appends what's missing.
       console.log(`${c.bold}[5/6] .gitignore${c.reset}`);
       try {
-        const gitignorePath = resolve(process.cwd(), ".gitignore");
+        const gitignorePath = resolve(cwd, ".gitignore");
         let current = "";
         try {
           current = await readFile(gitignorePath, "utf-8");
@@ -272,7 +278,7 @@ export async function cmdFix(): Promise<boolean> {
       console.log(`${c.bold}[6/6] Git Hooks${c.reset}`);
       if (config.hooks && Object.keys(config.hooks).length > 0) {
         try {
-          const hookResults = await installHooks(config.hooks);
+          const hookResults = await installHooks(config.hooks, ".git", cwd);
           const installed = hookResults.filter((r) => r.action === "installed");
           const updated = hookResults.filter((r) => r.action === "updated");
           const failed = hookResults.filter((r) => r.action === "failed");

--- a/src/flag-form-parity.test.ts
+++ b/src/flag-form-parity.test.ts
@@ -193,3 +193,56 @@ describe("kit secrets vault-migrate requires --from and --to explicitly", () => 
     }
   });
 });
+
+describe("no production command re-introduces the hand-rolled argv pattern", () => {
+  /**
+   * The sweep that made the two spellings agree was ~45 call sites across 13 files. A behavioural
+   * test per flag is not maintainable, and the next command added would not be covered by one
+   * anyway. This is the invariant instead: production code may not extract a flag's VALUE by
+   * indexing past `indexOf("--flag")`. That single pattern is what dropped `--flag=value`
+   * everywhere, and it is what produced the `args[0]` bug in `vault-migrate` when the flag was
+   * absent and `indexOf` returned -1.
+   *
+   * Two legitimate uses are allowed by name, not by shape, so a new one has to be argued for:
+   *   - `indexOf("--")` — the pass-through separator, an index into the argv array rather than a
+   *     flag value (`project.ts` splits the command line on it).
+   *   - `gate.ts` — reads `--format` with an explicit `=`-first, `indexOf`-second pair that was
+   *     already correct before the sweep.
+   */
+  it("no `args[indexOf('--flag') + 1]` value extraction survives outside the allowlist", async () => {
+    const { readFileSync, readdirSync, statSync } = await import("node:fs");
+    const { join: pjoin, resolve: presolve } = await import("node:path");
+
+    const SRC = presolve(import.meta.dirname, "..", "src");
+    const ALLOWED_FILES = new Set(["gate.ts"]);
+
+    const walk = (dir: string): string[] =>
+      readdirSync(dir).flatMap((entry) => {
+        const full = pjoin(dir, entry);
+        if (statSync(full).isDirectory()) return walk(full);
+        return entry.endsWith(".ts") && !entry.endsWith(".test.ts") ? [full] : [];
+      });
+
+    const offenders: string[] = [];
+    for (const file of walk(SRC)) {
+      const name = file.split("/").pop()!;
+      if (ALLOWED_FILES.has(name) || name === "flags.ts") continue;
+      const lines = readFileSync(file, "utf8").split("\n");
+      lines.forEach((line, i) => {
+        const trimmed = line.trim();
+        // Comments explaining the old pattern are not the pattern.
+        if (trimmed.startsWith("//") || trimmed.startsWith("*")) return;
+        // The `--` separator is an index, not a value.
+        if (/indexOf\(\s*"--"\s*\)/.test(line)) return;
+        if (/indexOf\(\s*"--[a-z][a-z0-9-]*"\s*\)/.test(line)) {
+          offenders.push(`${file.replace(SRC, "src")}:${i + 1}: ${trimmed}`);
+        }
+      });
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      `use flagValue/flagInt instead of a hand-rolled indexOf:\n${offenders.join("\n")}`,
+    );
+  });
+});

--- a/src/flag-form-parity.test.ts
+++ b/src/flag-form-parity.test.ts
@@ -1,0 +1,195 @@
+/**
+ * A value-taking flag must mean the same thing spelled `--flag value` and `--flag=value`.
+ *
+ * kit had three different argv idioms for the same job: `indexOf` (space form only),
+ * `startsWith("--flag=")` (equals form only), and `flagValue` (both). Whichever one a command
+ * happened to use decided which spelling silently did nothing:
+ *
+ *   kit self-audit --format json    -> printed TEXT, not JSON  (`--format=json` worked)
+ *   kit team audit log --limit 3    -> printed `(limit: 50)`   (`--limit=3` worked)
+ *
+ * `unknownFlags` cannot catch this class. The flag itself is known and spelled correctly; only
+ * its VALUE evaporates, and the value token is not `--`-prefixed so nothing inspects it. The
+ * command then reports a confident default. That is the same defect shape as a check that
+ * silently does not run.
+ *
+ * These tests are BEHAVIOURAL, running the real CLI. A unit test over `flagValue` proves the
+ * helper works — which it always did — not that the call sites reach it, which is what was
+ * broken. Each test asserts the TWO SPELLINGS AGREE, so it fails if either idiom is
+ * reintroduced at the call site, in either direction.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Compiles to dist/flag-form-parity.test.js, so the built CLI is its sibling.
+const CLI = resolve(import.meta.dirname, "cli.js");
+
+function project(): string {
+  const dir = mkdtempSync(join(tmpdir(), "kit-flagform-"));
+  writeFileSync(join(dir, ".kit.toml"), "version = 1\n");
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name: "ff", version: "1.0.0", private: true }) + "\n",
+  );
+  return dir;
+}
+
+/** Run the built CLI with an isolated HOME + identity dir; stdout and stderr merged. */
+function kit(args: string[], cwd: string): string {
+  const home = mkdtempSync(join(tmpdir(), "kit-flagform-home-"));
+  try {
+    return execFileSync(process.execPath, [CLI, ...args], {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        HOME: home,
+        KIT_IDENTITY_DIR: join(home, ".kit"),
+        KIT_HIDE_HOOK_SKIP_BANNER: "1",
+      },
+    });
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string };
+    return String(err.stdout ?? "") + String(err.stderr ?? "");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+describe("value flags accept both --flag value and --flag=value", () => {
+  it("kit team audit log --limit: both spellings yield the same limit", () => {
+    const dir = project();
+    try {
+      const spaced = kit(["team", "audit", "log", "--limit", "3"], dir);
+      const equals = kit(["team", "audit", "log", "--limit=3"], dir);
+      // The pair is the assertion. `--limit 3` used to fall through to the default and print
+      // `(limit: 50)` while `--limit=3` printed `(limit: 3)`.
+      assert.match(spaced, /limit: 3\b/, "space form must be honoured");
+      assert.match(equals, /limit: 3\b/, "equals form must stay honoured");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("kit team audit log --limit: a non-numeric value falls back, never NaN", () => {
+    const dir = project();
+    try {
+      const out = kit(["team", "audit", "log", "--limit=abc"], dir);
+      assert.doesNotMatch(out, /limit: NaN/, "unparsable limit must not surface as NaN");
+      assert.match(out, /limit: 50\b/, "it must fall back to the documented default");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("kit self-audit --format: both spellings produce JSON", () => {
+    const dir = project();
+    try {
+      // Parse the payload rather than pattern-matching a line: the output can carry Node's
+      // ExperimentalWarning on stderr, and a per-line shape test is easy to get wrong in a way
+      // that reports a code defect that isn't there.
+      const isJson = (s: string): boolean => {
+        const start = s.indexOf("{");
+        const end = s.lastIndexOf("}");
+        if (start < 0 || end <= start) return false;
+        try {
+          return typeof JSON.parse(s.slice(start, end + 1)) === "object";
+        } catch {
+          return false;
+        }
+      };
+      const spaced = kit(["self-audit", "--format", "json"], dir);
+      const equals = kit(["self-audit", "--format=json"], dir);
+      // `--format json` used to print the human table: a documented CI flag that quietly
+      // produced unparsable output for whoever piped it into jq.
+      assert.equal(isJson(spaced), true, "space form must produce JSON");
+      assert.equal(isJson(equals), true, "equals form must stay producing JSON");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("kit secrets vault-migrate requires --from and --to explicitly", () => {
+  const config =
+    '[secrets]\nstore = "1password"\n\n' +
+    '[secrets.keys.API_KEY]\nsource = "1password"\nref = "op://v/i/f"\n';
+
+  function migrateProject(): string {
+    const dir = mkdtempSync(join(tmpdir(), "kit-vaultmig-"));
+    writeFileSync(join(dir, ".kit.toml"), config);
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "vm", version: "1.0.0", private: true }) + "\n",
+    );
+    return dir;
+  }
+
+  it("a missing --from prints usage instead of consuming the next token", () => {
+    const dir = migrateProject();
+    try {
+      const out = kit(["secrets", "vault-migrate", "--to", "infisical"], dir);
+      // `args[args.indexOf("--from") + 1]` indexed args[0] when the flag was absent, so this
+      // printed `From: --to` and then `No keys with source="--to" found` — never the usage the
+      // `!fromArg` guard exists to print.
+      assert.match(out, /Usage:/, "usage must be printed when --from is missing");
+      assert.doesNotMatch(out, /From: .*--to/, "a flag token must never become the value");
+      assert.doesNotMatch(out, /source="--to"/, "the missing value must not reach the config scan");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("a missing --from is not filled in by a preceding boolean flag either", () => {
+    const dir = migrateProject();
+    try {
+      const out = kit(["secrets", "vault-migrate", "--dry-run", "--to", "infisical"], dir);
+      assert.match(out, /Usage:/);
+      assert.doesNotMatch(out, /From: .*--dry-run/, "--dry-run must not become the source backend");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("a missing --to prints usage instead of consuming the next token", () => {
+    const dir = migrateProject();
+    try {
+      const out = kit(["secrets", "vault-migrate", "--from", "1password"], dir);
+      assert.match(out, /Usage:/);
+      assert.doesNotMatch(out, /To: .*--from/, "a flag token must never become the target");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("both spellings still resolve a complete invocation identically", () => {
+    const dir = migrateProject();
+    try {
+      const spaced = kit(
+        ["secrets", "vault-migrate", "--from", "1password", "--to", "infisical", "--dry-run"],
+        dir,
+      );
+      const equals = kit(
+        ["secrets", "vault-migrate", "--from=1password", "--to=infisical", "--dry-run"],
+        dir,
+      );
+      // The other half of the pair: tightening the guard must not break either working form.
+      for (const [label, out] of [
+        ["space", spaced],
+        ["equals", equals],
+      ] as const) {
+        assert.match(out, /From: .*1password/, `${label} form must resolve --from`);
+        assert.match(out, /To: .*infisical/, `${label} form must resolve --to`);
+        assert.doesNotMatch(out, /Usage:/, `${label} form must not fall back to usage`);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/governance-middleware.ts
+++ b/src/governance-middleware.ts
@@ -45,6 +45,7 @@ export async function withGovernance<T>(
   config: kitConfig,
   context: OperationContext,
   operation: () => Promise<T>,
+  opts: { cwd?: string } = {},
 ): Promise<T> {
   const startTime = Date.now();
   const governanceConfig = await mergeGovernanceConfigAsync(config.governance);
@@ -57,13 +58,17 @@ export async function withGovernance<T>(
   // Audit a denied operation with the shared event shape. DRYs the 5 pre-execute
   // deny paths below — each fails closed (audit, then throw).
   const auditDeny = (error: string, extra?: Record<string, unknown>) =>
-    logAuditEvent(governanceConfig, {
-      operation: context.operation,
-      environment: governanceConfig.environment,
-      success: false,
-      error,
-      metadata: extra ? { ...context.metadata, ...extra } : context.metadata,
-    });
+    logAuditEvent(
+      governanceConfig,
+      {
+        operation: context.operation,
+        environment: governanceConfig.environment,
+        success: false,
+        error,
+        metadata: extra ? { ...context.metadata, ...extra } : context.metadata,
+      },
+      { cwd: opts.cwd },
+    );
 
   // 1. Check revocation status
   const revoked = await checkRevocationStatus(config.governance);
@@ -167,12 +172,16 @@ export async function withGovernance<T>(
   // success log alone is fail-open (the op would run unlogged if the audit
   // append failed) — this closes that gap for the operations that matter most.
   if (context.destructive) {
-    const logged = await logAuditEvent(governanceConfig, {
-      operation: context.operation,
-      environment: governanceConfig.environment,
-      success: true,
-      metadata: { ...context.metadata, phase: "authorized" },
-    });
+    const logged = await logAuditEvent(
+      governanceConfig,
+      {
+        operation: context.operation,
+        environment: governanceConfig.environment,
+        success: true,
+        metadata: { ...context.metadata, phase: "authorized" },
+      },
+      { cwd: opts.cwd },
+    );
     if (!logged) {
       throw new Error("audit-log unavailable; refusing destructive operation (fail-closed)");
     }
@@ -188,14 +197,18 @@ export async function withGovernance<T>(
     error = err instanceof Error ? err.message : String(err);
 
     // Log failure
-    await logAuditEvent(governanceConfig, {
-      operation: context.operation,
-      environment: governanceConfig.environment,
-      success: false,
-      duration_ms: Date.now() - startTime,
-      error,
-      metadata: context.metadata,
-    });
+    await logAuditEvent(
+      governanceConfig,
+      {
+        operation: context.operation,
+        environment: governanceConfig.environment,
+        success: false,
+        duration_ms: Date.now() - startTime,
+        error,
+        metadata: context.metadata,
+      },
+      { cwd: opts.cwd },
+    );
 
     throw err;
   }
@@ -203,13 +216,17 @@ export async function withGovernance<T>(
   // 6. Record usage and log success
   await recordUsage(config.governance, context.estimatedTokens || 0);
 
-  await logAuditEvent(governanceConfig, {
-    operation: context.operation,
-    environment: governanceConfig.environment,
-    success: true,
-    duration_ms: Date.now() - startTime,
-    metadata: context.metadata,
-  });
+  await logAuditEvent(
+    governanceConfig,
+    {
+      operation: context.operation,
+      environment: governanceConfig.environment,
+      success: true,
+      duration_ms: Date.now() - startTime,
+      metadata: context.metadata,
+    },
+    { cwd: opts.cwd },
+  );
 
   return result;
 }
@@ -237,6 +254,7 @@ export async function runGoverned<T>(
   config: kitConfig,
   context: OperationContext,
   operation: () => Promise<T>,
+  opts: { cwd?: string } = {},
 ): Promise<GovernedOutcome<T>> {
   const startTime = Date.now();
   const governanceConfig = await mergeGovernanceConfigAsync(config.governance);
@@ -251,13 +269,17 @@ export async function runGoverned<T>(
   }
 
   const auditDeny = (error: string, extra?: Record<string, unknown>) =>
-    logAuditEvent(governanceConfig, {
-      operation: context.operation,
-      environment: governanceConfig.environment,
-      success: false,
-      error,
-      metadata: extra ? { ...context.metadata, ...extra } : context.metadata,
-    });
+    logAuditEvent(
+      governanceConfig,
+      {
+        operation: context.operation,
+        environment: governanceConfig.environment,
+        success: false,
+        error,
+        metadata: extra ? { ...context.metadata, ...extra } : context.metadata,
+      },
+      { cwd: opts.cwd },
+    );
 
   // 1. Revocation
   if (await checkRevocationStatus(config.governance)) {
@@ -307,24 +329,32 @@ export async function runGoverned<T>(
   try {
     const result = await operation();
     await recordUsage(config.governance, context.estimatedTokens || 0);
-    await logAuditEvent(governanceConfig, {
-      operation: context.operation,
-      environment: governanceConfig.environment,
-      success: true,
-      duration_ms: Date.now() - startTime,
-      metadata: context.metadata,
-    });
+    await logAuditEvent(
+      governanceConfig,
+      {
+        operation: context.operation,
+        environment: governanceConfig.environment,
+        success: true,
+        duration_ms: Date.now() - startTime,
+        metadata: context.metadata,
+      },
+      { cwd: opts.cwd },
+    );
     return { ok: true, result };
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
-    await logAuditEvent(governanceConfig, {
-      operation: context.operation,
-      environment: governanceConfig.environment,
-      success: false,
-      duration_ms: Date.now() - startTime,
-      error,
-      metadata: context.metadata,
-    });
+    await logAuditEvent(
+      governanceConfig,
+      {
+        operation: context.operation,
+        environment: governanceConfig.environment,
+        success: false,
+        duration_ms: Date.now() - startTime,
+        error,
+        metadata: context.metadata,
+      },
+      { cwd: opts.cwd },
+    );
     return { ok: false, reason: error };
   }
 }
@@ -354,7 +384,7 @@ export async function runGovernedBrokered<T>(
   const outcome = await runBrokered(
     context,
     async () => {
-      const gov = await runGoverned(config, context, operation);
+      const gov = await runGoverned(config, context, operation, { cwd: opts.cwd });
       // Signal a governance denial (or op error) as a throw so the broker layer
       // surfaces it as a not-ok outcome with the same reason.
       if (!gov.ok) throw new Error(gov.reason ?? "denied");

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -16,8 +16,8 @@ import { kitWrapperPath } from "./kit-wrapper.js";
  * process cwd, so temp-dir tests that pass an absolute throwaway gitDir fall
  * back to `<gitDir>/hooks` even when the kit repo itself sets hooksPath.
  */
-export function resolveHooksDir(gitDir = ".git"): string {
-  const repoRoot = isAbsolute(gitDir) ? dirname(gitDir) : process.cwd();
+export function resolveHooksDir(gitDir = ".git", cwd = process.cwd()): string {
+  const repoRoot = isAbsolute(gitDir) ? dirname(gitDir) : cwd;
   try {
     const hp = execFileSync("git", ["-C", repoRoot, "config", "--get", "core.hooksPath"], {
       encoding: "utf-8",
@@ -27,7 +27,7 @@ export function resolveHooksDir(gitDir = ".git"): string {
   } catch {
     /* not a git repo, hooksPath unset, or git absent — fall back below */
   }
-  return resolve(process.cwd(), gitDir, "hooks");
+  return resolve(cwd, gitDir, "hooks");
 }
 
 /**
@@ -55,6 +55,7 @@ export interface HookInstallResult {
 export async function installHooks(
   config: HooksConfig,
   gitDir = ".git",
+  cwd = process.cwd(),
 ): Promise<HookInstallResult[]> {
   // Read-only mode: hooks are writes to .git/hooks/. Refuse + audit.
   const { isReadOnlyMode, refuseWrite } = await import("./read-only-mode.js");
@@ -65,7 +66,7 @@ export async function installHooks(
     return [{ hookName: "read-only-refusal", action: "failed", detail: refusal.reason }];
   }
   const results: HookInstallResult[] = [];
-  const hooksDir = resolveHooksDir(gitDir);
+  const hooksDir = resolveHooksDir(gitDir, cwd);
 
   // Ensure hooks directory exists
   try {
@@ -348,9 +349,10 @@ exit 0
 export async function uninstallHooks(
   hookNames: string[],
   gitDir = ".git",
+  cwd = process.cwd(),
 ): Promise<HookInstallResult[]> {
   const results: HookInstallResult[] = [];
-  const hooksDir = resolveHooksDir(gitDir);
+  const hooksDir = resolveHooksDir(gitDir, cwd);
 
   for (const hookName of hookNames) {
     const hookPath = resolve(hooksDir, hookName);

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -60,9 +60,11 @@ export async function installHooks(
   // Read-only mode: hooks are writes to .git/hooks/. Refuse + audit.
   const { isReadOnlyMode, refuseWrite } = await import("./read-only-mode.js");
   if (isReadOnlyMode()) {
-    const refusal = await refuseWrite("install-hooks", {
-      hook_count: Object.keys(config).length,
-    });
+    const refusal = await refuseWrite(
+      "install-hooks",
+      { hook_count: Object.keys(config).length },
+      { cwd },
+    );
     return [{ hookName: "read-only-refusal", action: "failed", detail: refusal.reason }];
   }
   const results: HookInstallResult[] = [];

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -63,8 +63,8 @@ function getkitDir(cwd?: string): string {
 /**
  * Ensure .kit directory exists
  */
-async function ensurekitDir(): Promise<void> {
-  const dir = getkitDir();
+async function ensurekitDir(cwd?: string): Promise<void> {
+  const dir = getkitDir(cwd);
   if (!existsSync(dir)) {
     await mkdir(dir, { recursive: true });
   }
@@ -93,9 +93,9 @@ export async function readSkillsLock(cwd?: string): Promise<SkillsLock | null> {
 /**
  * Write skills lock file
  */
-export async function writeSkillsLock(lock: SkillsLock): Promise<void> {
-  await ensurekitDir();
-  const lockPath = resolve(getkitDir(), SKILLS_LOCK_FILE);
+export async function writeSkillsLock(lock: SkillsLock, cwd?: string): Promise<void> {
+  await ensurekitDir(cwd);
+  const lockPath = resolve(getkitDir(cwd), SKILLS_LOCK_FILE);
 
   try {
     const content = JSON.stringify(lock, null, 2) + "\n";
@@ -130,9 +130,9 @@ export async function readCliLock(cwd?: string): Promise<CliLock | null> {
 /**
  * Write CLI lock file
  */
-export async function writeCliLock(lock: CliLock): Promise<void> {
-  await ensurekitDir();
-  const lockPath = resolve(getkitDir(), CLI_LOCK_FILE);
+export async function writeCliLock(lock: CliLock, cwd?: string): Promise<void> {
+  await ensurekitDir(cwd);
+  const lockPath = resolve(getkitDir(cwd), CLI_LOCK_FILE);
 
   try {
     const content = JSON.stringify(lock, null, 2) + "\n";
@@ -167,9 +167,9 @@ export async function readkitMeta(cwd?: string): Promise<kitMeta | null> {
 /**
  * Write kit metadata file
  */
-export async function writekitMeta(meta: kitMeta): Promise<void> {
-  await ensurekitDir();
-  const metaPath = resolve(getkitDir(), KIT_META_FILE);
+export async function writekitMeta(meta: kitMeta, cwd?: string): Promise<void> {
+  await ensurekitDir(cwd);
+  const metaPath = resolve(getkitDir(cwd), KIT_META_FILE);
 
   try {
     const content = JSON.stringify(meta, null, 2) + "\n";
@@ -250,8 +250,9 @@ function parseSkillVersion(
 export async function updateSkillsLock(
   skills: Record<string, string>,
   kit?: string,
+  cwd?: string,
 ): Promise<void> {
-  const existing = await readSkillsLock();
+  const existing = await readSkillsLock(cwd);
 
   const lock: SkillsLock = {
     version: 1,
@@ -278,7 +279,7 @@ export async function updateSkillsLock(
     };
   }
 
-  await writeSkillsLock(lock);
+  await writeSkillsLock(lock, cwd);
 }
 
 /**
@@ -286,8 +287,9 @@ export async function updateSkillsLock(
  */
 export async function updateCliLock(
   tools: Record<string, { version: string; source: CliLockEntry["source"]; auth?: string }>,
+  cwd?: string,
 ): Promise<void> {
-  const existing = await readCliLock();
+  const existing = await readCliLock(cwd);
 
   const lock: CliLock = {
     version: 1,
@@ -309,7 +311,7 @@ export async function updateCliLock(
     };
   }
 
-  await writeCliLock(lock);
+  await writeCliLock(lock, cwd);
 }
 
 /**

--- a/src/mcp-server.test.ts
+++ b/src/mcp-server.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, before, after, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, writeFile, rm, mkdir, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -715,48 +716,111 @@ describe("kit_init", () => {
 
 // ─── kit_map ───────────────────────────────────────────────────────────────
 /**
- * A cross-project `cwd` used to be answered rather than refused.
+ * A cross-project `cwd` is SERVED now. It used to be answered wrongly, then refused, and these
+ * tests are what changed the third time.
  *
- * The probe that found it: give project A a complete `.gitignore` and project B none, launch the
- * server in A, then call `kit_check({cwd: B})`. It replied
+ * The probe that found the original defect: give project A a complete `.gitignore` and project B
+ * none, launch the server in A, then call `kit_check({cwd: B})`. It replied
  * `pass — all .env patterns in .gitignore` about a project with no .gitignore at all — a security
- * pass earned by the wrong tree. `runCheckGate` resolves `cwd` only to load `.kit.toml`; every
- * dimension after that (`checkSecurity()`, `checkHooks()`, `checkTests()`, `isGitRepository()`)
- * resolves from `process.cwd()`.
+ * pass earned by the wrong tree. `kit_fix` was worse: it created B's lock files inside A. A
+ * refusal guard stood in for the fix while `cwd` was threaded through the dimensions, the lock
+ * writers, the design scan and the audit destination.
  *
- * Until cwd is threaded through all ten dimensions, the tools fail CLOSED. These tests pin both
- * halves: the mismatch is refused, and the two forms that were always correct still work.
+ * These tests are the ones that justify removing that guard, so they are written to fail if any of
+ * it regresses: the server's `process.cwd()` is the kit repo, `other` is a temp project, and each
+ * assertion is about `other`'s contents specifically — not merely that a call succeeded. A build
+ * that reverted any part of the threading answers about the kit repo instead and fails here.
  */
-describe("process-scoped tools refuse a cross-project cwd", () => {
+describe("process-scoped tools serve a cross-project cwd", () => {
   let other: string;
 
   before(async () => {
     other = await mkdtemp(join(tmpdir(), "kit-mcp-other-"));
     await writeFile(join(other, ".kit.toml"), FIXTURE_EMPTY, "utf-8");
+    // Deliberately NO .gitignore: the kit repo the server runs in has a complete one, so this is
+    // the discriminating fixture. "warn" here means the answer came from `other`; "pass" would
+    // mean it came from the server's own tree.
   });
 
   after(async () => {
     await rm(other, { recursive: true, force: true });
   });
 
-  for (const tool of ["kit_check", "kit_review", "kit_fix"]) {
-    it(`${tool} refuses a cwd that is not the server's own`, async () => {
-      const { client, cleanup } = await createTestClient();
-      try {
-        const result = await client.callTool({ name: tool, arguments: { cwd: other } });
-        assert.equal(result.isError, true, `${tool} must report an error`);
-        const data = parseResult(result) as { ok: boolean; error: string; fix: string };
-        assert.equal(data.ok, false);
-        assert.match(data.error, new RegExp(tool));
-        // The message must name BOTH directories — an operator cannot act on "wrong cwd".
-        assert.ok(data.error.includes(other), "names the requested cwd");
-        assert.ok(data.error.includes(process.cwd()), "names the server's cwd");
-        assert.match(data.fix, /omit cwd|kit check/);
-      } finally {
-        await cleanup();
-      }
-    });
-  }
+  it("kit_check reports the REQUESTED project's gitignore state, not the server's", async () => {
+    const { client, cleanup } = await createTestClient();
+    try {
+      const result = await client.callTool({ name: "kit_check", arguments: { cwd: other } });
+      assert.notEqual(result.isError, true, "a cross-project check is served, not refused");
+      const data = parseResult(result) as {
+        security?: { name: string; status: string; detail?: string }[];
+      };
+      const row = (data.security ?? []).find((c) => c.name.includes("gitignore"));
+      assert.ok(row, "the security dimension must report a gitignore row");
+      assert.notEqual(
+        row.status,
+        "pass",
+        `a project with no .gitignore must not get the server repo's pass (got ${row.status}: ${row.detail})`,
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("kit_review's design stage describes the requested project", async () => {
+    const { client, cleanup } = await createTestClient();
+    try {
+      const result = await client.callTool({
+        name: "kit_review",
+        arguments: { cwd: other, stages: ["design"] },
+      });
+      assert.notEqual(result.isError, true);
+      const data = parseResult(result) as {
+        stages: { stage: string; findings: { detail?: string }[] }[];
+      };
+      const design = data.stages.find((s) => s.stage === "design");
+      assert.ok(design, "the design stage must be present");
+      // The kit repo has hundreds of components; `other` has no src/ at all. Reporting the repo's
+      // findings for `other` is the exact false green the guard was standing in for.
+      const text = JSON.stringify(design.findings);
+      assert.doesNotMatch(
+        text,
+        /\.tsx|\.jsx/,
+        `a project with no components must not be described by the server repo's files: ${text}`,
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("kit_fix writes into the requested project and leaves the server's tree alone", async () => {
+    const { client, cleanup } = await createTestClient();
+    const serverLock = join(process.cwd(), ".kit", "skills-lock.json");
+    const serverLockBefore = existsSync(serverLock)
+      ? await readFile(serverLock, "utf-8")
+      : undefined;
+    try {
+      const result = await client.callTool({ name: "kit_fix", arguments: { cwd: other } });
+      assert.notEqual(result.isError, true);
+
+      assert.equal(
+        existsSync(join(other, ".kit", "skills-lock.json")),
+        true,
+        "the requested project must receive its lock files",
+      );
+      // The negative half, and the one that matters: this test runs inside the kit repo, so a
+      // regression would rewrite the repo's OWN lock file. Compare content, not just presence.
+      const serverLockAfter = existsSync(serverLock)
+        ? await readFile(serverLock, "utf-8")
+        : undefined;
+      assert.equal(
+        serverLockAfter,
+        serverLockBefore,
+        "the server's own lock file must be untouched by a fix aimed elsewhere",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
 
   it("an ABSENT cwd is still fine — the common case must not regress", async () => {
     const { client, cleanup } = await createTestClient();
@@ -764,7 +828,7 @@ describe("process-scoped tools refuse a cross-project cwd", () => {
       const result = await client.callTool({ name: "kit_check", arguments: {} });
       assert.notEqual(result.isError, true);
       const data = parseResult(result) as { dimensions: Record<string, boolean> };
-      assert.ok(data.dimensions, "a real verdict, not a refusal");
+      assert.ok(data.dimensions, "a real verdict");
     } finally {
       await cleanup();
     }
@@ -773,8 +837,9 @@ describe("process-scoped tools refuse a cross-project cwd", () => {
   it("a cwd EQUAL to the server's is fine, including a non-normalised spelling", async () => {
     const { client, cleanup } = await createTestClient();
     try {
-      // `<cwd>/.` resolves to the same directory — the guard compares resolved paths, not strings,
-      // so a client that appends a separator or a "." is not punished for spelling.
+      // `<cwd>/.` resolves to the same directory. This was a guard-era regression test (a lexical
+      // compare refused the same directory spelled differently); it is kept because the spelling
+      // must still resolve correctly now that it is threaded rather than compared.
       const result = await client.callTool({
         name: "kit_check",
         arguments: { cwd: join(process.cwd(), ".") },

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -97,11 +97,27 @@ function readOnlyRefusal(tool: string): {
  * `pass — all .env patterns in .gitignore` for a project that has no .gitignore at all. A client
  * asking about B got a security pass earned by A. That is the worst shape a gate can fail in.
  *
- * The real fix is to thread `cwd` through all ten dimensions and their callees; that is a wide
- * refactor of kit's most-used path and belongs in its own change (ROADMAP). Until then this fails
- * CLOSED: a cross-project call gets an actionable error instead of a verdict about the wrong tree.
- * Nothing that previously worked breaks — a client that launches the server inside the project it
- * asks about (what Claude Code does) passes a `cwd` equal to `process.cwd()`, or omits it.
+ * STATUS: the read path is now threaded, and this guard still stands anyway.
+ *
+ * `runCheckGate` passes `cwd` to every dimension that touches the filesystem — `checkSecurity`
+ * (all fifteen sub-checks AND all seven scanner spawns, which resolve `.` against the spawned
+ * process), `checkSecrets`, `checkHooks`, `isGitRepository`, `checkLockFiles`, `checkTests`,
+ * `loadBaselineForGate`, `checkExternalFindings`, `checkGateLiveness`. The other four dimensions
+ * were measured to touch no project path at all: `checkTools` resolves binaries on PATH,
+ * `checkSkills` reads an absolute homedir path, `checkServices` and `checkWebSearch` neither.
+ * `check-security-cwd.test.ts` proves it behaviourally, in both directions.
+ *
+ * What still blocks lifting the refusal, and why it is not lifted here:
+ *   - `kit_fix` WRITES. `cmdFix` takes no `cwd` and loads `.kit.toml` from `process.cwd()`, so a
+ *     cross-project fix would still create B's lock files inside A — the original symptom.
+ *   - `kit_review` runs its own collector, not `runCheckGate` alone.
+ *   - Relaxing a fail-closed access boundary is a deliberate decision with its own tests, not a
+ *     tail-end edit to a change that was fixing something else.
+ *
+ * So this still fails CLOSED: a cross-project call gets an actionable error instead of a verdict
+ * about the wrong tree. Nothing that previously worked breaks — a client that launches the server
+ * inside the project it asks about (what Claude Code does) passes a `cwd` equal to
+ * `process.cwd()`, or omits it.
  */
 function crossProjectRefusal(
   cwd: string | undefined,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -143,18 +143,24 @@ function readOnlyRefusal(tool: string): {
  *   - end to end over the real MCP protocol: the `serves a cross-project cwd` block in
  *     `mcp-server.test.ts`, driving a client against a server whose `process.cwd()` is A.
  *
- * And what it does NOT cover, which is the weakest link in this decision and belongs in the same
- * comment rather than a nicer one: the scanner subprocesses are not proven against the real tools.
- * trivy, semgrep, osv-scanner and guarddog are absent from CI, so their coverage is a chain of two
- * — a source-level guard that every `execFileNoThrow` in `check-security.ts` passes `cwd: root`,
- * plus a behavioural test that the option actually relocates a child process. That is weaker than
- * running trivy against two trees and observing which one it read.
+ *   - a REAL scanner subprocess: `semgrep` is run over two trees, one tripping a local rule and
+ *     one clean, and the verdicts must differ. `semgrep .` resolves "." against the spawned
+ *     process, so this is the direct proof that `cwd: root` is what decides which tree is read.
  *
- * One write was found only by enumerating writes, because no probe here could reach it:
- * `logSupplyChainFindings` appends bumblebee findings to `<root>/.kit-findings.jsonl` and was
- * called without a `cwd`, so a check run FOR another project appended that project's findings to
- * the caller's file. Bumblebee is not installed in the probe environment, so the branch never ran.
- * A behavioural probe is not a substitute for reading the write surface.
+ * What it does NOT cover: trivy, osv-scanner and guarddog are distributed as GitHub release
+ * binaries, and this environment answers 403 for any repository outside the session's allowlist,
+ * so they cannot be fetched here. Their coverage is the chain of three — every `execFileNoThrow`
+ * in `check-security.ts` passes `cwd: root` (source guard), the option demonstrably relocates a
+ * child process, and semgrep demonstrably honours it end to end. Strong by inference, not
+ * measured per tool. Anyone with those binaries installed should re-run the cross-project probe.
+ *
+ * One write was found only by enumerating the write surface, and the reason no probe reached it is
+ * worth stating precisely: `logSupplyChainFindings` appends bumblebee findings to
+ * `<root>/.kit-findings.jsonl` and was called without a `cwd`. Bumblebee IS provisioned here
+ * (under `~/.kit/tools/bumblebee/<version>/`) and does run — but the write is gated on
+ * `findings.length > 0`, and a freshly created temp project has no known exposures, so the branch
+ * is unreachable from any clean fixture. A green probe over a clean fixture says nothing about the
+ * paths only a dirty one reaches.
  */
 
 /** Refusal result for a mutating tool blocked by the governance floor (revocation,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -107,9 +107,20 @@ function readOnlyRefusal(tool: string): {
  * `checkSkills` reads an absolute homedir path, `checkServices` and `checkWebSearch` neither.
  * `check-security-cwd.test.ts` proves it behaviourally, in both directions.
  *
+ * `kit_fix`'s write path is threaded too, on both surfaces: `cmdFix(cwd)` for the CLI, and the
+ * copy of the lock step inside `register_kit_fix` below — which `cmdFix`'s fix did NOT reach,
+ * because that handler reimplements the step to return structured actions instead of console
+ * output. `lock.ts` had the asymmetry the wrong way round: its readers took a `cwd` and its
+ * WRITERS did not, so a caller read its own project's locks and wrote the process's.
+ * `fix-cwd.test.ts` asserts where the bytes landed, in both trees.
+ *
  * What still blocks lifting the refusal, and why it is not lifted here:
- *   - `kit_fix` WRITES. `cmdFix` takes no `cwd` and loads `.kit.toml` from `process.cwd()`, so a
- *     cross-project fix would still create B's lock files inside A — the original symptom.
+ *   - The AUDIT DESTINATION. `withGovernance` takes no `cwd` and `logAuditEvent` has none either,
+ *     so a cross-project write would be recorded in the calling process's `.kit-audit.jsonl`.
+ *     `exec-broker/broker.ts`'s own `audit()` docstring already names why that matters: evidence
+ *     from other projects pollutes the host repo's chain and poisons
+ *     `kit broker enforce-readiness`, "whose verdict is only as honest as the evidence file it
+ *     reads". A write served for B whose proof lands in A is not a write kit can stand behind.
  *   - `kit_review` runs its own collector, not `runCheckGate` alone.
  *   - Relaxing a fail-closed access boundary is a deliberate decision with its own tests, not a
  *     tail-end edit to a change that was fixing something else.
@@ -416,19 +427,24 @@ function register_kit_fix(server: McpServer): void {
           .string()
           .optional()
           .describe(
-            "Working directory. Must equal the server process's own cwd (or be omitted): the lock-file writes resolve paths from the process, so a different value is REFUSED rather than written into the wrong project.",
+            "Working directory. Must equal the server process's own cwd (or be omitted): a different value is REFUSED. The lock-file writes now resolve from this argument, but the governance audit trail does not, so a cross-project fix would leave its proof in the wrong project.",
           ),
       },
     },
     async ({ cwd }) => {
       if (isReadOnlyMode()) return readOnlyRefusal("kit_fix");
-      // Worse than a wrong verdict: a wrong-target WRITE. The lock-file helpers resolve from
-      // process.cwd() (see the comment on the lock step below), so cwd=B created B's lock files
-      // inside A. Refuse the mismatch rather than write into the wrong project.
+      // Worse than a wrong verdict: a wrong-target WRITE. The lock-file helpers resolved from
+      // process.cwd(), so cwd=B created B's lock files inside A. Those writes are threaded now
+      // (see the lock step below), but the AUDIT destination is not — `withGovernance` takes no
+      // cwd — so a cross-project fix would still file its evidence in the wrong project. Still
+      // refused, for that reason rather than the original one.
       const scoped = crossProjectRefusal(cwd, "kit_fix");
       if (scoped) return scoped;
       try {
         const config = await loadConfig(configPath(cwd));
+        // One resolution, used by both the broker context and the lock step below — two
+        // independent `cwd ?? process.cwd()` expressions is how they drift apart.
+        const target = cwd ?? process.cwd();
 
         const gov = await runGovernedBrokered(
           config,
@@ -456,19 +472,23 @@ function register_kit_fix(server: McpServer): void {
               }
             }
 
-            // Fix missing lock files (lock functions use process.cwd())
-            const skillsLock = await readSkillsLock();
-            const cliLock = await readCliLock();
+            // Fix missing lock files. This handler carries its OWN copy of the lock step rather
+            // than calling `cmdFix` (it needs structured actions, not console output), which means
+            // threading `cwd` through `cmdFix` did NOT reach here — the same CLI-vs-MCP divergence
+            // this codebase has been bitten by before. Both readers and writers take it now.
+            const skillsLock = await readSkillsLock(target);
+            const cliLock = await readCliLock(target);
 
             if (!skillsLock) {
               const skills: Record<string, string> = {
                 ...config.skills?.required,
                 ...config.skills?.optional,
               };
-              const meta = await readkitMeta();
+              const meta = await readkitMeta(target);
               await updateSkillsLock(
                 skills,
                 meta?.name ? `${meta.name}@${meta.version}` : undefined,
+                target,
               );
               actions.push({
                 name: "skills-lock.json",
@@ -487,7 +507,7 @@ function register_kit_fix(server: McpServer): void {
                   tools[name] = { version, source: "mise" };
                 }
               }
-              await updateCliLock(tools);
+              await updateCliLock(tools, target);
               actions.push({
                 name: "cli-lock.json",
                 action: "generated",
@@ -497,7 +517,7 @@ function register_kit_fix(server: McpServer): void {
 
             return actions;
           },
-          { cwd: cwd ?? process.cwd() },
+          { cwd: target },
         );
         if (!gov.ok) return governanceRefusal(gov.reason ?? "denied");
         const actions = gov.result!;

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -114,16 +114,19 @@ function readOnlyRefusal(tool: string): {
  * WRITERS did not, so a caller read its own project's locks and wrote the process's.
  * `fix-cwd.test.ts` asserts where the bytes landed, in both trees.
  *
- * What still blocks lifting the refusal, and why it is not lifted here:
- *   - The AUDIT DESTINATION. `withGovernance` takes no `cwd` and `logAuditEvent` has none either,
- *     so a cross-project write would be recorded in the calling process's `.kit-audit.jsonl`.
- *     `exec-broker/broker.ts`'s own `audit()` docstring already names why that matters: evidence
- *     from other projects pollutes the host repo's chain and poisons
- *     `kit broker enforce-readiness`, "whose verdict is only as honest as the evidence file it
- *     reads". A write served for B whose proof lands in A is not a write kit can stand behind.
- *   - `kit_review` runs its own collector, not `runCheckGate` alone.
- *   - Relaxing a fail-closed access boundary is a deliberate decision with its own tests, not a
- *     tail-end edit to a change that was fixing something else.
+ * The AUDIT DESTINATION is threaded now too — `withGovernance`, `runGoverned`, `logAuditEvent`
+ * and `refuseWrite` all take a `cwd`, so a governed operation performed for B records its proof
+ * in B's chain rather than polluting the host repo's and poisoning
+ * `kit broker enforce-readiness`, "whose verdict is only as honest as the evidence file it reads"
+ * (`exec-broker/broker.ts`). `fix-cwd.test.ts` asserts the line lands in B and NOT in A.
+ *
+ * What still blocks lifting the refusal:
+ *   - `kit_review` runs its own collector, not `runCheckGate` alone, so its cross-project
+ *     behaviour has not been measured.
+ *   - Nothing measured yet says lifting it for `kit_check` / `kit_fix` is SAFE. Every claim above
+ *     is about a path that is now threaded; none of them is a test of the refusal being removed.
+ *     Relaxing a fail-closed access boundary needs its own change with its own probes — the
+ *     ordinary discipline, not an exception for a boundary that now looks liftable.
  *
  * So this still fails CLOSED: a cross-project call gets an actionable error instead of a verdict
  * about the wrong tree. Nothing that previously worked breaks — a client that launches the server

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -120,13 +120,18 @@ function readOnlyRefusal(tool: string): {
  * `kit broker enforce-readiness`, "whose verdict is only as honest as the evidence file it reads"
  * (`exec-broker/broker.ts`). `fix-cwd.test.ts` asserts the line lands in B and NOT in A.
  *
- * What still blocks lifting the refusal:
- *   - `kit_review` runs its own collector, not `runCheckGate` alone, so its cross-project
- *     behaviour has not been measured.
- *   - Nothing measured yet says lifting it for `kit_check` / `kit_fix` is SAFE. Every claim above
- *     is about a path that is now threaded; none of them is a test of the refusal being removed.
- *     Relaxing a fail-closed access boundary needs its own change with its own probes — the
- *     ordinary discipline, not an exception for a boundary that now looks liftable.
+ * `kit_review`'s collector is measured too. `collectReview` passes `opts.cwd` to all four stages
+ * so it READ as threaded, but `runDesignGate` handed that `cwd` to the baseline loader and then
+ * called `checkDesign(...)` without it — the source roots and every finding's display path came
+ * from `process.cwd()`. Fixed; `review-cwd.test.ts` covers it. `check`, `standards` and `adr`
+ * were already correct.
+ *
+ * What still blocks lifting the refusal: nothing measured yet says REMOVING it is safe. Every
+ * claim above is that a path is now threaded, which is a different proposition from "a
+ * cross-project call is served correctly end to end". That needs its own change with its own
+ * probes — a real server in A, each tool called for B over stdio, assertions on where every byte
+ * and every audit line landed. Ordinary discipline, not an exception for a boundary that now
+ * merely looks liftable.
  *
  * So this still fails CLOSED: a cross-project call gets an actionable error instead of a verdict
  * about the wrong tree. Nothing that previously worked breaks — a client that launches the server

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -28,7 +28,7 @@ import { recordTriageRun } from "./commands/triage.js";
 import { openMemoryDb, searchMessages, getMemoryDbPath, recordQuery } from "./memory/db.js";
 import { searchShared } from "./memory/shared.js";
 import { getCurrentProjectRoot } from "./memory/project.js";
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync } from "node:fs";
 
 const KIT_FILE = ".kit.toml";
 
@@ -133,48 +133,29 @@ function readOnlyRefusal(tool: string): {
  * and every audit line landed. Ordinary discipline, not an exception for a boundary that now
  * merely looks liftable.
  *
- * So this still fails CLOSED: a cross-project call gets an actionable error instead of a verdict
- * about the wrong tree. Nothing that previously worked breaks — a client that launches the server
- * inside the project it asks about (what Claude Code does) passes a `cwd` equal to
- * `process.cwd()`, or omits it.
+ * LIFTED. The refusal is gone because the paths were threaded AND that was measured end to end —
+ * not because the code now reads correct. What the measurement covers:
+ *
+ *   - readers: `check-security-cwd.test.ts`, `review-cwd.test.ts`. A gets a complete `.gitignore`
+ *     and a component with an a11y violation, B gets neither, and the two answers must DIFFER.
+ *   - writes + audit: `fix-cwd.test.ts`. The locks, the `.gitignore` edit, the generated template
+ *     and the `"operation":"fix"` audit line land in B, and A gains none of them.
+ *   - end to end over the real MCP protocol: the `serves a cross-project cwd` block in
+ *     `mcp-server.test.ts`, driving a client against a server whose `process.cwd()` is A.
+ *
+ * And what it does NOT cover, which is the weakest link in this decision and belongs in the same
+ * comment rather than a nicer one: the scanner subprocesses are not proven against the real tools.
+ * trivy, semgrep, osv-scanner and guarddog are absent from CI, so their coverage is a chain of two
+ * — a source-level guard that every `execFileNoThrow` in `check-security.ts` passes `cwd: root`,
+ * plus a behavioural test that the option actually relocates a child process. That is weaker than
+ * running trivy against two trees and observing which one it read.
+ *
+ * One write was found only by enumerating writes, because no probe here could reach it:
+ * `logSupplyChainFindings` appends bumblebee findings to `<root>/.kit-findings.jsonl` and was
+ * called without a `cwd`, so a check run FOR another project appended that project's findings to
+ * the caller's file. Bumblebee is not installed in the probe environment, so the branch never ran.
+ * A behavioural probe is not a substitute for reading the write surface.
  */
-function crossProjectRefusal(
-  cwd: string | undefined,
-  tool: string,
-): { content: { type: "text"; text: string }[]; isError: true } | null {
-  if (cwd === undefined) return null;
-  // Compare REAL paths, not lexical ones: on macOS `/tmp` and `/var` are symlinks
-  // into /private, so process.chdir("/var/…") reports cwd "/private/var/…" while
-  // the caller's argument still says "/var/…" — a lexical compare refuses the
-  // SAME directory. Fail-soft: an unresolvable path falls back to the lexical
-  // form, which can only make the guard stricter, never leak a wrong-tree pass.
-  const real = (p: string): string => {
-    try {
-      return realpathSync(p);
-    } catch {
-      return resolve(p);
-    }
-  };
-  if (real(cwd) === real(process.cwd())) return null;
-  return {
-    content: [
-      {
-        type: "text" as const,
-        text: JSON.stringify(
-          {
-            ok: false,
-            error: `${tool}: cwd "${resolve(cwd)}" differs from this server's working directory "${resolve(process.cwd())}"`,
-            why: "This tool's checks resolve paths from the server process's working directory, so a verdict for another project would describe THIS one. Refusing rather than returning a green earned by the wrong tree.",
-            fix: "Start the kit MCP server inside the project you want to check (Claude Code does this per-project), or omit cwd, or run `kit check` in that directory.",
-          },
-          null,
-          2,
-        ),
-      },
-    ],
-    isError: true,
-  };
-}
 
 /** Refusal result for a mutating tool blocked by the governance floor (revocation,
  *  budget, permission/approval, expired secrets). Mirrors the CLI's fail-closed deny. */
@@ -245,13 +226,11 @@ function register_kit_check(server: McpServer): void {
           .string()
           .optional()
           .describe(
-            "Working directory. Must equal the server process's own cwd (or be omitted): the check dimensions resolve paths from the process, so a different value is REFUSED rather than answered for the wrong project.",
+            "Project directory to check (defaults to the server process's own). Every dimension that reads the filesystem resolves paths from this argument, including the scanner subprocesses, so a value pointing at another project is answered ABOUT that project.",
           ),
       },
     },
     async ({ cwd }) => {
-      const scoped = crossProjectRefusal(cwd, "kit_check");
-      if (scoped) return scoped;
       try {
         const r = await runCheckGate({ cwd });
         return {
@@ -325,8 +304,6 @@ function register_kit_review(server: McpServer): void {
       },
     },
     async ({ cwd, enforce, stages, category, concise }) => {
-      const scoped = crossProjectRefusal(cwd, "kit_review");
-      if (scoped) return scoped;
       try {
         const { collectReview } = await import("./commands/review.js");
         const report = await collectReview({ cwd, enforce, stages, category });
@@ -435,19 +412,16 @@ function register_kit_fix(server: McpServer): void {
           .string()
           .optional()
           .describe(
-            "Working directory. Must equal the server process's own cwd (or be omitted): a different value is REFUSED. The lock-file writes now resolve from this argument, but the governance audit trail does not, so a cross-project fix would leave its proof in the wrong project.",
+            "Project directory to fix (defaults to the server process's own). Every write resolves from this argument — the lock files, the .gitignore hardening, the generated .env.template — and so does the governance audit entry, so a fix aimed at another project both acts on it and files its evidence there.",
           ),
       },
     },
     async ({ cwd }) => {
       if (isReadOnlyMode()) return readOnlyRefusal("kit_fix");
-      // Worse than a wrong verdict: a wrong-target WRITE. The lock-file helpers resolved from
-      // process.cwd(), so cwd=B created B's lock files inside A. Those writes are threaded now
-      // (see the lock step below), but the AUDIT destination is not — `withGovernance` takes no
-      // cwd — so a cross-project fix would still file its evidence in the wrong project. Still
-      // refused, for that reason rather than the original one.
-      const scoped = crossProjectRefusal(cwd, "kit_fix");
-      if (scoped) return scoped;
+      // A wrong-target WRITE is worse than a wrong verdict, which is why this handler carried a
+      // cross-project refusal until the write surface was threaded AND measured: the lock files,
+      // the .gitignore edit, the generated template and the governance audit line all have to land
+      // in `cwd`. `fix-cwd.test.ts` asserts each one lands in B and that A gains none of them.
       try {
         const config = await loadConfig(configPath(cwd));
         // One resolution, used by both the broker context and the lock step below — two

--- a/src/plugins-cli.ts
+++ b/src/plugins-cli.ts
@@ -5,6 +5,7 @@
  * scaffolding in create-plugin.ts — this module is the argv-facing shell.
  */
 
+import { flagValue } from "./utils/flags.js";
 import {
   searchPlugins,
   listPlugins,
@@ -42,8 +43,7 @@ export async function cmdPlugin(): Promise<boolean> {
   try {
     switch (subcommand) {
       case "list": {
-        const tagIndex = args.indexOf("--tag");
-        const tag = tagIndex !== -1 ? args[tagIndex + 1] : undefined;
+        const tag = flagValue(args, "--tag");
 
         const plugins = listPlugins(tag);
         if (plugins.length === 0) {

--- a/src/read-only-mode.ts
+++ b/src/read-only-mode.ts
@@ -61,14 +61,21 @@ export function activateReadOnlyMode(source: "flag" | "env" | "policy"): void {
 export async function refuseWrite(
   operation: string,
   metadata: Record<string, unknown> = {},
+  opts: { cwd?: string } = {},
 ): Promise<{ ok: false; reason: string }> {
   const reason = `read-only mode active — refusing "${operation}"`;
-  await appendAuditEventDirect({
-    operation: "read-only-mode-refusal",
-    environment: process.env.NODE_ENV ?? "unknown",
-    success: false,
-    metadata: { refused_operation: operation, ...metadata },
-  });
+  // A refusal is evidence, and evidence belongs to the project the write was aimed at. Callers
+  // that know their target pass it; the eleven that operate on the process's own tree pass
+  // nothing and behave exactly as before.
+  await appendAuditEventDirect(
+    {
+      operation: "read-only-mode-refusal",
+      environment: process.env.NODE_ENV ?? "unknown",
+      success: false,
+      metadata: { refused_operation: operation, ...metadata },
+    },
+    { cwd: opts.cwd },
+  );
   return { ok: false, reason };
 }
 

--- a/src/review-cwd.test.ts
+++ b/src/review-cwd.test.ts
@@ -1,0 +1,207 @@
+/**
+ * `collectReview({cwd})` must describe the project it was asked about, in every stage.
+ *
+ * `collectReview` looked threaded: it passes `opts.cwd` to all four stages. But `runDesignGate`
+ * passed that `cwd` to `loadBaselineForGate` and then called `checkDesign(...)` WITHOUT it, and
+ * `checkDesign` resolved its source roots — and the display path of every finding — from
+ * `process.cwd()`. So the baseline came from B while the files scanned came from A. A parameter
+ * that reaches one collaborator and not the next is the same false green as no parameter at all,
+ * and reading `collectReview` alone would never show it.
+ *
+ * Each test asserts the two trees produce DIFFERENT findings. Fixtures matter more than usual
+ * here: while writing them I twice produced "the two trees are identical" and twice it was the
+ * FIXTURE, not the code — an ADR file in MADR heading style that kit's parser (YAML frontmatter
+ * with an `id`) correctly ignored, and a standards stage whose five rows only measure tool
+ * availability, which two temp dirs share. A probe that cannot tell the hypothesis from its
+ * negation is not evidence, so each fixture below differs in something the stage actually reads.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { collectReview } from "./commands/review.js";
+
+function baseProject(): string {
+  const dir = mkdtempSync(join(tmpdir(), "kit-review-cwd-"));
+  writeFileSync(join(dir, ".kit.toml"), "version = 1\n");
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name: "rv", version: "1.0.0", private: true }) + "\n",
+  );
+  return dir;
+}
+
+/** A component with an a11y violation the design stage reports on (img without alt). */
+function withComponent(dir: string): void {
+  mkdirSync(join(dir, "src"), { recursive: true });
+  writeFileSync(join(dir, "src", "Bad.tsx"), 'export const Bad = () => <img src="x.png" />;\n');
+}
+
+/** An ADR in the shape kit's parser accepts: YAML frontmatter with an `id`, plus an enforce block. */
+function withAdr(dir: string): void {
+  mkdirSync(join(dir, "docs", "adr"), { recursive: true });
+  writeFileSync(
+    join(dir, "docs", "adr", "0001-no-axios.md"),
+    [
+      "---",
+      "id: ADR-0001",
+      "title: No axios",
+      "status: accepted",
+      "---",
+      "",
+      "## Decision",
+      "",
+      "Use fetch.",
+      "",
+      "```toml kit-enforce",
+      "[[forbid_pattern]]",
+      'pattern = "axios"',
+      'paths = "src/**/*.tsx"',
+      'message = "use fetch"',
+      "```",
+      "",
+    ].join("\n"),
+  );
+}
+
+async function inCwd<T>(dir: string, fn: () => Promise<T>): Promise<T> {
+  const prevCwd = process.cwd();
+  const prevId = process.env.KIT_IDENTITY_DIR;
+  const idDir = mkdtempSync(join(tmpdir(), "kit-review-id-"));
+  process.env.KIT_IDENTITY_DIR = idDir;
+  process.chdir(dir);
+  try {
+    return await fn();
+  } finally {
+    process.chdir(prevCwd);
+    if (prevId === undefined) delete process.env.KIT_IDENTITY_DIR;
+    else process.env.KIT_IDENTITY_DIR = prevId;
+    rmSync(idDir, { recursive: true, force: true });
+  }
+}
+
+type Report = Awaited<ReturnType<typeof collectReview>>;
+
+function stage(r: Report, name: string): Report["stages"][number] | undefined {
+  return r.stages.find((s) => s.stage === name);
+}
+
+describe("collectReview honours cwd in every stage", () => {
+  it("the design stage scans the governed tree's components, not the process's", async () => {
+    const A = baseProject();
+    const B = baseProject();
+    withComponent(A); // A has a component with a violation; B has no src/ at all
+    try {
+      const aboutA = await inCwd(A, () => collectReview({ cwd: A, stages: ["design"] }));
+      const aboutB = await inCwd(A, () => collectReview({ cwd: B, stages: ["design"] }));
+
+      const a = stage(aboutA, "design");
+      const b = stage(aboutB, "design");
+      // The pair is the assertion: before the fix both answers described A.
+      assert.notDeepEqual(
+        b?.findings,
+        a?.findings,
+        "a project with no components must not inherit A's design findings",
+      );
+      assert.equal((a?.findings.length ?? 0) > (b?.findings.length ?? 0), true);
+    } finally {
+      rmSync(A, { recursive: true, force: true });
+      rmSync(B, { recursive: true, force: true });
+    }
+  });
+
+  it("a design finding's file path is relative to the governed tree", async () => {
+    const A = baseProject();
+    const B = baseProject();
+    withComponent(B); // this time the component is in the TARGET, not the process's tree
+    try {
+      const aboutB = await inCwd(A, () => collectReview({ cwd: B, stages: ["design"] }));
+      const text = JSON.stringify(stage(aboutB, "design")?.findings ?? []);
+      // `relative(process.cwd(), file)` produced a path escaping upward out of A (../…/src/Bad.tsx)
+      // for a file that sits plainly at src/Bad.tsx inside B.
+      assert.doesNotMatch(text, /\.\.\//, `a finding must not be reported via a ../ path: ${text}`);
+    } finally {
+      rmSync(A, { recursive: true, force: true });
+      rmSync(B, { recursive: true, force: true });
+    }
+  });
+
+  it("the adr stage reads the governed tree's ADRs", async () => {
+    const A = baseProject();
+    const B = baseProject();
+    withAdr(A); // A has one accepted, enforcing ADR; B has none
+    try {
+      const aboutA = await inCwd(A, () => collectReview({ cwd: A, stages: ["adr"] }));
+      const aboutB = await inCwd(A, () => collectReview({ cwd: B, stages: ["adr"] }));
+
+      assert.match(
+        JSON.stringify(stage(aboutA, "adr")?.findings),
+        /enforced ADR/,
+        "A declares an enforcing ADR",
+      );
+      assert.match(
+        JSON.stringify(stage(aboutB, "adr")?.findings),
+        /no ADRs found/,
+        "B declares none and must be reported as such",
+      );
+    } finally {
+      rmSync(A, { recursive: true, force: true });
+      rmSync(B, { recursive: true, force: true });
+    }
+  });
+
+  it("the check stage still discriminates through collectReview", async () => {
+    const A = baseProject();
+    const B = baseProject();
+    writeFileSync(join(A, ".gitignore"), ".env\n.env.local\n.env.*.local\nnode_modules\n");
+    try {
+      const aboutA = await inCwd(A, () => collectReview({ cwd: A, stages: ["check"] }));
+      const aboutB = await inCwd(A, () => collectReview({ cwd: B, stages: ["check"] }));
+      assert.notDeepEqual(
+        stage(aboutB, "check")?.findings,
+        stage(aboutA, "check")?.findings,
+        "B has no .gitignore and must not inherit A's security verdict",
+      );
+    } finally {
+      rmSync(A, { recursive: true, force: true });
+      rmSync(B, { recursive: true, force: true });
+    }
+  });
+
+  it("omitting cwd is identical to passing process.cwd()", async () => {
+    const A = baseProject();
+    withComponent(A);
+    try {
+      const omitted = await inCwd(A, () => collectReview({ stages: ["design"] }));
+      const explicit = await inCwd(A, () => collectReview({ cwd: A, stages: ["design"] }));
+      assert.deepEqual(
+        stage(omitted, "design")?.findings,
+        stage(explicit, "design")?.findings,
+        "the default must resolve to the process's own tree",
+      );
+    } finally {
+      rmSync(A, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("the standards stage passes cwd to all five runners", () => {
+  // Deliberately a SOURCE-level check, and the docstring says why rather than pretending
+  // otherwise: the standards stage's five rows report tool availability (lizard, jscpd, scc,
+  // eslint, tsc), which two temp projects necessarily share, so a behavioural pair cannot
+  // discriminate here without installing those tools. What CAN be asserted is that no runner is
+  // invoked without the cwd `runStandardsGate` resolved — the exact omission that made
+  // `runDesignGate` wrong.
+  it("no checkStandards* call in standards-run.ts omits cwd", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+    const src = readFileSync(resolve(import.meta.dirname, "..", "src", "standards-run.ts"), "utf8");
+    const calls = src.split(/checkStandards\w*\(/).slice(1);
+    assert.equal(calls.length > 0, true, "sanity: the gate must invoke at least one runner");
+    const missing = calls.filter((c) => !/\bcwd\b/.test(c.slice(0, 400)));
+    assert.deepEqual(missing, [], "every standards runner must receive the governed cwd");
+  });
+});

--- a/src/secrets-rotate-cli.ts
+++ b/src/secrets-rotate-cli.ts
@@ -129,6 +129,7 @@ export function buildPlaybook(keyName: string): RotationPlaybook {
 }
 
 import { loadConfig } from "./config.js";
+import { flagValue } from "./utils/flags.js";
 import { resolve } from "node:path";
 import { isNonInteractive } from "./environment.js";
 import { writeSecretToBackend } from "./secrets-migrate.js";
@@ -204,8 +205,7 @@ async function cmdSecretsRotateSupabaseMgmt(keyName: string, args: string[]): Pr
   console.log(`${c.dim}${"─".repeat(50)}${c.reset}\n`);
 
   // Project ref: --project <ref> flag or SUPABASE_PROJECT_REF env var.
-  const projectIdx = args.indexOf("--project");
-  const projectRef = projectIdx >= 0 ? args[projectIdx + 1] : process.env.SUPABASE_PROJECT_REF;
+  const projectRef = flagValue(args, "--project") ?? process.env.SUPABASE_PROJECT_REF;
   if (!projectRef) {
     console.error(`${c.red}--project <ref> required (or set SUPABASE_PROJECT_REF).${c.reset}`);
     console.error(
@@ -215,9 +215,7 @@ async function cmdSecretsRotateSupabaseMgmt(keyName: string, args: string[]): Pr
   }
 
   // Rotation mode: explicit --mode, otherwise auto-detect from project state.
-  const modeIdx = args.indexOf("--mode");
-  let mode: "scoped-key-mint" | "jwt-secret-roll" | undefined =
-    modeIdx >= 0 ? (args[modeIdx + 1] as "scoped-key-mint" | "jwt-secret-roll") : undefined;
+  let mode = flagValue(args, "--mode") as "scoped-key-mint" | "jwt-secret-roll" | undefined;
   if (mode !== undefined && mode !== "scoped-key-mint" && mode !== "jwt-secret-roll") {
     console.error(
       `${c.red}Invalid --mode "${mode}" — use "scoped-key-mint" or "jwt-secret-roll".${c.reset}`,
@@ -410,22 +408,22 @@ export async function cmdSecretsRotate(): Promise<boolean> {
     return false;
   }
 
-  const valueIdx = args.indexOf("--value");
-  const explicitValue = valueIdx >= 0 ? args[valueIdx + 1] : undefined;
-  const randomIdx = args.indexOf("--random");
+  const explicitValue = flagValue(args, "--value");
+  // `--random` is an OPTIONAL-value flag: bare means "generate", `--random 32` / `--random=32`
+  // means a length. So presence and value are read separately — `flagValue` alone would treat the
+  // next token as the length even when it is the following flag, and the digit test is what keeps
+  // `--random --dry-run` meaning "generate", not "length --dry-run".
+  // Presence cannot go through `hasFlag`: it compares whole tokens, so `--random=32` would not
+  // register as present at all and the length would be silently dropped.
+  const randomPresent = args.some((a) => a === "--random" || a.startsWith("--random="));
   let randomFlag: number | true | undefined;
-  if (randomIdx >= 0) {
-    const next = args[randomIdx + 1];
-    if (next && /^\d+$/.test(next)) {
-      randomFlag = Number.parseInt(next, 10);
-    } else {
-      randomFlag = true;
-    }
+  if (randomPresent) {
+    const next = flagValue(args, "--random");
+    randomFlag = next && /^\d+$/.test(next) ? Number.parseInt(next, 10) : true;
   }
   const dryRun = args.includes("--dry-run");
   const fromCli = args.includes("--from-cli");
-  const viaIdx = args.indexOf("--via");
-  const via = viaIdx >= 0 ? args[viaIdx + 1] : undefined;
+  const via = flagValue(args, "--via");
 
   // ── Supabase Management API rotation ─────────────────────────────────────
   if (via === "supabase-mgmt-api") {
@@ -518,9 +516,9 @@ export async function cmdSecretsRotate(): Promise<boolean> {
   console.log(`  ${c.green}✓${c.reset} ${writeResult.detail}\n`);
 
   // ── R2: propagate to deploy platforms ────────────────────────────────────
-  const propagateIdx = args.indexOf("--propagate");
-  if (propagateIdx >= 0) {
-    const spec = args[propagateIdx + 1];
+  const propagatePresent = args.some((a) => a === "--propagate" || a.startsWith("--propagate="));
+  if (propagatePresent) {
+    const spec = flagValue(args, "--propagate");
     const targets = spec ? parseTargets(spec) : [];
     if (targets.length === 0) {
       console.error(
@@ -530,20 +528,20 @@ export async function cmdSecretsRotate(): Promise<boolean> {
     }
 
     const propOpts: PropagationOptions = {};
-    const envIdx = args.indexOf("--target-env");
-    if (envIdx >= 0) propOpts.env = args[envIdx + 1] as PropagationOptions["env"];
-    const flyAppIdx = args.indexOf("--fly-app");
-    if (flyAppIdx >= 0) propOpts.flyApp = args[flyAppIdx + 1];
-    const cfWorkerIdx = args.indexOf("--cf-worker");
-    if (cfWorkerIdx >= 0) propOpts.cfWorker = args[cfWorkerIdx + 1];
-    const railwayServiceIdx = args.indexOf("--railway-service");
-    if (railwayServiceIdx >= 0) propOpts.railwayService = args[railwayServiceIdx + 1];
-    const awsRegionIdx = args.indexOf("--aws-region");
-    if (awsRegionIdx >= 0) propOpts.awsRegion = args[awsRegionIdx + 1];
-    const ghRepoIdx = args.indexOf("--github-repo");
-    if (ghRepoIdx >= 0) propOpts.githubRepo = args[ghRepoIdx + 1];
-    const vercelScopeIdx = args.indexOf("--vercel-scope");
-    if (vercelScopeIdx >= 0) propOpts.vercelScope = args[vercelScopeIdx + 1];
+    const targetEnv = flagValue(args, "--target-env");
+    if (targetEnv !== undefined) propOpts.env = targetEnv as PropagationOptions["env"];
+    const flyApp = flagValue(args, "--fly-app");
+    if (flyApp !== undefined) propOpts.flyApp = flyApp;
+    const cfWorker = flagValue(args, "--cf-worker");
+    if (cfWorker !== undefined) propOpts.cfWorker = cfWorker;
+    const railwayService = flagValue(args, "--railway-service");
+    if (railwayService !== undefined) propOpts.railwayService = railwayService;
+    const awsRegion = flagValue(args, "--aws-region");
+    if (awsRegion !== undefined) propOpts.awsRegion = awsRegion;
+    const ghRepo = flagValue(args, "--github-repo");
+    if (ghRepo !== undefined) propOpts.githubRepo = ghRepo;
+    const vercelScope = flagValue(args, "--vercel-scope");
+    if (vercelScope !== undefined) propOpts.vercelScope = vercelScope;
 
     console.log(`${c.bold}Propagation${c.reset}  ${c.dim}→ ${targets.join(", ")}${c.reset}\n`);
     const results = await propagate(plan.key, value, targets, propOpts);


### PR DESCRIPTION
## Description

Defects found by re-measuring shipped claims against the released 6.3.1 tree, then the whole ROADMAP `cwd` arc — read path, write path, audit destination — and finally the lift of the MCP cross-project refusal that all of it was standing in for. Every number ships with the command that produced it; every fix is mutation-proved.

The headline: **kit had never produced a GitHub artifact attestation.** `docs/VERIFY.md` promised one, the publish step errored in 327ms on every release, and `continue-on-error` reported it as green. That is this repo's own thesis failing on itself — a check that could not run, recorded as one that passed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Refactoring

## Changes Made

**1. `exec-broker`: unsigned policy read from the wrong tree (fail-OPEN)**

`brokerPolicyPath()` resolved `.kit-exec-broker.json` against `process.cwd()` while `brokerExec` measured writes against `opts.cwd`. Two-sided probe:

| policy lives in | governed project | before |
|---|---|---|
| B (the governed project) | B | **ALLOWED** — a write outside B's declared root ran |
| A (the server's cwd) | B | denied (1 violation) |

A server launched in A and asked to write B's `.env.local` ignored B's policy entirely and — since "no policy file" means "not configured" — ran the write unmediated with full env. One direction needed closing too, or the fix would have been a net loosening: absence of a policy is only an opt-out for the tree the process lives in, so a brokered process now default-denies a *foreign* tree with no policy of its own. Unbrokered processes are untouched.

**2. `cwd` threaded through the whole check gate**

`runCheckGate` resolved `opts.cwd` only to load `.kit.toml`. `kit_check({cwd: B})` from a server in A answered `pass — all .env patterns in .gitignore` for a B with no `.gitignore`.

The part worth reading twice: **threading the path alone would not have fixed it.** `trivy fs .`, `trivy config .`, `osv-scanner -r .` and `semgrep .` resolve `.` against the *spawned* process, and not one of the seven scanner spawns passed a `cwd`. Both halves are here: 15 path reads → a `root` argument, 7 exec sites pinned with `cwd: root`.

Four of the ten dimensions needed nothing, measured rather than assumed: `checkTools` resolves binaries on PATH, `checkSkills` reads an absolute homedir path, `checkServices` and `checkWebSearch` touch no project path.

**3. The write path: `lock.ts` had the asymmetry backwards**

Its READ helpers all took a `cwd`; its WRITE helpers did not. So a caller read its own project's locks and wrote the process's — the ROADMAP symptom verbatim ("`kit_fix` created B's lock files inside A"). Also `cmdFix`'s config load, `.gitignore` hardening and relative `[secrets].template`, plus `installHooks`/`uninstallHooks`/`resolveHooksDir`.

Fixing `cmdFix` did **not** fix the MCP surface: `register_kit_fix` carries its own copy of the lock step (it returns structured actions, not console output) and had to be threaded separately — the CLI-vs-MCP divergence this repo has been bitten by before.

**4. The audit destination — the reason a cross-project write was not defensible**

`withGovernance` took no `cwd` and `logAuditEvent` resolved `.kit-audit.jsonl` against `process.cwd()`, so a fix performed for B filed its proof in A. This repo had already written down why that matters, in `exec-broker/broker.ts`'s own `audit()` docstring: foreign-project evidence pollutes the host chain and poisons `kit broker enforce-readiness`, "whose verdict is only as honest as the evidence file it reads". The governance middleware had the bug the broker had already fixed for itself.

`logAuditEvent`'s third parameter became `{ companyId?, cwd? }` — all 11 production callers omitted the old positional `companyId`, and it is not in `contracts/public-surface.json`. Side effect worth naming: the `companyId` that `[governance.audit].remote` is blocked on is now *reachable*. Reaching it is a separate decision about where a company id comes from.

**5. `kit_review`'s design stage measured the caller's tree**

`collectReview` passes `opts.cwd` to all four stages, so it *read* as threaded — but `runDesignGate` handed that `cwd` to the baseline loader and then called `checkDesign(...)` without it. Baseline from B, files scanned from A, and findings reported via a `../` path escaping out of A. `check`, `standards` and `adr` were already correct (verified: all five standards runners receive the resolved `cwd`; none of the five `check-standards*` modules reads `process.cwd()` outside a parameter default).

**6. The MCP cross-project refusal is LIFTED**

`kit_check`, `kit_review` and `kit_fix` refused a `cwd` differing from the server's own directory. That guard was a stand-in for the fixes above. It is removed because the end-to-end behaviour was **measured**, not because the code reads correct — a real MCP client driven against a server whose `process.cwd()` is A, each tool called for B, run once with the guard in place to establish the baseline and once bypassed to see what serving produced:

```
kit_check(cwd: B)   .env gitignored: warn — .gitignore not found
                    (used to answer "pass — all .env patterns in .gitignore" — A's answer)
kit_review(cwd: B)  design: skip — B has no src/
kit_fix(cwd: B)     B/.kit/skills-lock.json  true    A/.kit/skills-lock.json  false
                    B/.kit-audit.jsonl       true    A/.kit-audit.jsonl       false
```

The refusal tests were **replaced, not deleted**: the same block now asserts each tool's answer describes the requested project, and the `kit_fix` case compares this repo's own lock file byte-for-byte before and after, because that test runs inside the kit repo and a regression would rewrite it.

**7. Release: the GitHub artifact attestation never ran**

From the 6.3.1 publish run (`30804371457`, step 20):

```
Attestation type: Build Provenance
##[error]Error: Too many subjects specified (>1024). The maximum number of subjects is 1024.
##[end-action ... outcome=failure;conclusion=failure;duration_ms=327]
```

`subject-path: "dist/**/*"` matches 1920 files against a hard limit of 1024. `continue-on-error: true` then reported the conclusion to the jobs API as SUCCESS while the log said failure. Now: pack first and attest the tarball (one subject, the same bytes npm published), plus a step that annotates the run and job summary whenever the attestation did not happen. It cannot block — stranding a release whose publish already succeeded would be worse — but a swallowed failure can no longer read as green.

npm provenance is unaffected and real: 6.3.1's attestation carries a `slsa.dev/provenance/v1` statement, `ref refs/tags/v6.3.1`, `path .github/workflows/publish.yml` (fetched and decoded).

**8. One argv idiom for value flags, guarded**

Three idioms coexisted, so which spelling silently did nothing depended on which one a command happened to use:

```
kit self-audit --format json     -> printed the human table, not JSON
kit team audit log --limit 3     -> "(limit: 50)"
kit team audit log --limit=abc   -> "(limit: NaN)"
```

`unknownFlags` cannot catch this: the flag is known and spelled right, only its value evaporates. Plus a real defect — `cmdSecretsVaultMigrate` read `args[args.indexOf("--from") + 1]`, and `indexOf` returns -1 when absent, so `+ 1` indexed `args[0]`: `kit secrets vault-migrate --to infisical` printed `From: --to` instead of the usage text.

~45 sites across 13 files now go through `flagValue`/`flagInt`. Four flags needed care rather than a swap (`--random`, `--write`, `--init`, `--propagate`): presence and value are separate questions, and `hasFlag` compares whole tokens, so `--random=32` would not have registered as present at all. The durable part is a **guard test** that fails on any `indexOf("--flag")` outside a named allowlist (`indexOf("--")` the separator, and `gate.ts` whose reader was already correct).

**9. Three dependency advisories, two of them shipping**

| package | severity | ships? | path |
|---|---|---|---|
| `brace-expansion` 5.0.9 | high | no — dev only | eslint → minimatch |
| `fast-uri` 3.1.5 | high | **yes** | MCP SDK → ajv |
| `ip-address` 10.4.0 | high ×3 (SSRF / trust-boundary bypass) | **yes** | MCP SDK → express-rate-limit |

All three are in or under MCP SDK 1.30.0, which pulls in a webserver stack kit does not use but inherits. No demonstrated exploit path in kit for any of them — recorded as scope, not as a reason to ship a trust-boundary bypass in the dependency tree of a tool that gates other people's supply chains.

**10. Docs corrected, per row, measured against the released tree**

- `[governance.audit].remote` — the transport is implemented and unreachable; all 11 callers omit `companyId`. Was "✅ shipped".
- `redactSecrets` — 26 vendor patterns, not a universal filter. "Never echoed" was too strong.
- MCP bearer — narrowed, not withdrawn: `expiresAt` exists and *is* honoured, but is vendor-supplied and optional.
- `DATA_FLOW.md` — "the entire egress list" was not; two undocumented hosts named, `KIT_NO_DOWNLOAD` documented.
- `VERIFY.md` — "All four together = SLSA Level 3" does not hold, and "the build is reproducible from source" is withdrawn: SLSA v1.0 puts reproducibility out of scope and kit has no rebuild-and-compare. Step 2 now says the GitHub attestation is absent on ≤6.3.1, and the copy-pasteable CI snippet no longer hard-fails for anyone pinning those versions.

## Testing

- [x] Added new tests — `policy-cwd.test.ts` (10), `flag-form-parity.test.ts` (8), `check-security-cwd.test.ts` (10), `fix-cwd.test.ts` (8), `review-cwd.test.ts` (6)
- [x] All tests pass — **3840 pass, 1 skipped**

Every file is deliberately **two-sided**. `ROADMAP.md` already warned that "a test that merely passes `cwd` proves nothing", so each test asserts the two trees / two spellings produce *different* or *identical* outcomes as appropriate. A unit test over `flagValue` would have passed throughout the entire period the call sites were broken.

Mutation-proved, every fix:

| mutation | tests that fail |
|---|---|
| `brokerPolicyPath` back to `process.cwd()` | 6 |
| remove the foreign-tree default-deny | 2 |
| `flagValue` drops the space form / the `=` form | 3 / 3 |
| `vault-migrate` `fromArg` back to unguarded `indexOf` | 2 |
| `checkSecurity` ignores its `cwd` argument | 3 |
| revert only `checkEnvGitignored` to `process.cwd()` | 3 |
| drop `cwd` from the semgrep spawn alone | 1 |
| lock **writers** ignore `cwd` again | 2 |
| `.gitignore` + template resolve against the process | 3 |
| `logAuditEvent` ignores `cwd` | 1 |
| `runDesignGate` stops passing `cwd` to `checkDesign` | 1 |
| design finding paths back to `relative(process.cwd(), …)` | 1 |
| reintroduce the hand-rolled `indexOf` in `auth.ts` | 1 |

## Breaking Changes

None for the CLI or the published API. Three behaviour changes worth a reviewer's eye:

- **`kit_check` / `kit_review` / `kit_fix` no longer refuse a foreign `cwd`.** This removes a fail-closed boundary. It is the deliberate outcome of items 2–5 and is backed by the end-to-end probe in item 6, but it is the change to look at hardest.
- A brokered process asked to mediate a foreign tree with no policy of its own now default-denies instead of passing through. Before this PR that call was also denied, but for the wrong reason.
- Callers that passed a `cwd` to `runCheckGate` and silently got the process's tree now get the tree they asked for.

## Reviewer Notes

**The weakest link, stated plainly.** The scanner subprocesses are proven for **semgrep** — a real binary run over two trees, one tripping a local `eval(...)` rule and one clean, with the verdicts required to differ. trivy, osv-scanner and guarddog ship as GitHub release binaries that this environment cannot fetch (403 for any repository outside the session's allowlist), so they rest on a chain of three: every `execFileNoThrow` passes `cwd: root`, the option demonstrably relocates a child process, and semgrep demonstrably honours it end to end. Strong by inference, not measured per tool. The semgrep test **skips loudly** when the binary is absent rather than passing silently.

**Not measured, therefore not claimed.** The attestation fix has a measured *cause* but no measured *cure* — the attest step only runs on tag-publish, so the first proof arrives with the next release: `gh attestation verify sandstream-kit-<v>.tgz --owner sandstream --repo kit` must return verified and the job summary must show the ✅ line. `docs/VERIFY.md` keeps its caveat until then.

**Things walked back after measurement rather than accepted:**

- The seven MCP tools *not* behind the old guard already threaded `cwd` correctly. The guard covered exactly the three that did not; the broker was the real defect.
- The ~45 remaining `indexOf("--flag")` sites were all `idx >= 0` guarded, so none carried the `args[0]` bug.
- `actions/attest-build-provenance` *is* in the workflow and 6.3.1's npm attestation *is* real. The gap is narrower than "no provenance".
- Four of the ten check dimensions needed no threading at all.
- I claimed bumblebee was absent here and used that to explain a coverage gap. **False** — kit provisions it to `~/.kit/tools/bumblebee/<version>/` and it runs (`pass`, 36 packages). The real reason no probe reached `logSupplyChainFindings` is that the call is gated on `findings.length > 0` and a fresh temp project has no exposures: a green probe over a clean fixture says nothing about paths only a dirty one reaches. That write was found by enumerating the write surface, not by probing.
- I claimed the scanner path could not be proven without tools I could not install. Half false — I had not tried; semgrep installs from PyPI.

**One thing I cannot explain:** one of several full test runs reported `fail 1`. I had filtered the output before seeing which test it was, and every subsequent full run is green. I could not reproduce it and would rather flag it than invent a cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)