### PR TITLE
The security-headers step could not fail either — R1 now names the class

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -249,11 +249,29 @@ jobs:
           done
           echo "GDPR scan complete (warnings only)"
       - name: Security headers in code
+        # This step could not fail. It read `if grep -rE "…" src/ packages/ | head -1; then`,
+        # and `head` exits 0 on empty input, so the condition was ALWAYS true: "Security
+        # headers configured" printed unconditionally and the ::warning:: branch was
+        # unreachable. Same class as the publish.yml tag-signature gate fixed in 6.6.4 (a
+        # condition decided by the pipe's last command); self-audit R1-fail-open-ci now flags
+        # it, and found this one.
+        #
+        # Made honest rather than merely correct: kit is a CLI + MCP (stdio) tool, the same
+        # "no HTTP surface" that skips Stage 3 DAST above, so a missing CSP is not a finding
+        # here — a permanently-expected warning would just train people to ignore warnings.
+        # The check is therefore gated on a surface actually existing, and fires the day one
+        # lands. Measured when written: every one of these server patterns matches 0 lines in
+        # src/ and packages/.
         run: |
-          if grep -rE "Content-Security-Policy|Strict-Transport-Security|X-Frame-Options" src/ packages/ 2>/dev/null | head -1; then
+          set -o pipefail
+          if ! grep -rqE "createServer|express\(|fastify\(|Bun\.serve|\.listen\(" src/ packages/ 2>/dev/null; then
+            echo "No HTTP surface in src/ or packages/ — header check N/A (same reason Stage 3 DAST is skipped)"
+            exit 0
+          fi
+          if grep -rqE "Content-Security-Policy|Strict-Transport-Security|X-Frame-Options" src/ packages/; then
             echo "Security headers configured"
           else
-            echo "::warning::No security headers found in src/ or packages/ — required for web-facing code"
+            echo "::warning::HTTP surface found in src/ or packages/ but no security headers — required for web-facing code"
           fi
 
   # kit self-check (uses kit check-security)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A second gate that could not fail: the security-headers step.** `security.yml` read
+  `if grep -rE "Content-Security-Policy|…" src/ packages/ | head -1; then` — `head` exits 0 on
+  empty input, so the condition was always true, `Security headers configured` printed
+  unconditionally, and the `::warning::` branch was unreachable. Measured against a
+  guaranteed-absent pattern before fixing. Same class as the 6.6.4 tag-signature gate, and
+  found by the rule that fix installed.
+- **`R1-fail-open-ci` now names the class instead of the instance.** It flagged a condition
+  piped into `tee` or `cat`; it now flags any condition whose pipeline ENDS in a status-blind
+  sink (`tee`, `cat`, `head`, `tail`, `wc`, `sort`, `uniq`, `tr`). `grep -q` stays allowed —
+  there the pipe's last command IS the question. Adding the rule made kit's own self-audit
+  fail on `security.yml`, which is how the second instance surfaced.
+
+### Changed
+
+- **The security-headers check is now honest, not merely correct.** kit is a CLI + MCP (stdio)
+  tool — the same "no HTTP surface" that skips Stage 3 DAST — so a missing CSP is not a
+  finding here, and a permanently-expected warning would only train people to ignore warnings.
+  The check is gated on an HTTP surface actually existing (`createServer`, `express(`,
+  `fastify(`, `Bun.serve`, `.listen(` — each matching 0 lines when written) and fires the day
+  one lands. All three branches were driven in a fixture tree; the two that mattered had never
+  been reachable.
+
 ## [6.6.4] - 2026-08-18
 
 ### Added

--- a/src/self-audit.test.ts
+++ b/src/self-audit.test.ts
@@ -592,6 +592,32 @@ jobs:
     }
   });
 
