### PR TITLE
Ask whether the granted package was ever triaged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **The `install-script grants` check now asks whether the granted package was ever
+  triaged.** #475 deferred this on the grounds that no triage ledger existed to consult. That
+  was wrong: `.kit-triage.jsonl` has been there all along — `kit triage` appends a PASS to it
+  and the pre-commit `check-deps` gate reads it. The shape audit can only say how BROAD a
+  grant is; this asks the question shape cannot answer, and the answers rank differently. A
+  pinned grant for a package nothing has ever evaluated now warns at **high**, above an
+  unpinned grant for one kit cleared yesterday. A grant whose only triage is older than the
+  freshness window is reported separately, because "reviewed a month ago" and "never reviewed"
+  are not the same claim. `TRIAGE_MAX_AGE_DAYS` is now exported and imported rather than
+  copied, so `check-deps` and this check cannot drift to different windows.
+
+  When the log is absent — most repos have never run `kit triage` — the row says the
+  cross-check *did not run* instead of reporting every grant as untriaged. A confident finding
+  built on an absent file is the failure mode this codebase keeps catching in itself. A torn
+  append is skipped rather than allowed to fail the check.
+
 - **`scripts/trusted-publishing-wizard.sh` — the npm OIDC migration, walked.** The
   registry side of trusted publishing can only be done in a browser, one package at a time:
   npm allows exactly one trusted publisher per package, and `npm access` on 11.19.0 covers

--- a/src/check-security.test.ts
+++ b/src/check-security.test.ts
@@ -21,6 +21,7 @@ import {
   unpinnedNodeDeps,
   auditAllowScripts,
   checkAllowScripts,
+  grantsTriageCoverage,
   LOCKFILE_ECOSYSTEMS,
   type SecurityCheckResult,
 } from "./check-security.js";
