### PR TITLE
kit_check answers the question the agent asked — and offloads the rest

### DIFF
--- a/docs/MCP_TOOLS_REFERENCE.md
+++ b/docs/MCP_TOOLS_REFERENCE.md
@@ -25,7 +25,7 @@ governance floor (revocation, budget, permissions, expired-secret block).
 
 | Tool | Kind | Purpose |
 | --- | --- | --- |
-| `kit_check` | read | Run all checks — tools, services, secrets, skills, hooks, deploy env, security, tests, locks — and return the same verdict `kit check` computes. |
+| `kit_check` | read | Run all checks — tools, services, secrets, skills, hooks, deploy env, security, tests, locks — and return the same verdict `kit check` computes, as `{ ok, scope, dimensions, failed, findings, counts, passesOmitted, detail }`. Passing rows are left out of the response and the complete run is written to `detail.path`; a `skip` or a `didNotRun` is never left out, because lost coverage is not a pass. `detail: true` returns the full document inline instead (measured: 9,799 chars vs 3,210 — the response is paid per call, the tool schema once per session). |
 | `kit_review` | read | Full repo audit in one shot — the check, design, standards, and ADR gates as one structured report (`{ ok, failed, stages }`), from the same core `kit review` renders. `stages: ["standards"]` scopes to named gates (the fast, read-only lint loop — no full security scan), `category` scopes the standards stage, `concise: true` omits pass/skip rows (per-stage counts stay). |
 | `kit_fix` | write | Auto-fix what `kit_check` found: install missing tools, generate missing lock files. Returns actions taken. |
 | `kit_triage` | write | Security-triage a dependency **before** installing it (`type`: npm/pip/docker/brew/repo/skill + `target`). A PASS is recorded in the triage log the install gates read, so an MCP-run triage satisfies them identically to a CLI-run one. Refuses in read-only mode — an unrecordable pass could not satisfy the gates anyway. |

--- a/scripts/measure-mcp-output.mjs
+++ b/scripts/measure-mcp-output.mjs
@@ -1,0 +1,54 @@
+// Measure what kit's MCP surface actually costs an agent, in this repo, right now.
+//
+// Two numbers get confused with each other and only one of them dominates:
+//
+//   standing surface  — the tool schemas from `tools/list`, paid ONCE per session
+//   response          — one kit_check answer, paid on EVERY call, and an agent in a
+//                       check → fix → check loop calls it repeatedly
+//
+// A full kit_check response measured larger than the entire standing surface, which is why
+// the response is summarized by default and the complete run is offloaded to a file. This
+// script is how that claim stays honest: run it after touching the MCP surface and compare.
+//
+//   node scripts/measure-mcp-output.mjs
+//
+// Runs every real scanner (it is a real check), so it takes as long as `kit check` does.
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createMcpServer } from "../dist/mcp-server.js";
+
+const server = createMcpServer();
+const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+const client = new Client({ name: "measure-mcp-output", version: "1.0.0" }, { capabilities: {} });
+await server.connect(serverTransport);
+await client.connect(clientTransport);
+
+const chars = (r) => r.content.reduce((n, c) => n + c.text.length, 0);
+const check = (args) =>
+  client.callTool({ name: "kit_check", arguments: args }, undefined, { timeout: 600_000 });
+
+const summary = await check({});
+const full = await check({ detail: true });
+const { tools } = await client.listTools();
+
+const s = chars(summary);
+const f = chars(full);
+const parsed = JSON.parse(summary.content[0].text);
+
+console.log(
+  JSON.stringify(
+    {
+      standingSurfaceChars: JSON.stringify(tools).length,
+      fullResponseChars: f,
+      summaryResponseChars: s,
+      reductionPct: +(100 * (1 - s / f)).toFixed(1),
+      approxTokens: { full: Math.round(f / 4), summary: Math.round(s / 4) },
+      counts: parsed.counts,
+      findings: parsed.findings.length,
+      detailPath: parsed.detail?.path ?? null,
+    },
+    null,
+    2,
+  ),
+);
+await client.close();

