### PR TITLE
Release 6.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-## [6.6.5-rc.1] - 2026-08-19
-
-A prerelease with one job: prove that publishing works over OIDC now that the npm token is
-gone. It routes to the `next` dist-tag, so `latest` cannot move — nothing that came before
-this could verify the switch, because the only honest test of a publishing credential is a
-publish.
-
-Its contents are the accumulated `[Unreleased]` work below, which will be listed in full
-under `6.6.5` when that ships. Nothing in this prerelease is meant to be installed by anyone
-who is not testing the release path.
+## [6.6.5] - 2026-08-19
 
 ### Changed
 
@@ -110,6 +101,14 @@ who is not testing the release path.
   `fastify(`, `Bun.serve`, `.listen(` — each matching 0 lines when written) and fires the day
   one lands. All three branches were driven in a fixture tree; the two that mattered had never
   been reachable.
+
+## [6.6.5-rc.1] - 2026-08-19
+
+Prerelease of 6.6.5, published to the `next` dist-tag so the OIDC publishing path could be
+proven before `latest` moved. Nothing before it could verify the switch: the only honest test
+of a publishing credential is a publish. Its contents are the 6.6.5 entries above, minus the
+token-restriction change — that was done after this prerelease shipped, and because it
+shipped.
 
 ## [6.6.4] - 2026-08-18
 

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -1173,7 +1173,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "6.6.5-rc.1"
+    "version": "6.6.5"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "6.6.5-rc.1",
+  "version": "6.6.5",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
The version `6.6.5-rc.1` was for. The prerelease proved publishing works over OIDC with no npm token; this is the same work under `latest`, plus the token restriction that the rc's success made safe to turn on.

## What ships

- **Publishing runs on trusted publishing (OIDC); the npm token is gone** — and a test fails if any executing line in `publish.yml` carries one again, because npm prefers a token whenever present, making a re-added one a silent downgrade.
- **Token publishing disallowed on all 13 packages** — *require 2FA and disallow bypass 2fa tokens*, read back from each settings page.
- **Two fail-open gates in kit's own CI, found and fixed.** The tag-signature gate took its verdict from a pipe (`| tee`), so it could not fail and an unsigned `v6.6.3` published. Widening `R1-fail-open-ci` to the whole class then found the second one in `security.yml` (`| head -1`, and `head` exits 0 on empty input), where the warning branch had never been reachable.
- **The install gate holds install-script approval** — `npm approve-scripts` / `npm install-scripts approve`, with the read-only faces deliberately exempt — and the new `install-script grants` check audits what those approvals write, including whether the granted package was ever triaged.
- **`kit init` generates only what the repo proves**, and **`kit_check` over MCP costs 67% less per call.**
- **`scripts/trusted-publishing-wizard.sh`** plus the dialect gate that pins it to the shell it runs in.

## CHANGELOG structure fixed

Preparing the rc, I inserted its heading *above* the accumulated entries, which left them all inside the prerelease section and `[Unreleased]` empty — while the rc's own prose claimed its contents were listed under `[Unreleased]` below. The entries now belong to `6.6.5`, and the rc section says what it actually was: a prerelease published to `next` to prove the path, whose contents are the 6.6.5 entries minus the token restriction, since that came after it and because of it.

Both sections still render: `changelog-section.mjs 6.6.5` and `… 6.6.5-rc.1` each produce notes, which is what the publish job checks before it publishes.

## Verification

`npm test` 4258 pass / 0 fail · `kit self-audit` 16 rules, 0 fail, 0 warn · `lint` 0 errors · `format:check` clean · `contracts/kit.opencli.json` regenerated for the version.

## After merge

Tag the squash commit signed and push; approve `npm-publish`. This is the first release where **`latest` moves over OIDC**. Expected: `latest: 6.6.5`, the tarball installs and runs, provenance and both SBOMs present.

Known and unchanged: the eleven plugin trusted publishers stay unexercised — their versions did not change, so the workspace loop skips them as already published. The first plugin bump is what proves those, and with no token fallback left, a wrong field there fails that package's step and is fixed in npm's UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)