### PR TITLE
Publish over OIDC — the npm token is gone

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,12 +8,16 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # Protected environment gate: NPM_TOKEN is a secret SCOPED to this environment,
-    # so it is released only after the environment's required-reviewer / branch
-    # rules pass. This is the primary defense against "anyone who can push a v* tag
-    # ships to npm" — configure required reviewers on the `npm-publish` environment
-    # in repo Settings → Environments. Without that config the token is never
-    # exposed (secret lives on the environment, not the repo).
+    # Protected environment gate. There is no npm token here any more: all 13 packages
+    # have a GitHub Actions trusted publisher naming this repo, THIS workflow file, and
+    # THIS environment, so npm mints a short-lived credential from the job's OIDC identity
+    # and only for runs that reach this environment. That makes the environment part of the
+    # credential rather than merely the guard around a secret — configure required reviewers
+    # on `npm-publish` in Settings → Environments, or the human gate does not exist.
+    #
+    # The npm side is what enforces the workflow name and environment; keep this job
+    # triggered directly by the tag push. Behind `workflow_call`, npm's validation reads the
+    # CALLING workflow's name and the check breaks. See docs/RELEASING.md.
     environment: npm-publish
     permissions:
       # write (not read) because this job creates the GitHub release for the tag
@@ -246,16 +250,22 @@ jobs:
         run: npm publish --dry-run --tag ${{ steps.disttag.outputs.tag }}
 
       - name: Publish to npm with provenance