@@ -1098,5 +1099,124 @@ describe("checkAllowScripts — the check around the audit", () => {
       withPkg({ name: "x", dependencies: { sharp: "1.0.0" }, allowScripts: { sharp: true } }),
     );
     assert.match(String(r.rule?.id), /CWE-829/);
+  });
+});
+
+describe("checkAllowScripts — the triage cross-check in the verdict", () => {
+  const repo = (pkg: unknown, ledger?: string): string => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-grants-triage-"));
+    writeFileSync(join(dir, "package.json"), JSON.stringify(pkg));
+    if (ledger !== undefined) writeFileSync(join(dir, ".kit-triage.jsonl"), ledger);
+    return dir;
+  };
+  const fresh = (target: string) =>
+    JSON.stringify({ type: "npm", target, timestamp: new Date().toISOString(), sandbox: false });
+
+  it("an untriaged grant outranks a shape finding — severity high", async () => {
+    const r = await checkAllowScripts(
+      repo(
+        { name: "x", dependencies: { evil: "1.0.0" }, allowScripts: { "evil@1.0.0": true } },
+        `${fresh("sharp")}\n`,
+      ),
+    );
+    assert.strictEqual(r.status, "warn");
+    assert.strictEqual(r.severity, "high");
+    assert.match(r.detail, /evil@1\.0\.0/);
+    assert.match(r.detail, /never triaged|no triage/i);
+  });
+
+  it("a pinned grant backed by a fresh triage passes", async () => {
+    const r = await checkAllowScripts(
+      repo(
+        { name: "x", dependencies: { sharp: "0.33.5" }, allowScripts: { "sharp@0.33.5": true } },
+        `${fresh("sharp")}\n`,
+      ),
+    );
+    assert.strictEqual(r.status, "pass");
+  });
+
+  it("says the cross-check did not run when there is no ledger", async () => {
+    // Rather than reporting every grant as untriaged on the strength of an absent file.
+    const r = await checkAllowScripts(
+      repo({
+        name: "x",
+        dependencies: { sharp: "0.33.5" },
+        allowScripts: { "sharp@0.33.5": true },
+      }),
+    );
+    assert.strictEqual(r.status, "pass");
+    assert.match(r.detail, /triage cross-check did not run|no \.kit-triage\.jsonl/i);
+  });
+
+  it("a torn ledger line does not fail the check", async () => {
+    const r = await checkAllowScripts(
+      repo(
+        { name: "x", dependencies: { sharp: "0.33.5" }, allowScripts: { "sharp@0.33.5": true } },
+        `{"type":"npm","target":"sha\n${fresh("sharp")}\n`,
+      ),
+    );
+    assert.strictEqual(r.status, "pass");
+  });
+});
+
+describe("grantsTriageCoverage — was the granted package ever triaged?", () => {
+  const day = 86_400_000;
+  const now = Date.parse("2026-08-18T12:00:00.000Z");
+  const entry = (target: string, daysAgo: number, type = "npm") => ({
+    type,
+    target,
+    timestamp: new Date(now - daysAgo * day).toISOString(),
+  });
+
+  it("a grant for a package with a fresh npm triage PASS is covered", () => {
+    const c = grantsTriageCoverage(["sharp@0.33.5"], [entry("sharp", 1)], now);
+    assert.deepStrictEqual(c.untriaged, []);
+    assert.deepStrictEqual(c.stale, []);
+    assert.strictEqual(c.ledgerMissing, undefined);
+  });
+
+  it("a grant with no entry at all is the strongest finding", () => {
+    // Install-script execution handed to a package nothing ever evaluated.
+    const c = grantsTriageCoverage(["evil@1.0.0"], [entry("sharp", 1)], now);
+    assert.deepStrictEqual(c.untriaged, ["evil@1.0.0"]);
+    assert.deepStrictEqual(c.stale, []);
+  });
+
+  it("separates an OLD triage from no triage — they are not the same claim", () => {
+    const c = grantsTriageCoverage(["sharp@0.33.5"], [entry("sharp", 30)], now);
+    assert.deepStrictEqual(c.stale, ["sharp@0.33.5"]);
+    assert.deepStrictEqual(c.untriaged, []);
+  });
+
+  it("matches the bare name on both sides — a version suffix is not identity", () => {
+    // The ledger records `rest` from `npm:<rest>`, so a triage of `sharp@0.33.5` and a
+    // grant keyed `sharp` are the same package.
+    assert.deepStrictEqual(
+      grantsTriageCoverage(["sharp"], [entry("sharp@0.33.5", 1)], now).untriaged,
+      [],
+    );
+    assert.deepStrictEqual(
+      grantsTriageCoverage(["@scope/pkg@1.2.3"], [entry("@scope/pkg", 1)], now).untriaged,
+      [],
+    );
+  });
+
+  it("a pip or brew entry does not cover an npm grant", () => {
+    const c = grantsTriageCoverage(["sharp"], [entry("sharp", 1, "pip")], now);
+    assert.deepStrictEqual(c.untriaged, ["sharp"]);
+  });
+
+  it("no ledger means the cross-check did NOT run — never that nothing was triaged", () => {
+    // Most repos have never run `kit triage`. Reporting every grant as untriaged there
+    // would be a confident claim built on an absent file.
+    const c = grantsTriageCoverage(["sharp"], null, now);
+    assert.strictEqual(c.ledgerMissing, true);
+    assert.deepStrictEqual(c.untriaged, []);
+    assert.deepStrictEqual(c.stale, []);
+  });
+
+  it("ignores an unparseable ledger line instead of throwing", () => {
+    const c = grantsTriageCoverage(["sharp"], [entry("sharp", 1)], now);
+    assert.deepStrictEqual(c.untriaged, []);
   });
 });

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -12,6 +12,7 @@ import { classifyGuardDog } from "./guarddog.js";
 import { depsHashFor, loadGuardDogCache, saveGuardDogCache } from "./guarddog-cache.js";
 import { buildSemgrepArgs, semgrepConfig, isAirGap, isLocalSemgrepConfig } from "./scanners.js";
 import { ruleForCheck, type RuleRef } from "./rules/catalog.js";
+import { TRIAGE_MAX_AGE_DAYS } from "./commands/triage.js";
 import {
   ensureBumblebee,
   runScan,
@@ -853,6 +854,83 @@ export function auditAllowScripts(field: unknown, declared: Set<string>): AllowS
   return out;
 }
 
