### PR TITLE
fix(gate): recognise every spelling of a repo argument, and correct the pip maintainer probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The install-gate recognised one repo-argument form; the tool publishes two** (#507).
+  `ownerRepoArg` matched `^[\w.-]+/[\w.-]+$` — one slash, no scheme — so the payload of a
+  repo-fetching installer was triaged only when the argument happened to be written as
+  `owner/repo`. Measured against 6.7.0, with `npm install left-pad` still blocking as a control:
+
+  ```
+  npx skills add cursor/plugins                                   → BLOCKED
+  npx skills add https://github.com/cursor/plugins --skill unslop → allowed
+  npx skills add github.com/cursor/plugins                        → allowed
+  npx skills add git@github.com:cursor/plugins.git                → allowed
+  ```
+
+  And the bypass ran through the form the tool's own help recommends — `skills add --help` lists
+  both `vercel-labs/agent-skills` and `https://github.com/vercel-labs/agent-skills`, so this was
+  never a latent edge case. The argument is now normalised BEFORE matching (any scheme, an
+  optional `user@`, a host segment, scp-style `git@host:owner/repo`, a trailing `.git`, and a
+  deeper `…/tree/main/sub` path all reduce to `owner/repo`) rather than the pattern being
+  widened, which would have started matching npm scopes and file paths. `@scope/name` is still
+  not a repo, and neither is a filesystem path — `./local/path/file.txt` used to reduce to
+  `./local`, which the table test caught.
+
+- **The pip maintainer count was declared unavailable on a claim that was wrong.** The previous
+  entry said PyPI publishes no maintainer list. Measured, it does: `requests` carries
+  `maintainer_email = "Ian Stapleton Cordasco <…>, Nate Prewitt <…>"`. Two things still keep it
+  from being npm's number, and both are now in the output rather than in a comment: PEP 621
+  leaves `maintainer` null so the value hides in `maintainer_email` (and sometimes only in
+  `author_email` — `opensandbox-server` had exactly that), and PyPI's list is **self-declared
+  package metadata** while npm's is the registry's own record of who may publish. So the probe
+  runs, reports `N declared maintainer(s) in <field> (self-declared package metadata)`, and when
+  it warns it says outright that this is *not registry publish rights* and *not comparable to
+  npm's maintainer count*. A package that names nobody still declares the probe unavailable —
+  with an accurate reason this time.
+
+  Consequence, measured: `pip opensandbox-server` goes from `100/100` with a partial-coverage
+  note to `88/100` with a single-maintainer warning — the same reason npm's packages scored 88.
+  Counting is bracket-aware, so `"Cordasco, Ian <one@example>"` is one maintainer, not two.
+
 ### Added
 
 - **`[context]` can declare the IDENTITY a repo must use, and kit asserts it** (#503). `kit check`

--- a/skills/triage/scripts/triage.py
+++ b/skills/triage/scripts/triage.py
@@ -30,8 +30,10 @@ Scope (what a PASS DOES and does NOT mean):
   - PASS means the SPECIFIC target — including a pinned version or dist-tag (`name@1.2.3`,
     `name@next`, `name==1.2.3`) — EXISTS and clears the health checks: not-found, deprecated,
     or yanked is a CRITICAL; newness / abandonment / single-maintainer / no-license are
-    warnings. npm and pip run the same probe set except maintainer count, which the pip
-    path declares as unavailable instead of leaving unmentioned. A pinned version is triaged directly, so a clean `latest` never vouches for a
+    warnings. npm and pip run the same probe set; the maintainer count differs in KIND rather
+    than presence -- npm reads the registry's publisher list, pip reads self-declared package
+    metadata (`maintainer_email`, falling back to `author_email`) and says so, or declares the
+    probe unavailable when the package names nobody. A pinned version is triaged directly, so a clean `latest` never vouches for a
     yanked or malicious pinned version.
   - PASS is NOT a malware verdict. This gate does no typosquat, install-script, or behavioral
     analysis. Deep malware detection is GuardDog (opt-in, separate + heavier: `KIT_GUARDDOG=1`
@@ -395,6 +397,27 @@ def _resolve_pip_spec(spec, release_keys):
     return cands[-1] if cands else None
 
 
+def _declared_maintainers(info):
+    """Count the maintainers a PyPI package DECLARES, or (None, reason) when it declares none.
+
+    Reads `maintainer_email` first (its purpose), falling back to `author_email` (what PEP 621
+    actually fills in). Counting is bracket-aware: display names may contain commas
+    ("Cordasco, Ian <x@y>"), so `<...>` pairs are counted when present and only a bracket-free
+    value is split on commas. Returns (count, field_name) or (None, None).
+    """
+    for field in ("maintainer_email", "author_email", "maintainer", "author"):
+        raw = (info.get(field) or "").strip()
+        if not raw:
+            continue
+        brackets = re.findall(r"<[^<>@\s]+@[^<>\s]+>", raw)
+        if brackets:
+            return len(brackets), field
+        parts = [p.strip() for p in raw.split(",") if p.strip()]
+        if parts:
+            return len(parts), field
+    return None, None
+
+
 def triage_pip(rep):
     pkg, spec = _split_pip_spec(rep.target)
     url = f"{PYPI_INDEX}/pypi/{urllib.parse.quote(pkg)}/json"
@@ -460,14 +483,33 @@ def triage_pip(rep):
         if first_days < NEW_DAYS:
             rep.warn(f"package is very new ({first_days} days) -- limited track record")
 
-    # The one npm probe PyPI cannot answer. `info.maintainer` / `maintainer_email` are
-    # free-text and usually empty, and the JSON API publishes no maintainer list at all, so
-    # a count here would be invented. Declared instead of silently skipped.
-    rep.notchecked(
-        "maintainer count",
-        "PyPI's JSON API publishes no maintainer list (info.maintainer is free-text and "
-        "usually empty), so bus-factor / account-takeover risk was NOT assessed",
-    )
+    # Maintainer count. The earlier claim here -- "PyPI publishes no maintainer list" -- was
+    # wrong, and measured wrong: requests carries
+    #   maintainer_email = "Ian Stapleton Cordasco <...>, Nate Prewitt <...>"
+    # which is countable. Two caveats decide how it is reported:
+    #   1. same trap as `author`: `maintainer` is null under PEP 621 and the value lives in
+    #      `maintainer_email`; opensandbox-server had maintainer_email null with one entry in
+    #      author_email, so a counter must weigh both and be able to answer "don't know";
+    #   2. the SEMANTICS differ from npm's. npm's list is the registry's own -- who may publish.
+    #      PyPI's is self-declared metadata inside the package. Two names in a field are not
+    #      evidence of two accounts with publish rights, so this must not be presented as npm's
+    #      number.
+    count, source = _declared_maintainers(info)
+    if count is None:
+        rep.notchecked(
+            "maintainer count",
+            "neither maintainer_email nor author_email names anyone for this package, and "
+            "PyPI's JSON API does not expose registry publish rights -- bus-factor / "
+            "account-takeover risk was NOT assessed",
+        )
+    else:
+        rep.fact(f"{count} declared maintainer(s) in {source} (self-declared package metadata)")
+        if count <= 1:
+            rep.warn(
+                f"single declared maintainer in {source} -- bus-factor risk. NOTE: this is "
+                "self-declared metadata, not registry publish rights; PyPI does not expose who "
+                "may publish, so it is not comparable to npm's maintainer count"
+            )
 
 
 def _owner_repo(target):

--- a/src/install-gate.test.ts
+++ b/src/install-gate.test.ts
@@ -8,6 +8,7 @@ import {
   decideBashGate,
   extractCommandFromHookPayload,
   explainUnverifiable,
+  ownerRepoArg,
 } from "./install-gate.js";
 import type { GateDeps } from "./triage-gate.js";
 import type { TriageType } from "./triage.js";
@@ -1030,5 +1031,81 @@ describe("install-gate — the refusal names the hazard (#501)", () => {
     const v = await decideBashGate("$PM install evil");
     assert.equal(v.block, true);
     assert.match(v.reason, /cannot reduce to a triage target/);
+  });
+});
+
+/**
+ * The gate recognised one argument form; the tool documents two.
+ *
+ * `skills add --help` lists both `vercel-labs/agent-skills` and
+ * `https://github.com/vercel-labs/agent-skills`. Measured against 6.7.0: the short form was
+ * BLOCKED and every equivalent spelling went through — so the bypass ran through the invocation
+ * the tool's own help recommends (#507). The fix normalises before matching; a looser regex
+ * would start matching npm scopes and file paths, and the defect was never strictness.
+ */
+describe("install-gate — repo argument forms (#507)", () => {
+  it("reduces every equivalent spelling to owner/repo", () => {
+    const cases: Array<[string, string | null]> = [
+      ["cursor/plugins", "cursor/plugins"],
+      ["https://github.com/cursor/plugins", "cursor/plugins"],
+      ["http://github.com/cursor/plugins", "cursor/plugins"],
+      ["github.com/cursor/plugins", "cursor/plugins"],
+      ["https://github.com/cursor/plugins.git", "cursor/plugins"],
+      ["git@github.com:cursor/plugins.git", "cursor/plugins"],
+      ["git@github.com:cursor/plugins", "cursor/plugins"],
+      ["ssh://git@github.com/cursor/plugins.git", "cursor/plugins"],
+      ["git+https://github.com/cursor/plugins.git", "cursor/plugins"],
+      ["https://gitlab.example.com/cursor/plugins", "cursor/plugins"],
+      ["https://github.com/cursor/plugins/", "cursor/plugins"],
+      // A deeper URL still names the repo that gets fetched.
+      ["https://github.com/cursor/plugins/tree/main/unslop", "cursor/plugins"],
+    ];
+    for (const [input, expected] of cases) {
+      assert.equal(ownerRepoArg(input), expected, input);
+    }
+  });
+
+  it("still refuses what is not a repo reference", () => {
+    for (const input of [
+      "@scope/name", // npm scope
+      "left-pad", // bare npm name
+      "https://github.com/cursor", // one segment
+      "github.com", // host only
+      "--skill", // a flag
+      "", // nothing
+      "./local/path/file.txt", // a filesystem path, not a repo
+      "../sibling/repo",
+      "~/notes/file.md",
+      "/abs/path/thing",
+    ]) {
+      assert.equal(ownerRepoArg(input), null, input);
+    }
+  });
+
+  it("every form yields the same github: ref through the real parser", () => {
+    const forms = [
+      "npx skills add cursor/plugins",
+      "npx skills add cursor/plugins --skill unslop",
+      "npx skills add https://github.com/cursor/plugins --skill unslop",
+      "npx skills add github.com/cursor/plugins",
+      "npx skills add git@github.com:cursor/plugins.git",
+      "npx skills add ssh://git@github.com/cursor/plugins.git",
+      "npx skills add https://github.com/cursor/plugins/tree/main/unslop",
+    ];
+    for (const cmd of forms) {
+      const probe = parseInstallCommand(cmd);
+      assert.ok(
+        probe.refs.some((r) => String(r).includes("github:cursor/plugins")),
+        `${cmd} — the repo payload must be triaged, not just the wrapper package`,
+      );
+    }
+  });
+
+  it("an npm scope passed to the fetcher does not become a repo ref", () => {
+    const probe = parseInstallCommand("npx skills add @scope/name");
+    assert.equal(
+      probe.refs.some((r) => String(r).startsWith("github:")),
+      false,
+    );
   });
 });

--- a/src/install-gate.ts
+++ b/src/install-gate.ts
@@ -856,10 +856,59 @@ function hasExecCallFlag(tokens: string[]): boolean {
  */
 const REPO_FETCHER_PACKAGES = new Set(["skills"]);
 
-/** `owner/repo` shape — no npm scope (`@scope/name`), no scheme, no protocol. */
-function ownerRepoArg(tok: string): string | null {
+/**
+ * Reduce every spelling of a repo argument to `owner/repo`, or null when the token is not one.
+ *
+ * The gate recognised ONE form and the tool documents two. `skills add --help` lists both
+ * `vercel-labs/agent-skills` and `https://github.com/vercel-labs/agent-skills`, and measured
+ * against 6.7.0 the short form was BLOCKED while every equivalent form went through:
+ *
+ *     npx skills add cursor/plugins                        → BLOCKED
+ *     npx skills add https://github.com/cursor/plugins     → allowed
+ *     npx skills add github.com/cursor/plugins             → allowed
+ *     npx skills add git@github.com:cursor/plugins.git     → allowed
+ *
+ * So the bypass ran through the invocation the tool's own help recommends. The fix normalises
+ * BEFORE matching rather than widening the pattern: a looser regex would start matching npm
+ * scopes and file paths, and the defect was never that the pattern was too strict — it was that
+ * one form was implemented and its equivalents were not.
+ *
+ * Deliberately kept out: `@scope/name` (an npm package, not a repo) and anything that does not
+ * reduce to exactly two path segments after the host.
+ */
+export function ownerRepoArg(tok: string): string | null {
+  if (!tok || tok.startsWith("-")) return null;
   if (tok.startsWith("@")) return null; // npm scope, not a repo
-  return /^[\w.-]+\/[\w.-]+$/.test(tok) ? tok : null;
+  // A filesystem path is not a repo reference. Without this, `./local/path/file.txt` reduced to
+  // `./local` — caught by the table test, and exactly the kind of over-eager match that
+  // widening the regex would have produced everywhere.
+  if (/^[./~]/.test(tok)) return null;
+
+  let t = tok.trim();
+  // scp-style SSH: git@host:owner/repo(.git) — the colon separates host from path.
+  const scp = /^[\w.-]+@([\w.-]+):(.+)$/.exec(t);
+  if (scp) {
+    t = scp[2];
+  } else {
+    // Any scheme (https, http, ssh, git, git+ssh) plus optional user@host, then the path.
+    t = t.replace(/^[a-z][a-z0-9+.-]*:\/\//i, "").replace(/^[\w.-]+@/, "");
+    // A leading host segment: something with a dot (github.com, gitlab.example.com) or
+    // localhost, optionally with a port. Bare `owner/repo` has neither and is left alone.
+    t = t.replace(/^(?:localhost|[\w-]+(?:\.[\w-]+)+)(?::\d+)?\//, "");
+  }
+
+  t = t
+    .replace(/\.git$/, "")
+    .replace(/^\/+/, "")
+    .replace(/\/+$/, "");
+  const parts = t.split("/").filter(Boolean);
+  // Exactly two segments. A deeper URL (…/tree/main/sub) still names the repo it fetches, so
+  // the first two win; a single segment is not a repo reference.
+  if (parts.length < 2) return null;
+  const [owner, repo] = parts;
+  if (owner.startsWith("@")) return null;
+  if (owner === "." || owner === ".." || repo === "." || repo === "..") return null;
+  return /^[\w.-]+$/.test(owner) && /^[\w.-]+$/.test(repo) ? `${owner}/${repo}` : null;
 }
 
 /**

--- a/src/triage-ecosystem-parity.test.ts
+++ b/src/triage-ecosystem-parity.test.ts
@@ -47,6 +47,7 @@ function pypiPackage(opts: {
   lastReleaseDaysAgo: number;
   authorEmail?: string | null;
   author?: string | null;
+  maintainerEmail?: string | null;
   license?: string;
 }): unknown {
   const older = `0.0.1`;
@@ -55,6 +56,8 @@ function pypiPackage(opts: {
       version: opts.version,
       author: opts.author ?? null,
       author_email: opts.authorEmail ?? null,
+      maintainer: null,
+      maintainer_email: opts.maintainerEmail ?? null,
       license: opts.license ?? "Apache-2.0",
       classifiers: ["License :: OSI Approved :: Apache Software License"],
     },
@@ -160,7 +163,11 @@ describe("triage ecosystem parity (real triage.py against a local registry)", ()
     }
   };
 
-  it("a clean pip package cannot print 100/100 without saying what it did not check", async (t) => {
+  it("a single declared maintainer warns, and says the number is not npm's", async (t) => {
+    // Was: this fixture scored 100/100 with a PARTIAL-coverage note, because the maintainer
+    // probe was declared unavailable on the claim that PyPI publishes no maintainer list.
+    // Measured wrong — `author_email` names one here, so the probe RUNS, warns, and the score
+    // drops for the same reason npm's did. What must not come back is presenting it as parity.
     routes.set(
       "/pypi/opensandbox-server/json",
       pypiPackage({
@@ -173,14 +180,13 @@ describe("triage ecosystem parity (real triage.py against a local registry)", ()
     const out = await runTriage("pip", "opensandbox-server", t);
     if (out === null) return;
 
-    assert.match(out, /Health score: 100\/100/);
-    assert.match(out, /Probes declared unavailable: 1/);
-    assert.match(out, /Coverage: PARTIAL/);
-    assert.match(out, /NOT CHECKED: maintainer count/);
-    assert.match(out, /bus-factor \/ account-takeover risk was NOT assessed/);
+    assert.match(out, /Health score: 88\/100/);
+    assert.match(out, /single declared maintainer in author_email/);
+    assert.match(out, /not comparable to npm's maintainer count/);
+    assert.match(out, /Probes declared unavailable: 0/);
     assert.ok(
       out.split("\n").includes("TRIAGE PASSED"),
-      "declared coverage gaps must not withhold PASS — they are unknowns, not findings",
+      "a warning is not a critical — the package still passes",
     );
   });
 
@@ -217,7 +223,10 @@ describe("triage ecosystem parity (real triage.py against a local registry)", ()
 
     assert.match(out, /first published 4 days ago/);
     assert.match(out, /package is very new \(4 days\) -- limited track record/);
-    assert.match(out, /Health score: 88\/100/);
+    // Two warnings now: newness AND a single declared maintainer (author_email names one).
+    // 100 - 12 - 12 = 76. The old 88 encoded a maintainer probe that did not run.
+    assert.match(out, /Health score: 76\/100/);
+    assert.match(out, /single declared maintainer/);
   });
 
   it("an npm package with the same shape scores the same as pip on the shared probes", async (t) => {
@@ -297,5 +306,94 @@ describe("triage ecosystem parity (real triage.py against a local registry)", ()
     assert.match(out, /CRITICAL: package 'no-such-package-xyz' not found on PyPI/);
     assert.ok(out.split("\n").includes("TRIAGE FAILED"));
     assert.doesNotMatch(out, /TRIAGE PASSED/);
+  });
+  /**
+   * The maintainer count, corrected.
+   *
+   * The first pass declared this probe unavailable on the claim that "PyPI publishes no maintainer
+   * list". Measured, that was wrong: `requests` carries
+   * `maintainer_email = "Ian Stapleton Cordasco <…>, Nate Prewitt <…>"`, which is countable.
+   * Two things still make it NOT npm's number, and both are asserted here: PEP 621 leaves
+   * `maintainer` null so the value hides in `maintainer_email` (and sometimes only in
+   * `author_email`), and PyPI's list is self-declared metadata inside the package while npm's is
+   * the registry's own record of who may publish. So the count is reported for what it is, or the
+   * probe is declared unavailable when the package names nobody — never presented as parity.
+   */
+  describe("pip maintainer count (self-declared, not publish rights)", () => {
+    it("counts two comma-separated maintainers out of maintainer_email", async (t) => {
+      routes.set(
+        "/pypi/two-maintainers/json",
+        pypiPackage({
+          version: "2.32.0",
+          firstReleaseDaysAgo: 4000,
+          lastReleaseDaysAgo: 30,
+          authorEmail: "Kenneth Reitz <me@example.test>",
+          maintainerEmail: "Ian Cordasco <a@example.test>, Nate Prewitt <b@example.test>",
+        }),
+      );
+      const out = await runTriage("pip", "two-maintainers", t);
+      if (out === null) return;
+      assert.match(out, /2 declared maintainer\(s\) in maintainer_email/);
+      assert.doesNotMatch(out, /single declared maintainer/);
+      assert.match(out, /Probes declared unavailable: 0/);
+    });
+
+    it("falls back to author_email, warns, and refuses to claim npm parity", async (t) => {
+      routes.set(
+        "/pypi/one-maintainer/json",
+        pypiPackage({
+          version: "0.2.2",
+          firstReleaseDaysAgo: 200,
+          lastReleaseDaysAgo: 20,
+          authorEmail: "Solo Dev <solo@example.test>",
+          maintainerEmail: null,
+        }),
+      );
+      const out = await runTriage("pip", "one-maintainer", t);
+      if (out === null) return;
+      assert.match(out, /1 declared maintainer\(s\) in author_email/);
+      assert.match(out, /single declared maintainer in author_email/);
+      // The caveat is the point: this number is not npm's.
+      assert.match(out, /not registry publish rights/);
+      assert.match(out, /not comparable to npm's maintainer count/);
+      assert.match(out, /Health score: 88\/100/);
+    });
+
+    it("counts by email brackets, so a comma inside a display name is not a second maintainer", async (t) => {
+      routes.set(
+        "/pypi/comma-name/json",
+        pypiPackage({
+          version: "1.0.0",
+          firstReleaseDaysAgo: 900,
+          lastReleaseDaysAgo: 40,
+          maintainerEmail: "Cordasco, Ian <only@example.test>",
+        }),
+      );
+      const out = await runTriage("pip", "comma-name", t);
+      if (out === null) return;
+      assert.match(out, /1 declared maintainer\(s\)/);
+      assert.doesNotMatch(out, /2 declared maintainer/);
+    });
+
+    it("declares the probe unavailable — with an accurate reason — when nobody is named", async (t) => {
+      routes.set(
+        "/pypi/anonymous-pkg/json",
+        pypiPackage({
+          version: "1.0.0",
+          firstReleaseDaysAgo: 900,
+          lastReleaseDaysAgo: 40,
+          author: null,
+          authorEmail: null,
+          maintainerEmail: null,
+        }),
+      );
+      const out = await runTriage("pip", "anonymous-pkg", t);
+      if (out === null) return;
+      assert.match(out, /NOT CHECKED: maintainer count/);
+      assert.match(out, /neither maintainer_email nor author_email names anyone/);
+      // The old wording claimed PyPI has no such field at all. It does; this package has none.
+      assert.doesNotMatch(out, /publishes no maintainer list/);
+      assert.match(out, /Coverage: PARTIAL/);
+    });
   });
 });


### PR DESCRIPTION
Closes #507. Also corrects the maintainer half of #489, which was closed by #493 on a claim that turned out to be wrong — details below.

## #507 — the gap is not latent, and the measurement says why

The one line that could not be run from a web session, run here:

```
$ npx skills add --help
add <package>        Add a skill package (alias: a)
                     e.g. vercel-labs/agent-skills
                          https://github.com/vercel-labs/agent-skills
```

The CLI documents **both** forms. So the gate was blocking the short form while letting through the invocation the tool's own help recommends — not an edge case waiting to matter.

(The package itself was triaged before being executed: `skills` 1.5.23, `vercel-labs/skills`, 2 maintainers, `TRIAGE PASSED`.)

### The fix normalises, it does not widen

`ownerRepoArg` matched `^[\w.-]+/[\w.-]+$` — one slash, no scheme. Widening that pattern would have started matching npm scopes and file paths; the defect was never strictness, it was that one form was implemented and its equivalents were not. So the token is reduced first: any scheme (`https`, `http`, `ssh`, `git+https`), an optional `user@`, a host segment (dotted host or `localhost`, optional port), scp-style `git@host:owner/repo`, a trailing `.git`, and a deeper `…/tree/main/sub` path all collapse to `owner/repo`.

Verified through the real parser — every form now yields the same `github:cursor/plugins` ref:

| argument | ref extracted |
|---|---|
| `cursor/plugins` | ✓ |
| `cursor/plugins --skill unslop` | ✓ |
| `https://github.com/cursor/plugins --skill unslop` | ✓ |
| `github.com/cursor/plugins` | ✓ |
| `git@github.com:cursor/plugins.git` | ✓ |
| `ssh://git@github.com/cursor/plugins.git` | ✓ |
| `https://github.com/cursor/plugins/tree/main/unslop` | ✓ |
| `@scope/name` | — (npm scope, not a repo) |

The table test caught a flaw in my own first pass: `./local/path/file.txt` reduced to `./local`. Filesystem paths are now refused outright (`.`, `..`, `~`, `/` prefixes and `.`/`..` segments), which is the over-eager matching a looser regex would have produced everywhere.

**Not bundled, as you asked:** the gate triages the whole repo while `--skill unslop` installs one subtree of a monorepo. Repo-level is a superset answer, `kit triage skill` exists for the module question, and nothing connects them on this path. That is a separate decision, not a line in this diff.

## #489 — the maintainer probe, corrected

#493 shipped the newness probe, the `author_email` fallback and the make-absence-visible reporting. It also declared the maintainer probe unavailable with this reason:

> PyPI's JSON API publishes no maintainer list

Your correction is right, and it measures out:

```
requests            maintainer_email = "Ian Stapleton Cordasco <…>, Nate Prewitt <…>"   → countable
opensandbox-server  maintainer_email = null, author_email = one entry                   → countable, other field
deepsec (pypi)      all four fields null                                                 → nothing to count
```

So the probe now runs, and reports what the number **is** rather than implying npm's:

```
. 2 declared maintainer(s) in maintainer_email (self-declared package metadata)

! WARNING: single declared maintainer in author_email -- bus-factor risk. NOTE: this is
  self-declared metadata, not registry publish rights; PyPI does not expose who may publish,
  so it is not comparable to npm's maintainer count
```

Two properties worth naming:

- **It weighs both fields and can still answer "don't know".** PEP 621 leaves `maintainer` null; a package that names nobody at all keeps the `NOT CHECKED` row, now with an accurate reason (*this package names nobody*) rather than a false claim about the API.
- **Counting is bracket-aware.** `"Cordasco, Ian <one@example.test>"` is one maintainer, not two — display names contain commas.

Measured consequence: `pip opensandbox-server` moves from `100/100` with a partial-coverage note to `88/100` with a single-maintainer warning — the same reason npm's packages scored 88, and now with the caveat attached instead of implied.

Two existing tests asserted the old (wrong) answer — `100/100` for that fixture, and `88/100` for the very-new one that now also warns on a single maintainer (`76/100`). Both were updated with the reasoning in the test body, since the correction changes what the right answer is.

## Tests

- `install-gate.test.ts` — a 12-row table over every equivalent spelling, a refusal table (npm scope, bare name, host-only, single segment, flags, four path shapes), the same forms through `parseInstallCommand`, and an npm scope that must not become a repo ref. 102 tests in the file, all green.
- `triage-ecosystem-parity.test.ts` — four new cases against the local registry fixture: two comma-separated maintainers counted, `author_email` fallback with the caveat asserted verbatim, a comma inside a display name counted as one, and a package naming nobody declaring the probe unavailable with the corrected wording (and explicitly **not** the old "publishes no maintainer list" text).

## #470 — already shipped, verified again here

`kit audit verify --all` landed in #492 and works on this machine:

```
$ kit audit verify --all
✓ 4 anchored log(s): 3 verified · 0 stalled · 1 missing · 0 failed
```

`missing` and `stalled` are distinct outcomes: a vanished temp-dir log never fails the verdict, an unsealed tail warns and fails under `--strict`. Part 2 (`elevation.ts` threading `cwd`) needed no change — it was already correct at the version the report measured:

```
$ git show v6.6.3:src/elevation.ts | grep -A2 'appendAuditEventDirect'
  return appendAuditEventDirect(
    { operation: "elevation-check", … },
    { cwd },
```

## Verification

- `npm test`: **4415 tests, 0 fail, 0 skipped** (macOS, non-root). 0 skipped rather than 1: semgrep is installed here, so the scanner-subprocess test runs too — the two chmod guards ran and passed, which is what the report asked to confirm.
- `eslint src`: 0 errors · `prettier --check "src/**/*.ts"` clean · `kit self-audit`: 16 rules, 0 fail
- `npx skills add --help` and all five argument forms exercised against the built CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
