### PR TITLE
fix(test): npm test deleted the real MCP tokens, and a failure could lose its name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ id_ed25519
 .env.local.*
 .kit-audit.pending
 .kit-skipped-commits.jsonl
+
+# Full TAP report from `npm test` — written so an intermittent failure keeps its name.
+.kit-test-run.tap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to kit are documented in this file. This project adheres to 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Fixed
+
+- **`npm test` deleted the developer's real MCP tokens.**
+  `src/mcp-orchestrator.test.ts` operated on `~/.kit/mcp-tokens.json` — the actual
+  path, not a fixture — and calls `rmSync` on it before every test and in
+  `afterEach`. It had no choice: `mcp-orchestrator.ts` bound `TOKEN_FILE` to
+  `homedir()` in a module-level `const`, so no test could redirect it. Measured
+  both ways: with a sentinel file at that path, the old code left
+  `No such file or directory` behind and the fixed code leaves the sentinel
+  untouched. The path now resolves per call and honours `KIT_MCP_TOKENS_DIR`,
+  matching `identityDir()` / `KIT_AUDIT_ANCHOR_DIR` / `KIT_MEMORY_DIR`, and the
+  test redirects into a temp dir. Also listed in `kit knobs`.
+
+- **A failing test could lose its own name.** A run of the suite reported
+  `# fail 1` while piped through `tail`, which discarded everything above the
+  summary; four re-runs were green, so the flake was never named. `npm test` now
+  always writes a complete TAP report to `.kit-test-run.tap` (gitignored) in
+  addition to stdout, so the detail no longer depends on how the caller redirected
+  output. Proven by failing a test on purpose and reading the name out of the log
+  while stdout was piped to `tail -1`. The stdout reporter deliberately reproduces
+  node's own adaptive default (`spec` on a TTY, `tap` when piped) rather than
+  forcing one, because naming a reporter replaces that default and would have
+  silently broken `npm test | grep '# fail'`.
+
+  The intermittent failure itself is **still unidentified** — eight clean full runs
+  since. One later run showed 75 failures with whole test files erroring, but that
+  was self-inflicted: `dist/` was rebuilt while the suite was running.
+
 ## [6.4.0] - 2026-08-04
 
 ### Added

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -56,9 +56,39 @@ if (files.length === 0) {
   process.exit(1);
 }
 
+// A FULL TAP log always lands on disk, in addition to whatever the caller sees on stdout.
+//
+// Why: a run of this suite reported `# fail 1` and the failing test's NAME was unrecoverable,
+// because the invocation was piped through `tail` and everything above the summary was discarded.
+// Four re-runs were green, so the flake could not be re-caught, and an intermittent failure with no
+// name is the shape that teaches people to re-run until green. The detail must not depend on how the
+// caller happened to redirect stdout — so node writes a second, complete report to a file itself.
+//
+// `--test-reporter`/`--test-reporter-destination` are positional PAIRS: spec to stdout for humans,
+// tap to the log for the next time this happens.
+// Naming a reporter REPLACES node's default entirely, and that default is adaptive: `spec` when
+// stdout is a TTY, `tap` when it is piped. Forcing one would silently change the output contract —
+// a `npm test | grep '# fail'` that worked before would stop matching. So the stdout reporter is
+// node's own choice, reproduced, and the file reporter is purely additive.
+const TAP_LOG = ".kit-test-run.tap";
+const stdoutReporter = process.stdout.isTTY ? "spec" : "tap";
 const result = spawnSync(
   process.execPath,
-  ["--test", "--test-timeout=180000", "--test-concurrency=2", ...files],
+  [
+    "--test",
+    "--test-timeout=180000",
+    "--test-concurrency=2",
+    `--test-reporter=${stdoutReporter}`,
+    "--test-reporter-destination=stdout",
+    "--test-reporter=tap",
+    `--test-reporter-destination=${TAP_LOG}`,
+    ...files,
+  ],
   { stdio: "inherit", env },
 );
+if (result.status !== 0) {
+  console.error(
+    `\n[kit] full TAP report written to ${TAP_LOG} — grep '^not ok' for the failing test names.`,
+  );
+}
 process.exit(result.status ?? 1);

