### PR TITLE
Hold install-script approval, audit the grants it writes — 6.6.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,9 +175,17 @@ jobs:
         env:
           TAG: ${{ github.ref_name }}
         run: |
+          # pipefail because this step's verdict IS an exit status: piping the check into
+          # anything makes the pipeline report the LAST command. `if ! git verify-tag … | tee`
+          # read tee's always-zero status, so this gate never fired and an unsigned v6.6.3
+          # published. GitHub's default step shell is `bash -e {0}` — no pipefail — hence both
+          # the flag and the redirect below. Asserted by src/publish-workflow.test.ts, and the
+          # pattern is now caught repo-wide by self-audit R1-fail-open-ci.
+          set -o pipefail
           # The maintainer public key was imported + trusted in the previous
           # step, so git verify-tag can now check the signature chain.
-          if ! git verify-tag "$TAG" 2>&1 | tee /tmp/tag-verify.log; then
+          if ! git verify-tag "$TAG" > /tmp/tag-verify.log 2>&1; then
+            cat /tmp/tag-verify.log
             if grep -q 'no signature found' /tmp/tag-verify.log; then
               echo "::error::Tag $TAG is not GPG-signed. Sign with: git tag -s $TAG"
               exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,23 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Install an npm that can do trusted publishing
+        # npm is retiring 2FA-bypass granular access tokens as a publishing credential: from
+        # ~January 2027 such a token can only read private packages and STAGE a publish for
+        # human 2FA approval. The migration target is trusted publishing — an OIDC exchange
+        # with NO long-lived secret — and it exists only in npm >= 11.5.1 (node >= 22.14.0).
+        # setup-node ships npm 10.9.x for node 22, so the client in this job would have no
+        # OIDC exchange to make. Installed here so the prerequisite is already true when the
+        # registry-side switch lands (13 per-package configs on npmjs.com — docs/RELEASING.md).
+        #
+        # Measured on npm 11.19.0 against this repo before wiring: `npm ci` and
+        # `npm publish --dry-run` both behave identically, and npm >= 11's skip-install-scripts
+        # default costs nothing here (esbuild's postinstall is the only one in the tree, and
+        # the build + tests pass without it). Asserted by src/publish-workflow.test.ts.
+        run: |
+          npm i -g npm@^11.5.1
+          npm --version
+
       - name: Install dependencies
         # npm ci uses package-lock.json exactly — no version drift.
         run: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   configurations that migration needs and the two constraints (`workflow_call` breaks npm's
   validation; self-hosted runners are unsupported).
 
