### PR TITLE
chore(release): v6.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [6.5.0] - 2026-08-05
+
 ### Added
 
 - **`kit memory install` now wires Codex lifecycle hooks, not only Claude Code.**

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -1131,7 +1131,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "6.4.2"
+    "version": "6.5.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "6.4.2",
+  "version": "6.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "6.4.2",
+      "version": "6.5.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "6.4.2",
+  "version": "6.5.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
## v6.5.0

Minor release containing:
- Codex lifecycle hook support for memory capture
- guard shim handoff/self-healing fix from #462

## Release verification
- full suite: 4037 passed, 0 failed
- OpenCLI snapshot: 9 passed
- CLI reports 6.5.0
- npm pack dry-run: sandstream-kit@6.5.0, 1,964 files
- security gate: 0 failed

After merge: create and push signed v6.5.0 tag, monitor publish workflow, then verify npm and installed hook behavior.