### PR TITLE
fix(wrapper): point the machine-wide wrapper at the installed kit, not at whoever wrote it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **The machine-wide wrapper pointed at whichever kit wrote it** (#509). `~/.kit/bin/kit` is what
+  every kit hook in every repo execs, and `ensureKitWrapper()` baked in `process.argv[1]` — so one
+  `kit hooks add` run from a development checkout aimed the whole machine's enforcement floor at
+  `…/dist/cli.js`, a path `npm run build` deletes on its first step. Measured: a session in an
+  unrelated repo failed with `kit CLI entrypoint missing: …/kit-public/dist/cli.js` and kept going
+  **ungated**, because a hook that cannot start is reported non-blocking.
+
+  Four properties made it worse than a stale path, and the fix addresses each: a repo-local
+  command had a machine-wide effect; a dev build is transient *by design*; it failed open; and it
+  was silent in both directions.
+
+  Now: an **installed** kit wins over a checkout when the wrapper is written (probing the usual
+  global bin dirs), `KIT_WRAPPER_ALLOW_DEV=1` still wins over that so an explicit dev pin is not
+  silently overridden, and a checkout with no install to fall back on is written but **loud**
+  — refusing outright would leave the hooks with no wrapper at all. The result line names the
+  entrypoint instead of just saying "refreshed".
+
+  `kit check`'s `git hook floor` row now also judges the wrapper, since the hooks resolve through
+  it: a **missing** entrypoint fails high (every hook on the machine is dead, and it fails open),
+  and an entrypoint inside a git working tree warns (it works until the next build).
+
+  Both new env knobs are registered in `kit config knobs`: `KIT_WRAPPER_ALLOW_DEV` (marked
+  dangerous) and `KIT_TOOL_LATEST_TTL_H`, which had been missing since it was introduced.
+
+### Fixed
+
 - **The install-gate recognised one repo-argument form; the tool publishes two** (#507).
   `ownerRepoArg` matched `^[\w.-]+/[\w.-]+$` — one slash, no scheme — so the payload of a
   repo-fetching installer was triaged only when the argument happened to be written as

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -206,6 +206,21 @@ export async function checkGitHookFloor(cwd?: string): Promise<SecurityCheckResu
     config = undefined;
   }
   const verdict = judgeHookFloor(describeHookFloor(root, config));
+  // The wrapper is the other half of the same floor: the hooks resolve through it, so a hook
+  // directory full of correct hooks says nothing if the wrapper's entrypoint is gone (#509).
+  const { describeWrapper, judgeWrapper } = await import("./hook-floor.js");
+  const wrapper = judgeWrapper(describeWrapper());
+  if (wrapper.status === "fail" || (wrapper.status === "warn" && verdict.status === "pass")) {
+    return wrapper.severity
+      ? {
+          category,
+          name: "git hook floor",
+          status: wrapper.status,
+          severity: wrapper.severity,
+          detail: wrapper.detail,
+        }
+      : { category, name: "git hook floor", status: wrapper.status, detail: wrapper.detail };
+  }
   return verdict.severity
     ? { category, name, status: verdict.status, severity: verdict.severity, detail: verdict.detail }
     : { category, name, status: verdict.status, detail: verdict.detail };

--- a/src/hook-floor.ts
+++ b/src/hook-floor.ts
@@ -30,6 +30,8 @@ import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { resolve, sep } from "node:path";
 import { resolveHooksDir } from "./hooks.js";
+import { pathInWorkingTree } from "./kit-wrapper.js";
+import { homedir } from "node:os";
 import type { kitConfig } from "./config.js";
 
 /** The kit-managed built-in hooks, keyed by the git hook file they install into. */
@@ -182,4 +184,95 @@ export function judgeHookFloor(report: HookFloorReport): HookFloorVerdict {
     status: "pass",
     detail: `${report.installed.length} kit hook(s) wired in ${where}: ${report.installed.join(", ")}`,
   };
+}
+
+/**
+ * The OTHER half of the floor: the machine-wide wrapper every hook goes through.
+ *
+ * `~/.kit/bin/kit` used to be written with whatever entrypoint happened to be running, so one
+ * `kit hooks add` from a checkout aimed every hook on the machine at `…/dist/cli.js` — a path
+ * `npm run build` deletes on its first step. Measured: a session in an unrelated repo failed with
+ * "kit CLI entrypoint missing" and continued UNGATED, because a hook that cannot start is
+ * non-blocking (#509). Reporting the hook directory (above) while saying nothing about the
+ * wrapper leaves half the floor unmeasured.
+ */
+export interface WrapperReport {
+  path: string;
+  /** Present and kit-managed. */
+  managed: boolean;
+  /** The entrypoint it execs, when it could be read. */
+  entry: string | null;
+  /** The entrypoint does not exist — every hook on this machine is dead until it returns. */
+  entryMissing: boolean;
+  /** The entrypoint is inside a git working tree, i.e. a build artifact rather than an install. */
+  entryInWorkingTree: boolean;
+}
+
+/** Read the wrapper and the state of what it points at. */
+export function describeWrapper(home = homedir()): WrapperReport {
+  const path = resolve(home, ".kit", "bin", "kit");
+  const empty: WrapperReport = {
+    path,
+    managed: false,
+    entry: null,
+    entryMissing: false,
+    entryInWorkingTree: false,
+  };
+  let body: string;
+  try {
+    body = readFileSync(path, "utf-8");
+  } catch {
+    return empty;
+  }
+  if (!body.includes("kit-managed wrapper")) return { ...empty, managed: false };
+  // The generated wrapper's last line is `exec "<node>" "<cli>" "$@"`.
+  const m = /^exec\s+"([^"]+)"\s+"([^"]+)"/m.exec(body);
+  const entry = m?.[2] ?? null;
+  return {
+    path,
+    managed: true,
+    entry,
+    entryMissing: entry !== null && !existsSync(entry),
+    entryInWorkingTree: entry !== null && pathInWorkingTree(entry),
+  };
+}
+
+/**
+ * Verdict for the wrapper. A missing entrypoint is the loud case: every kit hook on the machine
+ * is dead, in every repo, and it fails open. A working-tree entrypoint is the latent one — it
+ * works right now and breaks on the next build.
+ */
+export function judgeWrapper(r: WrapperReport): HookFloorVerdict {
+  if (!r.managed) {
+    return { status: "skip", detail: `no kit-managed wrapper at ${r.path}` };
+  }
+  if (r.entry === null) {
+    return {
+      status: "warn",
+      severity: "medium",
+      detail: `${r.path} is kit-managed but its exec target could not be read — refresh it with 'kit agent-config'`,
+    };
+  }
+  if (r.entryMissing) {
+    return {
+      status: "fail",
+      severity: "high",
+      detail:
+        `the wrapper every kit hook goes through points at ${r.entry}, which does not exist — ` +
+        `EVERY kit hook on this machine is dead until it returns, and a hook that cannot start ` +
+        `is non-blocking, so sessions run ungated. Refresh it from the installed kit: ` +
+        `'kit agent-config' (or 'kit memory install') run from the global binary.`,
+    };
+  }
+  if (r.entryInWorkingTree) {
+    return {
+      status: "warn",
+      severity: "medium",
+      detail:
+        `the wrapper points at ${r.entry}, inside a git working tree — a build that cleans ` +
+        `dist/ will disarm every kit hook on this machine until it finishes. Re-run ` +
+        `'kit agent-config' from the installed kit to pin the install instead.`,
+    };
+  }
+  return { status: "pass", detail: `wrapper → ${r.entry}` };
 }

--- a/src/kit-wrapper-entry.test.ts
+++ b/src/kit-wrapper-entry.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Which kit the machine-wide wrapper points at.
+ *
+ * `~/.kit/bin/kit` is what every kit hook in every repo execs, and it used to be written with
+ * whatever entrypoint happened to be running. So one `kit hooks add` from a development checkout
+ * aimed the whole machine's enforcement floor at `…/kit-public/dist/cli.js` — a path
+ * `npm run build` deletes on its first step (`clean-dist.mjs`). Measured (#509): a session in an
+ * unrelated repo failed with
+ *
+ *     PreToolUse:Bash hook error … kit CLI entrypoint missing: …/kit-public/dist/cli.js
+ *
+ * and kept going UNGATED, because a hook that cannot start is reported non-blocking.
+ *
+ * Three properties are pinned here: an installed kit wins over a checkout; an explicit
+ * `KIT_WRAPPER_ALLOW_DEV` still wins over that (asking for a dev pin must not be silently
+ * overridden); and a checkout with no install to fall back on is written but LOUD, because
+ * refusing outright would leave the hooks with no wrapper at all — worse than a fragile one.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { chooseWrapperEntry, pathInWorkingTree, defaultGlobalBins } from "./kit-wrapper.js";
+import { describeWrapper, judgeWrapper } from "./hook-floor.js";
+
+const CHECKOUT = "/work/kit-public/dist/cli.js";
+const INSTALLED = "/home/dev/.npm-global/bin/kit";
+const inTree = (p: string): boolean => p.startsWith("/work/");
+const installedExists = (p: string): boolean => p === INSTALLED;
+
+describe("chooseWrapperEntry", () => {
+  it("prefers an installed kit over the checkout that is doing the writing", () => {
+    const r = chooseWrapperEntry({
+      running: CHECKOUT,
+      globalBins: ["/home/dev/.npm-global/bin"],
+      exists: installedExists,
+      inWorkingTree: inTree,
+    });
+    assert.deepEqual(r, { path: INSTALLED, source: "installed" });
+  });
+
+  it("honours an explicit dev pin instead of quietly overriding the request", () => {
+    const r = chooseWrapperEntry({
+      running: CHECKOUT,
+      globalBins: ["/home/dev/.npm-global/bin"],
+      exists: installedExists,
+      inWorkingTree: inTree,
+      allowDev: true,
+    });
+    assert.equal(r?.path, CHECKOUT);
+    assert.equal(r?.source, "running");
+    assert.match(r?.warning ?? "", /by request/);
+    assert.match(r?.warning ?? "", /disarm every kit hook/);
+  });
+
+  it("falls back to the checkout when nothing is installed — but says what that means", () => {
+    const r = chooseWrapperEntry({
+      running: CHECKOUT,
+      globalBins: ["/nowhere/bin"],
+      exists: () => false,
+      inWorkingTree: inTree,
+    });
+    assert.equal(r?.path, CHECKOUT);
+    assert.match(r?.warning ?? "", /no installed kit found/);
+    assert.match(r?.warning ?? "", /npm i -g sandstream-kit/);
+  });
+
+  it("keeps a running entrypoint that is already an install, without probing", () => {
+    const r = chooseWrapperEntry({
+      running: "/usr/local/lib/node_modules/sandstream-kit/dist/cli.js",
+      globalBins: ["/nowhere/bin"],
+      exists: () => false,
+      inWorkingTree: inTree,
+    });
+    assert.equal(r?.source, "running");
+    assert.equal(r?.warning, undefined);
+  });
+
+  it("uses the install when there is no running entrypoint at all", () => {
+    const r = chooseWrapperEntry({
+      globalBins: ["/home/dev/.npm-global/bin"],
+      exists: installedExists,
+      inWorkingTree: inTree,
+    });
+    assert.deepEqual(r, { path: INSTALLED, source: "installed" });
+  });
+
+  it("returns null rather than inventing a path when there is nothing to point at", () => {
+    assert.equal(
+      chooseWrapperEntry({ globalBins: ["/nowhere"], exists: () => false, inWorkingTree: inTree }),
+      null,
+    );
+  });
+
+  it("probes the usual global bin dirs, most specific first", () => {
+    const bins = defaultGlobalBins("/home/dev");
+    assert.equal(bins[0], join("/home/dev", ".npm-global", "bin"));
+    assert.ok(bins.includes("/usr/local/bin"));
+    assert.ok(bins.includes("/opt/homebrew/bin"));
+  });
+});
+
+describe("pathInWorkingTree", () => {
+  it("finds a .git above the path", () => {
+    const exists = (p: string): boolean => p === "/work/kit-public/.git";
+    assert.equal(pathInWorkingTree("/work/kit-public/dist/cli.js", exists), true);
+  });
+
+  it("says no for an install path with no .git above it", () => {
+    assert.equal(
+      pathInWorkingTree("/usr/local/lib/node_modules/sandstream-kit/dist/cli.js", () => false),
+      false,
+    );
+  });
+});
+
+describe("describeWrapper / judgeWrapper", () => {
+  const wrapperBody = (node: string, cli: string): string =>
+    ["#!/bin/sh", "# kit-managed wrapper (do not edit)", `exec "${node}" "${cli}" "$@"`, ""].join(
+      "\n",
+    );
+
+  const withHome = (body?: string): string => {
+    const home = mkdtempSync(join(tmpdir(), "kit-wrap-"));
+    if (body !== undefined) {
+      mkdirSync(join(home, ".kit", "bin"), { recursive: true });
+      writeFileSync(join(home, ".kit", "bin", "kit"), body);
+    }
+    return home;
+  };
+
+  it("skips when there is no wrapper to judge", () => {
+    const home = withHome();
+    try {
+      const v = judgeWrapper(describeWrapper(home));
+      assert.equal(v.status, "skip");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("does not claim an unmanaged file at that path", () => {
+    const home = withHome('#!/bin/sh\nexec /somewhere/else "$@"\n');
+    try {
+      const r = describeWrapper(home);
+      assert.equal(r.managed, false);
+      assert.equal(judgeWrapper(r).status, "skip");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("FAILS when the entrypoint is gone — every hook on the machine is dead", () => {
+    const home = withHome(wrapperBody("/usr/bin/node", "/gone/dist/cli.js"));
+    try {
+      const r = describeWrapper(home);
+      assert.equal(r.entry, "/gone/dist/cli.js");
+      assert.equal(r.entryMissing, true);
+      const v = judgeWrapper(r);
+      assert.equal(v.status, "fail");
+      assert.equal(v.severity, "high");
+      assert.match(v.detail, /EVERY kit hook on this machine is dead/);
+      assert.match(v.detail, /non-blocking, so sessions run ungated/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("warns when the entrypoint is inside a working tree — it works until the next build", () => {
+    const home = withHome("");
+    const tree = mkdtempSync(join(tmpdir(), "kit-wrap-tree-"));
+    try {
+      mkdirSync(join(tree, ".git"), { recursive: true });
+      mkdirSync(join(tree, "dist"), { recursive: true });
+      const cli = join(tree, "dist", "cli.js");
+      writeFileSync(cli, "// build artifact");
+      mkdirSync(join(home, ".kit", "bin"), { recursive: true });
+      writeFileSync(join(home, ".kit", "bin", "kit"), wrapperBody("/usr/bin/node", cli));
+
+      const r = describeWrapper(home);
+      assert.equal(r.entryMissing, false);
+      assert.equal(r.entryInWorkingTree, true);
+      const v = judgeWrapper(r);
+      assert.equal(v.status, "warn");
+      assert.match(v.detail, /inside a git working tree/);
+      assert.match(v.detail, /disarm every kit hook/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(tree, { recursive: true, force: true });
+    }
+  });
+
+  it("passes for an installed entrypoint, and names it", () => {
+    const home = withHome("");
+    const install = mkdtempSync(join(tmpdir(), "kit-wrap-install-"));
+    try {
+      const cli = join(install, "cli.js");
+      writeFileSync(cli, "// installed");
+      mkdirSync(join(home, ".kit", "bin"), { recursive: true });
+      writeFileSync(join(home, ".kit", "bin", "kit"), wrapperBody("/usr/bin/node", cli));
+
+      const v = judgeWrapper(describeWrapper(home));
+      assert.equal(v.status, "pass");
+      assert.match(v.detail, new RegExp(cli.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(install, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/kit-wrapper.ts
+++ b/src/kit-wrapper.ts
@@ -152,6 +152,103 @@ function defaultMiseShimsDir(home: string): string | undefined {
 }
 
 /**
+ * Where a wrapper entrypoint may point, ranked.
+ *
+ * `~/.kit/bin/kit` is the machine-wide wrapper every kit hook in every repo goes through, and it
+ * used to be written with whatever entrypoint happened to be running (`process.argv[1]`). One
+ * `kit hooks add` from a development checkout therefore aimed the whole machine's enforcement
+ * floor at `…/kit-public/dist/cli.js` — a path `npm run build` DELETES on its first step. Measured
+ * consequence (#509): a session in an unrelated repo failed with
+ *
+ *     PreToolUse:Bash hook error … kit CLI entrypoint missing: …/kit-public/dist/cli.js
+ *
+ * and continued UNGATED, because a hook that cannot start is non-blocking.
+ *
+ * So: prefer an INSTALLED kit, whose path is stable by construction, and treat a working-tree
+ * path as the last resort it is.
+ */
+export interface EntryCandidates {
+  /** The entrypoint of the kit process doing the writing (`process.argv[1]`). */
+  running?: string;
+  /** Global npm bin dirs to look for an installed `kit` in. */
+  globalBins: string[];
+  exists: (p: string) => boolean;
+  /** True when `p` sits inside a git working tree — i.e. a checkout, not an install. */
+  inWorkingTree: (p: string) => boolean;
+  /** Opt-in to pinning the wrapper at a checkout anyway. */
+  allowDev?: boolean;
+}
+
+export interface EntryChoice {
+  path: string;
+  source: "installed" | "running";
+  /** Set when the chosen path is a working tree the wrapper should not normally pin. */
+  warning?: string;
+}
+
+/**
+ * Pick the entrypoint to bake into the wrapper. Pure — every branch is testable without a
+ * machine that has (or lacks) a global install.
+ */
+export function chooseWrapperEntry(c: EntryCandidates): EntryChoice | null {
+  const installed = c.globalBins.map((bin) => join(bin, "kit")).find((p) => c.exists(p));
+  const running = c.running;
+  const runningIsCheckout = running !== undefined && c.inWorkingTree(running);
+
+  // Explicit opt-in wins: KIT_WRAPPER_ALLOW_DEV means "pin the checkout on purpose", so the
+  // installed-kit preference must not quietly override the request.
+  if (c.allowDev && running !== undefined && runningIsCheckout) {
+    return {
+      path: running,
+      source: "running",
+      warning: `pinned to a working tree by request (KIT_WRAPPER_ALLOW_DEV): ${running} — a build that cleans dist/ will disarm every kit hook on this machine`,
+    };
+  }
+  // Otherwise an installed kit wins over a checkout: same tool, stable path.
+  if (installed && (runningIsCheckout || running === undefined)) {
+    return { path: installed, source: "installed" };
+  }
+  if (running === undefined) {
+    return installed ? { path: installed, source: "installed" } : null;
+  }
+  if (!runningIsCheckout) {
+    return { path: running, source: "running" };
+  }
+  // A checkout with no installed kit to fall back on: write it, but say what it means. Refusing
+  // outright would leave the hooks with no wrapper at all, which is worse.
+  return {
+    path: running,
+    source: "running",
+    warning:
+      `no installed kit found, so the wrapper points at a working tree: ${running}. ` +
+      `A build that cleans dist/ will disarm every kit hook on this machine until it finishes. ` +
+      `Install kit globally (npm i -g sandstream-kit) and re-run to fix this.`,
+  };
+}
+
+/** Global npm bin dirs worth probing, most specific first. */
+export function defaultGlobalBins(home: string): string[] {
+  return [
+    join(home, ".npm-global", "bin"),
+    join(home, ".npm", "bin"),
+    "/usr/local/bin",
+    "/opt/homebrew/bin",
+  ];
+}
+
+/** Is `p` inside a git working tree? Walks up looking for `.git`. */
+export function pathInWorkingTree(p: string, exists: (q: string) => boolean = existsSync): boolean {
+  let dir = dirname(resolve(p));
+  for (let i = 0; i < 40; i++) {
+    if (exists(join(dir, ".git"))) return true;
+    const up = dirname(dir);
+    if (up === dir) return false;
+    dir = up;
+  }
+  return false;
+}
+
+/**
  * Create or refresh ~/.kit/bin/kit. Idempotent (no write when already current),
  * 0755, and never clobbers an unmanaged file at that path. Returns what it did.
  */
@@ -159,14 +256,28 @@ export function ensureKitWrapper(opts: EnsureWrapperOpts = {}): EnsureWrapperRes
   const home = opts.home ?? homedir();
   const path = kitWrapperPath(home);
 
-  const cliEntry = opts.cliPath ?? (process.argv[1] ? resolve(process.argv[1]) : undefined);
-  if (!cliEntry) {
+  // An explicit cliPath (tests, callers that know better) wins. Otherwise prefer an INSTALLED
+  // kit over the running entrypoint — see chooseWrapperEntry and #509.
+  const choice = opts.cliPath
+    ? { path: resolve(opts.cliPath), source: "running" as const, warning: undefined }
+    : chooseWrapperEntry({
+        running: process.argv[1] ? resolve(process.argv[1]) : undefined,
+        globalBins: defaultGlobalBins(home),
+        exists: existsSync,
+        inWorkingTree: (p) => pathInWorkingTree(p),
+        allowDev: ["1", "true", "yes"].includes(
+          (process.env.KIT_WRAPPER_ALLOW_DEV ?? "").trim().toLowerCase(),
+        ),
+      });
+  if (!choice) {
     return {
       path,
       action: "skipped",
       detail: "could not resolve kit's cli.js path — wrapper not written",
     };
   }
+  const cliEntry = choice.path;
+  if (choice.warning) console.error(`[kit] wrapper: ${choice.warning}`);
 
   const spec: WrapperSpec = {
     nodePath: opts.nodePath ?? process.execPath,
@@ -195,14 +306,22 @@ export function ensureKitWrapper(opts: EnsureWrapperOpts = {}): EnsureWrapperRes
     writeFileSync(path, desired, "utf-8");
     chmodSync(path, 0o755);
     ensureCmdShim(home, spec);
-    return { path, action: "updated", detail: "refreshed node/cli/PATH" };
+    return {
+      path,
+      action: "updated",
+      detail: `refreshed node/cli/PATH → ${cliEntry}${choice.source === "installed" ? " (installed kit)" : ""}`,
+    };
   }
 
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, desired, "utf-8");
   chmodSync(path, 0o755);
   ensureCmdShim(home, spec);
-  return { path, action: "written", detail: "created self-healing wrapper" };
+  return {
+    path,
+    action: "written",
+    detail: `created self-healing wrapper → ${cliEntry}${choice.source === "installed" ? " (installed kit)" : ""}`,
+  };
 }
 
 /**

--- a/src/knobs.ts
+++ b/src/knobs.ts
@@ -164,6 +164,17 @@ export const KNOBS: KnobGroup[] = [
         desc: "air-gap mode: no outbound network; cloud-only scanners are dropped",
       },
       {
+        name: "KIT_TOOL_LATEST_TTL_H",
+        kind: "env",
+        desc: "hours a tool's latest-version answer stays cached in ~/.kit/tool-latest.json (default 24). The gate itself never calls a registry — it reads this cache and says so when it is cold",
+      },
+      {
+        name: "KIT_WRAPPER_ALLOW_DEV",
+        kind: "env",
+        desc: "let ~/.kit/bin/kit point at a kit checkout instead of the installed kit. Every hook on the machine then execs a build artifact that `npm run build` deletes — for kit development only",
+        danger: true,
+      },
+      {
         name: "KIT_NO_HINTS",
         kind: "env",
         desc: "silence the 💡 contextual tips",


### PR DESCRIPTION
Closes #509.

## What went wrong

`~/.kit/bin/kit` is what **every kit hook in every repo** execs. It was written with whatever entrypoint happened to be running:

```ts
// src/kit-wrapper.ts:162 (before)
const cliEntry = opts.cliPath ?? (process.argv[1] ? resolve(process.argv[1]) : undefined);
```

So one `kit hooks add` run as `node dist/cli.js …` from a development checkout aimed the whole machine's enforcement floor at `…/kit-public/dist/cli.js` — a path `npm run build` deletes on its first step (`clean-dist.mjs`). It happened here, and the failure landed in an unrelated repo:

```
PreToolUse:Bash hook error
Failed with non-blocking status code: [kit] hook cannot start:
kit CLI entrypoint missing: /Users/…/kit-public/dist/cli.js
```

The hook died and the session **continued ungated**.

Four properties made it worse than a stale path, and each one is addressed:

| property | fix |
|---|---|
| a repo-local command had a machine-wide effect | the entrypoint no longer depends on where the command ran |
| a dev build is transient *by design* | an installed kit is preferred, because its path is stable by construction |
| it failed open | `kit check` now fails **high** when the wrapper's entrypoint is missing |
| it was silent both ways | the wrapper result names the entrypoint; a working-tree pin warns at write time and in the gate |

## The choice, and its one deliberate exception

`chooseWrapperEntry()` is pure and injectable, so every branch is a table row rather than a machine state:

| running entrypoint | installed kit present | result |
|---|---|---|
| a checkout | yes | **installed** wins |
| a checkout | yes, but `KIT_WRAPPER_ALLOW_DEV=1` | the checkout, with a warning — an explicit dev pin must not be silently overridden |
| a checkout | no | the checkout, **loud**: naming what a build will do, and how to fix it (`npm i -g sandstream-kit`) |
| already an install | — | kept as-is |
| none | yes | installed |
| none | no | `null` — no wrapper written, rather than a path invented |

The third row is the judgement call: refusing outright would leave the hooks with **no** wrapper at all, which is worse than a fragile one. So it writes and says so.

## The gate reports it

The `git hook floor` row (#496/#497) reported the hook *directory*; the wrapper is the other half of the same question, since every hook resolves through it. `judgeWrapper()`:

- **fail (high)** — the entrypoint does not exist: *"EVERY kit hook on this machine is dead until it returns, and a hook that cannot start is non-blocking, so sessions run ungated"*
- **warn (medium)** — the entrypoint is inside a git working tree: it works until the next build
- **pass** — naming the entrypoint
- **skip** — no kit-managed wrapper, or an unmanaged file at that path (never claimed as kit's)

## Knobs

`KIT_WRAPPER_ALLOW_DEV` is registered in `kit config knobs`, marked dangerous. `KIT_TOOL_LATEST_TTL_H` was missing from that surface since it was introduced yesterday and is now registered too — a documented knob that `kit config knobs` does not list is the same class of gap as the rest of this arc.

## Tests

`src/kit-wrapper-entry.test.ts` — 14:

- the six `chooseWrapperEntry` branches above, including that `allowDev` beats the installed-kit preference (the first implementation had that ordering wrong, caught by the table)
- `pathInWorkingTree` finds a `.git` above a path and says no for an install layout
- `describeWrapper` / `judgeWrapper` against real temp homes: absent wrapper → skip; an unmanaged file at that path → skip, never claimed; a missing entrypoint → fail high with the ungated-sessions wording; an entrypoint inside a real `.git` tree → warn; an installed entrypoint → pass, named

## Verification on this machine

The wrapper was regenerated from the installed kit before this change, as the workaround:

```
before:  exec node /Users/…/kit-public/dist/cli.js
after:   exec /usr/local/bin/node /Users/…/.npm-global/bin/kit
```

and verified by moving the checkout's `dist/` aside — `~/.kit/bin/kit --version` still answered. With this change, the same regeneration run from a checkout produces the installed path by default rather than needing the workaround.

- `npm test`: **4429 tests, 0 fail, 0 skipped** (macOS, non-root)
- `eslint src`: 0 errors · `prettier --check "src/**/*.ts"` clean · `kit self-audit`: 16 rules, 0 fail, 0 warn

## Not in this change

Failing **closed** when the wrapper cannot start (issue proposal 5). A broken wrapper blocking every tool call is its own outage, and the useful half — making it loud rather than a single non-blocking line — belongs in the harness contract, not in kit's wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