+### Fixed
+
+- **The publish job's tag-signature gate was fail-open, and `v6.6.3` shipped unsigned.**
+  The step read `if ! git verify-tag "$TAG" 2>&1 | tee /tmp/tag-verify.log; then` — `git`
+  exits 1 on an unsigned tag, but a pipeline reports its LAST command, and `tee` always
+  exits 0. GitHub's default step shell is `bash -e {0}`, which does not set `pipefail`, so
+  the condition was never true: the gate could not fail, and every GPG control around it
+  (the pinned `MAINTAINER_KEY_FPR`, the single-key keyring check, the ownertrust import) was
+  intact and useless. `v6.6.3` was tagged with `git tag -a` and published; `git tag -v
+  v6.6.3` prints `error: no signature found`. Re-signing it would mean force-pushing a
+  published tag, which re-triggers the publish workflow against a version already on the
+  registry, so the tag stands and `docs/VERIFY.md` records why. Fixed with `set -o pipefail`
+  and a redirect instead of the pipe; `src/publish-workflow.test.ts` asserts the verdict
+  cannot come from a pass-through sink, and both assertions were mutation-tested by
+  reintroducing the pipe.
+
+- **Self-audit `R1-fail-open-ci` now catches the class, not just `|| true`.** A condition
+  piped into a pass-through sink (`tee`, `cat`) takes its status from the sink, so the rule
+  flags it unless the step actually sets `pipefail`. "Actually" is load-bearing: the first
+  implementation walked back looking for the word and was satisfied by the fixed step's own
+  explanatory comment — documented rather than enforced, the same disease the rule exists to
+  catch. A pipe whose last command IS the question (`if cmd | grep -q x`) is left alone.
+
 ### Changed
 
 - **The install gate holds install-script approval, not just installs.** `npm approve-scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,84 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [6.6.4] - 2026-08-18
+
+### Added
+
+- **`kit check` audits npm's install-script grants.** npm no longer runs a dependency's
+  `preinstall`/`install`/`postinstall`/`prepare` unless `package.json`'s `allowScripts` names
+  it, which makes that field the standing record of which dependencies were handed
+  install-time code execution. The new `install-script grants` check (CWE-829) reads it and
+  flags the two shapes that outlive their review: a **bare-name or range key**, which also
+  covers the release nobody has seen yet, and a **stale grant** for a package the manifest no
+  longer depends on — a standing permission for a name an attacker can re-introduce
+  (`npm install-scripts prune` clears those). A field shape npm does not write is reported as
+  `didNotRun` rather than read as "no grants", because treating an unparseable allowlist as
+  empty would report the most dangerous state as the safest one. The shapes were measured
+  against npm 11.19.0, not taken from the docs page, which describes `{pkg: "1.2.3"}` while
+  the client actually writes the version into the key: `{"esbuild@0.28.1": true}` pinned,
+  `{"esbuild": true}` unpinned, `{"esbuild": false}` denied.
+
+- **`docs/RELEASING.md`** — how a release is cut, what the publish job refuses to publish,
+  and the migration off a long-lived npm token, including the 13 per-package trusted-publisher
+  configurations that migration needs and the two constraints (`workflow_call` breaks npm's
+  validation; self-hosted runners are unsupported).
+
+### Changed
+
+- **The install gate holds install-script approval, not just installs.** `npm approve-scripts
+  <pkg>` and `npm install-scripts approve <pkg>` are the moment an already-installed
+  dependency gains arbitrary code execution — the exact decision the gate exists to hold —
+  and neither was matched, so an agent in auto-mode could grant it unchecked. Both spellings
+  now triage the named package like an install target; `--all` / `-a` and the bare
+  interactive form name nothing and fail closed; `pnpm approve-builds` is covered the same
+  way. The read-only faces are deliberately never blocked — `install-scripts ls`, `deny`,
+  `prune`, `--dry-run` and `--allow-scripts-pending` hand out no permission, and blocking the
+  review step would push an agent straight to `--all`.
+
+- **The supply-chain check's install-script advice names the review, not the skip.** It said
+  "install with `npm ci --ignore-scripts` where possible"; skipping is npm's own default now,
+  so that described what already happens. It now points at `npm install-scripts ls` and a
+  per-package pinned grant, never `--all`.
+
+- **The publish job installs `npm@^11.5.1` before anything else.** npm's OIDC trusted
+  publishing — the migration target now that 2FA-bypass tokens lose direct publish rights
+  (~January 2027) — exists only in npm ≥ 11.5.1 on node ≥ 22.14.0, and `actions/setup-node`
+  ships npm 10.9.x for node 22. Verified against this repo on npm 11.19.0 before wiring:
+  `npm ci` and `npm publish --dry-run` behave identically, and npm's skip-install-scripts
+  default costs nothing here (esbuild's postinstall is the only one in the tree; build and
+  tests pass without it). `src/publish-workflow.test.ts` asserts the step exists, clears the
+  version floor, and precedes every publish — a comment cannot fail CI, and a publish job
+  runs only on a tag push, the worst moment to learn the client is too old.
+
+- **`kit init` generates only what the repo proves — and asks about the rest.** The
+  operator's `~/.kit/defaults.toml [init] services` were appended to every new project, so a
+  repo with no PostHog got a `[services.posthog]` block and three POSTHOG keys, and the
+  framework table handed `verify = "pnpm build"` to repos that use npm. A plausible generated
+  value is worse than an absent one: an absent line is a question, a plausible line looks
+  like a decision somebody made, so nobody re-reads it. `known_services` is now a menu —
+  detected services are written, known-but-absent ones come back as `offered` and are put to
+  whoever can answer — `generateToml` returns `{ toml, gaps }` where every declined field
+  carries the command that settles it, and the old `services` key still reads with a rename
+  notice. `promptMultiSelect` returns `null` rather than a default when nobody is there,
+  which is why it exists beside `promptSelect`, whose "answer with the recommended option"
+  convention had been silently choosing a secret backend on every agent and CI run. Also:
+  `bun.lock` now counts as bun (the 1.2 rename to the text lockfile made every current bun
+  repo detect as npm), and the build refuses to run on cloud-sync conflict copies instead of
+  hiding them behind a `tsconfig` exclude that never matched.
+
+- **`kit_check` over MCP answers the question and offloads the rest.** The standing MCP
+  surface is paid once per session (7,788 chars); a `kit_check` response is paid on every
+  call, and an agent in a check → fix → check loop calls it repeatedly. The response is now
+  the verdict plus every non-passing row — 9,799 → 3,210 chars, **67% off per call** — with
+  the complete run written to `.kit/runs/check-<stamp>.json` and returned as `detail.path`
+  (`detail: true` still returns the whole document inline). Two invariants bound the saving:
+  only `pass` rows may be omitted, so a `skip` or `didNotRun` always survives and omitted
+  passes stay counted; and `scope` is carried verbatim, so a `--category`-narrowed green
+  cannot read as a whole-repo green. A failed detail write returns no reference at all — a
+  verbose answer beats a dangling pointer. `scripts/measure-mcp-output.mjs` reproduces both
+  numbers.
+
 ## [6.6.3] - 2026-08-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -436,7 +436,9 @@ TRIAGE PASSED
 
 Trust model documented in [`docs/THREAT_MODEL.md`](./docs/THREAT_MODEL.md);
 data flow per command in [`docs/DATA_FLOW.md`](./docs/DATA_FLOW.md);
-release-verification in [`docs/VERIFY.md`](./docs/VERIFY.md). kit's verdicts are
+release-verification in [`docs/VERIFY.md`](./docs/VERIFY.md); how a release is cut, and
+the migration off a long-lived npm token, in
+[`docs/RELEASING.md`](./docs/RELEASING.md). kit's verdicts are
 produced by deterministic code, never an LLM — a CI-enforced contract, see
 [`docs/ZERO_LLM_CONTRACT.md`](./docs/ZERO_LLM_CONTRACT.md).
 

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -1173,7 +1173,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "6.6.3"
+    "version": "6.6.4"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,115 @@
+# Releasing kit
+
+How a kit release is cut, what the publish job refuses to publish, and the migration
+away from a long-lived npm token. For the consumer side — verifying a release you did
+not build — see [`docs/VERIFY.md`](./VERIFY.md).
+
+## What a release is
+
+One tag. `.github/workflows/publish.yml` triggers on `v*` and builds **the tree that tag
+points at**, publishing 13 packages: the `sandstream-kit` CLI, `sandstream-kit-adapter-sdk`,
+and the eleven `sandstream-kit-plugin-*` workspaces.
+
+Because the tag's tree is what ships, the tag goes on the commit whose `package.json` and
+`CHANGELOG.md` describe the release — not on whatever `main` happens to be. When feature
+work merges after the release-prep commit, that work waits for the next version rather
+than shipping under a version whose changelog does not mention it.
+
+```bash
+# 1. Prepare: bump package.json, write the CHANGELOG section, merge that PR.
+# 2. Tag the prep commit itself (signed — the job verifies the signature):
+git tag -s v6.6.4 <prep-commit> -m "v6.6.4 — <one line>"
+git push origin v6.6.4
+# 3. Approve the `npm-publish` environment when GitHub asks.
+```
+
+## What the job refuses to publish
+
+Each of these fails the release rather than shipping something unverifiable:
+
+- the tag does not match `package.json`'s version;
+- `CHANGELOG.md` has no section for that version (checked **before** the publish, so an
+  undocumented release aborts while aborting is still free);
+- the tag is unsigned, or signed by a key whose fingerprint is not the one pinned in the
+  `MAINTAINER_KEY_FPR` secret (the in-repo public key alone is not trusted — a tag pusher
+  could swap it);
+- `npm audit --audit-level=high` finds a high CVE;
+- the bumblebee supply-chain catalog matches anything, **or could not run**;
+- the test suite fails, or the production build fails;
+- a plugin's `sandstream-kit-adapter-sdk` peer range does not admit the SDK version being
+  published, or the SDK major has drifted off its frozen `1.x` contract.
+
+A prerelease version (any `-` identifier) publishes under the `next` dist-tag, so `latest`
+only ever moves on a stable release.
+
+## Credentials: today
+
+The publish steps authenticate with `NODE_AUTH_TOKEN` from the `NPM_TOKEN` secret, which is
+scoped to the **`npm-publish` environment** rather than the repository. The token is
+therefore released only after that environment's required-reviewer rule passes; configure
+those reviewers in Settings → Environments, or the human gate does not exist.
+
+## Credentials: the migration to trusted publishing
+
+npm is retiring 2FA-bypass granular access tokens as a publishing credential:
+
+| Phase | When | Effect |
+| --- | --- | --- |
+| 1 | ~August 2026 | such a token no longer skips 2FA for sensitive operations (token create/delete, package access, maintainer/org/team changes). Publishing still works. |
+| 2 | ~January 2027 | such a token **cannot publish directly**. It can read private packages and *stage* a publish for human 2FA approval. |
+
+The migration target is **trusted publishing**: GitHub Actions exchanges its OIDC identity
+for a short-lived credential, so there is no long-lived npm secret in the repository at all.
+
+**Prerequisite, already in place.** Trusted publishing exists only in **npm ≥ 11.5.1** on
+**node ≥ 22.14.0**. `actions/setup-node` ships npm 10.9.x for node 22, so the job installs
+`npm@^11.5.1` explicitly before doing anything else. `src/publish-workflow.test.ts` asserts
+that step exists, pins a high-enough version, and runs before any publish — a comment cannot
+fail CI, and a publish job runs only on a tag push, the worst moment to discover a too-old
+client.
+
+**The remaining work is registry-side and manual.** Each package is configured
+individually on npmjs.com, and each can have exactly one trusted publisher at a time, so
+this is 13 configurations:
+
+| Package | | |
+| --- | --- | --- |
+| `sandstream-kit` | `sandstream-kit-adapter-sdk` | `sandstream-kit-plugin-cloudflare` |
+| `sandstream-kit-plugin-fly` | `sandstream-kit-plugin-github` | `sandstream-kit-plugin-railway` |
+| `sandstream-kit-plugin-sentrux` | `sandstream-kit-plugin-sentry` | `sandstream-kit-plugin-snyk` |
+| `sandstream-kit-plugin-stripe` | `sandstream-kit-plugin-supabase` | `sandstream-kit-plugin-vercel` |
+| `sandstream-kit-plugin-wiz` | | |
+
+For each: Settings → Publishing access → add a GitHub Actions trusted publisher with
+repository `sandstream/kit`, workflow `publish.yml`, and environment **`npm-publish`**.
+Naming the environment is the part worth not skipping: it means only the reviewer-gated job
+can mint a credential, where today the environment only protects the secret.
+
+Two constraints to respect when the switch happens:
+
+- **Do not move the publish behind `workflow_call`.** npm's validation reads the *calling*
+  workflow's name, not the one that actually runs `npm publish`, so a reusable-workflow
+  indirection breaks the check. `publish.yml` is triggered directly by the tag push today —
+  keep it that way.
+- **Self-hosted runners are not supported.** The job runs on `ubuntu-latest`
+  (GitHub-hosted), which is.
+
+Once every package is configured, the workflow change is a deletion: drop the
+`NODE_AUTH_TOKEN`/`NPM_TOKEN` env from both publish steps, and drop `--provenance` — with
+trusted publishing from GitHub Actions, provenance is generated automatically. `id-token:
+write` is already granted. Keep a read-only granular token only if a private dependency
+ever needs installing.
+
+Verify the first OIDC release the same way as any other: `npm view sandstream-kit version`,
+install the published tarball and run its binary, and confirm both SBOMs are attached to the
+GitHub release. `npm audit signatures` should still report a verified registry signature and
+provenance.
+
+## After the release
+
+- Confirm the published version really runs, not merely that the job was green:
+  `npm i sandstream-kit@<version>` in a scratch directory, then `kit --version`.
+- Check the GitHub release carries `sbom.cyclonedx.json` and `sbom.spdx.json`.
+- If the attest step warned, the release has npm provenance but no GitHub artifact
+  attestation — `gh attestation verify` will find nothing for it. That is a warning, not a
+  failed release, and it is worth re-running rather than leaving silently unattested.

--- a/docs/VERIFY.md
+++ b/docs/VERIFY.md
@@ -104,6 +104,19 @@ Import the maintainer's public key once:
 gh api /users/sandstream/gpg_keys --jq '.[0].raw_key' | gpg --import
 ```
 
