### PR TITLE
chore(release): 6.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [6.7.0] - 2026-08-20
+
 ### Added
 
 - **`kit check` now reports the git-hook floor: where it is, and whether it can fail.** README

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -1173,7 +1173,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "6.6.5"
+    "version": "6.7.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "6.6.5",
+  "version": "6.7.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
Prep commit for `v6.7.0` — `package.json`, `contracts/kit.opencli.json`, and the CHANGELOG section. Per `docs/RELEASING.md` the tag goes on **this** commit once merged, signed, and the `npm-publish` environment is approved.

## Why minor, not patch

`kit` now rejects a flag it does not accept, on every command (#488). Nothing documented stops working — the surface is generated from the source and a drift test keeps it that way — but an invocation that silently did nothing now exits 1, and a script that passed a flag kit ignored will notice. Previous 6.6.x patches carried additions; a user-visible behaviour change is a different signal.

## What's in it

- **#488** — every command rejects unknown flags, from a declared, generated surface (71 verbs). `kit check --category security` ran the full check for six majors; `kit upgrade --self.` rewrote lock-file timestamps and printed success.
- **#470** — `kit audit verify --all`, the union view over every audit log this machine sealed, with `missing` and `stalled` as distinct outcomes.
- **#491** — `self-audit` checks documentation in both directions; the inverse rule found 13 undocumented commands.
- **#496 / #497** — the git-hook floor reports where it is (an absolute `core.hooksPath` can put it outside the repo) and whether an installed gate can actually fail (`context-check` with no `[context]` passed every push).
- **#489** — `triage`'s pip path no longer scores higher than npm's by running fewer probes; absence is printed rather than scored, and PEP 621 attribution resolves.
- `kit add --list` lists the adapters instead of trying to provision a service called `--list`.

## Verification

- `npm test` on this commit: **4342 tests, 0 fail, 0 skipped** (macOS, non-root)
- `kit --version` → `6.7.0`; `publish-workflow.test.ts` + `cli.test.ts` green (63 tests)
- CHANGELOG heading is `## [6.7.0] - 2026-08-20`, matching `package.json` — the publish job refuses a version the changelog does not document
- Dated today, the day it ships. 6.6.3 was dated five days early and went stale twice before it went out.

## Before the tag: the human gate does not exist yet

`publish.yml` and `docs/RELEASING.md` both state that required reviewers on the `npm-publish` environment are what limit credential minting — "configure required reviewers on `npm-publish` in Settings → Environments, or the human gate does not exist". Measured just now:

```
$ gh api repos/sandstream/kit/environments/npm-publish
protection rules: []
```

There are none, so a `v*` tag push publishes all 13 packages with no approval step. Worth fixing before the tag; it is a repo-admin setting rather than something this PR can carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
