### PR TITLE
fix(test): the MCP test client inherited a 60s wall-clock deadline it could not meet

### DIFF
--- a/src/mcp-server.test.ts
+++ b/src/mcp-server.test.ts
@@ -28,6 +28,23 @@ MISSING_VAR = { source = "env" }
 `;
 
 /**
+ * Per-request timeout for every call made through `createTestClient`.
+ *
+ * The SDK's default is 60s of wall clock (`DEFAULT_REQUEST_TIMEOUT_MSEC`), and
+ * several tests below run a FULL `kit check` over the real kit repo — the point of
+ * those tests is precisely that the server's own cwd is served, so they cannot be
+ * pointed at a cheap fixture. Measured on this repo: ~25s for that call with the
+ * file run alone, and 59.8s / >60s for the two of them when the whole suite runs
+ * at `--test-concurrency=2`. Past the line the failure reads
+ * `MCP error -32001: Request timed out` — machine load, not a defect, and it
+ * names a test that passes on a re-run, which is the most expensive kind of red.
+ *
+ * Deliberately below the runner's own `--test-timeout=180000` so a genuine hang is
+ * still bounded, and bounded by node with the request-level error surfacing first.
+ */
+const REQUEST_TIMEOUT_MS = 150_000;
+
+/**
  * Create a connected Client + McpServer pair using in-memory transport.
  * Returns the client (already connected) and a cleanup function.
  */
@@ -36,6 +53,16 @@ async function createTestClient(): Promise<{ client: Client; cleanup: () => Prom
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
   const client = new Client({ name: "test-client", version: "1.0.0" }, { capabilities: {} });
+
+  // Applied here rather than at ~40 call sites: the SDK takes the timeout per
+  // request, so a default set in the harness is what keeps the next real-repo call
+  // from reintroducing the flake. An explicit `options.timeout` still wins.
+  const callTool = client.callTool.bind(client);
+  client.callTool = ((params, resultSchema?, options?) =>
+    callTool(params, resultSchema, {
+      timeout: REQUEST_TIMEOUT_MS,
+      ...options,
+    })) as typeof client.callTool;
 
   await server.connect(serverTransport);
   await client.connect(clientTransport);


### PR DESCRIPTION
## What

`createTestClient` in `src/mcp-server.test.ts` now supplies a **150s default
per-request timeout** instead of inheriting the SDK's 60s
`DEFAULT_REQUEST_TIMEOUT_MSEC`.

## Why

A full-suite run failed with:

```
not ok 5 - a cwd EQUAL to the server's is fine, including a non-normalised spelling
    duration_ms: 60003.089625
    error: 'MCP error -32001: Request timed out'
```

Its sibling — "an ABSENT cwd is still fine" — passed the same run at **59784ms**,
216ms inside the same cliff. Both call `kit_check` with no `cwd` or with the
server's own directory, which is precisely what they exist to verify, so neither
can be pointed at a cheap temp fixture: each runs a *full* check over this repo
(~25–46s on its own, past 60s when the suite runs them alongside another file at
`--test-concurrency=2`).

The resulting red names a test that is green on re-run — the most expensive kind
of failure, because it costs a full re-run to learn nothing.

The default is set in the harness rather than at the ~40 call sites: the SDK takes
the timeout per request, so a harness default is what keeps the *next* real-repo
call from re-earning the same flake. An explicit `options.timeout` still wins.
150s stays under the runner's own `--test-timeout=180000`, so a genuine hang is
still bounded — and the request-level error is the one that surfaces first.

## Verification

Failing direction first, since a timeout change is only meaningful if the new
number is provably the one in force:

| Check | Result |
|---|---|
| Suite under 9 CPU hogs | the two tests fail at **exactly 150000ms**, not 60000ms — the harness default is threaded to the SDK, not merely written down |
| Full suite, unloaded | **4012 pass / 0 fail**; the pair at 46.0s and 31.3s |
| `tsc --noEmit` | clean |
| `npm run lint` | 0 errors (140 pre-existing warnings) |
| `npm run format:check` | clean |

What this does **not** claim: under load that extreme even 150s is exceeded. The
change raises a ceiling that was too low for the work being done; it does not make
a full repo check fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)