--- a/src/check-detail-store.test.ts
+++ b/src/check-detail-store.test.ts
@@ -1,0 +1,80 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  chmodSync,
+  mkdirSync,
+  existsSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeCheckDetail, pruneCheckDetails, RUNS_DIR, KEEP_RUNS } from "./check-detail-store.js";
+
+function tmpProject(): string {
+  return mkdtempSync(join(tmpdir(), "kit-runs-"));
+}
+
+describe("writeCheckDetail", () => {
+  it("writes the payload where the returned path says it did", () => {
+    const cwd = tmpProject();
+    const ref = writeCheckDetail(cwd, { ok: true, security: [] }, 1000);
+    assert.ok(ref, "expected a reference");
+    // The whole point of the reference: it has to resolve. Reading it back IS the assertion.
+    assert.deepEqual(JSON.parse(readFileSync(ref.path, "utf-8")), { ok: true, security: [] });
+    assert.equal(ref.path, join(cwd, RUNS_DIR, "check-1000.json"));
+  });
+
+  it("returns null instead of a dangling reference when the write fails", () => {
+    const cwd = tmpProject();
+    // A .kit that cannot be written into: mkdir of .kit/runs fails, so there is no file.
+    mkdirSync(join(cwd, ".kit"));
+    chmodSync(join(cwd, ".kit"), 0o500);
+    try {
+      assert.equal(writeCheckDetail(cwd, { ok: true }, 1000), null);
+    } finally {
+      chmodSync(join(cwd, ".kit"), 0o700);
+    }
+  });
+
+  it("keeps the newest runs and drops the rest", () => {
+    const cwd = tmpProject();
+    for (let i = 1; i <= KEEP_RUNS + 3; i++) writeCheckDetail(cwd, { run: i }, i);
+    const left = readdirSync(join(cwd, RUNS_DIR)).sort();
+    assert.equal(left.length, KEEP_RUNS);
+    // The three oldest stamps are the ones gone — pruning is by run order, not by mtime.
+    assert.ok(!left.includes("check-1.json"));
+    assert.ok(!left.includes("check-3.json"));
+    assert.ok(left.includes(`check-${KEEP_RUNS + 3}.json`));
+  });
+
+  it("sorts by stamp numerically, not lexically", () => {
+    const cwd = tmpProject();
+    // 9 would beat 100 under a string sort, and the newest run would be the one deleted.
+    for (const stamp of [9, 100, 101, 102]) writeCheckDetail(cwd, { stamp }, stamp);
+    assert.deepEqual(pruneCheckDetails(cwd, 2).sort(), ["check-100.json", "check-9.json"]);
+    const left = readdirSync(join(cwd, RUNS_DIR)).sort();
+    assert.deepEqual(left, ["check-101.json", "check-102.json"]);
+  });
+});
+
+describe("pruneCheckDetails", () => {
+  it("is a no-op when nothing was ever written", () => {
+    const cwd = tmpProject();
+    assert.deepEqual(pruneCheckDetails(cwd), []);
+    assert.equal(existsSync(join(cwd, RUNS_DIR)), false);
+  });
+
+  it("leaves files this store did not write alone", () => {
+    const cwd = tmpProject();
+    writeCheckDetail(cwd, { ok: true }, 1);
+    const dir = join(cwd, RUNS_DIR);
+    const foreign = join(dir, "notes.md");
+    writeFileSync(foreign, "not ours\n");
+    pruneCheckDetails(cwd, 0);
+    assert.equal(existsSync(foreign), true, "an unrelated file must survive pruning");
+    assert.equal(existsSync(join(dir, "check-1.json")), false);
+  });
+});

