### PR TITLE
chore(config): stamp .kit.toml at schema v1 — by hand, because migrate eats comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ id_ed25519
 
 # Full TAP report from `npm test` — written so an intermittent failure keeps its name.
 .kit-test-run.tap
+
+# kit config migration leaves this behind; git history is the real backup
+.kit.toml.backup

--- a/.kit.toml
+++ b/.kit.toml
@@ -1,3 +1,5 @@
+version = 1
+
 [tools]
 node = "22"
 pnpm = "latest"


### PR DESCRIPTION
The `config schema` row from #511 did its job on the first repo it ran in: kit's own `.kit.toml` was at v0 while the schema is v1.

## Why by hand

`kit config migrate` fixes the version and deletes every comment in the file:

```
$ kit config migrate --dry-run
Changes:
  + version = 1                    ← the whole preview

$ kit config migrate && git diff --stat .kit.toml
 .kit.toml | 36 ++++++++++++++++++++----------------

comment lines before: 8      after: 0
```

The parsed data is identical apart from the added `version`, so re-validation passes and nothing flags the loss. What went with it was the reasoning — why those scanners are declared, why the refs are `aqua:`-scheme-qualified (bare names are untriageable and the gate blocks them), where the scanner tokens resolve from, and an inline comment documenting the accepted values of `environment`.

That is filed as **#513** (with the proposals: patch the text instead of re-serialising; refuse silent comment loss; make the dry run report it, since a preview that omits the destructive half is worse than none). This PR does not work around it quietly — it stamps the one line by hand and leaves the defect visible.

## What is in the diff

- `.kit.toml`: `version = 1` at the top. Comments intact (8 before, 8 after).
- `.gitignore`: `.kit.toml.backup`. `migrate` leaves that file behind and nothing ignored it, so the artifact was committable. Git history is the real backup.

## Verification

- `kit config migrate --check` → exit 0
- `kit status` → `✓ config schema  v1, current` (was `○ v0, current is v1`)
- parsed before/after identical apart from `version` (checked with `smol-toml`, not by eye)
- `npm test`: 4439 tests, 0 fail, 0 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)