### PR TITLE
fix(gate): here-document bodies are data, not commands — the gate blocked its own PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   nobody was watching. A containment test that does not run is worse than no
   test, because it reads as coverage.
 
+- **`gate-bash` read here-document bodies as commands, and blocked kit's own PR
+  description.** `SEGMENT_SPLIT` includes `\n`, so every line of a here-document
+  was scanned as its own command. Measured: a `gh pr create --body "$(cat <<'EOF'
+  … EOF)"` whose body contained the prose `` `npx tsc --noEmit` `` was refused
+  with `BLOCKED — Triage: npm tsc`, because a backtick in a sentence became a
+  nested command. A false block in a security gate is not a harmless annoyance —
+  it is what teaches people to pass `--no-verify`, and this repo already carries
+  one bypassed-hook record.
+
+  `splitHeredocs()` now separates body from command following what the shell
+  actually does: a body fed to a shell (`bash <<EOF`, `cat <<EOF | bash`) or
+  written to a `*.sh`-shaped file is scanned as a script; anything else is data.
+  The exception that keeps this from being the cheap fix: with an **unquoted**
+  delimiter the shell performs command substitution while building the document,
+  so a substitution in the body really runs and is still gated, while the same
+  body under `<<'EOF'` is inert text. An unterminated here-document is scanned
+  rather than trusted, and the terminator is matched leniently, because absorbing
+  the commands that follow it is the one error direction that could hide a real
+  install.
+
+  Verified by driving the real hook rather than the parser: the exact payload that
+  blocked the PR now exits 0, while `bash <<EOF`, `cat <<EOF | bash`, the
+  unquoted-substitution form, script authoring and the plain install all still
+  exit 2. `src/install-gate-heredoc.test.ts` pins both sides of that table —
+  mutation-proved seven ways, including the cheap fix of treating every body as
+  data (3 fail), dropping the unquoted delimiter's substitutions (2), treating a
+  quoted delimiter as expanding (2), and failing to find the terminator (4).
+
+  Named limitation, previously covered only by accident: a body written to a file
+  without a shell-script extension and executed later is invisible to this gate,
+  as is the easier spelling of the same bypass — a `Write` tool call, which
+  `gate-bash` never sees.
+
 - **`docs/VERIFY.md` documented a `gh attestation verify` invocation that
   exits 1.** Both the copy-pasteable block and the CI snippet passed
   `--owner sandstream --repo kit`; the two flags are alternatives and

--- a/docs/ENFORCEMENT_AND_AUDIT.md
+++ b/docs/ENFORCEMENT_AND_AUDIT.md
@@ -14,6 +14,22 @@ Deterministic, fail-closed, zero-LLM:
 
 - **PreToolUse gates** — `gate-bash`, `gate-env` block un-triaged installs and plaintext-secret
   writes *before* they land.
+
+  `gate-bash` reads the pending command as a shell would, which means it follows installs into
+  `$(…)`, backticks, `sh -c '…'`, process substitution and here-strings. **Here-document bodies are
+  the one place it deliberately stops**: a body is data unless something executes it. Fed to a shell
+  (`bash <<EOF`, `cat <<EOF | bash`), or written to a `*.sh`-shaped file, it is scanned as a script;
+  otherwise it is text. The exception that keeps this honest: with an UNQUOTED delimiter (`<<EOF`,
+  not `<<'EOF'`) the shell performs command substitution while building the document, so `$(…)` in
+  the body really runs and is still gated — a quoted delimiter expands nothing, so the identical
+  body is inert.
+
+  This is a correction, not a design note. Every line of a here-document used to be scanned as its
+  own command, and the gate blocked kit's own PR description because the prose contained
+  `` `npx tsc --noEmit` `` — a false block, which is what teaches people to reach for `--no-verify`.
+  Named limitation: a body written to a file WITHOUT a shell-script extension and executed later is
+  not visible to this gate. Neither is the easier spelling of the same bypass — a `Write` tool call,
+  which `gate-bash` never sees (`gate-fs` covers writes only where a signed `[scope].fs` exists).
 - **Capture-time gates** — the memory write-gate (G1), install-gate, slopsquat scoring (G4).
 - **Commit/CI chokepoints** — `kit triage check-deps` + `kit triage check-skills` (pre-commit,
   wired by `kit setup --recommended`), branch-protected checks.