--- a/src/check-detail-store.ts
+++ b/src/check-detail-store.ts
@@ -1,0 +1,73 @@
+/**
+ * Durable store for full `kit_check` runs, so the MCP response can hand back a reference
+ * instead of the whole document (see `check-mcp-summary.ts` for why).
+ *
+ * The constraint that shapes this file: **the reference must resolve to something that still
+ * exists.** Offloading output to a pointer that has already been cleaned up trades tokens for
+ * a dangling path, which is worse than the verbosity it replaced. So the write happens before
+ * the response is built, a failed write is reported as "no reference" rather than swallowed,
+ * and pruning keeps the newest runs rather than deleting by age.
+ *
+ * Location: `.kit/runs/` — already gitignored (`.kit/*` with a `!.kit/shared/` exception), so
+ * these never become repo noise.
+ */
+import { mkdirSync, writeFileSync, readdirSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+export const RUNS_DIR = join(".kit", "runs");
+/** How many runs to keep. Enough for an agent's check → fix → check loop to look back. */
+export const KEEP_RUNS = 10;
+
+const FILE_RE = /^check-(\d+)\.json$/;
+
+/**
+ * Write one full run and return its path, or null when it could not be written.
+ *
+ * `stamp` is passed in rather than read from the clock so a caller can make the name
+ * deterministic; it is a millisecond timestamp and the sort order of the filenames is the
+ * order of the runs.
+ */
+export function writeCheckDetail(
+  cwd: string,
+  payload: unknown,
+  stamp: number,
+): { path: string; hint: string } | null {
+  const dir = join(cwd, RUNS_DIR);
+  const file = join(dir, `check-${stamp}.json`);
+  try {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(file, `${JSON.stringify(payload, null, 2)}\n`, "utf-8");
+  } catch {
+    return null; // read-only checkout, missing permission — say "no reference", never lie about one
+  }
+  pruneCheckDetails(cwd);
+  return {
+    path: file,
+    hint: "complete run, including every passing check — read this file only if the summary is not enough",
+  };
+}
+
+/** Keep the newest KEEP_RUNS documents; ignore anything not written by this store. */
+export function pruneCheckDetails(cwd: string, keep = KEEP_RUNS): string[] {
+  const dir = join(cwd, RUNS_DIR);
+  if (!existsSync(dir)) return [];
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const mine = names
+    .filter((n) => FILE_RE.test(n))
+    .sort((a, b) => Number(b.match(FILE_RE)![1]) - Number(a.match(FILE_RE)![1]));
+  const removed: string[] = [];
+  for (const name of mine.slice(keep)) {
+    try {
+      rmSync(join(dir, name));
+      removed.push(name);
+    } catch {
+      // A file we cannot delete is not a reason to fail the check that just ran.
+    }
+  }
+  return removed;
+}

--- a/src/check-mcp-summary.test.ts
+++ b/src/check-mcp-summary.test.ts
@@ -1,0 +1,147 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { summarizeCheckRun, fullCheckPayload } from "./check-mcp-summary.js";
+import type { CheckRunResult } from "./check-run.js";
+
+/** A run with one of everything: a pass, a fail, a warn, an honest skip, and lost coverage. */
+function runFixture(over: Partial<CheckRunResult> = {}): CheckRunResult {
+  return {
+    ok: false,
+    verdict: {
+      ok: false,
+      dimensions: [
+        { name: "tools", ok: true, detail: "1/1" },
+        { name: "security", ok: false, detail: "1 real issue" },
+      ],
+      failed: ["security"],
+    } as unknown as CheckRunResult["verdict"],
+    tools: [{ name: "node", required: "22", installed: "22.1.0", ok: true }],
+    services: [],
+    secrets: { templateExists: true, keys: [] },
+    skills: [],
+    hooks: [],
+    webSearch: null,
+    deploy: [],
+    security: [
+      {
+        category: "dependency",
+        name: "npm audit",
+        status: "fail",
+        detail: "2 high severity",
+        severity: "high",
+      },
+      { category: "secrets", name: "secrets scan", status: "warn", detail: "4 unverified" },
+      {
+        category: "supply-chain",
+        name: "guarddog",
+        status: "skip",
+        detail: "opt-in — not enabled",
+      },
+      {
+        category: "dependency",
+        name: "trivy",
+        status: "skip",
+        detail: "binary absent",
+        didNotRun: true,
+      },
+      { category: "exposure", name: ".env gitignored", status: "pass", detail: "all patterns" },
+    ],
+    tests: [{ name: "unit-test coverage", status: "pass", detail: "84 files" }] as never,
+    locks: [],
+    scope: null,
+    ...over,
+  } as CheckRunResult;
+}
+
+describe("summarizeCheckRun", () => {
+  it("keeps the verdict and drops only passing rows", () => {
+    const s = summarizeCheckRun(runFixture());
+    assert.equal(s.ok, false);
+    assert.deepEqual(s.failed, ["security"]);
+    assert.equal(s.summarized, true);
+    const names = s.findings.map((f) => f.name);
+    assert.deepEqual(names, ["npm audit", "secrets scan", "guarddog", "trivy"]);
+    assert.equal(s.passesOmitted, 3); // node, .env gitignored, unit-test coverage
+  });
+
+  it("never omits a skip — lost looking must not compress into not failing", () => {
+    const s = summarizeCheckRun(runFixture());
+    const guarddog = s.findings.find((f) => f.name === "guarddog");
+    assert.ok(guarddog, "an honest skip has to survive summarization");
+    assert.equal(guarddog.status, "skip");
+  });
+
+  it("never omits a didNotRun row, and carries the flag through", () => {
+    const s = summarizeCheckRun(runFixture());
+    const trivy = s.findings.find((f) => f.name === "trivy");
+    assert.ok(trivy, "a check that could not run has to survive summarization");
+    assert.equal(trivy.didNotRun, true);
+    assert.equal(s.counts.didNotRun, 1);
+  });
+
+  it("counts every row, including the ones it left out", () => {
+    const s = summarizeCheckRun(runFixture());
+    assert.deepEqual(s.counts, { passed: 3, failed: 1, warnings: 1, skipped: 2, didNotRun: 1 });
+  });
+
+  it("keeps severity on a finding", () => {
+    const s = summarizeCheckRun(runFixture());
+    assert.equal(s.findings.find((f) => f.name === "npm audit")?.severity, "high");
+  });
+
+  it("carries scope, so a narrowed green cannot read as a full one", () => {
+    const s = summarizeCheckRun(runFixture({ scope: ["security"], ok: true }));
+    assert.deepEqual(s.scope, ["security"]);
+  });
+
+  it("says nothing about a detail file unless one was written", () => {
+    assert.equal(summarizeCheckRun(runFixture()).detail, undefined);
+    const withRef = summarizeCheckRun(runFixture(), { path: "/tmp/x.json", hint: "full run" });
+    assert.equal(withRef.detail?.path, "/tmp/x.json");
+  });
+
+  it("is materially smaller than the full payload it replaces", () => {
+    const run = runFixture();
+    const summary = JSON.stringify(summarizeCheckRun(run)).length;
+    const full = JSON.stringify(fullCheckPayload(run)).length;
+    assert.ok(summary < full, `summary ${summary} should be smaller than full ${full}`);
+  });
+
+  it("an all-green run summarizes to the verdict and no findings", () => {
+    const green = runFixture({
+      ok: true,
+      security: [
+        { category: "exposure", name: ".env gitignored", status: "pass", detail: "ok" },
+      ] as never,
+      tests: [],
+    });
+    const s = summarizeCheckRun(green);
+    assert.deepEqual(s.findings, []);
+    assert.equal(s.ok, true);
+    assert.equal(s.counts.failed, 0);
+  });
+});
+
+describe("fullCheckPayload", () => {
+  it("carries every dimension, so detail:true loses nothing", () => {
+    const p = fullCheckPayload(runFixture());
+    for (const key of [
+      "ok",
+      "scope",
+      "dimensions",
+      "failed",
+      "tools",
+      "services",
+      "secrets",
+      "skills",
+      "hooks",
+      "webSearch",
+      "deploy",
+      "security",
+      "tests",
+      "locks",
+    ]) {
+      assert.ok(key in p, `missing ${key}`);
+    }
+  });
+});

--- a/src/check-mcp-summary.ts
+++ b/src/check-mcp-summary.ts
@@ -1,0 +1,106 @@
+/**
+ * Compact `kit_check` payload for the MCP surface.
+ *
+ * Measured on this repo: the standing surface (initialize instructions + tools/list) is
+ * ~7.4 KB and is paid ONCE per session, while one full `kit_check` response is ~9.8 KB and is
+ * paid on EVERY call — and an agent in a check → fix → check loop calls it repeatedly. The
+ * number that dominates the context bill is the output, not the schema.
+ *
+ * Almost every one of those calls asks the same question: is it green, and if not, what broke.
+ * The full pass list answers a question nobody asked. So the response carries the verdict and
+ * every non-passing row in full, and the complete run is written to a file whose path comes
+ * back as a reference the agent can read when it genuinely needs the rest.
+ *
+ * Two rules this module exists to keep, both learned from `scan-diff.ts`:
+ *
+ * 1. **A summary must never read as a pass.** Only `pass` rows are dropped. A `skip` stays,
+ *    because a skip is the coverage story — "stopped looking" must not compress into
+ *    "stopped failing" — and any row flagged `didNotRun` stays even if something later
+ *    decides skips are noise.
+ * 2. **A partial run must never read as a full one.** `scope` is carried verbatim, so a
+ *    `--category`-narrowed green cannot be mistaken for a whole-repo green.
+ */
+import { checkRunToJsonChecks, type CheckRunResult, type CheckCategory } from "./check-run.js";
+import type { JsonCheck } from "./cli-checks-shared.js";
+import type { CheckVerdict } from "./check-verdict.js";
+
+export interface CheckSummaryCounts {
+  passed: number;
+  failed: number;
+  warnings: number;
+  skipped: number;
+  /** Checks that could not run — kept separate because these are lost coverage, not results. */
+  didNotRun: number;
+}
+
+export interface CheckSummary {
+  ok: boolean;
+  /** Non-null only for a narrowed run: the dimensions that actually ran. */
+  scope: CheckCategory[] | null;
+  dimensions: CheckVerdict["dimensions"];
+  failed: CheckVerdict["failed"];
+  /** Every row that is not a plain pass, in full. */
+  findings: JsonCheck[];
+  counts: CheckSummaryCounts;
+  /** Always true, so a consumer can tell this payload from the complete one. */
+  summarized: true;
+  /** How many passing rows were left out. Their names live in the detail document. */
+  passesOmitted: number;
+  /**
+   * Where the complete run was written. Absent when it could not be written — and then
+   * the caller must send the full payload instead, because a reference that resolves to
+   * nothing is worse than a verbose answer.
+   */
+  detail?: { path: string; hint: string };
+}
+
+/** True for a row that carries information about a problem or about lost coverage. */
+function isFinding(check: JsonCheck): boolean {
+  return check.status !== "pass" || check.didNotRun === true;
+}
+
+export function summarizeCheckRun(
+  run: CheckRunResult,
+  detail?: { path: string; hint: string },
+): CheckSummary {
+  const rows = checkRunToJsonChecks(run);
+  const findings = rows.filter(isFinding);
+  const counts: CheckSummaryCounts = {
+    passed: rows.filter((c) => c.status === "pass").length,
+    failed: rows.filter((c) => c.status === "fail").length,
+    warnings: rows.filter((c) => c.status === "warn").length,
+    skipped: rows.filter((c) => c.status === "skip").length,
+    didNotRun: rows.filter((c) => c.didNotRun === true).length,
+  };
+  return {
+    ok: run.ok,
+    scope: run.scope,
+    dimensions: run.verdict.dimensions,
+    failed: run.verdict.failed,
+    findings,
+    counts,
+    summarized: true,
+    passesOmitted: rows.length - findings.length,
+    ...(detail ? { detail } : {}),
+  };
+}
+
+/** The complete run, in the shape `kit_check` has always returned. */
+export function fullCheckPayload(run: CheckRunResult): Record<string, unknown> {
+  return {
+    ok: run.ok,
+    scope: run.scope,
+    dimensions: run.verdict.dimensions,
+    failed: run.verdict.failed,
+    tools: run.tools,
+    services: run.services,
+    secrets: run.secrets.keys,
+    skills: run.skills,
+    hooks: run.hooks,
+    webSearch: run.webSearch,
+    deploy: run.deploy,
+    security: run.security,
+    tests: run.tests,
+    locks: run.locks,
+  };
+}

--- a/src/mcp-server.test.ts
+++ b/src/mcp-server.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { mkdtemp, writeFile, rm, mkdir, readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
@@ -131,6 +132,117 @@ describe("MCP server tool registration", () => {
   });
 });
 
