### PR TITLE
Prepare 6.6.5-rc.1 — the OIDC smoke test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [6.6.5-rc.1] - 2026-08-19
+
+A prerelease with one job: prove that publishing works over OIDC now that the npm token is
+gone. It routes to the `next` dist-tag, so `latest` cannot move — nothing that came before
+this could verify the switch, because the only honest test of a publishing credential is a
+publish.
+
+Its contents are the accumulated `[Unreleased]` work below, which will be listed in full
+under `6.6.5` when that ships. Nothing in this prerelease is meant to be installed by anyone
+who is not testing the release path.
+
 ### Changed
 
 - **Publishing runs on trusted publishing (OIDC); the npm token is gone.** All 13 packages

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -1173,7 +1173,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "6.6.4"
+    "version": "6.6.5-rc.1"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "6.6.4",
+  "version": "6.6.5-rc.1",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/src/changelog-section.test.ts
+++ b/src/changelog-section.test.ts
@@ -86,7 +86,13 @@ describe("changelog-section", () => {
 
   it("covers every published version currently in the CHANGELOG", () => {
     const changelog = readFileSync(join(REPO_ROOT, "CHANGELOG.md"), "utf8");
-    const versions = [...changelog.matchAll(/^## \[?(\d+\.\d+\.\d+)\]?/gm)].map((m) => m[1]);
+    // The prerelease suffix is part of the version, not noise after it: `## [6.6.5-rc.1]`
+    // used to capture as `6.6.5`, so this test looked for a section that does not exist and
+    // failed on the repo's first prerelease heading. publish.yml renders notes for the exact
+    // version in package.json, hyphen and all — parse the same shape it will ask for.
+    const versions = [...changelog.matchAll(/^## \[?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\]?/gm)].map(
+      (m) => m[1],
+    );
     assert.ok(versions.length > 0, "no versions parsed out of CHANGELOG.md");
     for (const v of versions) {
       const r = run([v]);


### PR DESCRIPTION
A prerelease with one job: prove that publishing works now that the credential is the job's OIDC identity and not a token (#482). `publish.yml` routes any hyphenated version to the **`next`** dist-tag, so `latest` cannot move.

Everything so far verified that OIDC is *wired* — 13 trusted publishers read back from their settings pages, `NODE_AUTH_TOKEN` removed, a gate that fails if it returns. None of that verifies it **works**. The only honest test of a publishing credential is a publish.

## What lands here

- `package.json` → `6.6.5-rc.1`, `contracts/kit.opencli.json` regenerated for the version
- a `## [6.6.5-rc.1]` CHANGELOG section — the job refuses to publish a version the changelog does not document, and checks that *before* publishing. Its body says what the prerelease is for and points at `[Unreleased]` for the actual contents, which will be listed in full under `6.6.5`. No duplicated hundred lines that then move.

## One test fixed, found by this very heading

`changelog-section.test.ts` parsed version headings with `/^## \[?(\d+\.\d+\.\d+)\]?/`, so `## [6.6.5-rc.1]` captured as `6.6.5` — a section that does not exist — and the test failed:

```
not ok 3 - covers every published version currently in the CHANGELOG
  expected: 0
  actual: 1
```

The repo's first prerelease heading is what exposed it. `publish.yml` renders notes for the exact version in `package.json`, hyphen and all, so the test now parses the same shape the job will ask for.

## After merge

Tag the squash commit **signed** (`git tag -s v6.6.5-rc.1`) and push; approve `npm-publish` when GitHub asks. Then the checks that matter:

- the publish job's own log shows the trusted-publisher exchange rather than a token
- `npm view sandstream-kit dist-tags` → `next` moves to `6.6.5-rc.1`, **`latest` stays `6.6.4`**
- the published tarball installs and its binary runs
- `npm audit signatures` still reports a verified registry signature and provenance

If a package 404/403s, its publisher fields do not match — the workspace loop is idempotent, so fixing that one and re-running the job completes the set.

`npm test`: **4258 pass / 0 fail**. `kit self-audit`: 16 rules, 0 fail, 0 warn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)