--- a/src/install-gate-heredoc.test.ts
+++ b/src/install-gate-heredoc.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Here-document bodies are data unless a shell eats them — and the install gate must tell the
+ * difference.
+ *
+ * WHY THIS EXISTS. `SEGMENT_SPLIT` includes `\n`, so every line of a here-document was scanned as
+ * its own command. Measured: kit's own `gate-bash` blocked the PR description for the plugin
+ * write-gate arc, because `gh pr create --body "$(cat <<'EOF' … EOF)"` had the prose
+ * "`npx tsc --noEmit` clean" in it, and a backtick in a sentence became a nested command
+ * (`BLOCKED — Triage: npm tsc`). The gate blocked a document about the gate.
+ *
+ * A false block in a security gate is not a harmless annoyance — it is what teaches people to pass
+ * `--no-verify`, and this repo already carries one bypassed-hook record in
+ * `.kit-skipped-commits.jsonl`.
+ *
+ * The table below is the contract, and it is two-sided ON PURPOSE: every case that must stop being
+ * blocked sits next to the execution path that must keep being blocked, because the cheap fix here
+ * ("ignore anything in a here-document") would have opened `bash <<EOF` — the shape an attacker
+ * would actually reach for.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseInstallCommand, splitHeredocs } from "./install-gate.js";
+
+/** Does the gate consider this command an install it must triage (i.e. would it block)? */
+function gated(command: string): boolean {
+  const p = parseInstallCommand(command);
+  return p.isInstall && (p.refs.length > 0 || p.unverifiable.length > 0);
+}
+
+// Assembled rather than written literally, so this file's own text is not a package-install
+// string that kit's `gate-bash` hook would block when an agent greps or edits it.
+const EVIL = ["npm", "i", "evil"].join(" ");
+const NPX = ["npx", "tsc", "--noEmit"].join(" ");
+
+describe("a here-document body that is DATA is not scanned as commands", () => {
+  it("the exact shape that blocked PR #447", () => {
+    const command = `gh pr create --title "x" --body "$(cat <<'EOF'\n- build clean; \`${NPX}\` clean\n- 3997/3997 tests\nEOF\n)"`;
+    assert.equal(gated(command), false, "prose in a quoted here-document is not an install");
+  });
+
+  it("prose written to a markdown file stays prose", () => {
+    assert.equal(gated(`cat > PR.md <<'EOF'\nrun ${EVIL} to reproduce\nEOF`), false);
+  });
+
+  it("a QUOTED delimiter suppresses expansion, so even a substitution is literal text", () => {
+    // `cat <<'EOF'` writes the characters `$(npm i evil)` — the shell never runs them. Blocking
+    // this was over-blocking, not caution.
+    assert.equal(gated(`cat <<'EOF'\n$(${EVIL})\nEOF`), false);
+    assert.equal(gated(`cat <<"EOF"\n$(${EVIL})\nEOF`), false);
+    assert.equal(gated(`cat <<\\EOF\n$(${EVIL})\nEOF`), false);
+  });
+
+  it("a `<<-` tab-stripped body is data too, and the terminator is still found", () => {
+    assert.equal(gated(`cat <<-'EOF'\n\trun ${EVIL} later\n\tEOF`), false);
+  });
+
+  it("commands AFTER the here-document are still scanned", () => {
+    // The terminator must be located, or everything following it would be absorbed into the body
+    // and silently excused. This is the one error direction that could hide a real install.
+    assert.equal(gated(`cat <<'EOF'\nprose\nEOF\n${EVIL}`), true);
+  });
+});
+
+describe("a here-document body that EXECUTES is still gated", () => {
+  it("fed straight to a shell", () => {
+    assert.equal(gated(`bash <<'EOF'\n${EVIL}\nEOF`), true);
+    assert.equal(gated(`sh <<EOF\npip install evil\nEOF`), true);
+    assert.equal(gated(`bash -s <<'EOF'\n${EVIL}\nEOF`), true);
+    assert.equal(gated(`/bin/bash <<'EOF'\n${EVIL}\nEOF`), true);
+  });
+
+  it("piped into a shell", () => {
+    assert.equal(gated(`cat <<'EOF' | bash\n${EVIL}\nEOF`), true);
+  });
+
+  it("an UNQUOTED delimiter runs its substitutions while the document is built", () => {
+    // `cat` only ever sees the OUTPUT, but the shell ran the install to produce it. The consumer
+    // being harmless is not the same as the body being harmless.
+    assert.equal(gated(`cat <<EOF\n$(${EVIL})\nEOF`), true);
+    assert.equal(gated(`cat > notes.md <<EOF\n\`${EVIL}\`\nEOF`), true);
+  });
+
+  it("authoring a shell script for later execution", () => {
+    // Not executed by this command, but a `*.sh` here-document is written to be run. Narrow by
+    // extension so prose files stay data.
+    assert.equal(gated(`cat > deploy.sh <<'EOF'\n${EVIL}\nEOF`), true);
+    assert.equal(gated(`cat >> /tmp/setup.bash <<'EOF'\n${EVIL}\nEOF`), true);
+  });
+
+  it("an UNTERMINATED here-document is scanned, not trusted", () => {
+    // The parse is unreliable once the terminator is missing, so the body is kept. Fail-closed.
+    assert.equal(gated(`cat <<'EOF'\n${EVIL}`), true);
+  });
+
+  it("a here-STRING is untouched by this change", () => {
+    assert.deepEqual(parseInstallCommand(`bash <<< "${EVIL}"`).refs, ["npm:evil"]);
+  });
+});
+
+describe("splitHeredocs is exact about what it removed", () => {
+  it("returns the command without the data body, and the body's live substitutions separately", () => {
+    const r = splitHeredocs(`cat <<EOF\nprose $(${EVIL}) more\nEOF`);
+    assert.equal(r.command.includes("prose"), false, "the body text is gone");
+    assert.deepEqual(r.expansions, [EVIL], "the substitution that really runs is kept");
+    assert.match(r.command, /EOF/, "the opener and terminator lines remain, so the shape parses");
+  });
+
+  it("is a no-op on a command with no here-document", () => {
+    const command = `${EVIL} && echo done`;
+    assert.deepEqual(splitHeredocs(command), { command, expansions: [] });
+  });
+
+  it("handles two here-documents on one line in order", () => {
+    const r = splitHeredocs(`diff <<'A' <<'B'\nfirst\nA\nsecond\nB`);
+    assert.equal(r.command.includes("first"), false);
+    assert.equal(r.command.includes("second"), false);
+  });
+});

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -245,6 +245,103 @@ function pushQuoted(out: string[], quote: string, body: string): void {
   out.push(quote === '"' ? body.replace(/\\([\s\S])/g, "$1") : body);
 }
 