+// ─── kit_check output cost ─────────────────────────────────────────────────
+
+describe("kit_check response is summarized, and the reference resolves", () => {
+  // Why this suite exists: one full kit_check response measured ~9.8 KB against a ~7.4 KB
+  // standing surface paid once per session. The response is the term that dominates, because
+  // an agent in a check → fix → check loop pays it every iteration. Passing rows are the bulk
+  // of it and answer a question nobody asked — but a summary that can hide lost coverage would
+  // buy those tokens with the exact failure kit exists to prevent, so that is what these
+  // assertions pin down.
+  let dir: string;
+  let savedCwd: string;
+
+  before(async () => {
+    dir = await mkdtemp(join(tmpdir(), "kit-mcp-summary-"));
+    await writeFile(join(dir, ".kit.toml"), FIXTURE_EMPTY, "utf-8");
+    savedCwd = process.cwd();
+    process.chdir(dir);
+  });
+
+  after(async () => {
+    process.chdir(savedCwd);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("answers with the verdict, findings and counts — not the dimension arrays", async () => {
+    const { client, cleanup } = await createTestClient();
+    try {
+      const result = await client.callTool({ name: "kit_check", arguments: { cwd: dir } });
+      const data = parseResult(result) as Record<string, unknown>;
+      assert.equal(data.summarized, true);
+      for (const key of ["ok", "dimensions", "failed", "findings", "counts", "passesOmitted"]) {
+        assert.ok(key in data, `summary must carry ${key}`);
+      }
+      for (const key of ["tools", "services", "secrets", "skills", "hooks", "locks"]) {
+        assert.ok(!(key in data), `${key} belongs in the detail document, not the response`);
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("every finding it reports is a non-pass, and no pass survives", async () => {
+    const { client, cleanup } = await createTestClient();
+    try {
+      const result = await client.callTool({ name: "kit_check", arguments: { cwd: dir } });
+      const data = parseResult(result) as {
+        findings: { status: string; didNotRun?: boolean }[];
+        counts: { passed: number };
+        passesOmitted: number;
+      };
+      for (const f of data.findings) {
+        assert.ok(f.status !== "pass" || f.didNotRun === true, `a pass leaked: ${f.status}`);
+      }
+      // The passes are still accounted for — omitted is not the same as unmeasured.
+      assert.equal(data.passesOmitted, data.counts.passed);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("detail.path exists and parses to the complete run", async () => {
+    const { client, cleanup } = await createTestClient();
+    try {
+      const result = await client.callTool({ name: "kit_check", arguments: { cwd: dir } });
+      const data = parseResult(result) as { detail?: { path: string } };
+      assert.ok(data.detail?.path, "a summary must hand back a reference");
+      // The rule that makes offloading safe: the pointer resolves. Reading it IS the assertion.
+      const full = JSON.parse(readFileSync(data.detail.path, "utf-8")) as Record<string, unknown>;
+      for (const key of ["tools", "services", "secrets", "skills", "hooks", "security", "locks"]) {
+        assert.ok(key in full, `detail document must carry ${key}`);
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("detail:true returns the complete run inline instead", async () => {
+    const { client, cleanup } = await createTestClient();
+    try {
+      const result = await client.callTool({
+        name: "kit_check",
+        arguments: { cwd: dir, detail: true },
+      });
+      const data = parseResult(result) as Record<string, unknown>;
+      assert.ok("tools" in data && "security" in data);
+      assert.ok(!("summarized" in data), "the full document must not claim to be a summary");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("costs materially fewer characters than the full document", async () => {
+    const { client, cleanup } = await createTestClient();
+    try {
+      const summary = await client.callTool({ name: "kit_check", arguments: { cwd: dir } });
+      const full = await client.callTool({
+        name: "kit_check",
+        arguments: { cwd: dir, detail: true },
+      });
+      const size = (r: typeof summary) =>
+        (r.content as Array<{ text: string }>).reduce((n, c) => n + c.text.length, 0);
+      assert.ok(
+        size(summary) < size(full),
+        `summary ${size(summary)} chars should be smaller than full ${size(full)} chars`,
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
 // ─── kit_check ─────────────────────────────────────────────────────────────
 
 describe("kit_check", () => {
@@ -159,7 +271,10 @@ describe("kit_check", () => {
     await writeFile(join(tempDir, ".kit.toml"), FIXTURE_EMPTY, "utf-8");
     const { client, cleanup } = await createTestClient();
     try {
-      const result = await client.callTool({ name: "kit_check", arguments: { cwd: tempDir } });
+      const result = await client.callTool({
+        name: "kit_check",
+        arguments: { cwd: tempDir, detail: true },
+      });
       // ok depends on repo-level security checks — test structure, not ok
       const data = parseResult(result) as { ok: boolean; tools: unknown[]; secrets: unknown[] };
       assert.equal(data.tools.length, 0);
@@ -173,7 +288,10 @@ describe("kit_check", () => {
     await writeFile(join(tempDir, ".kit.toml"), FIXTURE_CONFIG_SECRET, "utf-8");
     const { client, cleanup } = await createTestClient();
     try {
-      const result = await client.callTool({ name: "kit_check", arguments: { cwd: tempDir } });
+      const result = await client.callTool({
+        name: "kit_check",
+        arguments: { cwd: tempDir, detail: true },
+      });
       const data = parseResult(result) as { secrets: Array<{ name: string; available: boolean }> };
       // The secret itself is correct regardless of security check results
       assert.equal(data.secrets[0].name, "APP_KEY");
@@ -187,7 +305,10 @@ describe("kit_check", () => {
     await writeFile(join(tempDir, ".kit.toml"), FIXTURE_MISSING_ENV_SECRET, "utf-8");
     const { client, cleanup } = await createTestClient();
     try {
-      const result = await client.callTool({ name: "kit_check", arguments: { cwd: tempDir } });
+      const result = await client.callTool({
+        name: "kit_check",
+        arguments: { cwd: tempDir, detail: true },
+      });
       const data = parseResult(result) as {
         ok: boolean;
         secrets: Array<{ name: string; available: boolean }>;
@@ -204,7 +325,10 @@ describe("kit_check", () => {
     await writeFile(join(tempDir, ".kit.toml"), FIXTURE_EMPTY, "utf-8");
     const { client, cleanup } = await createTestClient();
     try {
-      const result = await client.callTool({ name: "kit_check", arguments: { cwd: tempDir } });
+      const result = await client.callTool({
+        name: "kit_check",
+        arguments: { cwd: tempDir, detail: true },
+      });
       const data = parseResult(result) as Record<string, unknown>;
       assert.ok("ok" in data);
       assert.ok("tools" in data);
@@ -793,11 +917,13 @@ describe("process-scoped tools serve a cross-project cwd", () => {
     try {
       const result = await client.callTool({ name: "kit_check", arguments: { cwd: other } });
       assert.notEqual(result.isError, true, "a cross-project check is served, not refused");
+      // Read from `findings`, the summarized default: a non-passing row must survive
+      // summarization, so this doubles as the check that the offload cannot hide a failure.
       const data = parseResult(result) as {
-        security?: { name: string; status: string; detail?: string }[];
+        findings?: { name: string; status: string; detail?: string }[];
       };
-      const row = (data.security ?? []).find((c) => c.name.includes("gitignore"));
-      assert.ok(row, "the security dimension must report a gitignore row");
+      const row = (data.findings ?? []).find((c) => c.name.includes("gitignore"));
+      assert.ok(row, "the findings must report a gitignore row");
       assert.notEqual(
         row.status,
         "pass",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -5,6 +5,8 @@ import { resolve, join, relative } from "node:path";
 import { loadConfig } from "./config.js";
 import { checkTools } from "./check-tools.js";
 import { runCheckGate } from "./check-run.js";
+import { summarizeCheckRun, fullCheckPayload } from "./check-mcp-summary.js";
+import { writeCheckDetail } from "./check-detail-store.js";
 import { installTools } from "./install.js";
 import { generateSecrets } from "./secrets.js";
 import {
@@ -226,7 +228,7 @@ function register_kit_check(server: McpServer): void {
     "kit_check",
     {
       description:
-        "Run kit check and return structured status for all tools, services, secrets, and security checks.",
+        "Run kit check and return the verdict plus every non-passing check: { ok, scope, dimensions, failed, findings, counts, passesOmitted, detail }. Passing rows are omitted from the response (they are the bulk of it and answer a question nobody asked) — a skip or a didNotRun is NEVER omitted, because lost coverage is not a pass. The complete run is written to detail.path; read that file only when the summary is not enough. Pass detail:true to get the full document inline instead.",
       inputSchema: {
         cwd: z
           .string()
@@ -234,34 +236,31 @@ function register_kit_check(server: McpServer): void {
           .describe(
             "Project directory to check (defaults to the server process's own). Every dimension that reads the filesystem resolves paths from this argument, including the scanner subprocesses, so a value pointing at another project is answered ABOUT that project.",
           ),
+        detail: z
+          .boolean()
+          .optional()
+          .describe(
+            "Return the complete run inline (every passing check included). Costs several times the summary in context and is rarely what a check → fix → check loop needs; prefer reading detail.path from the summary.",
+          ),
       },
     },
-    async ({ cwd }) => {
+    async ({ cwd, detail }) => {
       try {
         const r = await runCheckGate({ cwd });
+        const full = fullCheckPayload(r);
+        if (detail) {
+          return { content: [{ type: "text" as const, text: JSON.stringify(full, null, 2) }] };
+        }
+        // Written BEFORE the response is built: a reference the agent cannot resolve is worse
+        // than a verbose answer, so a failed write falls back to the full payload rather than
+        // pointing at a file that is not there.
+        const ref = writeCheckDetail(cwd ?? process.cwd(), full, Date.now());
+        const payload = ref ? summarizeCheckRun(r, ref) : full;
         return {
           content: [
             {
               type: "text" as const,
-              text: JSON.stringify(
-                {
-                  ok: r.ok,
-                  dimensions: r.verdict.dimensions,
-                  failed: r.verdict.failed,
-                  tools: r.tools,
-                  services: r.services,
-                  secrets: r.secrets.keys,
-                  skills: r.skills,
-                  hooks: r.hooks,
-                  webSearch: r.webSearch,
-                  deploy: r.deploy,
-                  security: r.security,
-                  tests: r.tests,
-                  locks: r.locks,
-                },
-                null,
-                2,
-              ),
+              text: JSON.stringify(payload, null, 2),
             },
           ],
         };


### PR DESCRIPTION
From `docs/research/agent-loop-levels-and-kits-output-cost.md` in the research repo, which
corrected an earlier note: kit's **standing** MCP surface was measured and framed as *the*
context cost, but it is paid once per session, while a `kit_check` response is paid on every
call — and an agent in a check → fix → check loop calls it repeatedly.

Measured here, this repo, every scanner running (`node scripts/measure-mcp-output.mjs`):

| | chars | ≈tokens | paid |
| --- | --- | --- | --- |
| standing surface (`tools/list`) | 7,788 | ~1,950 | once per session |
| `kit_check` response — before | 9,799 | ~2,450 | **per call** |
| `kit_check` response — after | **3,210** | ~800 | per call |

**67% off every call.** 23 passing rows omitted, 12 findings kept, verdict unchanged.

## What the response looks like now

`{ ok, scope, dimensions, failed, findings, counts, passesOmitted, detail }` — the verdict and
every non-passing row in full. The complete run goes to `.kit/runs/check-<stamp>.json`
(already gitignored via `.kit/*`), returned as `detail.path`. `detail: true` returns the full
document inline for the rare caller that wants it.

## The two rules this could not break

Both borrowed from `scan-diff.ts`, which already ranks lost coverage above a regression:

- **A summary must never read as a pass.** Only `pass` rows are dropped. A `skip` survives —
  a skip is the coverage story, and "stopped looking" compressing into "stopped failing" would
  buy the tokens with the exact failure kit exists to prevent. Any row flagged `didNotRun`
  survives unconditionally. Omitted passes are still counted, so omitted never means unmeasured.
- **A partial run must never read as a full one.** `scope` is carried verbatim, so a
  `--category`-narrowed green cannot be mistaken for a whole-repo green. The previous full
  payload did not carry `scope` at all — that is a fix, not just a port.

And the reference has to resolve, or offloading trades tokens for a dangling pointer: the write
happens before the response is built, pruning keeps the newest 10 **by run order** (a lexical
sort would delete `check-100` and keep `check-9`), and a failed write returns *no* reference —
the response falls back to the full payload rather than pointing at a file that is not there.

## Verification

- 16 new unit tests (`check-mcp-summary`, `check-detail-store`) plus 5 MCP-level tests driven
  through the SDK transport: the skip and the `didNotRun` row survive summarization, no pass
  leaks, `passesOmitted == counts.passed`, `detail.path` is read back and parsed, and the
  summary is asserted smaller than the full document.
- The four existing `kit_check` tests that inspect dimension arrays now pass `detail: true`;
  the cross-project gitignore test reads `findings` instead, which makes it double as proof
  that a failing row cannot be hidden by the offload.
- Gates: `npm run build` clean, `npm test` **4145/4145**, `npm run format:check` clean,
  `kit check` 30/31 (the one finding is the known secrets-scan warn, already accepted).

Stacks independently of #471 — no shared files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
