### PR TITLE
fix(gate): the install-gate refusal names the hazard, not the machinery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The install-gate's refusal described its own machinery instead of the hazard it caught.**
+  A blocked `git commit -m "… \`deployment:env:view\` …"` was reported as a false positive; the
+  gate was right. Backticks inside DOUBLE quotes are command substitution, so the shell runs the
+  token and splices its output into the argument — measured, the words silently vanish:
+
+  ```
+  $ bash -c 'echo "... the permission `deployment:env:view` ..."'
+  bash: deployment:env:view: command not found
+  ... the permission  ...
+  ```
+
+  The refusal named a triage target and offered `kit triage` / `kit pkg`, both nonsense for that
+  command, so the operator concluded kit had mis-parsed a commit message and routed around it with
+  `-F` — hiding a command that would have committed a message with a hole in it. The refusal now
+  names the substitution, says single quotes are literal, and points at `git commit -F <file>`;
+  the triage advice is appended only when the block really is about an install target. Fail-closed
+  behaviour is unchanged (#501).
+
 ## [6.7.0] - 2026-08-20
 
 ### Added

--- a/src/commands/gate.ts
+++ b/src/commands/gate.ts
@@ -37,6 +37,15 @@ export async function cmdGateBash(): Promise<boolean> {
   } catch {
     return true; // unparseable hook payload → do not block (avoid breaking the agent)
   }
+  // "Triage it first" is the right next step for a blocked PACKAGE, and nonsense for a refusal
+  // about shell semantics — a double-quoted backtick is command substitution, not a package to
+  // triage. Appending it there is what made a correct block read as a mis-parse (#501), so the
+  // advice follows the reason instead of being stapled to every refusal.
+  const triageAdvice = (reason: string, lead = " — "): string =>
+    /COMMAND SUBSTITUTION/.test(reason)
+      ? ""
+      : `${lead}Triage it first: \`kit triage …\`, or install via \`kit pkg <eco>:<name>\`.`;
+
   // Agent-agnostic command extraction (Claude/Codex/Amazon Q/Gemini tool_input.command,
   // Cursor top-level command, Cline preToolUse.parameters.command) — shared pure helper.
   const { decideBashGate, extractCommandFromHookPayload } = await import("../install-gate.js");
@@ -53,7 +62,7 @@ export async function cmdGateBash(): Promise<boolean> {
       console.log(
         JSON.stringify({
           cancel: true,
-          errorMessage: `kit install-gate: ${verdict.reason} — triage first (kit triage …) or install via kit pkg <eco>:<name>`,
+          errorMessage: `kit install-gate: ${verdict.reason}${triageAdvice(verdict.reason)}`,
         }),
       );
       return true;
@@ -61,7 +70,7 @@ export async function cmdGateBash(): Promise<boolean> {
     const { writeSync } = await import("node:fs");
     writeSync(
       2,
-      `kit install-gate: BLOCKED — ${verdict.reason}\nTriage it first: \`kit triage …\`, or install via \`kit pkg <eco>:<name>\`.\n`,
+      `kit install-gate: BLOCKED — ${verdict.reason}${triageAdvice(verdict.reason, "\n")}\n`,
     );
     process.exit(2); // PreToolUse deny
   }

--- a/src/gate-bash-refusal.test.ts
+++ b/src/gate-bash-refusal.test.ts
@@ -1,0 +1,71 @@
+/**
+ * What the operator actually reads when the install-gate blocks.
+ *
+ * The decision function had tests; the printed refusal did not — and the printed refusal is
+ * where the defect lived (#501). A correct block on
+ * `git commit -m "… \`deployment:env:view\` …"` was reported as a false positive because the
+ * message named a triage target instead of the command substitution it had caught. Backticks
+ * inside double quotes ARE substitution:
+ *
+ *     $ bash -c 'echo "... the permission `deployment:env:view` ..."'
+ *     bash: deployment:env:view: command not found
+ *     ... the permission  ...
+ *
+ * so the words silently vanish from the message. The gate prevented that and got distrusted
+ * for it. These tests drive the compiled CLI, because a helper that returns the right sentence
+ * to nobody is not a fixed message.
+ *
+ * Both cases are offline by construction — an unresolvable indirection is refused before any
+ * registry lookup — so this file never touches the network.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CLI_PATH = resolve(dirname(fileURLToPath(import.meta.url)), "cli.js");
+
+/**
+ * spawnSync, not execFile: the gate reads its payload from STDIN until EOF, and `execFile` has
+ * no `input` option — the pipe stays open and the process hangs forever. `input` closes it.
+ */
+function gateBash(command: string): { exitCode: number; stderr: string } {
+  const payload = JSON.stringify({ tool_name: "Bash", tool_input: { command } });
+  const r = spawnSync(process.execPath, [CLI_PATH, "gate-bash"], {
+    input: payload,
+    encoding: "utf-8",
+    env: { ...process.env, KIT_HIDE_HOOK_SKIP_BANNER: "1", KIT_AUDIT_ANCHOR: "0" },
+    timeout: 60_000,
+  });
+  return { exitCode: r.status ?? 1, stderr: r.stderr ?? "" };
+}
+
+describe("gate-bash refusal wording (compiled CLI)", () => {
+  it("names the command substitution and drops the triage advice", () => {
+    const r = gateBash("`deployment:env:view` install foo");
+    // exit 2 is the PreToolUse deny contract — the block itself must not soften.
+    assert.equal(r.exitCode, 2);
+    assert.match(r.stderr, /COMMAND SUBSTITUTION/);
+    assert.match(r.stderr, /single quotes are literal/);
+    assert.match(r.stderr, /git commit -F/);
+    assert.doesNotMatch(
+      r.stderr,
+      /Triage it first/,
+      "triage is nonsense advice for shell quoting, and stapling it there is what made a correct block read as a mis-parse",
+    );
+  });
+
+  it("keeps the triage advice for an install target it genuinely cannot resolve", () => {
+    const r = gateBash("$PM install evil");
+    assert.equal(r.exitCode, 2);
+    assert.match(r.stderr, /cannot reduce to a triage target/);
+    assert.match(r.stderr, /Triage it first/);
+  });
+
+  it("still allows a commit message whose backticks are single-quoted (no substitution)", () => {
+    const r = gateBash("git commit -qam 'naming the permission `deployment:env:view` here'");
+    assert.equal(r.exitCode, 0, r.stderr);
+  });
+});

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -7,6 +7,7 @@ import {
   parseInstallCommand,
   decideBashGate,
   extractCommandFromHookPayload,
+  explainUnverifiable,
 } from "./install-gate.js";
 import type { GateDeps } from "./triage-gate.js";
 import type { TriageType } from "./triage.js";
@@ -974,6 +975,60 @@ describe("decideBashGate — approval of install scripts", () => {
     const v = await decideBashGate("npm approve-scripts --all", deps);
     assert.equal(v.block, true);
     assert.equal(called, false, "nothing named → nothing to triage; block outright");
+    assert.match(v.reason, /cannot reduce to a triage target/);
+  });
+});
+
+/**
+ * A refusal that misdescribes what it caught trains people to route around the gate.
+ *
+ * Reported as a false positive: `git commit -m "… \`deployment:env:view\` …"` blocked with
+ * "cannot reduce to a triage target … run `kit triage`". The gate was RIGHT — backticks inside
+ * double quotes are command substitution, so the shell runs the token and splices its output in,
+ * silently deleting the words:
+ *
+ *     $ bash -c 'echo "... the permission `deployment:env:view` ..."'
+ *     bash: deployment:env:view: command not found
+ *     ... the permission  ...
+ *
+ * but the message talked about triage targets, so the operator concluded kit had mis-parsed a
+ * commit message and reached for `-F`, hiding a command that would have committed a hole. These
+ * tests pin the wording that names the hazard, and pin that ordinary install refusals keep the
+ * triage advice — the fix must not blunt the common case.
+ */
+describe("install-gate — the refusal names the hazard (#501)", () => {
+  it("explains a backtick substitution instead of naming a triage target", () => {
+    const msg = explainUnverifiable(["indirect-bin:`deployment:env:view`"]);
+    assert.ok(msg, "a substitution token must get its own explanation");
+    assert.match(msg, /COMMAND SUBSTITUTION/);
+    assert.match(msg, /single quotes are literal/);
+    assert.match(msg, /git commit -F/);
+    assert.doesNotMatch(msg, /triage/i, "triage is nonsense advice for shell quoting");
+  });
+
+  it("explains $( ) substitution too", () => {
+    const msg = explainUnverifiable(["indirect-bin:$(which npm)"]);
+    assert.ok(msg);
+    assert.match(msg, /COMMAND SUBSTITUTION/);
+    // No backtick-specific aside when the form is $( ).
+    assert.doesNotMatch(msg, /backticks substitute inside double quotes/);
+  });
+
+  it("leaves every other unverifiable reason to the generic wording", () => {
+    assert.equal(explainUnverifiable(["indirect-bin:$PM"]), null);
+    assert.equal(explainUnverifiable([]), null);
+  });
+
+  it("the blocked verdict carries the hazard, not the machinery", async () => {
+    const v = await decideBashGate("`deployment:env:view` install foo");
+    assert.equal(v.block, true);
+    assert.match(v.reason, /COMMAND SUBSTITUTION/);
+    assert.doesNotMatch(v.reason, /cannot reduce to a triage target/);
+  });
+
+  it("a bare-variable indirection still gets the generic refusal", async () => {
+    const v = await decideBashGate("$PM install evil");
+    assert.equal(v.block, true);
     assert.match(v.reason, /cannot reduce to a triage target/);
   });
 });

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -1064,6 +1064,44 @@ function refIsBareName(ref: string, bare: string): boolean {
  * plain `npx <name>` ref that a local `node_modules/.bin/<name>` shadows — npx
  * runs that local binary, never touching the registry package of the same name.
  */
+/**
+ * Explain an `indirect-bin:` refusal in terms of the HAZARD, not the machinery.
+ *
+ * The generic wording ("cannot reduce to a triage target … run `kit triage`") is accurate about
+ * kit's internals and useless about the command, and it was read as a false positive: a
+ * `git commit -m "… \`deployment:env:view\` …"` was blocked, and the operator concluded the gate
+ * had mis-parsed a commit message. It had not. Backticks inside DOUBLE quotes are command
+ * substitution, so that command never commits that text — the shell runs the backticked token
+ * and splices its output in, silently deleting the words:
+ *
+ *     $ bash -c 'echo "... the permission `deployment:env:view` ..."'
+ *     bash: deployment:env:view: command not found
+ *     ... the permission  ...
+ *
+ * The gate caught a real silent corruption and got distrusted for it, because the message
+ * described a triage target instead of the substitution. `kit triage` / `kit pkg` are nonsense
+ * advice for this command, and following the workaround (write the message to a file, use `-F`)
+ * hides the defect rather than fixing it. So: name it, and give the fix.
+ */
+export function explainUnverifiable(tokens: readonly string[]): string | null {
+  const substitution = tokens.find(
+    (t) => t.startsWith("indirect-bin:`") || t.startsWith("indirect-bin:$("),
+  );
+  if (!substitution) return null;
+  const tok = substitution.slice("indirect-bin:".length);
+  const backtick = tok.startsWith("`");
+  return (
+    `${tok} is COMMAND SUBSTITUTION, not text: the shell runs it and splices its output into ` +
+    `the argument, so the characters you typed never reach the command` +
+    (backtick
+      ? ` (backticks substitute inside double quotes too — single quotes are literal).`
+      : `.`) +
+    ` If you meant it literally, use single quotes, or pass the text via a file ` +
+    `(e.g. \`git commit -F <file>\`). If you meant to run it, run it as its own command so ` +
+    `kit can see what installs.`
+  );
+}
+
 export async function decideBashGate(
   command: string,
   deps?: GateDeps,
@@ -1074,9 +1112,15 @@ export async function decideBashGate(
     return { block: false, reason: "no in-scope package install detected", checked: [] };
   }
   if (probe.unverifiable.length > 0) {
+    // A refusal that misdescribes what it caught trains people to route around the gate, so
+    // the substitution case says what the shell would actually do (#501). Everything else
+    // keeps the generic wording, which is correct for a genuinely unresolvable install target.
+    const hazard = explainUnverifiable(probe.unverifiable);
     return {
       block: true,
-      reason: `cannot reduce to a triage target: ${probe.unverifiable.join(", ")} — run \`kit triage\` manually, or install via \`kit pkg\` (fail-closed)`,
+      reason:
+        hazard ??
+        `cannot reduce to a triage target: ${probe.unverifiable.join(", ")} — run \`kit triage\` manually, or install via \`kit pkg\` (fail-closed)`,
       checked: [],
     };
   }


### PR DESCRIPTION
Closes #501.

## The report was that the gate had a false positive. It did not.

`git commit -qam "… naming the permission \`deployment:env:view\` …"` was blocked. Backticks inside **double** quotes are command substitution, so that command never commits that text — the shell runs `deployment:env:view` and splices its output in. Measured:

```
$ bash -c 'echo "... naming the permission `deployment:env:view` ..."'
bash: deployment:env:view: command not found
... naming the permission  ...
```

The permission name is **silently deleted** from the commit message. `indirectInstall` (`src/install-gate.ts`) caught a real silent corruption: argv0 is an unresolvable substitution and an install verb is present, so it cannot verify what runs → fail closed. Single quotes are literal and are not blocked.

## What was actually broken: the wording

```
BLOCKED — cannot reduce to a triage target: indirect-bin:`deployment:env:view`
Triage it first: `kit triage …`, or install via `kit pkg <eco>:<name>`.
```

Both lines are about kit's internals, and both are nonsense advice for this command. The reasonable conclusion was "the gate mis-parsed my commit message", and the workaround that follows — write the message to a file, use `-F` — hides the defect instead of fixing it. A refusal that misdescribes what it caught teaches people to route around the gate.

Now:

```
BLOCKED — `deployment:env:view` is COMMAND SUBSTITUTION, not text: the shell runs it and
splices its output into the argument, so the characters you typed never reach the command
(backticks substitute inside double quotes too — single quotes are literal). If you meant it
literally, use single quotes, or pass the text via a file (e.g. `git commit -F <file>`). If you
meant to run it, run it as its own command so kit can see what installs.
```

and the `Triage it first` line is appended only when the block really is about an install target — `$PM install evil` keeps the generic wording.

Fail-closed behaviour is untouched: same block, same exit 2. This changes only what the operator is told.

## Tests

- `install-gate.test.ts` — `explainUnverifiable` for the backtick form, the `$( )` form (no backtick-specific aside), and `null` for every other unverifiable reason so the generic path is preserved; plus the verdict carrying the hazard, and `$PM install evil` still carrying the generic one.
- `gate-bash-refusal.test.ts` (new) — the **compiled CLI**, because a helper that returns the right sentence to nobody is not a fixed message: exit 2 preserved, the hazard wording present, `Triage it first` absent, the generic case unchanged, and a single-quoted commit message allowed. Offline by construction — an unresolvable indirection is refused before any registry lookup, so no network.

One test-harness note worth keeping: `execFile` has no `input` option, so the first version of the e2e test left the gate waiting on a stdin pipe that never closed and hung for two minutes. `spawnSync({ input })` closes it.

## Verification

- `npm test`: **4350 tests, 0 fail, 0 skipped** (macOS, non-root)
- `eslint src`: 0 errors; `prettier --check "src/**/*.ts"` clean
- Reproduced the block on both 6.6.5 (the reporter's version) and 6.7.0 before changing anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)