-        # --provenance generates an SLSA build provenance attestation signed
-        # by the GitHub Actions OIDC identity. Consumers can verify with:
+        # No NODE_AUTH_TOKEN: the credential comes from this job's OIDC identity, exchanged
+        # against the package's trusted publisher. npm PREFERS a token whenever one is
+        # present, so re-adding it would silently move publishing back onto the credential
+        # npm is retiring — src/publish-workflow.test.ts fails if any executing line carries
+        # one.
+        #
+        # --provenance stays: provenance is automatic under trusted publishing, so the flag
+        # is a no-op there and states the intent explicitly. Generates an SLSA build
+        # provenance attestation signed by the GitHub Actions OIDC identity. Consumers can
+        # verify with:
         #   npm audit signatures
         # or
         #   npm view sandstream-kit --json | jq '.dist'
         # --tag routes prereleases to `next` (see the resolve step) so they never
         # clobber `latest`.
         run: npm publish --provenance --access public --tag ${{ steps.disttag.outputs.tag }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish the adapter SDK and first-party plugins
         # WHY THIS EXISTS: `packages/` is not in the root tarball (files: ["dist","README.md",
@@ -277,7 +287,6 @@ jobs:
         # EPUBLISHCONFLICT. Never continue-on-error — a publish that silently did not happen is
         # the false green this repo exists to prevent.
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DIST_TAG: ${{ steps.disttag.outputs.tag }}
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Publishing runs on trusted publishing (OIDC); the npm token is gone.** All 13 packages
+  now carry a GitHub Actions trusted publisher naming `sandstream/kit`, `publish.yml` and the
+  `npm-publish` environment, with the single permission `npm publish` — not staged publish,
+  because the job publishes directly and least privilege is the point. `NODE_AUTH_TOKEN` is
+  removed from both publish steps, which is what actually switches the credential: npm prefers
+  a token whenever one is present, so the two cannot both be in effect. That also makes a
+  re-added token a SILENT downgrade back to the credential npm is retiring, so
+  `src/publish-workflow.test.ts` now fails if any executing line in the workflow carries one.
+  The environment is no longer merely the guard around a secret — it is part of the credential,
+  since npm only mints one for runs that reach it.
+
+  Two things worth knowing for the next package, both learned the hard way: npm requires
+  step-up 2FA (security key) per save and does **not** keep the session elevated, so it is one
+  key tap per package and a timed-out prompt loses that save (nothing half-saves — retrying is
+  free); and driving the UI quickly trips Cloudflare's bot check, which only a human can clear.
+
 ### Added
 
 - **The `install-script grants` check now asks whether the granted package was ever

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -42,14 +42,34 @@ Each of these fails the release rather than shipping something unverifiable:
 A prerelease version (any `-` identifier) publishes under the `next` dist-tag, so `latest`
 only ever moves on a stable release.
 
-## Credentials: today
+## Credentials: trusted publishing (no npm token)
 
-The publish steps authenticate with `NODE_AUTH_TOKEN` from the `NPM_TOKEN` secret, which is
-scoped to the **`npm-publish` environment** rather than the repository. The token is
-therefore released only after that environment's required-reviewer rule passes; configure
-those reviewers in Settings → Environments, or the human gate does not exist.
+There is no npm token in this repository any more. All 13 packages carry a GitHub Actions
+trusted publisher naming `sandstream/kit`, the workflow file `publish.yml`, and the
+environment `npm-publish`, with the single permission `npm publish` (not staged publish —
+least privilege). The job exchanges its OIDC identity for a short-lived credential, so the
+environment is part of the credential rather than merely the guard around a secret:
+configure required reviewers on `npm-publish` in Settings → Environments, or the human gate
+does not exist.
 
-## Credentials: the migration to trusted publishing
+Two constraints keep it working:
+
+- **Keep the publish job triggered directly by the tag push.** npm's validation reads the
+  *calling* workflow's name, so putting the publish behind `workflow_call` breaks the check.
+- **Never re-add `NODE_AUTH_TOKEN`.** npm prefers a token whenever one is present, so adding
+  one silently moves publishing back onto the credential npm is retiring.
+  `src/publish-workflow.test.ts` fails if any executing line in the workflow carries one.
+
+`--provenance` stays on the publish commands. Provenance is automatic under trusted
+publishing, so the flag is a no-op there and states the intent explicitly.
+
+**Still open:** npm's per-package "Publishing access" is set to *require two-factor
+authentication OR a granular access token with bypass 2fa enabled*. Switching each package to
+*disallow bypass 2fa tokens* is what turns "we also have OIDC" into "only OIDC can publish".
+Do that after a release has actually gone out over OIDC — it is the setting that removes the
+fallback.
+
+## Background: why the migration happened
 
 npm is retiring 2FA-bypass granular access tokens as a publishing credential:
 
@@ -68,9 +88,9 @@ that step exists, pins a high-enough version, and runs before any publish — a 
 fail CI, and a publish job runs only on a tag push, the worst moment to discover a too-old
 client.
 
-**The remaining work is registry-side and manual.** Each package is configured
-individually on npmjs.com, and each can have exactly one trusted publisher at a time, so
-this is 13 configurations:
+**The registry-side work is done** (2026-08-19): every package below was configured and its
+saved connection read back from its own settings page. The list is kept because a NEW package
+needs the same treatment before its first release — no token exists to fall back on.
 
 | Package | | |
 | --- | --- | --- |
@@ -80,19 +100,19 @@ this is 13 configurations:
 | `sandstream-kit-plugin-stripe` | `sandstream-kit-plugin-supabase` | `sandstream-kit-plugin-vercel` |
 | `sandstream-kit-plugin-wiz` | | |
 
-For each: Settings → Publishing access → add a GitHub Actions trusted publisher with
-repository `sandstream/kit`, workflow `publish.yml`, and environment **`npm-publish`**.
-Naming the environment is the part worth not skipping: it means only the reviewer-gated job
-can mint a credential, where today the environment only protects the secret.
+For each (and for any new package): its npm page → Settings → Trusted Publisher → GitHub
+Actions, then `Organization or user` = `sandstream`, `Repository` = `kit`,
+`Workflow filename` = `publish.yml` (filename only, no path), `Environment name` =
+`npm-publish`, `Allowed actions` = `npm publish` only. Naming the environment is the part
+worth not skipping: it is what limits credential minting to the reviewer-gated job.
 
-Two constraints to respect when the switch happens:
+npm requires step-up 2FA (security key) to save each one, and it does NOT keep the session
+elevated — expect one key tap per package, and expect a save to be lost if the prompt times
+out. Nothing half-saves, so a retry is free. Rapid automation of the UI also trips
+Cloudflare's bot check, which only a human can clear.
 
-- **Do not move the publish behind `workflow_call`.** npm's validation reads the *calling*
-  workflow's name, not the one that actually runs `npm publish`, so a reusable-workflow
-  indirection breaks the check. `publish.yml` is triggered directly by the tag push today —
-  keep it that way.
-- **Self-hosted runners are not supported.** The job runs on `ubuntu-latest`
-  (GitHub-hosted), which is.
+Self-hosted runners are not supported by trusted publishing; this job runs on
+`ubuntu-latest`, which is.
 
 **`scripts/trusted-publishing-wizard.sh` walks all of it.** It derives the package list from
 this repo rather than carrying a copy (a hardcoded list drifts the moment someone adds a
@@ -111,16 +131,11 @@ status/collaborators/grant/revoke and has no read or write path for a trusted pu
 the setting exists only in the web UI. What the wizard verifies is everything else: the
 workflow file, the npm client floor, the environment's existence, and the package list.
 
-Once every package is configured, the workflow change is a deletion: drop the
-`NODE_AUTH_TOKEN`/`NPM_TOKEN` env from both publish steps (npm uses the token whenever it is
-present, so OIDC only takes over once that env is gone — the two cannot both be in effect).
-`id-token: write` is already granted. Keep a read-only granular token only if a private
-dependency ever needs installing.
-
-`--provenance` stays. Provenance is automatic under trusted publishing, so the flag is a
-no-op there and leaving it in states the intent explicitly; if the first OIDC publish ever
-rejects it, dropping it is a one-line follow-up. That is a deliberate choice not to change two
-things at once in the release path.
+The workflow change that followed was a deletion: `NODE_AUTH_TOKEN` is gone from both publish
+steps, and `id-token: write` was already granted. Keep a read-only granular token only if a
+private dependency ever needs installing. If the first OIDC publish ever rejects
+`--provenance`, dropping that flag is a one-line follow-up — kept deliberately so the release
+path changed one thing, not two.
 
 **Prove it with a prerelease, not with the next real version.** publish.yml routes any version
 containing a hyphen to the `next` dist-tag, so `latest` does not move. Bump to

--- a/scripts/trusted-publishing-wizard.sh
+++ b/scripts/trusted-publishing-wizard.sh
@@ -203,6 +203,25 @@ finish() {
 # prerelease as the only honest test.
 # ──────────────────────────────────────────────────────────────────────────
 
+# Refuse to run where the questions would answer themselves. Every `read` in the
+# library returns immediately on EOF (they end in `|| true`, so a closed stdin is not
+# an error), which means a wizard started without a controlling terminal races through
+# every stage, takes the y/N default on each one, opens a browser tab per package, and
+# then reports everything as still-to-do. That is indistinguishable from a run that
+# happened, which is the worst thing a migration script can look like.
+#
+# This is not hypothetical: it is what happened the first time this script was run —
+# from an agent shell (Claude Code's `!` prefix), which has no tty. Same root cause as
+# gpg's pinentry failing there with "not a tty".
+if [[ ! -t 0 ]]; then
+  printf 'This wizard needs a real terminal: its stdin is not a tty, so every prompt\n' >&2
+  printf 'would read EOF and answer itself.\n\n' >&2
+  printf 'Open Terminal (or iTerm) and run it there:\n' >&2
+  printf '  cd %s\n' "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" >&2
+  printf '  ./scripts/trusted-publishing-wizard.sh\n' >&2
+  exit 1
+fi
+
 STATE_FILE="${STATE_FILE:-.kit/trusted-publishing.state}"
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$REPO_ROOT"

--- a/src/publish-workflow.test.ts
+++ b/src/publish-workflow.test.ts
@@ -45,6 +45,27 @@ function atLeast(found: readonly number[], min: readonly number[]): boolean {
   return true;
 }
 
+describe("publish.yml — publishes over OIDC, not a long-lived token", () => {
+  it("references no npm token in any executing line", () => {
+    // All 13 packages now have a GitHub Actions trusted publisher (repo sandstream/kit,
+    // workflow publish.yml, environment npm-publish, permission `npm publish`), verified on
+    // each package's settings page. npm prefers NODE_AUTH_TOKEN whenever it is present, so
+    // OIDC only takes effect once that env is gone — the two cannot both be in effect, which
+    // makes a re-added token a SILENT downgrade back to the credential npm is retiring
+    // (direct publishing dies ~Jan 2027). Hence a gate rather than a comment.
+    const offenders = EXECUTED.split("\n").filter((l) => /NPM_TOKEN|NODE_AUTH_TOKEN/.test(l));
+    assert.deepEqual(
+      offenders,
+      [],
+      "publish.yml must not carry an npm token: trusted publishing is the credential now",
+    );
+  });
+
+  it("still asks for the OIDC identity it publishes with", () => {
+    assert.match(WORKFLOW, /id-token:\s*write/);
+  });
+});
+
 describe("publish.yml — the signature gate cannot fail open", () => {
   it("takes the tag verdict from git verify-tag, not from a pipe", () => {
     // Shipped as `if ! git verify-tag "$TAG" 2>&1 | tee /tmp/tag-verify.log; then`. git exits

--- a/src/wizard-script.test.ts
+++ b/src/wizard-script.test.ts
@@ -65,6 +65,28 @@ describe("trusted-publishing wizard — runs in the shell it will be run in", ()
     assert.deepEqual(offenders, [], "macOS sed rejects `+?`/`*?` — restructure the expression");
   });
 
+  it("refuses to run without a tty instead of answering its own questions", () => {
+    // Run from Claude Code's `!` shell (no controlling tty), every `read` got EOF
+    // instantly: 18 stages flew past, all 13 y/N prompts defaulted to no, 13 browser
+    // tabs opened, and the wizard reported "still to do by hand" for everything it had
+    // just asked about. A wizard whose questions answer themselves is worse than one
+    // that will not start — it looks like a run that happened.
+    const r = spawnSync("bash", [WIZARD], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      cwd: REPO_ROOT,
+      timeout: 20_000,
+    });
+    assert.notEqual(r.status, 0, "must exit non-zero when stdin is not a tty");
+    const output = `${r.stdout}${r.stderr}`;
+    assert.match(output, /terminal|tty/i, "must say WHY it refused");
+    assert.doesNotMatch(
+      output,
+      /opening https/,
+      "must refuse before opening any browser tab — the tabs were the visible damage",
+    );
+  });
+
   it("is executable", () => {
     accessSync(WIZARD, constants.X_OK);
   });


### PR DESCRIPTION
The registry side of the trusted-publishing migration is done: all 13 packages carry a GitHub Actions trusted publisher naming `sandstream/kit`, `publish.yml`, and the `npm-publish` environment, with the single permission `npm publish` — not staged publish, since the job publishes directly and least privilege is the point. Each was configured and then **read back from its own settings page**:

```
sandstream/kit
publish.yml            npm-publish
Permissions: npm publish
```

## Removing the token is the switch

npm prefers `NODE_AUTH_TOKEN` whenever one is present, so OIDC only takes effect once that env is gone — the two cannot both be in effect. Which also means a re-added token is a **silent** downgrade back to the credential npm is retiring (direct publishing dies ~Jan 2027). So this is a gate, not a comment, and it was written RED first against the token still being there:

```
not ok 1 - references no npm token in any executing line   ← before
# tests 7 / pass 7                                          ← after
```

The `env:` key that held only the token goes with it (an empty `env:` is invalid YAML). Verified after the edit: the workflow parses, 25 steps, `DIST_TAG` intact in the workspace step.

`--provenance` stays — a no-op under trusted publishing, and changing one thing in the release path beats changing two. If npm ever rejects the flag, dropping it is a one-liner.

## The environment now means more than it did

It used to be the guard around a secret. npm only mints a credential for runs that reach `npm-publish`, so it is now part of the credential itself. The comment in `publish.yml` said the old thing; it now says the true one, including the constraint that keeps it true: the job must stay **directly tag-triggered**, because behind `workflow_call` npm's validation reads the *calling* workflow's name and the check breaks.

## What the migration actually cost (now in docs/RELEASING.md)

Two things that only show up by doing it, and that the next person — or the next new package — will hit:

- **npm requires step-up 2FA per save and does not keep the session elevated.** One security-key tap per package, and a timed-out prompt loses that save. Nothing half-saves, so retrying is free; `adapter-sdk`, `snyk` and `vercel` each needed a second run.
- **Driving the UI quickly trips Cloudflare's bot check.** Only a human can clear that, which is a hard limit on how much of this is automatable at all.

`.kit/trusted-publishing.state` records the 13 confirmations, diffed against the repo's own package list — nothing missing.

## Also: the wizard refuses to run without a tty

Run from an agent shell (no controlling tty) it raced through all 18 stages, answered its own 13 y/N prompts with the default *no*, opened 13 browser tabs, and then reported everything as still-to-do. A wizard whose questions answer themselves looks exactly like a run that happened, which is worse than one that will not start. `src/wizard-script.test.ts` asserts it exits non-zero, says why, and refuses **before** opening any tab.

## Verification

- `npm test`: **4258 pass / 0 fail**
- `kit self-audit`: 16 rules, 0 fail, 0 warn
- `format:check` clean, `lint` 0 errors
- workflow YAML re-parsed after the edit (25 steps, no `NODE_AUTH_TOKEN`, no childless `env:`)

**Not yet proven.** Nothing here shows OIDC publishing *works* — only that it is wired. The next step is a prerelease (`6.6.5-rc.1`), which `publish.yml` routes to the `next` dist-tag, so `latest` cannot move. If a package 404/403s, its publisher fields do not match and the workspace loop is idempotent, so fixing that one and re-running completes the set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)