### PR TITLE
fix(deps): pin hono 4.12.34 so the CORS ReDoS cannot reach us transitively

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1845,9 +1845,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.12.34",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
+      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "smol-toml": "1.6.1",
     "zod": "4.3.6"
   },
+  "overrides": {
+    "hono": "4.12.34"
+  },
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@types/node": "22.19.15",


### PR DESCRIPTION
## What

Adds one `overrides` entry to `package.json`:

```json
"overrides": { "hono": "4.12.34" }
```

## Why

`@modelcontextprotocol/sdk@1.30.0` pulls `hono` in twice — directly, and through
`@hono/node-server@2.0.12` whose range is `^4`. Both resolved to **4.12.31**,
inside the vulnerable range of [GHSA-8j4g-w8fx-2239](https://github.com/advisories/GHSA-8j4g-w8fx-2239)
(ReDoS in the CORS middleware via `Access-Control-Request-Headers`; fixed in
4.12.34). `1.30.0` is the latest SDK, so there is no upstream release to wait
for — the range is ours to raise.

`overrides` rather than a direct dependency: kit never imports hono. Declaring it
under `dependencies` would grow the stated runtime surface in order to fix a
range we only need to constrain. `4.12.34` rather than `4.13.0` keeps the bump
inside the patch line while still satisfying `^4`.

## Verification

| Check | Before | After |
|---|---|---|
| `npm ls hono` | `4.12.31` at both positions | `4.12.34 overridden`, deduped under `@hono/node-server` |
| `npm audit` | advisory named, `range: <4.12.34` | `found 0 vulnerabilities` |
| `kit check --category security` | osv-scanner flagged hono | `osv-scanner (deps): no known dependency vulnerabilities`; `pinned versions: all dependencies pinned` |

`npm run build` clean. Full suite: 4011/4012. The single failure is the
load-dependent 60s MCP request timeout in `mcp-server.test.ts` ("a cwd EQUAL to
the server's"), which passes standalone in 25s and cannot involve hono — that
suite speaks over `InMemoryTransport`, never an HTTP server. Its thin timeout
headroom is being addressed separately.

The remaining `kit check` warn is the unchanged secrets-history baseline
(15 unverified, 0 verified-live).

The CHANGELOG entry lands with the next version, per the file's stated practice of
accumulating unreleased changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)