+/** One line of `.kit-triage.jsonl` — the log `kit triage` appends a PASS to, and the
+ *  pre-commit `check-deps` gate reads. Only the fields this check needs. */
+export interface TriageLogRow {
+  type: string;
+  target: string;
+  timestamp: string;
+}
+
+/** Did anything ever evaluate the package we granted install-script execution to?
+ *
+ * The allowScripts audit can only see the SHAPE of a grant. This asks the question that
+ * shape cannot answer: an unpinned grant for a package kit triaged yesterday is a different
+ * risk from a pinned grant for a package nothing has ever looked at.
+ *
+ * `ledger === null` means the log does not exist — most repos have never run `kit triage` —
+ * and is reported as "the cross-check did not run", never as "nothing was triaged". A
+ * confident finding built on an absent file is exactly the failure mode this codebase keeps
+ * finding in itself. Pure; exported for tests.
+ */
+export interface TriageCoverage {
+  /** Granted, with no matching triage entry at all. */
+  untriaged: string[];
+  /** Granted and triaged, but every entry is older than the freshness window. */
+  stale: string[];
+  /** No ledger to consult — the cross-check could not run. */
+  ledgerMissing?: boolean;
+}
+
+export function grantsTriageCoverage(
+  grantKeys: string[],
+  ledger: TriageLogRow[] | null,
+  now: number,
+  maxAgeDays: number = TRIAGE_MAX_AGE_DAYS,
+): TriageCoverage {
+  if (ledger === null) return { untriaged: [], stale: [], ledgerMissing: true };
+  const cutoff = now - maxAgeDays * 86_400_000;
+  // The ledger records `rest` from an `npm:<rest>` ref, so an entry may carry a version
+  // while the grant key does not (or the reverse). Identity is the NAME.
+  const npmEntries = ledger
+    .filter((row) => row.type === "npm")
+    .map((row) => ({ name: splitAllowScriptsKey(row.target).name, at: Date.parse(row.timestamp) }))
+    .filter((row) => Number.isFinite(row.at));
+  const out: TriageCoverage = { untriaged: [], stale: [] };
+  for (const key of grantKeys) {
+    const { name } = splitAllowScriptsKey(key);
+    const matches = npmEntries.filter((row) => row.name === name);
+    if (matches.length === 0) {
+      out.untriaged.push(key);
+      continue;
+    }
+    if (!matches.some((row) => row.at >= cutoff)) out.stale.push(key);
+  }
+  return out;
+}
+
+/** Read `.kit-triage.jsonl`, tolerating a damaged line rather than failing the check.
+ *  Returns null when the log does not exist — see `grantsTriageCoverage`. */
+async function readTriageLedger(root: string): Promise<TriageLogRow[] | null> {
+  let text: string;
+  try {
+    text = await readFile(resolve(root, ".kit-triage.jsonl"), "utf-8");
+  } catch {
+    return null;
+  }
+  const rows: TriageLogRow[] = [];
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const row = JSON.parse(line) as TriageLogRow;
+      if (typeof row.type === "string" && typeof row.target === "string") rows.push(row);
+    } catch {
+      // a torn append is not a reason to fail the check — skip the line
+    }
+  }
+  return rows;
+}
+
 /** The check around `auditAllowScripts`. Root package.json only — that is the manifest npm
  *  consults for the project's grants. */
 export async function checkAllowScripts(root: string): Promise<SecurityCheckResult> {
@@ -903,7 +981,24 @@ export async function checkAllowScripts(root: string): Promise<SecurityCheckResu
         "rewrite the field with `npm install-scripts approve <pkg>` so npm owns its shape",
     };
   }
+  // The shape audit says how BROAD each grant is. The triage cross-check says whether
+  // anything ever evaluated the package it was granted to — a pinned grant for a package
+  // nothing has looked at is worse than an unpinned grant for one kit cleared yesterday,
+  // so it carries the higher severity.
+  const grants = [...audit.pinned, ...audit.unpinned];
+  const coverage = grantsTriageCoverage(grants, await readTriageLedger(root), Date.now());
+
   const problems: string[] = [];
+  if (coverage.untriaged.length > 0) {
+    problems.push(
+      `${coverage.untriaged.length} grant(s) never triaged: ${coverage.untriaged.join(", ")} — install-script execution granted to a package nothing evaluated`,
+    );
+  }
+  if (coverage.stale.length > 0) {
+    problems.push(
+      `${coverage.stale.length} grant(s) whose triage is older than ${TRIAGE_MAX_AGE_DAYS} days: ${coverage.stale.join(", ")}`,
+    );
+  }
   if (audit.unpinned.length > 0) {
     problems.push(
       `${audit.unpinned.length} unpinned grant(s): ${audit.unpinned.join(", ")} — covers releases nobody reviewed`,
@@ -914,21 +1009,30 @@ export async function checkAllowScripts(root: string): Promise<SecurityCheckResu
       `${audit.stale.length} stale grant(s): ${audit.stale.join(", ")} — no longer a declared dependency`,
     );
   }