--- a/src/knobs.ts
+++ b/src/knobs.ts
@@ -119,6 +119,11 @@ export const KNOBS: KnobGroup[] = [
         desc: "emit a signed gate-attestation receipt (same as `kit check --attest`)",
       },
       {
+        name: "KIT_MCP_TOKENS_DIR",
+        kind: "env",
+        desc: "relocate the MCP token store (default ~/.kit) — lets tests avoid the real one",
+      },
+      {
         name: "KIT_AUDIT_ANCHOR_DIR",
         kind: "env",
         desc: "relocate the HMAC audit-anchor key + record (default ~/.kit)",

--- a/src/mcp-orchestrator.test.ts
+++ b/src/mcp-orchestrator.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, afterEach } from "node:test";
+import { describe, it, afterEach, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { rmSync, existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
+import { rmSync, existsSync, readFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   getMcpToken,
@@ -14,7 +14,30 @@ import {
 } from "./mcp-orchestrator.js";
 import type { McpServerConfig } from "./config.js";
 
-const TOKEN_FILE = join(homedir(), ".kit", "mcp-tokens.json");
+/**
+ * The token store, redirected into a temp dir for the whole file.
+ *
+ * This used to be `join(homedir(), ".kit", "mcp-tokens.json")` — the developer's REAL token store —
+ * and `reset()` below deletes it. So `npm test` destroyed whatever MCP tokens the machine had, on
+ * every run, silently. The path could not be redirected because `mcp-orchestrator.ts` bound it to
+ * `homedir()` in a module-level const; it now resolves per call and honours KIT_MCP_TOKENS_DIR,
+ * which is what makes this containment possible.
+ */
+let TOKEN_DIR: string;
+let TOKEN_FILE: string;
+const prevTokenDir = process.env.KIT_MCP_TOKENS_DIR;
+
+before(() => {
+  TOKEN_DIR = mkdtempSync(join(tmpdir(), "kit-mcp-tokens-"));
+  TOKEN_FILE = join(TOKEN_DIR, "mcp-tokens.json");
+  process.env.KIT_MCP_TOKENS_DIR = TOKEN_DIR;
+});
+
+after(() => {
+  if (prevTokenDir === undefined) delete process.env.KIT_MCP_TOKENS_DIR;
+  else process.env.KIT_MCP_TOKENS_DIR = prevTokenDir;
+  rmSync(TOKEN_DIR, { recursive: true, force: true });
+});
 
 async function reset() {
   if (existsSync(TOKEN_FILE)) rmSync(TOKEN_FILE);

--- a/src/mcp-orchestrator.ts
+++ b/src/mcp-orchestrator.ts
@@ -30,8 +30,21 @@ import { dirname, join } from "node:path";
 import type { McpConfig, McpServerConfig } from "./config.js";
 import { secureFile, secureDir } from "./utils/secure-perms.js";
 
-// path.join (not a hard-coded "/") so the path is correct on Windows too. #43.
-const TOKEN_FILE = join(homedir(), ".kit", "mcp-tokens.json");
+/**
+ * Path to the MCP token store. Resolved on every CALL, with an env override, matching
+ * `identityDir()` / `auditAnchorDir()` / `KIT_MEMORY_DIR`.
+ *
+ * It used to be a module-level `const` bound straight to `homedir()`, which had a consequence
+ * nobody had looked for: `src/mcp-orchestrator.test.ts` deletes this file in `afterEach` and before
+ * every test, so a developer's REAL MCP tokens were destroyed by `npm test` — silently, on every
+ * run. A module-load-time absolute path in the user's home directory cannot be redirected by a
+ * test, which is exactly why the test had to point at the real one.
+ *
+ * path.join (not a hard-coded "/") so the path is correct on Windows too. #43.
+ */
+function tokenFile(): string {
+  return join(process.env.KIT_MCP_TOKENS_DIR ?? join(homedir(), ".kit"), "mcp-tokens.json");
+}
 
 export interface McpToken {
   /** Bearer token issued by the MCP server. */
@@ -50,7 +63,7 @@ type TokenStore = Record<string, McpToken>;
 
 async function readTokenStore(): Promise<TokenStore> {
   try {
-    const raw = await readFile(TOKEN_FILE, "utf-8");
+    const raw = await readFile(tokenFile(), "utf-8");
     return JSON.parse(raw) as TokenStore;
   } catch {
     return {};
@@ -62,10 +75,11 @@ async function writeTokenStore(store: TokenStore): Promise<void> {
   // would briefly exist with default permissions (typically 0o644) before
   // chmod tightens it. mkdir(... mode: 0o700) keeps the parent dir
   // owner-only too — defense in depth for the token store.
-  const dir = dirname(TOKEN_FILE);
+  const file = tokenFile();
+  const dir = dirname(file);
   await mkdir(dir, { recursive: true, mode: 0o700 });
   secureDir(dir); // Windows: NTFS ignores mode bits — enforce owner-only via ACL (#43)
-  const tmp = `${TOKEN_FILE}.${process.pid}.tmp`;
+  const tmp = `${file}.${process.pid}.tmp`;
   try {
     // wx flag = fail if exists (no clobber); mode passed to open() so the
     // tmp file is 0o600 from the very first byte.
@@ -74,8 +88,8 @@ async function writeTokenStore(store: TokenStore): Promise<void> {
       mode: 0o600,
       flag: "wx",
     });
-    await rename(tmp, TOKEN_FILE);
-    secureFile(TOKEN_FILE); // owner-only on Windows too (#43)
+    await rename(tmp, file);
+    secureFile(file); // owner-only on Windows too (#43)
   } catch (err) {
     // Cleanup tmp if rename failed.
     await unlink(tmp).catch(() => {});
@@ -212,8 +226,8 @@ export async function storeStaticToken(
  */
 export async function _resetTokenStoreForTests(): Promise<void> {
   try {
-    await access(TOKEN_FILE);
-    await writeFile(TOKEN_FILE, "{}\n", "utf-8");
+    await access(tokenFile());
+    await writeFile(tokenFile(), "{}\n", "utf-8");
   } catch {
     /* nothing to reset */
   }


### PR DESCRIPTION
Two defects found while hunting the intermittent failure recorded in #451. **Neither is that flake** — it is still unidentified — but both were found on the way, and one of them destroys user data on every test run.

## `npm test` deleted `~/.kit/mcp-tokens.json`

`src/mcp-orchestrator.test.ts` operated on the **real** token store, not a fixture, and calls `rmSync` on it before every test and in `afterEach`. Every `npm test` wiped whatever MCP tokens the machine had, silently.

The test had no choice. `mcp-orchestrator.ts` bound `TOKEN_FILE` to `homedir()` in a module-level `const`, evaluated at import — so nothing could redirect it. The test pointed at the real path because that was the only path there was. Every sibling concern already has the escape hatch (`identityDir()`, `KIT_AUDIT_ANCHOR_DIR`, `KIT_MEMORY_DIR`); this one had been missed.

Measured both ways, with a sentinel written to that path:

| | after running the test file |
| --- | --- |
| old code | `cat: ~/.kit/mcp-tokens.json: No such file or directory` |
| fixed code | sentinel byte-identical |

The path now resolves per call, honours `KIT_MCP_TOKENS_DIR`, appears in `kit knobs` next to the other relocations, and the test redirects into a temp dir.

## A failing test could lose its own name

The flake was observed as `# fail 1` on a run piped through `tail`, which discarded everything above the summary. Four re-runs were green, so the name was gone for good — and an intermittent failure with no name is exactly what teaches people to re-run until green.

`npm test` now always writes a complete TAP report to `.kit-test-run.tap` (gitignored) alongside stdout, so the detail no longer depends on how the caller redirected output. Proven by failing a test on purpose and reading its name out of the log while stdout went through `tail -1`:

```
$ npm test 2>&1 | tail -1
[kit] full TAP report written to .kit-test-run.tap — grep '^not ok' for the failing test names.
$ grep '^not ok' .kit-test-run.tap
not ok 919 - deliberate failure
```

### A regression I introduced and then caught

Naming a reporter **replaces** node's default entirely, and that default is adaptive: `spec` on a TTY, `tap` when piped. My first version forced `spec` everywhere, which silently broke the piped-output contract — `npm test | grep '# fail'` stopped matching. The script now reproduces node's own choice, and both contracts are verified: piped stdout still yields `# fail 1`, and the log still names the test.

## On the flake itself

Still unidentified, after **eight clean full runs**.

One run in the hunt did report 75 failures with whole test files erroring — but that was self-inflicted, not evidence: `dist/` was rebuilt (`git stash` → build) while the suite was running, so files vanished mid-load and the failures came out alphabetically clustered. Recorded here so a future session does not mistake that log for a lead.

Next occurrence will name itself, which is the actual deliverable.

## Gates

- build clean; typecheck clean
- **4012/4012 tests, 0 fail**
- `format:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
