### PR TITLE
chore(release): 6.4.0 — policy reaches the plugin write surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to kit are documented in this file. This project adheres to 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [6.4.0] - 2026-08-04
 
 ### Added
 

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -1131,7 +1131,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "6.3.2"
+    "version": "6.4.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -57,7 +57,7 @@ versioned and signed independently of project config. They are complementary
 layers.
 
 > **`[policy.agent_writes]` is ENFORCED as of 6.3.2, and reaches the plugin write surfaces
-> after it.** It was declarative through 6.3.1 — parsed, folded into `KIT_POLICY_HASH`, and
+> from 6.4.0.** It was declarative through 6.3.1 — parsed, folded into `KIT_POLICY_HASH`, and
 > consulted by nothing — and this note said so. What it enforces now:
 >
 > - **Inside kit**, at `propagate()`'s choke point and in `secrets-rotate-cli.ts`, deciding via

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "6.3.2",
+  "version": "6.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "6.3.2",
+      "version": "6.4.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -2781,7 +2781,7 @@
     },
     "packages/kit-plugin-cloudflare": {
       "name": "sandstream-kit-plugin-cloudflare",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "devDependencies": {
         "@types/node": "22.19.15",
         "typescript": "5.9.3"
@@ -2789,7 +2789,7 @@
     },
     "packages/kit-plugin-fly": {
       "name": "sandstream-kit-plugin-fly",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "devDependencies": {
         "@types/node": "22.19.15",
         "typescript": "5.9.3"
@@ -2797,7 +2797,7 @@
     },
     "packages/kit-plugin-github": {
       "name": "sandstream-kit-plugin-github",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "devDependencies": {
         "sandstream-kit-adapter-sdk": "*",
         "typescript": "5.9.3"
@@ -2827,7 +2827,7 @@
     },
     "packages/kit-plugin-sentry": {
       "name": "sandstream-kit-plugin-sentry",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "devDependencies": {
         "@types/node": "22.19.15",
         "typescript": "5.9.3"
@@ -2843,7 +2843,7 @@
     },
     "packages/kit-plugin-stripe": {
       "name": "sandstream-kit-plugin-stripe",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "devDependencies": {
         "@types/node": "22.19.15",
         "typescript": "5.9.3"
@@ -2851,7 +2851,7 @@
     },
     "packages/kit-plugin-supabase": {
       "name": "sandstream-kit-plugin-supabase",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "devDependencies": {
         "sandstream-kit-adapter-sdk": "*",
         "typescript": "5.9.3"
@@ -2862,7 +2862,7 @@
     },
     "packages/kit-plugin-vercel": {
       "name": "sandstream-kit-plugin-vercel",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "devDependencies": {
         "sandstream-kit-adapter-sdk": "*",
         "typescript": "5.9.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "6.3.2",
+  "version": "6.4.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/packages/kit-plugin-cloudflare/package.json
+++ b/packages/kit-plugin-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit-plugin-cloudflare",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Cloudflare Workers secret + API token surface for kit",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/kit-plugin-fly/package.json
+++ b/packages/kit-plugin-fly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit-plugin-fly",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Fly.io app-secret rotation via flyctl GraphQL API",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/kit-plugin-github/package.json
+++ b/packages/kit-plugin-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit-plugin-github",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "kit plugin: GitHub REST API (repo + org secrets, deploy keys, workflow runs).",
   "type": "module",
   "exports": {

--- a/packages/kit-plugin-sentry/package.json
+++ b/packages/kit-plugin-sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit-plugin-sentry",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Sentry REST API client for kit — issue triage, release tagging, project introspection.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/kit-plugin-stripe/package.json
+++ b/packages/kit-plugin-stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit-plugin-stripe",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Stripe Management API surface for kit (webhook endpoint rotation + account introspection)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/kit-plugin-supabase/package.json
+++ b/packages/kit-plugin-supabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit-plugin-supabase",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "kit plugin: Supabase Management API integration (service-role key rotation, project introspection).",
   "type": "module",
   "exports": {

--- a/packages/kit-plugin-vercel/package.json
+++ b/packages/kit-plugin-vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit-plugin-vercel",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "kit plugin: Vercel Management API (env management, project metadata, redeploy triggers).",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Cuts **6.4.0** from the four PRs merged today (#447, #448, #449, #450).

## Why a minor, not a patch

6.3.2 shipped the equivalent policy enforcement as a patch, so the precedent pointed at 6.3.3. This release is a minor anyway, because it **adds a capability** rather than correcting one: `[policy.agent_writes]` now gates the `kit-plugin-*` write surfaces, and eight ops joined the registry — `resolve_issue`, `create_release`, `trigger_deploy`, `env_unset`, `api_token_revoke`, `webhook_create`, `webhook_delete`, `scoped_key_revoke`.

The seven touched plugins go to **0.2.0**, not the 0.1.1 first committed. In 0.x the minor slot is the breaking channel, and these packages gained a refusal path they did not have: a call that previously reached the vendor can now throw, once an operator declares that vendor in their policy block. Patch would have understated it.

## Contents

| PR | What |
| --- | --- |
| #447 | `[policy.agent_writes]` reaches the plugin write surfaces — plus four fail-opens the work exposed |
| #449 | `gate-bash` read here-document bodies as commands and blocked kit's own PR description |
| #450 | the dependency-surface count was stale in four places (120 → 94); an upstream item parked behind a 403 that never applied |
| #448 | five decisions promoted to the curated shared tier |

The four fail-opens from #447, worst first, all found by measuring rather than reading:

1. **`kit-plugin-supabase` honored no containment guard at all.** With `KIT_READ_ONLY=1` set and the client pointed at a local listener, all three write surfaces sent their request and `rollJwtSecret` — which invalidates every anon, service_role, signed-URL and session token — returned a rolled secret. Six sibling plugins had the guard.
2. **`unknownPolicyEntries()` had no production caller** while four documents described it as reporting to the operator.
3. **`kit knobs` advertised an op the registry rejected.**
4. **The plugin test suites had never run** — 11 compiled files, 76 tests, outside what `scripts/test.mjs` collected.

## Version locations bumped

`package.json`, `contracts/kit.opencli.json`, `package-lock.json`, and the seven plugin manifests. `docs/POLICY.md` now names 6.4.0 as the release where the plugin surfaces come under the gate, replacing a vaguer "after it".

## Gates

- build clean — kit and all seven plugins
- `format:check` clean
- changelog gate renders 6.4.0 (`changelog-section` suite: 9/9)
- `kit check --category security` — 22/24, the two standing pre-existing findings (an osv dependency advisory and trufflehog git-history noise), untouched by this arc
- **4012/4012 tests**

### One thing not swept under the rug

An earlier run of this same suite on this branch reported `# fail 1`. Four subsequent full runs are green, 4012/4012 each. The failing test's **name was lost**, because that run was piped through `tail` and everything above the summary was discarded — so it is an unidentified intermittent failure, 1 in 5 runs, not reproduced in four attempts.

Recorded here rather than dropped. The process lesson is the reusable part: don't pipe a release gate's output through `tail`, because the one run that matters is the one whose detail you then cannot read.

## After merge

The tag has to be signed by hand — `gpg-agent` has no cached passphrase and reports `No pinentry` from an agent session:

```
git checkout main && git pull
git tag -s v6.4.0 -m "kit 6.4.0" && git push origin v6.4.0
```

Publishing is what actually delivers the containment fix: `publish_ws` skips any package whose version is already on npm, so until the tag lands, every installed copy of the seven plugins is still the ungated one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
