### PR TITLE
chore(release): 6.4.1 — the MCP token store stops being collateral of npm test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to kit are documented in this file. This project adheres to 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [6.4.1] - 2026-08-04
 
 ### Fixed
 

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -1131,7 +1131,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "6.4.0"
+    "version": "6.4.1"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "6.4.0",
+      "version": "6.4.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
A patch. No plugin changes, so `publish_ws` will skip all seven at 0.2.0.

## Contents (#452, #453)

- **`npm test` no longer deletes the developer's real `~/.kit/mcp-tokens.json`.** The path resolves per call and honours `KIT_MCP_TOKENS_DIR`, matching every sibling relocation kit already had (`identityDir()`, `KIT_AUDIT_ANCHOR_DIR`, `KIT_MEMORY_DIR`), and the test redirects into a temp dir. Measured both ways against a sentinel file: old code left `No such file or directory`, fixed code leaves it byte-identical.
- **`npm test` always writes a full TAP report to `.kit-test-run.tap`**, so an intermittent failure keeps its name regardless of how the caller redirected stdout. The stdout reporter reproduces node's adaptive default (`spec` on a TTY, `tap` when piped) rather than forcing one — a first attempt forced `spec` and silently broke `npm test | grep '# fail'`.
- One shared-memory entry: don't pipe a release gate through `tail`.

## Why cut it now rather than let it sit

Nothing here fixes a user-facing defect — the destructive bug only hit contributors running the suite. But this session kept tripping over the same class: a lingering unreleased section is how documentation drifts from the artifact. `POLICY.md` said `[policy.agent_writes]` was "declarative only" long after it was enforced; a 403 note stayed parked for a day after it stopped applying; a dependency count sat stale in four places. Right now `kit knobs` on main advertises `KIT_MCP_TOKENS_DIR` and no published version honours it. Small, but the same shape as the OWASP row that cited a function with no caller.

## Gates

- build clean; typecheck clean
- **4012/4012 tests, 0 fail**
- `format:check` clean
- changelog gate renders 6.4.1; opencli contract bumped

## After merge

Signed tag, by hand — `gpg-agent` reports `No pinentry` from an agent session:

```
git checkout main && git pull
git tag -s v6.4.1 -m "kit 6.4.1" && git push origin v6.4.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)