### PR TITLE
chore(release): 6.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [6.8.0] - 2026-08-21
+
 ### Fixed
 
 - **`kit config migrate` deleted every comment in `.kit.toml`, and the dry run did not say so**

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -1181,7 +1181,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "6.7.0"
+    "version": "6.8.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "6.7.0",
+  "version": "6.8.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
Prep commit for `v6.8.0` — `package.json`, `contracts/kit.opencli.json`, and the CHANGELOG section. Per `docs/RELEASING.md` the tag goes on **this** commit once merged, signed, and the `npm-publish` environment is approved.

## Why 6.8.0

Nothing documented was removed or downgraded, and exit codes stay `[0, 1]` per `public-surface.ts`. But the release adds commands, adds declarable config fields, and adds conditions that can turn a previously-green gate red — the same shape as 6.7.0, which was also a minor.

Notably user-visible:

- `kit check` can now **fail** where it used to say nothing: a wrapper whose entrypoint is missing (every hook on the machine is dead), an installed `context-check` with no `[context]` to compare against, and a `cli-lock.json` naming the wrong installer.
- `kit hooks add context-check` **refuses** without a `[context]` block.
- `kit config migrate` **refuses** to re-serialise a commented config unless `--allow-comment-loss` is passed.
- `kit status` grew a `config schema` row, so a repo whose `.kit.toml` predates the current schema now shows one more `○`.

## What's in it

| issue | change |
|---|---|
| #496 / #497 | the git-hook floor reports where it resolves to and whether an installed gate can actually fail; `context-check` is refused unarmed; per-hook test hints |
| #500 | tool verification: `latest` compared against the installer that would satisfy it, `cli-lock.json` recording measured version + provenance, `kit tools list [--latest]` inventorying declared **and** undeclared CLIs |
| #501 | the install-gate refusal names the hazard (a double-quoted backtick is command substitution) instead of the machinery |
| #503 | `[context]` can declare the identity a repo must use — `vercel.user`, `github.user`, `convex.account` — asserted like `git.email`, with the per-tool profile mechanism as remediation |
| #507 | every spelling of a repo argument reduces to `owner/repo`, so the payload of a repo-fetching installer is triaged whichever form the user typed |
| #509 | the machine-wide wrapper points at the installed kit rather than whichever kit wrote it, and `kit check` fails when its entrypoint is gone |
| #511 | config drift reported both ways: a `config schema` row for the detector that had no caller, and `kit config recommend` for the features that had no detector |
| #513 | `kit config migrate` applies add-only migrations as a text edit, so it stops deleting every comment — and the dry run says which path it would take |
| #489 (follow-up) | the pip maintainer probe counts what PyPI actually publishes and says the number is self-declared metadata, not npm's publish rights |

## Verification

- `npm test` on this commit: **4446 tests, 0 fail, 0 skipped** (macOS, non-root)
- `kit --version` → `6.8.0`; CHANGELOG heading is `## [6.8.0] - 2026-08-21`, matching `package.json` — the publish job refuses a version the changelog does not document
- `kit self-audit`: 16 rules, 0 fail, 0 warn · `eslint src`: 0 errors · `prettier --check` clean
- Board before cutting: **0 open PRs**; the only open issue is #349, a deferred epic

## Before the tag

Fetch the merge **before** tagging — `git fetch origin main` updates `FETCH_HEAD`, not `origin/main`, which put the `v6.7.0` tag on the wrong commit twice:

```sh
gh pr merge <this> --squash --delete-branch
git fetch origin && git checkout main && git reset --hard origin/main
grep -m1 '"version"' package.json      # must read 6.8.0
git tag -s v6.8.0 -m "v6.8.0 — …"
git push origin v6.8.0
```

Then approve the `npm-publish` environment when GitHub asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)