+> **`v6.6.3` is unsigned — known, and not retroactively fixable.** The publish job's
+> signature gate ran its check inside a pipe (`if ! git verify-tag … | tee …`), so the
+> pipeline reported `tee`'s always-zero exit and the gate never fired; `v6.6.3` was tagged
+> with `git tag -a` and published anyway, with every GPG pin around it intact and useless.
+> `git tag -v v6.6.3` therefore prints `error: no signature found`. Re-signing would mean
+> force-pushing a published tag, which re-triggers the publish workflow against a version
+> already on the registry — so the tag stands as it is and this note records why. The gate
+> was fixed in 6.6.4 (`set -o pipefail` plus a redirect instead of the pipe), is asserted by
+> `src/publish-workflow.test.ts`, and the pattern is now caught repo-wide by self-audit
+> `R1-fail-open-ci`. `v6.6.4` onward is signed; verify it as above. Every other control on
+> `v6.6.3` — npm provenance, the registry signature, both SBOMs — is unaffected and
+> verifiable.
+
 ### Verify the SBOM (auditor-only)
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "6.6.3",
+  "version": "6.6.4",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/check-security.test.ts
+++ b/src/check-security.test.ts
@@ -19,6 +19,8 @@ import {
   checkGateLiveness,
   checkDeviceIdOverride,
   unpinnedNodeDeps,
+  auditAllowScripts,
+  checkAllowScripts,
   LOCKFILE_ECOSYSTEMS,
   type SecurityCheckResult,
 } from "./check-security.js";
@@ -974,5 +976,127 @@ describe("unpinnedNodeDeps", () => {
 
   it("handles a missing dep map", () => {
     assert.deepStrictEqual(unpinnedNodeDeps(undefined, noMembers), []);
+  });
+});
+
+describe("auditAllowScripts — npm's install-script grants", () => {
+  // Shapes MEASURED against npm 11.19.0, not read off the docs page (which describes
+  // `{pkg: "1.2.3"}`; the client actually writes the version into the KEY):
+  //   npm install-scripts approve esbuild            -> {"esbuild@0.28.1": true}
+  //   npm install-scripts approve esbuild --no-allow-scripts-pin -> {"esbuild": true}
+  //   npm install-scripts deny esbuild               -> {"esbuild": false}
+  const declared = new Set(["sharp", "canvas", "@scope/pkg"]);
+
+  it("a version-pinned key is the reviewed shape", () => {
+    const a = auditAllowScripts({ "sharp@0.33.5": true }, declared);
+    assert.deepStrictEqual(a.pinned, ["sharp@0.33.5"]);
+    assert.deepStrictEqual(a.unpinned, []);
+    assert.deepStrictEqual(a.stale, []);
+    assert.strictEqual(a.shapeError, undefined);
+  });
+
+  it("keeps a scoped name intact — only the version suffix is a version", () => {
+    const a = auditAllowScripts({ "@scope/pkg@1.2.3": true }, declared);
+    assert.deepStrictEqual(a.pinned, ["@scope/pkg@1.2.3"]);
+    assert.deepStrictEqual(a.stale, []);
+  });
+
+  it("a bare-name grant carries to every future version (--no-allow-scripts-pin)", () => {
+    // The point of the field is that a review happened. A bare name grants the next
+    // release too — including the compromised one nobody has seen yet.
+    const a = auditAllowScripts({ sharp: true }, declared);
+    assert.deepStrictEqual(a.unpinned, ["sharp"]);
+    assert.deepStrictEqual(a.pinned, []);
+  });
+
+  it("a RANGE key is unpinned too — it admits unreviewed releases", () => {
+    assert.deepStrictEqual(auditAllowScripts({ "sharp@^0.33.0": true }, declared).unpinned, [
+      "sharp@^0.33.0",
+    ]);
+    assert.deepStrictEqual(auditAllowScripts({ "canvas@1 || 2": true }, declared).unpinned, [
+      "canvas@1 || 2",
+    ]);
+  });
+
+  it("`false` is a denial, never counted as a grant", () => {
+    const a = auditAllowScripts({ evil: false, "also-evil@1.0.0": false }, declared);
+    assert.deepStrictEqual(a.denied, ["evil", "also-evil@1.0.0"]);
+    assert.deepStrictEqual(a.unpinned, []);
+    assert.deepStrictEqual(a.stale, []);
+  });
+
+  it("a grant for a package the manifest no longer depends on is stale", () => {
+    const a = auditAllowScripts({ "left-pad@1.3.0": true }, declared);
+    assert.deepStrictEqual(a.stale, ["left-pad@1.3.0"]);
+    assert.deepStrictEqual(a.pinned, []);
+  });
+
+  it("a shape npm does not write is reported, never read as empty", () => {
+    // Silently treating an unparseable allowlist as "no grants" would report the most
+    // dangerous state as the safest one.
+    assert.match(String(auditAllowScripts(["sharp"], declared).shapeError), /array/i);
+    assert.ok(auditAllowScripts("sharp", declared).shapeError);
+    assert.ok(auditAllowScripts({ sharp: 3 }, declared).shapeError);
+  });
+});
+
+describe("checkAllowScripts — the check around the audit", () => {
+  const withPkg = (pkg: unknown): string => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-allowscripts-"));
+    writeFileSync(join(dir, "package.json"), JSON.stringify(pkg));
+    return dir;
+  };
+
+  it("skips a repo with no package.json", async () => {
+    const r = await checkAllowScripts(mkdtempSync(join(tmpdir(), "kit-allowscripts-none-")));
+    assert.strictEqual(r.status, "skip");
+  });
+
+  it("skips when no grant has been declared — npm v12's default state", async () => {
+    const r = await checkAllowScripts(withPkg({ name: "x", dependencies: { sharp: "0.33.5" } }));
+    assert.strictEqual(r.status, "skip");
+    assert.match(r.detail, /no install-script grant/i);
+  });
+
+  it("passes when every grant is exact-version and still a dependency", async () => {
+    const r = await checkAllowScripts(
+      withPkg({
+        name: "x",
+        dependencies: { sharp: "0.33.5" },
+        allowScripts: { "sharp@0.33.5": true },
+      }),
+    );
+    assert.strictEqual(r.status, "pass");
+  });
+
+  it("WARNs on an unpinned grant and names it", async () => {
+    const r = await checkAllowScripts(
+      withPkg({ name: "x", dependencies: { sharp: "0.33.5" }, allowScripts: { sharp: true } }),
+    );
+    assert.strictEqual(r.status, "warn");
+    assert.strictEqual(r.severity, "medium");
+    assert.match(r.detail, /sharp/);
+    assert.match(String(r.suggestion), /install-scripts approve/);
+  });
+
+  it("WARNs on a stale grant", async () => {
+    const r = await checkAllowScripts(
+      withPkg({ name: "x", dependencies: {}, allowScripts: { "left-pad@1.3.0": true } }),
+    );
+    assert.strictEqual(r.status, "warn");
+    assert.match(r.detail, /left-pad/);
+  });
+
+  it("an unparseable allowlist is didNotRun — the audit could not run", async () => {
+    const r = await checkAllowScripts(withPkg({ name: "x", allowScripts: ["sharp"] }));
+    assert.strictEqual(r.status, "warn");
+    assert.strictEqual(r.didNotRun, true);
+  });
+
+  it("cites the rule it enforces", async () => {
+    const r = await checkAllowScripts(
+      withPkg({ name: "x", dependencies: { sharp: "1.0.0" }, allowScripts: { sharp: true } }),
+    );
+    assert.match(String(r.rule?.id), /CWE-829/);
   });
 });

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -778,6 +778,160 @@ export function unpinnedNodeDeps(
   return unpinned;
 }
 
