### PR TITLE
Token publishing is disallowed on all 13 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ who is not testing the release path.
 
 ### Changed
 
+- **Token publishing is now disallowed on all 13 packages.** With 6.6.5-rc.1 proving the OIDC
+  path, every package's npm "Publishing access" moved to *require two-factor authentication and
+  disallow bypass 2fa tokens* — the setting that turns "we also have OIDC" into "only OIDC can
+  publish". Each was read back from its own settings page. There is no token fallback left, so
+  a misconfigured trusted publisher now fails that package's publish step and is fixed in npm's
+  UI rather than worked around; the workspace loop is idempotent, so re-running completes the
+  set. `docs/RELEASING.md` records the operational cost: npm's step-up 2FA is flaky under
+  repetition, `Update Package Settings` is a no-op unless the radio actually changed, and the
+  CLI equivalent (`npm access set mfa=publish`) needs a TOTP code that a security-key-only
+  account cannot produce.
+
 - **Publishing runs on trusted publishing (OIDC); the npm token is gone.** All 13 packages
   now carry a GitHub Actions trusted publisher naming `sandstream/kit`, `publish.yml` and the
   `npm-publish` environment, with the single permission `npm publish` — not staged publish,

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -63,11 +63,27 @@ Two constraints keep it working:
 `--provenance` stays on the publish commands. Provenance is automatic under trusted
 publishing, so the flag is a no-op there and states the intent explicitly.
 
-**Still open:** npm's per-package "Publishing access" is set to *require two-factor
-authentication OR a granular access token with bypass 2fa enabled*. Switching each package to
-*disallow bypass 2fa tokens* is what turns "we also have OIDC" into "only OIDC can publish".
-Do that after a release has actually gone out over OIDC — it is the setting that removes the
-fallback.
+**Token publishing is disallowed** (2026-08-19, after 6.6.5-rc.1 proved the OIDC path). Every
+package's "Publishing access" is set to *require two-factor authentication and disallow bypass
+2fa tokens*, which is what turns "we also have OIDC" into "only OIDC can publish". Each
+setting was read back from its own settings page.
+
+Consequences worth knowing before the next release:
+
+- **There is no token fallback left.** If a package's trusted publisher is misconfigured, its
+  publish step fails and the fix is to correct the publisher in npm's UI — not to publish with
+  a token. The workspace loop is idempotent, so re-running the job after the fix completes the
+  set.
+- **The CLI path for these settings needs TOTP.** `npm access set mfa=publish <pkg>` sets the
+  same thing without the web UI, but it returns `EOTP` and `--otp=<code>` needs an
+  authenticator app. A security-key-only account cannot use it, and npm does not offer adding
+  TOTP alongside an existing security key — only disabling 2FA and re-enrolling, which is not
+  worth doing for this.
+- **npm's step-up 2FA is flaky under repetition.** Expect saves to hang on "Verifying…" or
+  return "Something went wrong. Please try again later." Nothing half-saves; re-select the
+  radio and submit again. Select the value FIRST and submit only when you are ready to touch
+  the key — the prompt expires in about a minute, and `Update Package Settings` does nothing at
+  all if the radio has not actually changed.
 
 ## Background: why the migration happened
 


### PR DESCRIPTION
The last step of the trusted-publishing migration, done after `6.6.5-rc.1` proved the OIDC path actually works: every package's npm **Publishing access** now reads *require two-factor authentication and disallow bypass 2fa tokens*. Each was read back from its own settings page.

That is what turns "we also have OIDC" into "only OIDC can publish".

## Documents the consequences, not just the fact

- **No token fallback is left.** A misconfigured trusted publisher now fails that package's publish step, and the fix is npm's UI rather than a token. The workspace loop is idempotent, so re-running the job after the fix completes the set. Worth stating because 12 of the 13 publishers are still *unexercised* — `6.6.5-rc.1` only bumped the root package, so the plugins were all skipped as "already on npm".
- **The CLI shortcut is closed for this account.** `npm access set mfa=publish <pkg>` sets the same thing without the web UI, but returns `EOTP` and `--otp=<code>` needs an authenticator app. npm offers no way to add TOTP alongside an existing security key — only disabling 2FA and re-enrolling, which is a worse trade than clicking through a flaky UI, so it was not done.
- **npm's step-up 2FA is flaky under repetition.** Saves hang on `Verifying…` or return *"Something went wrong. Please try again later."* Nothing half-saves. Two things make it survivable, both learned the hard way: select the value **first** and submit only when ready to touch the key (the prompt expires in about a minute), and know that `Update Package Settings` is a **no-op** if the radio has not actually changed — which looks exactly like a broken button.

## Verification

All 13 read back individually from their settings pages; three needed retries (`stripe`, `vercel`, `wiz`). `npm test`: 4258 pass / 0 fail.

Lands under `[Unreleased]` alongside the OIDC switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)