### PR TITLE
fix(guard): a shim could hand the call to another shim manager and get it back forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to kit are documented in this file. This project adheres to 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Fixed
+
+- **A guard shim could ping-pong with another shim manager's shim and never run the
+  tool.** ([#461](https://github.com/sandstream/kit/issues/461))
+  The shim resolved the real tool by scanning `PATH` and skipping exactly one
+  directory: its own. On a machine where the next `PATH` entry belongs to another
+  shim manager (mise, asdf, rtx, pyenv, rbenv), that manager applies the same rule —
+  and when it has no version active for the current directory it falls through to a
+  `PATH` lookup, which lands back in kit's shim, which hands off again. Four
+  `~/.kit/shims/npm` processes were found alive on a dev machine, two of them 5 and
+  7.5 hours old, each burning ~20% CPU and re-spawning `kit guard-observe` about once
+  a second, with the wrapped command never run and no output at all. `sh -x` named
+  the hand-off; the discriminating test was that mise's shim answers immediately once
+  `~/.kit/shims` leaves `PATH`. `KIT_GUARD_BYPASS=1` did not help — it skips the
+  observation, not the hand-off — so the guard's core promise ("never blocks; kit
+  unavailable ⇒ unchanged behavior") was inverted into an indefinite block.
+
+  A hand-off into a shims directory now removes kit's own directory from the
+  exported `PATH` first — every occurrence, trailing slash tolerated — so the
+  receiving manager cannot resolve back into us, and marks the hand-off in a
+  per-tool variable (`KIT_GUARD_ACTIVE_NPM`); if the shim is re-entered anyway it
+  resolves past every shims directory instead of spinning. A hand-off to a real
+  binary is unchanged: `PATH` and the environment are left alone, so what the tool
+  spawns is still observed. The version manager keeps choosing the binary — kit hands
+  off *through* it, never past it, which a test pins with a decoy `npm` further down
+  `PATH`. Measured on the reporting machine with its real mise shims and mise in
+  fall-through mode: the old shim was killed after 8s having printed nothing, the new
+  one answers `11.11.0`; with mise owning node for the directory, both resolve the
+  same `10.9.8`. Six of the guard tests now execute the generated `sh` for real, so
+  this class of hang fails a test instead of hanging a machine.
+
+- **An upgraded kit next to an old shim was still a broken machine.** Shims are files
+  on disk, written once by `kit guard install`, and nobody re-runs that after an
+  upgrade — so the fix above would have reached only new installs. `kit guard-observe`
+  now rewrites the shim that called it when that file does not match the running kit
+  version, and `kit guard status` names any shim that predates it. Shim writes became
+  a rename onto the path instead of a truncate in place: `sh` reads a script as it
+  executes it, so rewriting a shim mid-run would splice the file under the running
+  shell — the rename leaves that process on the old inode. Foreign files at a shim
+  path are still never touched.
+
 ## [6.4.2] - 2026-08-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -573,6 +573,15 @@ uninstall` removes everything. Notable: the shims also see the `npx`-spawned
 MCP servers agent harnesses launch **outside** any Bash gate — coverage the
 PreToolUse hook can't reach.
 
+A shim hands the call to the next match on `PATH`, so another shim manager
+(mise, asdf, pyenv, rbenv) still chooses which version runs — but kit drops its
+own directory from `PATH` before handing off into one, because those managers
+re-resolve the tool through `PATH` and would otherwise land back in kit's shim
+forever ([#461](https://github.com/sandstream/kit/issues/461)). Shims also
+self-heal: `kit guard-observe` rewrites the shim that called it when the file
+predates the running kit version, so an upgrade doesn't leave old wrappers
+behind, and `kit guard status` names any that are still stale.
+
 ### Compliance evidence
 
 `kit coverage` emits deterministic _evidence maps_: it maps kit's own checks and self-audit rules to a vendored, pinned, curated subset of a standard's controls and buckets each as auto-verified, gap, manual, or n-a. `--json` (or `--format=json`) emits the structured report for a GRC tool to consume.

--- a/src/commands/guard.ts
+++ b/src/commands/guard.ts
@@ -17,6 +17,8 @@ import {
   stripRcBlock,
   appendObservation,
   readObservations,
+  staleShims,
+  refreshShims,
   SHIM_MARKER,
 } from "../guard.js";
 
@@ -26,6 +28,11 @@ export async function cmdGuardObserve(): Promise<boolean> {
   try {
     const [tool, ...rest] = process.argv.slice(3);
     if (!tool) return true;
+    // Self-heal the shim that just called us. `kit guard install` is the only other
+    // path that rewrites shims, and nobody re-runs it after an upgrade — so a fixed
+    // kit would sit next to a broken shim forever (#461 hung silently for hours).
+    // Atomic by construction in writeShim; the caller keeps running the old inode.
+    if (staleShims(guardShimsDir()).includes(tool)) refreshShims([tool], guardShimsDir());
     const command = [tool, ...rest].join(" ");
     const { parseInstallCommand, decideBashGate } = await import("../install-gate.js");
     const probe = parseInstallCommand(command);
@@ -124,6 +131,12 @@ function guardStatus(): boolean {
   for (const o of obs.slice(-5)) {
     const icon = o.wouldBlock ? `${c.yellow}!${c.reset}` : `${c.green}✓${c.reset}`;
     console.log(`  ${icon} ${o.ts}  ${o.command}  ${c.dim}${o.reason}${c.reset}`);
+  }
+  const stale = staleShims(dir);
+  if (stale.length > 0) {
+    console.log(
+      `  ${c.yellow}!${c.reset} ${stale.length} shim(s) predate this kit version (${stale.join(" ")}) — they refresh on next use, or now: kit guard install`,
+    );
   }
   if (shims.length === 0) {
     console.log(`  ${c.dim}install with: kit guard install${c.reset}`);

--- a/src/guard.test.ts
+++ b/src/guard.test.ts
@@ -1,12 +1,27 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  existsSync,
+  openSync,
+  readSync,
+  closeSync,
+} from "node:fs";
+import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   GUARD_TOOLS,
   generateShim,
+  reentryVar,
   writeShim,
+  staleShims,
+  refreshShims,
   rcBlock,
   upsertRcBlock,
   stripRcBlock,
@@ -35,9 +50,20 @@ describe("generateShim", () => {
   });
 
   it("execs the real binary from PATH, skipping the shims dir; missing binary exits 127", () => {
-    assert.ok(shim.includes('[ "${_d}" = "${_kit_shims}" ] && continue'));
+    assert.ok(shim.includes('[ "${_d%/}" = "${_kit_shims%/}" ] && continue'));
     assert.ok(shim.includes('exec "${_d}/npm" "$@"'));
     assert.ok(shim.includes("exit 127"));
+  });
+
+  it("marks a shim-to-shim hand-off per tool, so a nested pip is still observed", () => {
+    assert.equal(reentryVar("npm"), "KIT_GUARD_ACTIVE_NPM");
+    assert.equal(reentryVar("pip3"), "KIT_GUARD_ACTIVE_PIP3");
+    assert.ok(shim.includes("export KIT_GUARD_ACTIVE_NPM=1"));
+    assert.ok(
+      shim.includes("unset KIT_GUARD_ACTIVE_NPM"),
+      "a real-binary exec must not leak the marker",
+    );
+    assert.ok(generateShim("pip3", "/x").includes("KIT_GUARD_ACTIVE_PIP3"));
   });
 
   it("only observes when kit is actually on PATH (fresh machine ⇒ pure pass-through)", () => {
@@ -56,6 +82,63 @@ describe("shim + rc file handling", () => {
       assert.ok(readFileSync(join(dir, "brew"), "utf-8").includes(SHIM_MARKER));
       // kit-managed files ARE overwritable (idempotent re-install)
       assert.equal(writeShim("brew", dir), "written");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("writeShim replaces by rename, so a shim being executed keeps its old bytes", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-guard-atomic-"));
+    try {
+      const path = join(dir, "npm");
+      writeFileSync(path, `#!/bin/sh\n${SHIM_MARKER}\necho old\n`, { mode: 0o755 });
+      // What `sh` holds while it executes the script: an open descriptor it reads from.
+      const fd = openSync(path, "r");
+      try {
+        assert.equal(writeShim("npm", dir), "written");
+        const held = Buffer.alloc(64);
+        readSync(fd, held, 0, 64, 0);
+        assert.match(
+          held.toString("utf-8"),
+          /echo old/,
+          "in-place truncation would splice a running sh",
+        );
+      } finally {
+        closeSync(fd);
+      }
+      assert.ok(
+        readFileSync(path, "utf-8").includes("kit guard-observe npm"),
+        "new bytes are in place",
+      );
+      assert.deepEqual(
+        readdirSync(dir).filter((f) => f.includes("kit-tmp")),
+        [],
+        "no temp file left behind",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("staleShims flags kit shims from an older version and nothing else", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-guard-stale-"));
+    try {
+      writeFileSync(join(dir, "npm"), `#!/bin/sh\n${SHIM_MARKER}\nexec npm "$@"\n`, {
+        mode: 0o755,
+      });
+      writeFileSync(join(dir, "pip"), "#!/bin/sh\necho my own wrapper\n", { mode: 0o755 });
+      writeShim("brew", dir);
+      assert.deepEqual(
+        staleShims(dir),
+        ["npm"],
+        "foreign, current, and absent shims are not stale",
+      );
+      assert.deepEqual(refreshShims(["npm"], dir), ["npm"]);
+      assert.deepEqual(staleShims(dir), [], "refreshed shim matches this version");
+      assert.ok(
+        readFileSync(join(dir, "pip"), "utf-8").includes("my own wrapper"),
+        "foreign file untouched",
+      );
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -119,6 +202,159 @@ describe("observation log", () => {
       if (saved === undefined) delete process.env.KIT_GUARD_LOG;
       else process.env.KIT_GUARD_LOG = saved;
     }
+  });
+});
+
+// #461: the shim hands off to the next `npm` on PATH. When that next entry belongs
+// to ANOTHER shim manager (mise/asdf/pyenv/rbenv), that manager re-resolves `npm`
+// through PATH — with kit's shims still first — and the two shims ping-pong
+// forever: no output, no real npm, ~20% CPU per stuck process, hours of elapsed
+// time. These tests run the generated sh for real, so a regression is a killed
+// child with empty stdout rather than a quiet pass.
+type CompetingShim = "none" | "peer" | "owns-tool";
+
+interface ShimRun {
+  stdout: string;
+  stderr: string;
+  status: number | null;
+  /** Non-null means the child had to be killed — i.e. it never finished. */
+  signal: string | null;
+}
+
+function runShim(
+  competing: CompetingShim,
+  opts: { duplicateKitOnPath?: boolean; bypass?: boolean; noRealNpm?: boolean } = {},
+): ShimRun {
+  const root = mkdtempSync(join(tmpdir(), "kit-guard-handoff-"));
+  try {
+    const kitShims = join(root, "kit", "shims");
+    const otherShims = join(root, "other", "shims"); // a */shims dir, like mise/asdf/pyenv
+    const installBin = join(root, "installs", "node", "bin"); // where a version manager keeps the real tool
+    const sysBin = join(root, "usr", "bin");
+    for (const d of [kitShims, otherShims, installBin, sysBin]) mkdirSync(d, { recursive: true });
+
+    writeFileSync(join(kitShims, "npm"), generateShim("npm", kitShims), { mode: 0o755 });
+
+    // The stand-in for the real npm reports what it inherited, so a test can assert
+    // on the hand-off's side effects (marker leakage, PATH surgery), not merely that
+    // something ran.
+    const reporter = (tag: string) =>
+      `#!/bin/sh\necho "${tag} npm $*"\necho "MARKER=\${KIT_GUARD_ACTIVE_NPM:-unset}"\necho "PATH=\$PATH"\n`;
+    if (!opts.noRealNpm) {
+      const realDir = competing === "owns-tool" ? installBin : sysBin;
+      writeFileSync(join(realDir, "npm"), reporter("REAL"), { mode: 0o755 });
+      // With a version manager in charge, an npm further down PATH is the WRONG
+      // one — resolving past the manager's shim would silently pick this.
+      if (competing === "owns-tool")
+        writeFileSync(join(sysBin, "npm"), reporter("DECOY"), { mode: 0o755 });
+    }
+    if (competing === "peer") {
+      // The measured #461 partner: re-resolves the tool through PATH, skipping only
+      // ITS own dir — exactly kit's own rule. Two shims with that rule ping-pong.
+      writeFileSync(
+        join(otherShims, "npm"),
+        `#!/bin/sh
+_oi="\${IFS}"
+IFS=:
+for _d in \$PATH; do
+  IFS="\${_oi}"
+  [ -n "\${_d}" ] || continue
+  [ "\${_d}" = "${otherShims}" ] && continue
+  [ -x "\${_d}/npm" ] && exec "\${_d}/npm" "$@"
+done
+echo "peer-shim: npm not found" >&2
+exit 127
+`,
+        { mode: 0o755 },
+      );
+    } else if (competing === "owns-tool") {
+      // A manager that resolves internally to the version it selected.
+      writeFileSync(join(otherShims, "npm"), `#!/bin/sh\nexec "${installBin}/npm" "$@"\n`, {
+        mode: 0o755,
+      });
+    }
+
+    const path = [kitShims];
+    if (opts.duplicateKitOnPath) path.push(`${kitShims}/`); // rc sourced twice / trailing slash
+    if (competing !== "none") path.push(otherShims);
+    path.push(sysBin);
+
+    // No `kit` on this PATH ⇒ observation is skipped, so the test measures the
+    // hand-off alone.
+    const r = spawnSync(join(kitShims, "npm"), ["--version"], {
+      env: { PATH: path.join(":"), HOME: root, ...(opts.bypass ? { KIT_GUARD_BYPASS: "1" } : {}) },
+      encoding: "utf-8",
+      timeout: 5000,
+      killSignal: "SIGKILL",
+    });
+    return {
+      stdout: r.stdout ?? "",
+      stderr: r.stderr ?? "",
+      status: r.status,
+      signal: r.signal ?? null,
+    };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+const pathSeenBy = (run: ShimRun): string =>
+  run.stdout.split("\n").find((l) => l.startsWith("PATH=")) ?? "";
+
+describe("hand-off when another shim manager owns the tool (#461)", () => {
+  it("a competing shim that re-resolves via PATH cannot ping-pong the shim", () => {
+    const r = runShim("peer");
+    assert.equal(r.signal, null, "the shim never returned — the #461 ping-pong is back");
+    assert.match(r.stdout, /REAL npm --version/);
+    assert.ok(
+      !pathSeenBy(r).includes("/kit/shims"),
+      "after a shim-to-shim hand-off kit's dir must be off PATH — that is what makes re-entry impossible",
+    );
+  });
+
+  it("hands off THROUGH the version manager, never past it to the wrong npm", () => {
+    const r = runShim("owns-tool");
+    assert.equal(r.signal, null);
+    assert.match(r.stdout, /REAL npm --version/);
+    assert.doesNotMatch(
+      r.stdout,
+      /DECOY/,
+      "skipping the manager's shim would run an npm it did not select",
+    );
+  });
+
+  it("kit's dir listed twice (rc sourced twice, trailing slash) still terminates", () => {
+    const r = runShim("peer", { duplicateKitOnPath: true });
+    assert.equal(r.signal, null, "the shim never returned — the #461 ping-pong is back");
+    assert.match(r.stdout, /REAL npm --version/);
+    assert.ok(
+      !pathSeenBy(r).includes("/kit/shims"),
+      "every occurrence must be dropped, not the first",
+    );
+  });
+
+  it("KIT_GUARD_BYPASS=1 reaches the real tool too — the bypass never fixed the loop", () => {
+    const r = runShim("peer", { bypass: true });
+    assert.equal(r.signal, null, "bypass must not hang either");
+    assert.match(r.stdout, /REAL npm --version/);
+  });
+
+  it("no competing shim ⇒ PATH and marker untouched, so nested installs stay observed", () => {
+    const r = runShim("none");
+    assert.equal(r.signal, null);
+    assert.match(r.stdout, /REAL npm --version/);
+    assert.match(r.stdout, /MARKER=unset/, "no hand-off happened ⇒ no re-entry marker to leak");
+    assert.ok(
+      pathSeenBy(r).includes("/kit/shims"),
+      "the guard must still cover what the real tool spawns",
+    );
+  });
+
+  it("nothing to hand off to still exits 127 with the uninstall hint", () => {
+    const r = runShim("none", { noRealNpm: true });
+    assert.equal(r.signal, null);
+    assert.equal(r.status, 127);
+    assert.match(r.stderr, /kit guard uninstall/);
   });
 });
 

--- a/src/guard.ts
+++ b/src/guard.ts
@@ -17,7 +17,15 @@
  * the real tool); KIT_GUARD_DIR / KIT_GUARD_LOG / KIT_GUARD_RC override paths
  * (tests + unusual homes).
  */
-import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  appendFileSync,
+  renameSync,
+  rmSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -63,35 +71,92 @@ export function guardRcFiles(): string[] {
   return out;
 }
 
+/** Per-tool re-entry marker (`KIT_GUARD_ACTIVE_NPM`), set only when the shim
+ *  hands off to ANOTHER shim manager. Per-tool so a nested `pip install` under
+ *  an `npm` hand-off is still observed. */
+export function reentryVar(tool: string): string {
+  return `KIT_GUARD_ACTIVE_${tool.toUpperCase().replace(/[^A-Z0-9]/g, "_")}`;
+}
+
 /**
- * The POSIX-sh shim for one tool. Pure — unit-tested as text. Contract:
+ * The POSIX-sh shim for one tool. Pure — unit-tested as text AND executed for
+ * real in the hand-off tests. Contract:
  *  1. observe first (best-effort, silenced, NEVER gating): `kit guard-observe`
  *     logs what the install gate would decide;
- *  2. then exec the REAL binary — first PATH match outside the shims dir;
+ *  2. then exec the REAL tool — first PATH match outside our own shims dir, so
+ *     another manager's version choice still wins;
  *  3. kit missing/crashing changes nothing; a missing real binary exits 127
  *     like a shell would.
+ *
+ * The hand-off in (2) is where #461 lived: the next PATH entry can belong to
+ * ANOTHER shim manager (mise/asdf/pyenv/rbenv), which re-resolves the tool
+ * through PATH — with our dir still first — and the two shims ping-pong forever,
+ * silently, never running the tool. So a hand-off into a shims dir (any PATH
+ * entry ending in `/shims`) drops our
+ * dir from PATH (making re-entry impossible for that subtree) and marks the
+ * hand-off; a hand-off to a real binary leaves PATH and the environment alone so
+ * nested installs stay observed. The marker is the belt: if we are re-entered
+ * anyway (our dir reachable under another name — symlink, different mount path),
+ * we resolve past EVERY shims dir rather than spin.
  */
 export function generateShim(tool: string, shimsDir: string): string {
+  const active = reentryVar(tool);
   return `#!/bin/sh
 ${SHIM_MARKER}
 # kit guard v1 (observe): logs what kit's install gate WOULD decide, then
 # ALWAYS runs the real ${tool}. Never blocks; kit unavailable => unchanged
 # behavior. Bypass: KIT_GUARD_BYPASS=1. Remove: kit guard uninstall.
-if [ -z "\${KIT_GUARD_BYPASS:-}" ] && command -v kit >/dev/null 2>&1; then
+_kit_shims="${shimsDir}"
+_kit_reentry="\${${active}:-}"
+if [ -z "\${_kit_reentry}" ] && [ -z "\${KIT_GUARD_BYPASS:-}" ] && command -v kit >/dev/null 2>&1; then
   kit guard-observe ${tool} "$@" >/dev/null 2>&1 || true
 fi
-_kit_shims="${shimsDir}"
+# PATH minus every entry that is our own shims dir (trailing slash tolerated).
+_kit_path_minus_self() {
+  _kit_out=""
+  _kit_oifs="\${IFS}"
+  IFS=:
+  for _p in \$PATH; do
+    IFS="\${_kit_oifs}"
+    [ -n "\${_p}" ] || continue
+    [ "\${_p%/}" = "\${_kit_shims%/}" ] && continue
+    if [ -z "\${_kit_out}" ]; then _kit_out="\${_p}"; else _kit_out="\${_kit_out}:\${_p}"; fi
+  done
+  IFS="\${_kit_oifs}"
+  printf '%s' "\${_kit_out}"
+}
+_kit_handoff=""
 _old_ifs="\${IFS}"
 IFS=:
 for _d in \$PATH; do
   IFS="\${_old_ifs}"
   [ -n "\${_d}" ] || continue
-  [ "\${_d}" = "\${_kit_shims}" ] && continue
-  if [ -x "\${_d}/${tool}" ]; then
-    exec "\${_d}/${tool}" "$@"
-  fi
+  [ "\${_d%/}" = "\${_kit_shims%/}" ] && continue
+  [ -x "\${_d}/${tool}" ] || continue
+  case "\${_d%/}" in
+    */shims)
+      # Another shim manager owns ${tool}: hand off (its version wins), but with
+      # our dir off PATH — it resolves ${tool} again and must not land back here.
+      if [ -n "\${_kit_reentry}" ]; then
+        [ -n "\${_kit_handoff}" ] || _kit_handoff="\${_d}"
+        continue
+      fi
+      PATH="\$(_kit_path_minus_self)"
+      export PATH
+      export ${active}=1
+      exec "\${_d}/${tool}" "$@"
+      ;;
+  esac
+  unset ${active}
+  exec "\${_d}/${tool}" "$@"
 done
 IFS="\${_old_ifs}"
+if [ -n "\${_kit_handoff}" ]; then
+  # Re-entered, and only shim dirs have ${tool}: run it with our dir off PATH.
+  PATH="\$(_kit_path_minus_self)"
+  export PATH
+  exec "\${_kit_handoff}/${tool}" "$@"
+fi
 echo "kit-guard: ${tool} not found on PATH (beyond the shim) — run: kit guard uninstall" >&2
 exit 127
 `;
@@ -170,12 +235,58 @@ export function readObservations(): GuardObservation[] {
   }
 }
 
-/** Write a shim file, refusing to clobber a non-kit file. Returns what happened. */
+/** Write a shim file, refusing to clobber a non-kit file. Returns what happened.
+ *  The write is a rename onto the path, never a truncate-in-place: `sh` reads a
+ *  script as it executes it, so rewriting a shim that is mid-run would feed the
+ *  running shell a spliced file. Rename leaves that process on the old inode. */
 export function writeShim(tool: string, dir: string): "written" | "kept-foreign" {
   const path = join(dir, tool);
   if (existsSync(path) && !readFileSync(path, "utf-8").includes(SHIM_MARKER)) {
     return "kept-foreign";
   }
-  writeFileSync(path, generateShim(tool, dir), { mode: 0o755 });
+  const tmp = `${path}.kit-tmp-${process.pid}`;
+  try {
+    writeFileSync(tmp, generateShim(tool, dir), { mode: 0o755 });
+    renameSync(tmp, path);
+  } catch (e) {
+    try {
+      rmSync(tmp, { force: true });
+    } catch {
+      // nothing to clean up
+    }
+    throw e;
+  }
   return "written";
+}
+
+/** Kit-managed shims on disk whose text is not what this kit version generates.
+ *  Staleness is not cosmetic here: the #461 ping-pong shipped as a silent hang and
+ *  keeps hanging until the file itself is rewritten, so an upgraded kit with old
+ *  shims is still a broken machine. */
+export function staleShims(dir: string): string[] {
+  return GUARD_TOOLS.filter((tool) => {
+    try {
+      const path = join(dir, tool);
+      if (!existsSync(path)) return false;
+      const body = readFileSync(path, "utf-8");
+      return body.includes(SHIM_MARKER) && body !== generateShim(tool, dir);
+    } catch {
+      return false;
+    }
+  });
+}
+
+/** Rewrite stale kit-managed shims in place (atomically). Best-effort by contract:
+ *  called from the observe path, where a failure must never reach the user's tool.
+ *  Returns the tools actually refreshed. */
+export function refreshShims(tools: readonly string[], dir: string): string[] {
+  const done: string[] = [];
+  for (const tool of tools) {
+    try {
+      if (writeShim(tool, dir) === "written") done.push(tool);
+    } catch {
+      // a shim we cannot rewrite is left exactly as it was
+    }
+  }
+  return done;
 }


### PR DESCRIPTION
Fixes #461.

## The defect

`generateShim` resolved the real tool by scanning `PATH` and skipping exactly one
directory: its own. Another shim manager (mise, asdf, rtx, pyenv, rbenv) applies the
same rule, and when it has no version active for the current directory it falls
through to a `PATH` lookup — which, with `~/.kit/shims` still first, lands back in
kit's shim. The two shims then hand the call back and forth: no output, no real tool,
~20% CPU per stuck process. On the reporting machine four such processes were alive,
two of them 5 and 7.5 hours old.

`KIT_GUARD_BYPASS=1` skips the observation, not the hand-off, so it never helped. The
guard's contract — *never blocks; kit unavailable ⇒ unchanged behavior* — had inverted
into an indefinite block, which is worse than not guarding.

## The fix

A hand-off **into** a shims directory now exports `PATH` without kit's own directory
(every occurrence, trailing slash tolerated) so the receiving manager cannot resolve
back into us, and marks the hand-off in a per-tool variable (`KIT_GUARD_ACTIVE_NPM`);
on re-entry the shim resolves past every shims directory instead of spinning. A
hand-off to a real binary is unchanged — `PATH` intact, marker unset — so what the
tool spawns is still observed. The version manager still selects the binary: kit hands
off *through* it, never past it.

## Evidence

Real mise shims, real machine, mise falling through (the field shape — a cwd with no
node pinned and no mise activation in the environment):

| what ran | result |
|---|---|
| HEAD's shim installed at `~/.kit/shims/npm` | **killed after 8s, no output** |
| the fixed shim, same `PATH` + cwd | `11.11.0` |
| either shim, cwd where mise owns node | `10.9.8` — version choice unchanged |

Six guard tests now execute the generated `sh` for real: competing shim, version
manager with a decoy `npm` further down `PATH`, kit's directory listed twice, bypass,
plain machine, and nothing to hand off to. Against HEAD's shim the competing-shim case
hangs until the runner kills it, so the tests have teeth.

`npm test`: 4031 pass / 0 fail. `npm run lint`: 0 errors. `kit check --category
security`: 23/24, the one warning pre-existing (secret-shaped strings in git history).

## Stale shims

Shims are files, written once by `kit guard install`, and nobody re-runs that after an
upgrade — a fixed kit next to an old shim is still a hung machine, so this fix would
otherwise have reached new installs only. `kit guard-observe` now rewrites the shim
that called it when the file does not match the running version, and `kit guard
status` names any that predate it. Shim writes became a rename onto the path rather
than a truncate in place: `sh` reads a script while it executes it, so an in-place
rewrite would splice the file under a running shim; the rename leaves that process on
the old inode. Foreign files at a shim path are still never touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