+/**
+ * npm does not run a dependency's `preinstall`/`install`/`postinstall`/`prepare` unless
+ * package.json's `allowScripts` names it, so that field IS the record of which dependencies
+ * were granted install-time code execution. Shapes measured on npm 11.19.0 — the docs
+ * describe `{pkg: "1.2.3"}`, the client writes the version into the KEY:
+ *
+ *   npm install-scripts approve esbuild                          -> {"esbuild@0.28.1": true}
+ *   npm install-scripts approve esbuild --no-allow-scripts-pin   -> {"esbuild": true}
+ *   npm install-scripts deny esbuild                             -> {"esbuild": false}
+ *
+ * A grant is only as good as the review behind it, and two shapes outlive their review: a
+ * bare-name key also covers the release nobody has seen yet, and a grant left behind after
+ * the dependency is dropped is a standing permission for a name an attacker can
+ * re-introduce (`npm install-scripts prune` is what clears those). Pure; exported for tests.
+ */
+export interface AllowScriptsAudit {
+  /** Keys pinned to one exact version — the reviewed shape. */
+  pinned: string[];
+  /** Bare-name or range keys: admit versions nobody reviewed. */
+  unpinned: string[];
+  /** Granted, but no longer a declared dependency. */
+  stale: string[];
+  /** Explicit `false` — a denial, not a grant (npm keeps denials winning). */
+  denied: string[];
+  /** Set when the field is not the object map npm writes — the audit could NOT run. */
+  shapeError?: string;
+}
+
+/** An exact npm version (`1.2.3`, `1.2.3-rc.1`) — anything else admits more than one release. */
+const EXACT_NPM_VERSION = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)*$/;
+
+const ALLOW_SCRIPTS_SHAPE =
+  "npm writes an object mapping `<pkg>` or `<pkg>@<spec>` to true (granted) or false (denied)";
+
+/** Split an allowScripts key into package name + version spec. The spec is whatever follows
+ *  the LAST `@`, so a scoped name (`@scope/pkg`) survives with no spec at all. */
+function splitAllowScriptsKey(key: string): { name: string; spec: string } {
+  const at = key.lastIndexOf("@");
+  if (at <= 0) return { name: key, spec: "" };
+  return { name: key.slice(0, at), spec: key.slice(at + 1) };
+}
+
+export function auditAllowScripts(field: unknown, declared: Set<string>): AllowScriptsAudit {
+  const out: AllowScriptsAudit = { pinned: [], unpinned: [], stale: [], denied: [] };
+  if (Array.isArray(field)) {
+    out.shapeError = `allowScripts is an array — ${ALLOW_SCRIPTS_SHAPE}`;
+    return out;
+  }
+  if (typeof field !== "object" || field === null) {
+    out.shapeError = `allowScripts is a ${typeof field} — ${ALLOW_SCRIPTS_SHAPE}`;
+    return out;
+  }
+  for (const [key, value] of Object.entries(field as Record<string, unknown>)) {
+    if (value === false) {
+      out.denied.push(key);
+      continue;
+    }
+    // `true` is what the client writes. A string is tolerated because the docs describe a
+    // range-valued form; anything else is a shape we refuse to guess at, because reading an
+    // unknown allowlist as "no grants" would report the most dangerous state as the safest.
+    if (value !== true && typeof value !== "string") {
+      out.shapeError = `allowScripts["${key}"] is a ${typeof value} — ${ALLOW_SCRIPTS_SHAPE}`;
+      return out;
+    }
+    const { name, spec } = splitAllowScriptsKey(key);
+    if (!declared.has(name)) {
+      out.stale.push(key);
+      continue;
+    }
+    if (EXACT_NPM_VERSION.test(spec)) out.pinned.push(key);
+    else out.unpinned.push(key);
+  }
+  return out;
+}
+
+/** The check around `auditAllowScripts`. Root package.json only — that is the manifest npm
+ *  consults for the project's grants. */
+export async function checkAllowScripts(root: string): Promise<SecurityCheckResult> {
+  const name = "install-script grants";
+  const rule = ruleForCheck(name);
+  const base = { category: "supply-chain", name, rule } as const;
+  let pkg: {
+    allowScripts?: unknown;
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
+  };
+  try {
+    pkg = JSON.parse(await readFile(resolve(root, "package.json"), "utf-8"));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { ...base, status: "skip", detail: "no package.json" };
+    }
+    return {
+      ...base,
+      status: "warn",
+      didNotRun: true,
+      severity: "medium",
+      detail: `package.json could not be read: ${(err as Error).message}`,
+    };
+  }
+  if (pkg.allowScripts === undefined) {
+    return {
+      ...base,
+      status: "skip",
+      detail: "no install-script grant declared (npm skips dependency install scripts by default)",
+    };
+  }
+  const declared = new Set([
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.devDependencies ?? {}),
+    ...Object.keys(pkg.optionalDependencies ?? {}),
+  ]);
+  const audit = auditAllowScripts(pkg.allowScripts, declared);
+  if (audit.shapeError) {
+    return {
+      ...base,
+      status: "warn",
+      didNotRun: true,
+      severity: "medium",
+      detail: audit.shapeError,
+      suggestion:
+        "rewrite the field with `npm install-scripts approve <pkg>` so npm owns its shape",
+    };
+  }
+  const problems: string[] = [];
+  if (audit.unpinned.length > 0) {
+    problems.push(
+      `${audit.unpinned.length} unpinned grant(s): ${audit.unpinned.join(", ")} — covers releases nobody reviewed`,
+    );
+  }
+  if (audit.stale.length > 0) {
+    problems.push(
+      `${audit.stale.length} stale grant(s): ${audit.stale.join(", ")} — no longer a declared dependency`,
+    );
+  }
+  if (problems.length > 0) {
+    return {
+      ...base,
+      status: "warn",
+      severity: "medium",
+      detail: problems.join("; "),
+      suggestion:
+        "re-approve pinned (`npm install-scripts approve <pkg>` writes <pkg>@<version> by default), and clear the outlived ones with `npm install-scripts prune`",
+    };
+  }
+  const denied = audit.denied.length > 0 ? ` · ${audit.denied.length} denied` : "";
+  return {
+    ...base,
+    status: "pass",
+    detail: `${audit.pinned.length} grant(s), every one pinned to an exact version${denied}`,
+  };
+}
+
 /** Names of this repo's workspace member packages (empty set when none / on error). */
 function workspaceMemberNames(cwd: string): Set<string> {
   const names = new Set<string>();
@@ -2271,6 +2425,7 @@ export async function checkSecurity(cwd?: string): Promise<SecurityCheckResult[]
     osvResult,
     mavenResult,
     guarddogResult,
+    allowScriptsResult,
     ...lockfileResults
   ] = await Promise.all([
     checkNpmAudit(root),
@@ -2287,6 +2442,7 @@ export async function checkSecurity(cwd?: string): Promise<SecurityCheckResult[]
     checkOsvScanner(root),
     checkMavenAudit(root),
     checkGuardDog(root),
+    checkAllowScripts(root),
     ...(await checkLockfilesCommitted(root)),
   ]);
 