+  it("FAILS a condition ending in any status-blind sink, not just tee", () => {
+    // kit's own security.yml carried `if grep -rE "…" src/ | head -1; then`. `head` exits 0
+    // on empty input, so the condition was ALWAYS true: "Security headers configured" printed
+    // unconditionally and the ::warning:: branch was unreachable. Same class as the tee case,
+    // different sink — the rule has to name the class, not the one instance that was found.
+    for (const sink of ["head -1", "tail -1", "wc -l", "sort", "uniq", "cat", "tr -d x"]) {
+      const dir = workflow(`name: security
+on: [push]
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if grep -rE "Content-Security-Policy" src/ | ${sink}; then
+            echo ok
+          fi
+`);
+      try {
+        const res = ruleById("R1-fail-open-ci").run({ repoRoot: dir, sources: [], pkgJson: {} });
+        assert.equal(countStatus(res, "fail"), 1, sink);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
   it("does not accept pipefail that only appears in a comment", () => {
     // The first version of this check walked back looking for the word, and this step's own
     // explanatory comment satisfied it — documented, not enforced, which is the exact disease.

--- a/src/self-audit.ts
+++ b/src/self-audit.ts
@@ -229,6 +229,13 @@ function listWorkflowFiles(repoRoot: string): string[] {
   }
 }
 
+/** Commands whose exit status says nothing about the check that fed them: pass-throughs and
+ *  formatters. `head` and `tail` exit 0 on empty input, `wc`/`sort`/`uniq`/`tr`/`cat`/`tee`
+ *  effectively always do — so a condition ENDING in one of these is decided by the sink, not
+ *  by the check. `grep -q` is deliberately absent: there, the pipe's last command IS the
+ *  question being asked. */
+const STATUS_BLIND_SINK = /\|\s*(tee|cat|head|tail|wc|sort|uniq|tr)\b[^|]*$/;
+
 /** Does the `run:` block containing line `i` set pipefail? Walk back to the step boundary
  *  (`- name:` / `- run:` / `- uses:`) — with pipefail the pipeline reports the first failure,
  *  so a piped condition is no longer fail-open. */
@@ -287,16 +294,17 @@ const R1: SelfAuditRule = {
             detail: `workflow step uses '|| true', swallowing failures (fail-open): ${trimmed}`,
           });
         }
-        // A CONDITION piped into a pass-through sink takes its status from that sink, not
-        // from the check: `if ! git verify-tag "$TAG" 2>&1 | tee log; then` reads tee's
-        // always-zero exit, so the gate never fires. This shipped in kit's own publish.yml
-        // and let an UNSIGNED tag publish 6.6.3. GitHub's default step shell is `bash -e {0}`
+        // A CONDITION whose pipeline ENDS in a status-blind sink takes its verdict from that
+        // sink, not from the check. Two instances shipped in kit's own workflows: publish.yml
+        // read `if ! git verify-tag … | tee log` (tee always exits 0) and let an UNSIGNED tag
+        // publish 6.6.3; security.yml read `if grep -rE "…" src/ | head -1` (head exits 0 on
+        // empty input), so its header check printed "configured" unconditionally. GitHub's default step shell is `bash -e {0}`
         // — pipefail is NOT on unless the step sets it (or the step declares `shell: bash`),
         // so the fix is pipefail or no pipe at all. Only pass-through sinks are flagged: an
         // `if cmd | grep -q x` is deliberately asking about grep.
         if (
           /\bif\s+!?\s*\S/.test(trimmed) &&
-          /\|\s*(tee|cat)\b/.test(trimmed) &&
+          STATUS_BLIND_SINK.test(trimmed) &&
           !annotated &&
           !stepSetsPipefail(lines, i)
         ) {


### PR DESCRIPTION
The rule 6.6.4 added to catch the tag-signature gate found a second instance in kit's own workflows the first time it was widened.

## The bug

`security.yml`:

```bash
if grep -rE "Content-Security-Policy|Strict-Transport-Security|X-Frame-Options" src/ packages/ 2>/dev/null | head -1; then
  echo "Security headers configured"
else
  echo "::warning::No security headers found in src/ or packages/ — required for web-facing code"
fi
```

`head` exits 0 on empty input, so the condition is always true. Measured before touching it:

```
$ echo -n "" | head -1; echo "exit=$?"
exit=0
$ if grep -rE "ZZZ_definitely_not_present_ZZZ" src/ packages/ 2>/dev/null | head -1; then echo TRUE; fi
TRUE
```

So `Security headers configured` printed unconditionally and the `::warning::` branch was unreachable — for a repo where the grep actually matches **0 lines**.

## R1-fail-open-ci now names the class

It flagged `tee` and `cat`. It now flags any condition whose pipeline **ends** in a status-blind sink — `tee`, `cat`, `head`, `tail`, `wc`, `sort`, `uniq`, `tr` — because the verdict comes from the sink, not the check. `grep -q` stays allowed: there the pipe's last command *is* the question.

Adding the sink list made `runSelfAudit over the current kit tree returns ZERO fail results` fail on `security.yml`. That is how this surfaced — the fix for the first instance found the second, which is the whole point of writing the rule instead of just patching the line.

## The step is now honest, not merely correct

Making the condition work would have produced a permanently-expected warning, and a warning that always fires trains people to ignore warnings. kit is a CLI + MCP (stdio) tool — the same "no HTTP surface" that skips Stage 3 DAST — so a missing CSP is not a finding here. The check is gated on a surface actually existing and fires the day one lands:

| Pattern | Lines in `src/` + `packages/` |
| --- | --- |
| `createServer`, `express(`, `fastify(`, `Bun.serve`, `.listen(` | **0** each |

All three branches driven in a fixture tree — the two that mattered had never been reachable:

```
HTTP surface, no headers  -> ::warning::HTTP surface found but no security headers
HTTP surface, headers     -> Security headers configured
no surface                -> N/A — no HTTP surface   (exit 0)
```

## Verification

- `npm test`: **4237 pass / 0 fail**
- `kit self-audit`: 16 rules, **0 fail, 0 warn**
- `npm run lint` 0 errors, `format:check` clean

Lands under `[Unreleased]` — no version bump; 6.6.4 is already out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)