### PR TITLE
fix(hooks): the bypass banner counted commits that landed nowhere

### DIFF
--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -146,6 +146,15 @@ it back. A missing sentinel means `git commit --no-verify` was used; the event
 gets appended to `.kit-skipped-commits.jsonl` and a stderr banner appears on
 the next `kit` invocation.
 
+The log is append-only, so the banner counts the entries the repository still
+recognises rather than the lines in the file: a squash-merge keeps the change
+and discards the commit it recorded, and an entry no ref contains describes a
+bypass that landed nowhere. An entry is set aside only when git can disprove it
+— the object is present and unreachable. Anything unverifiable (a log carried
+between clones, an object gc'd away, a directory that is not a repository)
+stays counted, because a bypass that cannot be checked is not one that can be
+dismissed.
+
 ### Audit-log fail-closed
 
 When `appendAuditEventDirect()` cannot write (disk full, perm error), the

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -226,9 +226,14 @@ function cmdHelp(subcommand?: string): boolean {
  * Surfaces commits that bypassed the pre-commit hook (`git commit
  * --no-verify`). The post-commit detector installed by `kit hooks
  * install` writes one JSONL line per skip to `.kit-skipped-commits.jsonl`;
- * we read the last few lines and print a red banner on stderr so the next
- * `kit` invocation makes the bypass visible. Suppressed when
- * `KIT_HIDE_HOOK_SKIP_BANNER=1` (useful for ephemeral CI).
+ * we read it and print a red banner on stderr so the next `kit` invocation
+ * makes the bypass visible. Suppressed when `KIT_HIDE_HOOK_SKIP_BANNER=1`
+ * (useful for ephemeral CI).
+ *
+ * The log is append-only, so the count is the number of entries the repository
+ * still recognises, not the number of lines: a squash-merge discards the commit
+ * it recorded, and this banner used to report those forever. Entries that cannot
+ * be checked stay counted — see `skipped-commits.ts` for that direction.
  */
 async function showSkippedCommitBanner(): Promise<void> {
   if (process.env.KIT_HIDE_HOOK_SKIP_BANNER === "1") return;
@@ -239,19 +244,26 @@ async function showSkippedCommitBanner(): Promise<void> {
     const info = await stat(logPath).catch(() => null);
     if (!info) return;
     const content = await readFile(logPath, "utf-8");
-    const lines = content.trim().split("\n").filter(Boolean);
-    if (lines.length === 0) return;
-    const recent = lines.slice(-3);
-    process.stderr.write(
-      `${c.red}[kit] ${lines.length} commit(s) bypassed pre-commit hook — most recent:${c.reset}\n`,
+    const { parseSkippedCommits, partitionSkippedCommits, gitReachabilityProbe } =
+      await import("./skipped-commits.js");
+    const entries = parseSkippedCommits(content);
+    if (entries.length === 0) return;
+    const { live, orphaned } = partitionSkippedCommits(
+      entries,
+      gitReachabilityProbe(process.cwd()),
     );
-    for (const line of recent) {
-      try {
-        const entry = JSON.parse(line) as { timestamp: string; sha: string; reason: string };
-        process.stderr.write(`  ${entry.timestamp}  ${entry.sha.slice(0, 8)}  (${entry.reason})\n`);
-      } catch {
-        /* malformed line — ignore */
-      }
+    // Nothing the repo still contains — the log is history, not a finding.
+    if (live.length === 0) return;
+    process.stderr.write(
+      `${c.red}[kit] ${live.length} commit(s) bypassed pre-commit hook — most recent:${c.reset}\n`,
+    );
+    for (const entry of live.slice(-3)) {
+      process.stderr.write(`  ${entry.timestamp}  ${entry.sha.slice(0, 8)}  (${entry.reason})\n`);
+    }
+    if (orphaned.length > 0) {
+      process.stderr.write(
+        `  ${orphaned.length} earlier entr${orphaned.length === 1 ? "y is" : "ies are"} in no ref (squashed or amended) — not counted.\n`,
+      );
     }
     process.stderr.write(
       `  Review: cat ${SKIPPED_COMMITS_LOG} | jq .\n` + `  Suppress: KIT_HIDE_HOOK_SKIP_BANNER=1\n`,

--- a/src/skipped-commits.test.ts
+++ b/src/skipped-commits.test.ts
@@ -1,0 +1,243 @@
+/**
+ * The bypass banner counts commits that skipped the pre-commit hook. Its input is an
+ * append-only log, so an entry survives the commit it describes: after a squash-merge
+ * the recorded sha exists in no ref at all, and the banner kept reporting it —
+ * `3 commit(s) bypassed pre-commit hook` for three commits that never landed. A
+ * warning that cannot go down is a warning nobody reads.
+ *
+ * The rule these tests pin: an entry is dropped only when it can be DISPROVED — the
+ * object is present and no ref contains it. An entry that cannot be resolved at all
+ * (log copied between clones, object gc'd, not a git repo) stays counted, because a
+ * bypass we cannot check is not a bypass we can dismiss.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join, resolve, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync, execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+import {
+  parseSkippedCommits,
+  partitionSkippedCommits,
+  gitReachabilityProbe,
+  type ReachabilityProbe,
+} from "./skipped-commits.js";
+import { SKIPPED_COMMITS_LOG } from "./hooks.js";
+
+const exec = promisify(execFile);
+const CLI_PATH = resolve(dirname(fileURLToPath(import.meta.url)), "cli.js");
+
+const A = "a".repeat(40);
+const B = "b".repeat(40);
+
+function entry(sha: string, reason = "sentinel-missing") {
+  return { timestamp: "2026-08-04T10:00:00Z", sha, reason };
+}
+
+/** A probe answering from two explicit sets — no git, so the rule is what is tested. */
+function probeFrom(resolvable: string[], contained: string[]): ReachabilityProbe {
+  return {
+    resolves: (sha) => resolvable.includes(sha),
+    containedByAnyRef: (sha) => contained.includes(sha),
+  };
+}
+
+describe("parseSkippedCommits", () => {
+  it("keeps well-formed entries in log order and drops the rest", () => {
+    const content = [
+      JSON.stringify(entry(A)),
+      "{ not json",
+      "",
+      JSON.stringify(entry(B, "sentinel-stale")),
+      JSON.stringify({ timestamp: "2026-08-04T10:00:00Z", reason: "no-sha" }),
+    ].join("\n");
+
+    const entries = parseSkippedCommits(content);
+
+    assert.deepEqual(
+      entries.map((e) => [e.sha, e.reason]),
+      [
+        [A, "sentinel-missing"],
+        [B, "sentinel-stale"],
+      ],
+      "a malformed line must not shift or drop the entries around it",
+    );
+  });
+});
+
+describe("partitionSkippedCommits", () => {
+  it("counts a commit some ref still contains", () => {
+    const { live, orphaned } = partitionSkippedCommits([entry(A)], probeFrom([A], [A]));
+    assert.deepEqual(
+      live.map((e) => e.sha),
+      [A],
+    );
+    assert.deepEqual(orphaned, []);
+  });
+
+  it("drops a commit that resolves but no ref contains — the squash-merge case", () => {
+    // This is the whole bug: the merge kept the change and discarded the commit, so the
+    // log entry describes a sha that is in no branch, tag or remote ref.
+    const { live, orphaned } = partitionSkippedCommits([entry(A)], probeFrom([A], []));
+    assert.deepEqual(live, [], "an entry no ref contains is not a live finding");
+    assert.deepEqual(
+      orphaned.map((e) => e.sha),
+      [A],
+    );
+  });
+
+  it("keeps a commit that cannot be resolved at all — fail closed", () => {
+    // Unknown object: a log carried between clones, or one gc'd away. Nothing here
+    // disproves the bypass, and a security banner must not go quiet on I-don't-know.
+    const { live, orphaned } = partitionSkippedCommits([entry(A)], probeFrom([], []));
+    assert.deepEqual(
+      live.map((e) => e.sha),
+      [A],
+      "unverifiable must count as live, not as pruned",
+    );
+    assert.deepEqual(orphaned, []);
+  });
+
+  it("splits a mixed log instead of taking the first answer for all of it", () => {
+    const { live, orphaned } = partitionSkippedCommits(
+      [entry(A), entry(B)],
+      probeFrom([A, B], [B]),
+    );
+    assert.deepEqual(
+      [live.map((e) => e.sha), orphaned.map((e) => e.sha)],
+      [[B], [A]],
+      "each entry is judged on its own sha",
+    );
+  });
+});
+
+describe("gitReachabilityProbe — against real git", () => {
+  it("separates a squashed-away commit from one main still contains", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kit-skipped-git-"));
+    try {
+      const git = (...args: string[]) =>
+        execFileSync("git", ["-C", dir, ...args], { encoding: "utf-8" }).trim();
+      git("init", "-q", "-b", "main");
+      git("config", "user.email", "test@example.com");
+      git("config", "user.name", "Test");
+      git("commit", "-q", "--allow-empty", "-m", "on main");
+      const onMain = git("rev-parse", "HEAD");
+      git("checkout", "-q", "-b", "feature");
+      git("commit", "-q", "--allow-empty", "-m", "on a branch that gets deleted");
+      const orphan = git("rev-parse", "HEAD");
+      git("checkout", "-q", "main");
+      // The squash-merge shape: the work is gone from every ref, the object is still here.
+      git("branch", "-q", "-D", "feature");
+
+      const probe = gitReachabilityProbe(dir);
+
+      assert.equal(probe.resolves(orphan), true, "the object is still in the object store");
+      assert.equal(probe.containedByAnyRef(orphan), false, "but no ref reaches it any more");
+      assert.equal(probe.containedByAnyRef(onMain), true, "main's own commit is still reachable");
+
+      const { live, orphaned } = partitionSkippedCommits(
+        [entry(orphan), entry(onMain)],
+        gitReachabilityProbe(dir),
+      );
+      assert.deepEqual([live.map((e) => e.sha), orphaned.map((e) => e.sha)], [[onMain], [orphan]]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports every sha as unresolved outside a git repo — so nothing gets pruned", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kit-skipped-nogit-"));
+    try {
+      const probe = gitReachabilityProbe(dir);
+      assert.equal(probe.resolves(A), false);
+      assert.equal(probe.containedByAnyRef(A), false);
+      const { live } = partitionSkippedCommits([entry(A)], probe);
+      assert.equal(live.length, 1, "no git means no verdict, and no verdict means keep it");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("the CLI banner reflects the partition", () => {
+  async function runVersion(cwd: string) {
+    const { stderr } = await exec(process.execPath, [CLI_PATH, "--version"], {
+      cwd,
+      env: { ...process.env, KIT_HIDE_HOOK_SKIP_BANNER: "0" },
+      timeout: 60_000,
+    });
+    return stderr ?? "";
+  }
+
+  async function repoWithLog(shas: string[]): Promise<{ dir: string; onMain: string }> {
+    const dir = await mkdtemp(join(tmpdir(), "kit-skipped-cli-"));
+    const git = (...args: string[]) =>
+      execFileSync("git", ["-C", dir, ...args], { encoding: "utf-8" }).trim();
+    git("init", "-q", "-b", "main");
+    git("config", "user.email", "test@example.com");
+    git("config", "user.name", "Test");
+    git("commit", "-q", "--allow-empty", "-m", "on main");
+    const onMain = git("rev-parse", "HEAD");
+    git("checkout", "-q", "-b", "feature");
+    git("commit", "-q", "--allow-empty", "-m", "squashed away");
+    const orphan = git("rev-parse", "HEAD");
+    git("checkout", "-q", "main");
+    git("branch", "-q", "-D", "feature");
+    const resolved = shas.map((s) => (s === "ORPHAN" ? orphan : s === "MAIN" ? onMain : s));
+    await writeFile(
+      join(dir, SKIPPED_COMMITS_LOG),
+      resolved.map((s) => JSON.stringify(entry(s))).join("\n") + "\n",
+      "utf-8",
+    );
+    return { dir, onMain };
+  }
+
+  it("says nothing when every entry was squashed away", async () => {
+    const { dir } = await repoWithLog(["ORPHAN"]);
+    try {
+      const stderr = await runVersion(dir);
+      assert.doesNotMatch(
+        stderr,
+        /bypassed pre-commit hook/,
+        `a log of only orphaned entries must produce no banner, got: ${stderr}`,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("counts only the live entries, and says how many it set aside", async () => {
+    const { dir } = await repoWithLog(["ORPHAN", "MAIN"]);
+    try {
+      const stderr = await runVersion(dir);
+      assert.match(
+        stderr,
+        /1 commit\(s\) bypassed pre-commit hook/,
+        `the count must be the live one, not the line count, got: ${stderr}`,
+      );
+      assert.match(
+        stderr,
+        /1 earlier entr/,
+        `the set-aside entries are stated rather than silently dropped, got: ${stderr}`,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("still warns about a sha it cannot resolve", async () => {
+    const { dir } = await repoWithLog([A]);
+    try {
+      const stderr = await runVersion(dir);
+      assert.match(
+        stderr,
+        /1 commit\(s\) bypassed pre-commit hook/,
+        `an unverifiable entry must keep the banner up, got: ${stderr}`,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/skipped-commits.ts
+++ b/src/skipped-commits.ts
@@ -1,0 +1,134 @@
+/**
+ * The bypass log (`.kit-skipped-commits.jsonl`) is append-only: the post-commit
+ * detector writes one line per commit that skipped the pre-commit hook, and nothing
+ * ever removes a line. That is right for an audit trail and wrong for a counter —
+ * a squash-merge keeps the change and discards the commit, so the recorded sha ends
+ * up in no ref at all while the banner keeps reporting it. Three such entries sat in
+ * this repo's own log, counted on every `kit` invocation, describing commits that no
+ * longer exist in any branch, tag or remote.
+ *
+ * So an entry is set aside only when it can be DISPROVED: the object is present and
+ * no ref contains it. Anything unverifiable — a log carried between clones, an object
+ * gc'd away, a directory that is not a git repo — stays counted. A bypass we cannot
+ * check is not a bypass we can dismiss, and this banner is the only place a
+ * `--no-verify` becomes visible after the fact.
+ */
+import { execFileSync } from "node:child_process";
+
+export interface SkippedCommitEntry {
+  timestamp: string;
+  sha: string;
+  reason: string;
+  user?: string;
+}
+
+/**
+ * Reachability questions asked of the repository, injected so the classification rule
+ * can be tested without building a git fixture for every case.
+ */
+export interface ReachabilityProbe {
+  /** Is this sha a commit object present in the store? */
+  resolves(sha: string): boolean;
+  /** Does at least one ref reach it? */
+  containedByAnyRef(sha: string): boolean;
+}
+
+/**
+ * Read the JSONL log. Malformed lines are skipped rather than fatal: the writer is a
+ * shell hook appending under `|| true`, so a truncated line must not blind the banner
+ * to the entries around it.
+ */
+export function parseSkippedCommits(content: string): SkippedCommitEntry[] {
+  const entries: SkippedCommitEntry[] = [];
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed) as Partial<SkippedCommitEntry>;
+      if (typeof parsed.sha !== "string" || !parsed.sha) continue;
+      entries.push({
+        timestamp: typeof parsed.timestamp === "string" ? parsed.timestamp : "",
+        sha: parsed.sha,
+        reason: typeof parsed.reason === "string" ? parsed.reason : "unknown",
+        user: typeof parsed.user === "string" ? parsed.user : undefined,
+      });
+    } catch {
+      /* malformed line — best-effort log, keep reading */
+    }
+  }
+  return entries;
+}
+
+/**
+ * Split the log into entries still reachable from some ref (`live`) and entries the
+ * repository can prove landed nowhere (`orphaned`). Unverifiable entries land in
+ * `live` — see the file header for why that direction is the safe one.
+ */
+export function partitionSkippedCommits(
+  entries: SkippedCommitEntry[],
+  probe: ReachabilityProbe,
+): { live: SkippedCommitEntry[]; orphaned: SkippedCommitEntry[] } {
+  const live: SkippedCommitEntry[] = [];
+  const orphaned: SkippedCommitEntry[] = [];
+  for (const entry of entries) {
+    if (probe.containedByAnyRef(entry.sha)) live.push(entry);
+    else if (probe.resolves(entry.sha)) orphaned.push(entry);
+    else live.push(entry);
+  }
+  return { live, orphaned };
+}
+
+/**
+ * A probe backed by git in `cwd`. Reachability comes from a single `rev-list` walk
+ * rather than one `git` call per entry; only the shas missing from that set need an
+ * object lookup. Every git failure answers "unknown" (false), which the partition
+ * reads as keep-counting.
+ */
+export function gitReachabilityProbe(cwd: string): ReachabilityProbe {
+  const git = (args: string[]): string | null => {
+    try {
+      return execFileSync("git", ["-C", cwd, ...args], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+    } catch {
+      return null;
+    }
+  };
+
+  let reachable: Set<string> | null = null;
+  const reachableSet = (): Set<string> => {
+    if (reachable) return reachable;
+    // `HEAD` is named alongside `--all` so a detached HEAD — mid-rebase, mid-bisect,
+    // exactly when a fresh commit has no branch yet — is not mistaken for orphaned.
+    // It is not a ref `--all` enumerates. Fall back if HEAD is unborn.
+    const out = git(["rev-list", "--all", "HEAD"]) ?? git(["rev-list", "--all"]);
+    reachable = new Set(
+      (out ?? "")
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean),
+    );
+    return reachable;
+  };
+
+  // The log stores full shas, but a hand-edited or abbreviated one must not be read as
+  // "absent from the reachable set" and thereby pruned.
+  const resolved = new Map<string, string | null>();
+  const fullSha = (sha: string): string | null => {
+    const cached = resolved.get(sha);
+    if (cached !== undefined) return cached;
+    const out = git(["rev-parse", "--verify", "--quiet", `${sha}^{commit}`]);
+    const value = out?.trim() || null;
+    resolved.set(sha, value);
+    return value;
+  };
+
+  return {
+    resolves: (sha) => fullSha(sha) !== null,
+    containedByAnyRef: (sha) => {
+      const full = fullSha(sha);
+      return full !== null && reachableSet().has(full);
+    },
+  };
+}


### PR DESCRIPTION
## The bug

`.kit-skipped-commits.jsonl` is append-only, and `showSkippedCommitBanner` counted
its **lines**. A squash-merge keeps the change and discards the commit it recorded,
so the logged sha ends up in no ref at all — and the banner keeps reporting it on
every `kit` invocation, forever.

This repo's own log held three such entries. All three are unreachable:

```
4b05b51c  refs containing it: (none)
15cfd635  refs containing it: (none)
57f316f8  refs containing it: (none)
```

A warning that cannot go down is a warning nobody reads — and this banner is the
one control that makes a `git commit --no-verify` visible after the fact.

## The rule

The count is now the entries the repository still recognises. An entry is set aside
only when git can **disprove** it: the object resolves *and* no ref contains it.

Everything unverifiable stays counted — a log carried between clones, an object
gc'd away, a directory that is not a repository. A bypass that cannot be checked is
not one that can be dismissed. `rev-list` is asked for `--all HEAD`, not `--all`, so
a detached HEAD (mid-rebase, mid-bisect — exactly when a fresh commit has no branch
yet) is not read as orphaned. Set-aside entries are stated in the banner, never
silently dropped.

Reachability sits behind an injected `ReachabilityProbe`, so the rule is testable
without a git fixture per case; `gitReachabilityProbe` does one `rev-list` walk
rather than a `git` call per entry.

## Verification

Test-first, and then the tests were shown to have teeth — patching the compiled
partition back to "every line counts" **kills 5 of the 10**, including both
end-to-end CLI cases. A green suite alone would not have shown that.

| Check | Result |
|---|---|
| Real git fixture (commit on main + commit on a deleted branch) | orphan resolves, no ref contains it, pair partitions apart |
| CLI, log with only an orphaned sha | no banner |
| CLI, orphaned + live | `1 commit(s) bypassed` + `1 earlier entry is in no ref` |
| CLI, unresolvable sha | banner stays up (fail closed) |
| This repo | `node dist/cli.js --version` prints no banner, where `kit` printed `3 commit(s) bypassed pre-commit hook` |
| Full suite | **4022 pass / 0 fail** |
| `tsc --noEmit` / eslint / prettier | clean / 0 errors / clean |
| `kit check --category security` | 22/23, the one warn being the unchanged secrets-history baseline |

`docs/THREAT_MODEL.md` states the reachability rule under Bypass detection, since it
changes what the banner claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)