@@ -2305,6 +2461,7 @@ export async function checkSecurity(cwd?: string): Promise<SecurityCheckResult[]
     osvResult,
     mavenResult,
     guarddogResult,
+    allowScriptsResult,
   );
   results.push(...lockfileResults);
 

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -874,3 +874,106 @@ describe("decideBashGate — local node_modules/.bin shadowing (npx tsc case)", 
     }
   });
 });
+
+describe("parseInstallCommand — install-script approval is a grant, not a read", () => {
+  // Both spellings MEASURED on npm 11.19.0: the namespaced `npm install-scripts
+  // approve|deny|ls|prune` (what the client's own warning tells you to run) and the flat
+  // `npm approve-scripts` alias the docs describe.
+  const probe = (cmd: string) => parseInstallCommand(cmd);
+
+  it("`npm approve-scripts <pkg>` gates each named package", () => {
+    // npm skips a dependency's install scripts unless package.json's `allowScripts` names
+    // it. Approving is the moment that dependency gains arbitrary code execution at install
+    // time — the exact decision this gate exists to hold — so the operand is triaged.
+    assert.deepEqual(probe("npm approve-scripts sharp").refs, ["npm:sharp"]);
+    assert.deepEqual(probe("npm approve-scripts canvas sharp").refs, ["npm:canvas", "npm:sharp"]);
+    assert.equal(probe("npm approve-scripts sharp").isInstall, true);
+  });
+
+  it("`npm install-scripts approve <pkg>` gates the same way", () => {
+    assert.deepEqual(probe("npm install-scripts approve sharp").refs, ["npm:sharp"]);
+    assert.equal(probe("npm install-scripts approve sharp").isInstall, true);
+  });
+
+  it("carries the pinned version npm writes into the allowScripts key", () => {
+    assert.deepEqual(probe("npm approve-scripts sharp@0.33.5").refs, ["npm:sharp@0.33.5"]);
+  });
+
+  it("`--all` / `-a` approves everything pending — nothing to triage, so fail-closed", () => {
+    for (const cmd of [
+      "npm approve-scripts --all",
+      "npm install-scripts approve --all",
+      "npm install-scripts approve -a",
+    ]) {
+      const p = probe(cmd);
+      assert.equal(p.isInstall, true, cmd);
+      assert.deepEqual(p.refs, [], cmd);
+      assert.deepEqual(p.unverifiable, ["approve-scripts-all"], cmd);
+    }
+  });
+
+  it("a bare approve is an interactive grant → fail-closed", () => {
+    const p = probe("npm approve-scripts");
+    assert.equal(p.isInstall, true);
+    assert.deepEqual(p.unverifiable, ["approve-scripts-interactive"]);
+  });
+
+  it("the read-only faces are never gated", () => {
+    // Blocking review would push an agent straight to `--all`, the opposite of what this
+    // gate wants. `--dry-run` writes nothing; ls reports; deny and prune only REMOVE grants.
+    for (const cmd of [
+      "npm approve-scripts --allow-scripts-pending",
+      "npm approve-scripts --allow-scripts-pending --json",
+      "npm install-scripts ls",
+      "npm install-scripts deny sharp",
+      "npm install-scripts deny --all",
+      "npm install-scripts prune",
+      "npm install-scripts approve --all --dry-run",
+      "npm deny-scripts sharp",
+    ]) {
+      const p = probe(cmd);
+      assert.equal(p.isInstall, false, cmd);
+      assert.deepEqual(p.unverifiable, [], cmd);
+      assert.deepEqual(p.refs, [], cmd);
+    }
+  });
+
+  it("`pnpm approve-builds` grants the same execution, interactively → fail-closed", () => {
+    const p = probe("pnpm approve-builds");
+    assert.equal(p.isInstall, true);
+    assert.deepEqual(p.unverifiable, ["approve-builds-interactive"]);
+  });
+});
+
+describe("decideBashGate — approval of install scripts", () => {
+  it("BLOCKS approving a package that does not triage PASS", async () => {
+    const v = await decideBashGate("npm approve-scripts evil-pkg", fakeDeps(["evil-pkg"]));
+    assert.equal(v.block, true);
+    assert.match(v.reason, /evil-pkg/);
+  });
+
+  it("BLOCKS the namespaced spelling too", async () => {
+    const v = await decideBashGate("npm install-scripts approve evil-pkg", fakeDeps(["evil-pkg"]));
+    assert.equal(v.block, true);
+  });
+
+  it("allows approving a package that triages PASS", async () => {
+    const v = await decideBashGate("npm approve-scripts sharp", fakeDeps());
+    assert.equal(v.block, false);
+    assert.equal(v.checked.length, 1);
+  });
+
+  it("BLOCKS `--all` without triaging anything", async () => {
+    let called = false;
+    const deps: GateDeps = {
+      runTriage: async (type, target) => {
+        called = true;
+        return { type, target, passed: true, output: "" };
+      },
+    };
+    const v = await decideBashGate("npm approve-scripts --all", deps);
+    assert.equal(v.block, true);
+    assert.equal(called, false, "nothing named → nothing to triage; block outright");
+    assert.match(v.reason, /cannot reduce to a triage target/);
+  });
+});

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -548,6 +548,11 @@ interface Matcher {
   /** A RUNNER (npx/create/exec/uvx…): only the FIRST non-flag arg is the fetched
    *  package; the rest are arguments passed to it. Installers gate every arg. */
   single?: boolean;
+  /** A GRANT verb (npm v12 `approve-scripts`, pnpm `approve-builds`) names no package in
+   *  its `--all` / interactive forms, so the benign bare-reinstall read is wrong: those
+   *  hand install-time code execution to packages nobody triaged. Returns the fail-closed
+   *  reason to record instead. */
+  zeroTargetReason?: (tokens: string[]) => string;
   /** Gate ONLY the `--package`/`--with`/… flag packages, never a positional — for
    *  commands whose positional is a local script/command, not a fetched package
    *  (`uv run --with evil script.py`: gate `evil`, not `script.py`). Not an install
@@ -617,6 +622,33 @@ const MATCHERS: Matcher[] = [
       // yarn 1 global add / yarn global install
       if (bin === "yarn" && t[1] === "global" && /^(add|install)$/.test(t[2] ?? "")) return 3;
       return -1;
+    },
+  },
+  // `npm approve-scripts <pkg>` / `npm install-scripts approve <pkg>` (and pnpm's
+  // `approve-builds`) is not a fetch — it is the moment an already-installed dependency GAINS
+  // install-time code execution. npm skips
+  // preinstall/install/postinstall/prepare for anything absent from package.json's
+  // `allowScripts`, so approving is the trust decision this gate exists to hold. Gate the
+  // named operand exactly like an install target; the `--all` and interactive forms name
+  // nothing and fail closed (see `zeroTargetReason`).
+  {
+    scheme: "npm",
+    toName: npmName,
+    argStart: (t) => {
+      if (t[0] === "npm") {
+        if (t[1] === "approve-scripts") return 2;
+        // `npm install-scripts approve <pkg>` — the spelling the client's own skip warning
+        // tells you to run. `deny`/`ls`/`prune` never grant, and are short-circuited before
+        // the matchers run (see `isApprovalNoop`).
+        if (t[1] === "install-scripts" && t[2] === "approve") return 3;
+        return -1;
+      }
+      return t[0] === "pnpm" && t[1] === "approve-builds" ? 2 : -1;
+    },
+    zeroTargetReason: (t) => {
+      if (t[0] === "pnpm") return "approve-builds-interactive";
+      const all = t.includes("--all") || t.includes("-a");
+      return all ? "approve-scripts-all" : "approve-scripts-interactive";
     },
   },
   // package runners that fetch + execute immediately (high risk): npx/bunx <pkg>,
@@ -875,6 +907,13 @@ function applyMatcher(
   const targets = resolveTargets(m, pos.slice(start), tokens);
 
   if (targets.length === 0) {
+    // A grant verb with no named operand approves whatever npm has pending — there is no
+    // name to triage, so this is fail-closed, never the benign bare-reinstall read below.
+    if (m.zeroTargetReason) {
+      probe.isInstall = true;
+      probe.unverifiable.push(m.zeroTargetReason(tokens));
+      return true;
+    }
     // `echo evil | xargs npm i` feeds the package on stdin, leaving zero visible args while
     // still installing → fail-closed when this segment is an xargs target.
     if (raw.some((t) => binBase(t) === "xargs")) {
@@ -960,6 +999,17 @@ function stripRedirections(tokens: string[]): string[] {
   return out;
 }
 
+/** The faces of npm's approval flow that hand out nothing: `--allow-scripts-pending` and
+ *  `--dry-run` write no grant, and `install-scripts ls|deny|prune` report or REMOVE grants.
+ *  Flags live in `tokens` (never in the compacted positionals), the verb in `pos`. */
+function isApprovalNoop(tokens: string[], pos: string[]): boolean {
+  if (pos[0] !== "npm") return false;
+  const readOnly = tokens.includes("--allow-scripts-pending") || tokens.includes("--dry-run");
+  if (pos[1] === "approve-scripts") return readOnly;
+  if (pos[1] === "install-scripts") return pos[2] !== "approve" || readOnly;
+  return false;
+}
+
 /** Match one shell segment against the package-manager matchers, mutating `probe`. */
 function scanSegment(segment: string, probe: InstallProbe): void {
   const raw = stripRedirections(stripInlineComment(segment).trim().split(/\s+/).filter(Boolean))
@@ -973,6 +1023,11 @@ function scanSegment(segment: string, probe: InstallProbe): void {
 
   const pos = compactPositionals(tokens);
   if (pos.length === 0) return;
+
+  // Reviewing, denying and pruning grants write no permission at all. Blocking the review
+  // step would push an agent straight to `--all` — the opposite of what this gate wants — so
+  // those faces are never an install.
+  if (isApprovalNoop(tokens, pos)) return;
 
   for (const m of MATCHERS) {
     if (applyMatcher(m, pos, tokens, raw, probe)) break; // one matcher per segment

--- a/src/publish-workflow.test.ts
+++ b/src/publish-workflow.test.ts
@@ -1,0 +1,87 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * publish.yml ↔ npm's trusted-publishing prerequisites.
+ *
+ * npm is retiring 2FA-bypass granular access tokens as a publishing credential:
+ * from ~January 2027 such a token can only read private packages and STAGE a
+ * publish for human 2FA approval. The migration target is trusted publishing —
+ * an OIDC exchange with no long-lived secret at all — and it exists only in
+ * **npm >= 11.5.1 on node >= 22.14.0**.
+ *
+ * `actions/setup-node` with `node-version: "22"` ships npm 10.9.x, so the client
+ * in this job has no OIDC exchange to make. That is a prerequisite the repo can
+ * assert about itself today, before the registry-side switch (which is 13
+ * per-package configurations on npmjs.com — see docs/RELEASING.md), so the
+ * migration cannot arrive to find the runner too old.
+ *
+ * The gate is here rather than in prose because a comment cannot fail CI, and a
+ * publish job only ever runs on a tag push — the worst possible moment to learn
+ * that its npm is too old.
+ */
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const WORKFLOW = readFileSync(join(REPO_ROOT, ".github/workflows/publish.yml"), "utf-8");
+
+/** The workflow with its comment lines removed. Every assertion below is about what the job
+ *  RUNS, and this file is heavily commented — a comment that merely mentions `npm publish`
+ *  must not be mistaken for the step that performs it. */
+const EXECUTED = WORKFLOW.split("\n")
+  .filter((line) => !/^\s*#/.test(line))
+  .join("\n");
+
+/** npm's documented floor for trusted publishing. */
+const MIN_NPM = [11, 5, 1] as const;
+
+function atLeast(found: readonly number[], min: readonly number[]): boolean {
+  for (let i = 0; i < min.length; i++) {
+    const f = found[i] ?? 0;
+    if (f > min[i]) return true;
+    if (f < min[i]) return false;
+  }
+  return true;
+}
+
+describe("publish.yml — trusted-publishing prerequisites", () => {
+  it("installs an npm that has the OIDC exchange (>= 11.5.1)", () => {
+    const m = EXECUTED.match(/npm (?:i|install) -g npm@\^?(\d+)\.(\d+)\.(\d+)/);
+    assert.ok(
+      m,
+      "publish.yml must install npm explicitly: setup-node's bundled npm for node 22 is 10.9.x, which predates trusted publishing (>= 11.5.1)",
+    );
+    const found = [Number(m[1]), Number(m[2]), Number(m[3])];
+    assert.ok(
+      atLeast(found, MIN_NPM),
+      `publish.yml pins npm ${found.join(".")}, below trusted publishing's floor ${MIN_NPM.join(".")}`,
+    );
+  });
+
+  it("upgrades npm BEFORE the first publish", () => {
+    const upgrade = EXECUTED.search(/npm (?:i|install) -g npm@/);
+    const publish = EXECUTED.indexOf("npm publish");
+    assert.ok(publish > 0, "publish.yml no longer runs `npm publish`");
+    assert.ok(
+      upgrade > 0 && upgrade < publish,
+      "the npm upgrade must run before any publish step, or the publish uses the old client",
+    );
+  });
+
+  it("asks for a node that admits that npm (>= 22.14.0)", () => {
+    const m = EXECUTED.match(/node-version:\s*"?(\d+)(?:\.(\d+))?(?:\.(\d+))?"?/);
+    assert.ok(m, "publish.yml must declare a node-version");
+    const major = Number(m[1]);
+    // A bare major ("22") resolves to the latest 22.x, which is >= 22.14. A pinned
+    // minor must clear 22.14 itself.
+    if (m[2] === undefined) {
+      assert.ok(major >= 22, `node-version ${major} predates trusted publishing's node floor`);
+      return;
+    }
+    assert.ok(
+      atLeast([major, Number(m[2]), Number(m[3] ?? 0)], [22, 14, 0]),
+      `node-version ${m[0]} is below node 22.14.0`,
+    );
+  });
+});

--- a/src/publish-workflow.test.ts
+++ b/src/publish-workflow.test.ts
@@ -45,6 +45,30 @@ function atLeast(found: readonly number[], min: readonly number[]): boolean {
   return true;
 }
 
+describe("publish.yml — the signature gate cannot fail open", () => {
+  it("takes the tag verdict from git verify-tag, not from a pipe", () => {
+    // Shipped as `if ! git verify-tag "$TAG" 2>&1 | tee /tmp/tag-verify.log; then`. git exits
+    // 1 on an unsigned tag; the pipeline reported tee's zero, so the gate never fired and an
+    // unsigned v6.6.3 published with every GPG pin around it intact and useless. The default
+    // step shell is `bash -e {0}` — pipefail is not on unless the step asks for it.
+    const verify = EXECUTED.match(/if !\s*git verify-tag[^\n]*/);
+    assert.ok(verify, "publish.yml no longer verifies the tag signature");
+    assert.doesNotMatch(
+      verify[0],
+      /\|\s*(tee|cat)\b/,
+      "the verdict must not come from a pass-through sink",
+    );
+  });
+
+  it("sets pipefail in that step regardless", () => {
+    const step = EXECUTED.slice(
+      EXECUTED.indexOf("Verify tag is GPG-signed"),
+      EXECUTED.indexOf("if !", EXECUTED.indexOf("Verify tag is GPG-signed")),
+    );
+    assert.match(step, /set -o pipefail|set -euo pipefail/);
+  });
+});
+
 describe("publish.yml — trusted-publishing prerequisites", () => {
   it("installs an npm that has the OIDC exchange (>= 11.5.1)", () => {
     const m = EXECUTED.match(/npm (?:i|install) -g npm@\^?(\d+)\.(\d+)\.(\d+)/);

--- a/src/rules/catalog.ts
+++ b/src/rules/catalog.ts
@@ -74,6 +74,10 @@ export const SECURITY_RULES: Record<string, RuleRef> = {
     "A06:2021 Vulnerable and Outdated Components",
   ),
   "pinned versions": cwe(1104, "Use of Unmaintained Third Party Components"),
+  // npm v12's `allowScripts` records which dependencies may run install scripts; an
+  // unreviewed or outlived grant is exactly functionality pulled in from a sphere the
+  // project no longer controls.
+  "install-script grants": cwe(829, "Inclusion of Functionality from Untrusted Control Sphere"),
   "package-lock.json": owasp(
     "A08",
     "A08_2021-Software_and_Data_Integrity_Failures",

--- a/src/self-audit.test.ts
+++ b/src/self-audit.test.ts
@@ -537,6 +537,104 @@ jobs:
   });
 });
 
+describe("R1-fail-open-ci — a gate whose status comes from the wrong command", () => {
+  const workflow = (body: string): string => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-r1-pipe-"));
+    const wf = join(dir, ".github", "workflows");
+    mkdirSync(wf, { recursive: true });
+    writeFileSync(join(wf, "publish.yml"), body);
+    return dir;
+  };
+
+  it("FAILS a condition piped into tee — the pipeline reports tee, not the check", () => {
+    // This shipped in kit's own publish.yml: `git verify-tag` exits 1 on an unsigned tag,
+    // but the `if !` read tee's status (always 0), so the signature gate never fired and an
+    // unsigned v6.6.3 published. GitHub's default step shell is `bash -e {0}` — no pipefail.
+    const dir = workflow(`name: publish
+on: [push]
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if ! git verify-tag "$TAG" 2>&1 | tee /tmp/tag-verify.log; then
+            exit 1
+          fi
+`);
+    try {
+      const res = ruleById("R1-fail-open-ci").run({ repoRoot: dir, sources: [], pkgJson: {} });
+      const fail = res.find((r) => r.status === "fail");
+      assert.equal(fail?.severity, "high");
+      assert.match(String(fail?.detail), /pipe|pipefail/i);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts the same line when the step sets pipefail", () => {
+    const dir = workflow(`name: publish
+on: [push]
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          set -euo pipefail
+          if ! git verify-tag "$TAG" 2>&1 | tee /tmp/tag-verify.log; then
+            exit 1
+          fi
+`);
+    try {
+      const res = ruleById("R1-fail-open-ci").run({ repoRoot: dir, sources: [], pkgJson: {} });
+      assert.equal(countStatus(res, "fail"), 0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not accept pipefail that only appears in a comment", () => {
+    // The first version of this check walked back looking for the word, and this step's own
+    // explanatory comment satisfied it — documented, not enforced, which is the exact disease.
+    const dir = workflow(`name: publish
+on: [push]
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          # pipefail matters here because the verdict is an exit status
+          if ! git verify-tag "$TAG" 2>&1 | tee /tmp/tag-verify.log; then
+            exit 1
+          fi
+`);
+    try {
+      const res = ruleById("R1-fail-open-ci").run({ repoRoot: dir, sources: [], pkgJson: {} });
+      assert.equal(countStatus(res, "fail"), 1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves a condition that WANTS the last command's status alone", () => {
+    // `if cmd | grep -q x` is asking about grep, which is the whole point of the pipe.
+    const dir = workflow(`name: publish
+on: [push]
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if npm ls --json | grep -q evil; then exit 1; fi
+`);
+    try {
+      const res = ruleById("R1-fail-open-ci").run({ repoRoot: dir, sources: [], pkgJson: {} });
+      assert.equal(countStatus(res, "fail"), 0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("R11-script-paths", () => {
   it("delegates to runCiScriptAudit: fails on a missing script ref", () => {
     const dir = mkdtempSync(join(tmpdir(), "kit-r11-"));

--- a/src/self-audit.ts
+++ b/src/self-audit.ts
@@ -229,6 +229,23 @@ function listWorkflowFiles(repoRoot: string): string[] {
   }
 }
 
+/** Does the `run:` block containing line `i` set pipefail? Walk back to the step boundary
+ *  (`- name:` / `- run:` / `- uses:`) — with pipefail the pipeline reports the first failure,
+ *  so a piped condition is no longer fail-open. */
+function stepSetsPipefail(lines: string[], i: number): boolean {
+  for (let j = i; j >= 0; j--) {
+    const l = lines[j];
+    // A `set -o pipefail` (or `set -euo pipefail`) that actually RUNS. Prose mentioning
+    // pipefail must not count: this very step's comment explains the flag, and an earlier
+    // version of this helper read that comment as the fix being present — the same
+    // "documented, not enforced" failure the rule exists to catch.
+    if (/^\s*#/.test(l)) continue;
+    if (/(^|[\s;&|])set\s+-[a-zA-Z]*o\s+pipefail\b/.test(l)) return true;
+    if (/^\s*-\s+(name|run|uses):/.test(l) && j !== i) return false;
+  }
+  return false;
+}
+
 const R1: SelfAuditRule = {
   id: "R1-fail-open-ci",
   name: "fail-open in CI workflows",
@@ -268,6 +285,27 @@ const R1: SelfAuditRule = {
             status: "fail",
             severity: "high",
             detail: `workflow step uses '|| true', swallowing failures (fail-open): ${trimmed}`,
+          });
+        }
+        // A CONDITION piped into a pass-through sink takes its status from that sink, not
+        // from the check: `if ! git verify-tag "$TAG" 2>&1 | tee log; then` reads tee's
+        // always-zero exit, so the gate never fires. This shipped in kit's own publish.yml
+        // and let an UNSIGNED tag publish 6.6.3. GitHub's default step shell is `bash -e {0}`
+        // — pipefail is NOT on unless the step sets it (or the step declares `shell: bash`),
+        // so the fix is pipefail or no pipe at all. Only pass-through sinks are flagged: an
+        // `if cmd | grep -q x` is deliberately asking about grep.
+        if (
+          /\bif\s+!?\s*\S/.test(trimmed) &&
+          /\|\s*(tee|cat)\b/.test(trimmed) &&
+          !annotated &&
+          !stepSetsPipefail(lines, i)
+        ) {
+          findings.push({
+            file: sf,
+            line: i + 1,
+            status: "fail",
+            severity: "high",
+            detail: `condition takes its exit status from the pipe's last command, not the check (add 'set -o pipefail' or drop the pipe): ${trimmed}`,
           });
         }
         // `continue-on-error: true` is fail-open (WARN) unless explicitly opted-out.

--- a/src/supply-chain.test.ts
+++ b/src/supply-chain.test.ts
@@ -1,7 +1,11 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   findInstallScripts,
+  runSupplyChain,
   findLockDrift,
   findNonRegistryResolved,
   findDepConfusion,
@@ -102,5 +106,35 @@ describe("parseLockPkgs", () => {
     });
     assert.equal(pkgs.length, 1);
     assert.equal(pkgs[0].name, "x");
+  });
+});
+
+describe("runSupplyChain — install-scripts remediation names the review commands", () => {
+  it("points at `npm install-scripts ls`, not at --ignore-scripts", () => {
+    // `--ignore-scripts` is npm's DEFAULT now: skipping is what already happens, so telling
+    // someone to skip is no longer advice. What they have to do is review the pending list and
+    // grant pinned — the grants kit then audits as "install-script grants".
+    const dir = mkdtempSync(join(tmpdir(), "kit-sc-scripts-"));
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "x", dependencies: { esbuild: "0.28.1" } }),
+    );
+    writeFileSync(
+      join(dir, "package-lock.json"),
+      JSON.stringify({
+        lockfileVersion: 3,
+        packages: {
+          "node_modules/esbuild": {
+            version: "0.28.1",
+            resolved: "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+            hasInstallScript: true,
+          },
+        },
+      }),
+    );
+    const r = runSupplyChain(dir).find((x) => x.name === "install-scripts");
+    assert.equal(r?.status, "warn");
+    assert.match(String(r?.suggestion), /npm install-scripts ls/);
+    assert.doesNotMatch(String(r?.suggestion), /--ignore-scripts/);
   });
 });

--- a/src/supply-chain.ts
+++ b/src/supply-chain.ts
@@ -4,7 +4,7 @@
  *
  *  - install-scripts : deps that run pre/post/install scripts (the classic malware
  *                      execution vector) — surfaced so they can be reviewed / run
- *                      with `--ignore-scripts`.
+ *                      with `--ignore-scripts` (npm's own default since v11).
  *  - lockfile-drift  : a declared dependency missing from the lockfile, or a package
  *                      resolved from a NON-registry source (http/git/github tarball).
  *  - dep-confusion   : a dependency under one of your declared internal scopes that
@@ -196,7 +196,11 @@ export function runSupplyChain(cwd: string, internalScopes: string[] = []): Secu
           "warn",
           `${scripts.length} dep(s) run install scripts: ${scripts.slice(0, 8).join(", ")}${scripts.length > 8 ? "…" : ""}`,
           "medium",
-          "review them; install with `npm ci --ignore-scripts` where possible",
+          // Skipping IS npm's default now, so "install with --ignore-scripts" is no longer
+          // advice — it describes what already happens. The work is the review: list what is
+          // pending, then grant pinned. Those grants are audited by the "install-script
+          // grants" check in check-security.ts.
+          "review with `npm install-scripts ls`, then grant pinned per package (`npm install-scripts approve <pkg>`) — never `--all`",
         ),
   );
 


### PR DESCRIPTION
From the [npm install-time security changelog](https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/): npm no longer runs a dependency's `preinstall`/`install`/`postinstall`/`prepare` unless `package.json`'s `allowScripts` names it, and 2FA-bypass granular access tokens lose direct publishing (~Jan 2027).

The install-time half moves the dangerous moment from the install to the **approval** — and kit was watching only the install.

## The gap this closes

`install-gate.ts` matched `install|i|add|install-test|it|update|upgrade|ci|clean-install`. It did not match `npm approve-scripts`, so an agent in auto-mode could hand a dependency arbitrary install-time code execution without triaging anything — the exact decision the gate exists to hold.

Both spellings ship in npm 11.19 and both are now gated:

| Command | Verdict |
| --- | --- |
| `npm approve-scripts <pkg>` | triaged like an install target |
| `npm install-scripts approve <pkg>` | triaged like an install target |
| `npm approve-scripts --all` / `approve -a` | **blocked** — nothing named, nothing to triage |
| bare `npm approve-scripts` | **blocked** — interactive grant |
| `pnpm approve-builds` | **blocked** — interactive grant |
| `install-scripts ls` / `deny` / `prune` | never gated — they remove or report grants |
| `--dry-run`, `--allow-scripts-pending` | never gated — they write nothing |

The read-only exemptions are deliberate: blocking the review step would push an agent straight to `--all`.

Driven through the real `kit gate-bash`, not only unit tests:

```
npm approve-scripts --all                     exit=2  BLOCKED — cannot reduce to a triage target: approve-scripts-all
npm install-scripts approve left-pad          exit=2  BLOCKED — triage did not pass (npm left-pad)
npm install-scripts ls                        exit=0
npm install-scripts prune                     exit=0
npm install-scripts approve --all --dry-run   exit=0
```

## Measured, not read off the docs

`docs.npmjs.com` documents `allowScripts` as `{pkg: "1.2.3"}`. npm 11.19.0 writes the version into the **key**:

```
npm install-scripts approve esbuild                          -> {"esbuild@0.28.1": true}
npm install-scripts approve esbuild --no-allow-scripts-pin   -> {"esbuild": true}
npm install-scripts deny esbuild                             -> {"esbuild": false}
```

The first implementation followed the docs and was wrong; the tests were rewritten against the measured shapes before the parser was.

## New check: `install-script grants` (CWE-829)

Audits the field the approval writes. Two shapes outlive their review — a bare-name or range key (covers the release nobody has seen yet) and a grant for a package the manifest no longer declares (a standing permission for a name an attacker can re-introduce; `npm install-scripts prune` clears it). A shape npm does not write is reported as `didNotRun`, never read as "no grants" — treating an unparseable allowlist as empty would report the most dangerous state as the safest one.

Real `kit check --category security` against a fixture:

```
! install-script grants   warn  1 unpinned grant(s): esbuild — covers releases nobody reviewed;
                                1 stale grant(s): left-pad@1.3.0 — no longer a declared dependency  [medium] [CWE-829]
    re-approve pinned (`npm install-scripts approve <pkg>` writes <pkg>@<version> by default),
    and clear the outlived ones with `npm install-scripts prune`
✓ install-script grants   pass  1 grant(s), every one pinned to an exact version · 1 denied
```

On kit itself it skips — no grants declared, so no new noise.

## The publishing half

`publish.yml` now installs `npm@^11.5.1` before anything else: OIDC trusted publishing exists only in npm ≥ 11.5.1 on node ≥ 22.14.0, and `actions/setup-node` ships npm 10.9.x for node 22. Verified on npm 11.19.0 against this repo before wiring — `npm ci` and `npm publish --dry-run` behave identically, and the skip-install-scripts default costs nothing here (esbuild's postinstall is the only one in the tree; build and tests pass without it).

`src/publish-workflow.test.ts` asserts the step exists, clears the floor, and precedes every publish. A comment cannot fail CI, and a publish job runs only on a tag push — the worst moment to learn the client is too old. The test strips comment lines before measuring positions, so prose mentioning `npm publish` cannot satisfy or break it.

`docs/RELEASING.md` (new) documents the release path, what the job refuses to publish, and the migration's remaining **manual** work: 13 per-package trusted-publisher configurations on npmjs.com, bound to the `npm-publish` environment, plus the two constraints (`workflow_call` breaks npm's validation; self-hosted runners are unsupported).

## Deliberately out of scope

The strongest possible finding — "this package was approved but kit never triaged it" — needs a triage ledger to consult, and none exists (`gateInstall` runs triage live). Named here rather than half-built.

## Also released

6.6.4 carries the already-merged #471 (`kit init` generates only what the repo proves) and #473 (`kit_check` −67% output per call), neither of which had a CHANGELOG section.

## Verification

- `npm test`: **4230 pass / 0 fail** (4201 before; +29 new)
- `npm run build`, `npx tsc`, `npm run lint` (0 errors), `npm run format:check`: clean
- `contracts/kit.opencli.json` regenerated for the version bump
- `kit check --category security` on this repo: 24/25, the one warn being the pre-existing accepted-secrets finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)