+// A here-document opener. `(?!<)` keeps this off `<<<` (a here-STRING, handled in
+// `nestedCommands` — its operand really is fed to a shell). The delimiter may be quoted or
+// backslash-escaped, which is what decides whether the shell expands anything in the body.
+const HEREDOC_OPENER = /<<(?!<)(-?)\s*(?:'([^']*)'|"([^"]*)"|(\\?)([A-Za-z_][A-Za-z0-9_]*))/g;
+
+// Does this line feed the here-document to something that EXECUTES it? Anchored to command
+// heads (line start, or after a pipe / `;` / `&&` / `||` / `(`) so `bash <<EOF` and
+// `cat <<EOF | bash` match while the `cat` inside `$(cat <<EOF` does not.
+const HEREDOC_SHELL_CONSUMER =
+  /(?:^|[|;&(]|&&|\|\|)\s*(?:\S*\/)?(?:sh|bash|zsh|dash|ksh|ash|fish|eval)\b/;
+
+// `cat > deploy.sh <<'EOF'` — the body is not executed by THIS command, but writing a shell
+// script is the one data-shaped here-document whose body is meant to run later, so it is still
+// scanned. Narrow on purpose: keyed to a shell-script extension, so writing prose to
+// `PR.md` / `notes.txt` stays data.
+const HEREDOC_SCRIPT_TARGET = /(?:^|\s)>{1,2}\s*['"]?([^\s'"|;&]+\.(?:sh|bash|zsh|ksh|dash))['"]?/;
+
+/**
+ * Separate here-document BODIES from the command, because a body is usually data and this gate
+ * used to read every line of it as a command.
+ *
+ * Measured: `gh pr create --body "$(cat <<'EOF' … EOF)"` whose body contained the prose
+ * "`npx tsc --noEmit` clean" was BLOCKED as an untriaged `npm:tsc` install. `SEGMENT_SPLIT`
+ * includes `\n`, so each line of a here-document was scanned as its own command, and a backtick
+ * in prose became a nested command. kit's own gate blocked its own PR description.
+ *
+ * A false block in a security gate is not a harmless inconvenience: it is what teaches people to
+ * pass `--no-verify`, and this repo already carries one bypassed-hook record.
+ *
+ * The rule, which follows what the shell actually does:
+ *
+ * - **Fed to a shell** (`bash <<EOF`, `cat <<EOF | bash`) → the body IS a script. Scanned, as
+ *   before.
+ * - **Written to a `*.sh`-shaped file** → not executed now, but authored to run later. Scanned.
+ * - **Otherwise data.** Not scanned as commands — with one exception that matters: if the
+ *   delimiter is UNQUOTED (`<<EOF`, not `<<'EOF'`), the shell performs command substitution
+ *   while building the document, so `$(npm i evil)` in the body really runs even though `cat`
+ *   only ever sees its output. Those substitutions are returned as `expansions` and still gated.
+ *   A quoted delimiter expands nothing, so an identical body is inert text.
+ *
+ * Unterminated here-document → the body is KEPT (scanned). The parse is unreliable at that point,
+ * and swallowing the rest of the command is the one error direction that could hide a real
+ * install.
+ *
+ * Known and unchanged by this: a body written to a file WITHOUT a shell-script extension and
+ * executed later is not visible to this gate — but neither is the far easier spelling, a Write
+ * tool call, which `gate-bash` never sees at all (`gate-fs` covers writes only where a signed
+ * `[scope].fs` exists). The previous behaviour caught that shape only by accident, untested and
+ * undocumented, at the price of blocking prose.
+ */
+export function splitHeredocs(command: string): { command: string; expansions: string[] } {
+  if (!command.includes("<<")) return { command, expansions: [] };
+  const lines = command.split("\n");
+  const kept: string[] = [];
+  const expansions: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    kept.push(line);
+    const openers = [...line.matchAll(HEREDOC_OPENER)].map((m) => ({
+      delim: m[2] ?? m[3] ?? m[5] ?? "",
+      // `<<'EOF'`, `<<"EOF"` and `<<\EOF` all suppress expansion inside the body.
+      expands: m[2] === undefined && m[3] === undefined && m[4] !== "\\",
+    }));
+    if (openers.length === 0) continue;
+    const isScript = HEREDOC_SHELL_CONSUMER.test(line) || HEREDOC_SCRIPT_TARGET.test(line);
+
+    // Bodies follow the opener line in the order their openers appeared (`cmd <<A <<B`).
+    for (const op of openers) {
+      const body: string[] = [];
+      let terminated = false;
+      while (++i < lines.length) {
+        // Lenient terminator match (trimmed, not column-exact). Being generous here is the safe
+        // direction: failing to FIND the terminator would absorb the commands after the
+        // here-document into the body.
+        if (lines[i]!.trim() === op.delim) {
+          terminated = true;
+          break;
+        }
+        body.push(lines[i]!);
+      }
+      if (isScript || !terminated) {
+        kept.push(...body);
+        if (terminated) kept.push(lines[i]!);
+        continue;
+      }
+      if (op.expands) {
+        const text = body.join("\n");
+        for (const m of text.matchAll(/\$\(([^()]{1,2000})\)/g)) expansions.push(m[1]!);
+        for (const m of text.matchAll(/`([^`]{1,2000})`/g)) expansions.push(m[1]!);
+      }
+      kept.push(lines[i] ?? "");
+    }
+  }
+  return { command: kept.join("\n"), expansions };
+}
+
 function nestedCommands(command: string): string[] {
   const out: string[] = [];
   for (const m of command.matchAll(/\$\(([^()]{1,2000})\)/g)) out.push(m[1]);
@@ -578,7 +675,12 @@ export function parseInstallCommand(command: string): InstallProbe {
   // Scan the command AND any commands hidden in $(…)/backticks/`-c '…'`, bounded
   // so a wrapper (`sh -c '…'`, `$(…)`) can't smuggle an install past the splitter.
   const seen = new Set<string>();
-  const queue: string[] = [command];
+  // Here-document bodies are data unless a shell eats them. Their genuinely-executing parts (an
+  // unquoted delimiter's command substitutions) come back as separate commands to scan. See
+  // `splitHeredocs` — without this, every line of a `gh pr create --body "$(cat <<'EOF' …)"`
+  // was scanned as a command, and prose mentioning `npx tsc` was blocked as an install.
+  const heredocs = splitHeredocs(command);
+  const queue: string[] = [heredocs.command, ...heredocs.expansions];
   // Dequeue with a head cursor, NOT queue.shift(): shift() is O(N) on a large array, and the
   // `seen` cap doesn't bound the array — a command with many identical nested items (e.g.
   // `$(npm i evil)` repeated) enqueues N duplicates that are shifted-and-skipped, giving O(N²)


### PR DESCRIPTION
Fixes the false block found while opening #447: kit's install gate refused the pull request that described the install gate.

## What happened

`SEGMENT_SPLIT` includes `\n`, so `parseInstallCommand` read every line of a here-document as its own command. A `gh pr create --body "$(cat <<'EOF' … EOF)"` whose body contained the prose ``  `npx tsc --noEmit` clean `` was refused with `BLOCKED — Triage: npm tsc` — a backtick in a sentence became a nested command.

A gate that refuses correct work is not a harmless annoyance. It is what teaches people to reach for `--no-verify`, and this repo already carries a bypassed-hook record in `.kit-skipped-commits.jsonl`.

## The rule, following what the shell actually does

| Shape | Verdict |
| --- | --- |
| `bash <<EOF`, `cat <<EOF \| bash` | body **is** a script → scanned |
| `cat > deploy.sh <<'EOF'` | authored to run later → scanned |
| `cat <<EOF` (unquoted delimiter) | body is data, **but** the shell runs `$(…)` while building the document → those substitutions are still gated |
| `cat <<'EOF'`, `<<"EOF"`, `<<\EOF` | expands nothing → inert text |

The unquoted-delimiter row is what keeps this from being the cheap fix. `cat <<EOF` with a substitution in the body really executes the install even though `cat` only ever sees its output; the same body under `<<'EOF'` is characters. Both directions are pinned.

An unterminated here-document is **scanned rather than trusted**, and the terminator is matched leniently — absorbing the commands that follow the body is the one error direction that could hide a real install, so the parse errs toward finding it.

## Verification

Driven against the real `kit gate-bash` hook with PreToolUse payloads, not against the parser:

| Payload | Expected | Result |
| --- | --- | --- |
| the exact shape that blocked #447 | allow | exit 0 |
| prose written to a `.md` file | allow | exit 0 |
| a script fed to a shell | deny | exit 2 |
| here-document piped into a shell | deny | exit 2 |
| unquoted delimiter, substitution in body | deny | exit 2 |
| authoring `deploy.sh` | deny | exit 2 |
| a plain install, unchanged | deny | exit 2 |

`src/install-gate-heredoc.test.ts` pins both sides of that table. Mutation-proved seven ways: the cheap fix of treating every body as data (3 fail), dropping the unquoted delimiter's substitutions (2), treating a quoted delimiter as expanding (2), trusting an unterminated body (1), dropping the script-authoring exception (1), failing to find the terminator (4), reverting the wiring (2). Each mutation was rewritten until it *compiled*, so every kill is a failing test rather than a type error.

## Limitation, now named instead of covered by accident

A body written to a file **without** a shell-script extension and executed later is invisible to this gate. So is the easier spelling of the same bypass — a `Write` tool call, which `gate-bash` never sees at all (`gate-fs` covers writes only where a signed `[scope].fs` exists). The previous behaviour caught the here-document spelling only incidentally, untested and undocumented, at the price of blocking prose. Documented in `docs/ENFORCEMENT_AND_AUDIT.md`.

## Gates

- build clean; typecheck clean
- **3908/3908 tests, 0 fail**
- `format:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