+  // Reported when the log is absent so a green row cannot be mistaken for "every grant is
+  // triaged" — the check ran, one of its questions could not be asked.
+  const crossCheck = coverage.ledgerMissing
+    ? " · triage cross-check did not run (no .kit-triage.jsonl in this repo)"
+    : "";
   if (problems.length > 0) {
     return {
       ...base,
       status: "warn",
-      severity: "medium",
-      detail: problems.join("; "),
+      // An untriaged grant is a different class from a too-broad one: nothing has evaluated
+      // the code that will run.
+      severity: coverage.untriaged.length > 0 ? "high" : "medium",
+      detail: problems.join("; ") + crossCheck,
       suggestion:
-        "re-approve pinned (`npm install-scripts approve <pkg>` writes <pkg>@<version> by default), and clear the outlived ones with `npm install-scripts prune`",
+        coverage.untriaged.length > 0
+          ? "triage before granting: `kit triage npm <pkg>`, then re-approve pinned (`npm install-scripts approve <pkg>`); clear outlived grants with `npm install-scripts prune`"
+          : "re-approve pinned (`npm install-scripts approve <pkg>` writes <pkg>@<version> by default), and clear the outlived ones with `npm install-scripts prune`",
     };
   }
   const denied = audit.denied.length > 0 ? ` · ${audit.denied.length} denied` : "";
   return {
     ...base,
     status: "pass",
-    detail: `${audit.pinned.length} grant(s), every one pinned to an exact version${denied}`,
+    detail: `${audit.pinned.length} grant(s), every one pinned to an exact version${denied}${crossCheck}`,
   };
 }
 

--- a/src/commands/triage.ts
+++ b/src/commands/triage.ts
@@ -425,7 +425,11 @@ async function readMcpPins(
 }
 
 const TRIAGE_LOG_FILE = ".kit-triage.jsonl";
-const TRIAGE_MAX_AGE_DAYS = 7;
+/** A triage PASS counts as current for this long. Exported so every consumer reads ONE
+ *  number: `check-deps` gates new manifest entries on it, and the "install-script grants"
+ *  security check asks the same freshness question about a package granted install scripts.
+ *  Two copies of a policy window drift, and the drift is silent. */
+export const TRIAGE_MAX_AGE_DAYS = 7;
 
 interface TriageLogEntry {
   timestamp: string;


### PR DESCRIPTION
**Correcting #475.** That PR deferred this cross-check with "needs a triage ledger to consult, and none exists (`gateInstall` runs triage live)". The ledger exists: `.kit-triage.jsonl`, which `kit triage` appends a PASS to and the pre-commit `check-deps` gate already reads. The premise was wrong, so the capability was parked for no reason.

```
$ head -2 .kit-triage.jsonl
{"timestamp":"2026-06-24T15:04:13.422Z","type":"npm","target":"cross-env","sandbox":false,"granter":"petersandstrom"}
{"timestamp":"2026-07-24T22:55:17.435Z","type":"npm","target":"eslint","sandbox":false,"deep":false,"granter":"petersandstrom"}
```

## What it adds

The shape audit says how **broad** a grant is. It cannot say whether anything ever evaluated the package that will run code at install time. Those rank differently, so the severities do:

| Situation | Verdict |
| --- | --- |
| pinned grant, package never triaged | **warn / high** — "install-script execution granted to a package nothing evaluated" |
| unpinned or stale-dependency grant | warn / medium (unchanged) |
| grant whose only triage predates the window | reported separately from "never" |
| pinned grant + fresh triage | pass |

"Reviewed a month ago" and "never reviewed" are different claims; collapsing them makes the finding easy to dismiss.

## The parts that could have gone wrong

- **Identity is the package name on both sides.** The ledger records `rest` from an `npm:<rest>` ref, so an entry may carry a version the grant key does not, or the reverse. `sharp@0.33.5` in the log covers a grant keyed `sharp`, and a scoped name survives intact.
- **A `pip` or `brew` entry does not cover an npm grant.** (My own `kit triage brew pinentry-mac` from earlier today is in that log — a good reminder that the type field matters.)
- **`TRIAGE_MAX_AGE_DAYS` is exported and imported, not copied.** `check-deps` and this check now read one number; two copies of a policy window drift, and the drift is silent.
- **No ledger → the row says the cross-check *did not run*.** Most repos have never run `kit triage`. Reporting every grant there as untriaged would be a confident finding built on an absent file — the failure mode this repo keeps catching in itself. A torn append is skipped rather than allowed to fail the check.

## Verified through the real CLI

A fixture repo granting `esbuild` (triaged today) and `evil` (never), with a real `.kit-triage.jsonl`:

```
! install-script grants  warn  1 grant(s) never triaged: evil@1.0.0 — install-script execution
                               granted to a package nothing evaluated  [high] [CWE-829]
    triage before granting: `kit triage npm <pkg>`, then re-approve pinned
    (`npm install-scripts approve <pkg>`); clear outlived grants with `npm install-scripts prune`
```

`esbuild@0.28.1` is silently covered. On kit itself the check still skips — no grants declared, no new noise.

- `npm test`: **4255 pass / 0 fail** (4244 before; +11)
- `kit self-audit`: 16 rules, 0 fail, 0 warn
- `lint` 0 errors, `format:check` clean

Lands under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)