### PR TITLE
fix(ci): a skipped check is neither a failure nor a pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`kit ci` rendered a skipped check as a failure on GitHub and as a pass on GitLab** (#517).
+  Two surfaces, two opposite lies, one missing case.
+
+  The step-summary icon was `pass ? ✅ : warn ? ⚠️ : ❌` — no branch for `skip` — so a run in a
+  directory that is not a project printed twenty-plus ❌ rows above a footer reading
+  *"2 passed, 1 failed, 1 warnings"*: the table and the tally contradicted each other in the same
+  output, because the summary counted skips and the footer never printed them. Three of those red
+  rows were worse than misleading — `socket scan` is **excluded by design** (cloud-only),
+  `bumblebee` was **switched off by the operator** via `KIT_BUMBLEBEE`, and SAST/guarddog are
+  **opt-in** — so kit's own documented design read as broken.
+
+  The GitLab JUnit writer emitted a *bare* `<testcase>` for a skip, and JUnit reads an empty
+  testcase as PASSED. Measured on the same run: `tests="26" failures="1"`, zero `<skipped>` tags,
+  24 empty testcases — 24 checks that never ran, reported green.
+
+  Now: skips get their own icon (`➖`) with the reason they already carried, the footer reads
+  `N passed, N failed, N warnings, N skipped` so the rows add up, the table is ordered
+  failures → warnings → passes → skips (twenty always-red rows at the top is how a report becomes
+  unread), and JUnit emits `<skipped message="…"/>` with a `skipped=` count on the suite.
+
+  Skips still do not gate: `allOk` remains `failed === 0 && (!failOnWarning || warnings === 0)`.
+  Only what the report *says* changed. The machine-read surface was already correct — annotations
+  only ever fired for `fail`/`warn` — which is the worse way round, since the human is the one
+  who concludes "twenty things are broken here".
+
 ## [6.8.0] - 2026-08-21
 
 ### Fixed

--- a/src/ci-report-skip.test.ts
+++ b/src/ci-report-skip.test.ts
@@ -1,0 +1,156 @@
+/**
+ * A check that could not run must read as neither passed nor failed.
+ *
+ * `kit ci` got this wrong in opposite directions on the two CI surfaces (#517). The GitHub
+ * step-summary icon was `pass ? ✅ : warn ? ⚠️ : ❌` — no branch for `skip` — so a run in a
+ * directory that is not a project printed twenty-plus ❌ rows above a footer reading
+ * "**2 passed, 1 failed, 1 warnings**". Among the red rows: `socket scan` (excluded by design,
+ * cloud-only), `bumblebee` (switched off via `KIT_BUMBLEBEE`), and opt-in SAST — kit's own
+ * documented design rendered as broken. The GitLab JUnit writer emitted a **bare** testcase for
+ * a skip, and JUnit reads an empty testcase as PASSED: measured 24 of 26 checks green that never
+ * ran.
+ *
+ * The machine-read surface was right the whole time (`emitGithubAnnotations` annotates only
+ * `fail`/`warn`, and `allOk` never gated on skips), which is the worse way round: the human is
+ * the one who concludes "twenty things are broken" or "everything is green".
+ *
+ * So the properties pinned here are arithmetic ones — the rows and the tally must add up, and a
+ * skipped check must be distinguishable from a passing one in every format that prints both.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { statusIcon, statusRank } from "./commands/ci.js";
+
+const CLI_PATH = resolve(dirname(fileURLToPath(import.meta.url)), "cli.js");
+
+/** A repo where almost nothing applies: no git, no manifests — the shape that exposed this. */
+function bareRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "kit-ci-skip-"));
+  writeFileSync(join(dir, ".kit.toml"), '[secrets.keys]\nMY_KEY = { source = "env" }\n');
+  return dir;
+}
+
+function runCi(dir: string, args: string[], env: Record<string, string> = {}): string {
+  const r = spawnSync(process.execPath, [CLI_PATH, "ci", ...args], {
+    cwd: dir,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      KIT_HIDE_HOOK_SKIP_BANNER: "1",
+      KIT_AUDIT_ANCHOR: "0",
+      // Keep MY_KEY unset so exactly one check fails, as in the report that prompted this.
+      ...env,
+    },
+    timeout: 300_000,
+  });
+  return (r.stdout ?? "") + (r.stderr ?? "");
+}
+
+describe("statusIcon / statusRank", () => {
+  it("gives a skip its own icon rather than the failure one", () => {
+    assert.equal(statusIcon("pass"), "✅");
+    assert.equal(statusIcon("warn"), "⚠️");
+    assert.equal(statusIcon("fail"), "❌");
+    assert.equal(statusIcon("skip"), "➖");
+    // Any future status must not silently borrow ❌ either.
+    assert.equal(statusIcon("something-new"), "➖");
+  });
+
+  it("orders what must be acted on first and what could not run last", () => {
+    const order = ["skip", "pass", "fail", "warn"].sort((a, b) => statusRank(a) - statusRank(b));
+    assert.deepEqual(order, ["fail", "warn", "pass", "skip"]);
+  });
+});
+
+describe("GitHub step summary", () => {
+  it("adds up: every icon count matches the footer, and skips are not failures", () => {
+    const dir = bareRepo();
+    const summary = join(dir, "summary.md");
+    try {
+      runCi(dir, ["--format", "github"], {
+        GITHUB_ACTIONS: "true",
+        GITHUB_STEP_SUMMARY: summary,
+      });
+      assert.ok(existsSync(summary), "the step summary must be written");
+      const md = readFileSync(summary, "utf-8");
+
+      const count = (icon: string): number =>
+        md.split("\n").filter((l) => l.startsWith(`| ${icon} |`)).length;
+      const footer = /\*\*(\d+) passed, (\d+) failed, (\d+) warnings, (\d+) skipped\*\*/.exec(md);
+      assert.ok(footer, `footer must report all four counts:\n${md.slice(-300)}`);
+      const [, passed, failed, warnings, skipped] = footer.map(Number);
+
+      assert.equal(count("✅"), passed, "pass rows vs footer");
+      assert.equal(count("❌"), failed, "fail rows vs footer");
+      assert.equal(count("⚠️"), warnings, "warn rows vs footer");
+      assert.equal(count("➖"), skipped, "skip rows vs footer");
+
+      // The shape that produced the report: many skips, exactly one real failure.
+      assert.ok(skipped > 5, "a bare directory skips most checks");
+      assert.equal(failed, 1, "only the unset secret actually failed");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("puts the failure first and the skips last", () => {
+    const dir = bareRepo();
+    const summary = join(dir, "summary.md");
+    try {
+      runCi(dir, ["--format", "github"], {
+        GITHUB_ACTIONS: "true",
+        GITHUB_STEP_SUMMARY: summary,
+      });
+      const rows = readFileSync(summary, "utf-8")
+        .split("\n")
+        .filter((l) => /^\| (✅|⚠️|❌|➖) \|/.test(l));
+      const icons = rows.map((l) => l.slice(2, l.indexOf(" |", 2)));
+      assert.equal(icons[0], "❌", "act-on-this belongs at the top");
+      assert.equal(icons[icons.length - 1], "➖", "could-not-run belongs at the bottom");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("GitLab JUnit", () => {
+  it("marks a skipped check as skipped, not as an empty (passing) testcase", () => {
+    const dir = bareRepo();
+    try {
+      runCi(dir, ["--format", "gitlab"]);
+      const xml = readFileSync(join(dir, "kit-report.xml"), "utf-8");
+
+      const attrs = /tests="(\d+)" failures="(\d+)" errors="\d+" skipped="(\d+)"/.exec(xml);
+      assert.ok(attrs, "the suite must declare a skipped count");
+      const [, tests, failures, skipped] = attrs.map(Number);
+      assert.ok(skipped > 5);
+      assert.equal(failures, 1);
+
+      const skippedTags = (xml.match(/<skipped /g) ?? []).length;
+      assert.equal(skippedTags, skipped, "one <skipped> per skipped check");
+
+      // No testcase may be empty: an empty one reads as passed, which is how 24 checks that
+      // never ran showed up green.
+      const cases = xml.match(/<testcase [^>]*>([\s\S]*?)<\/testcase>/g) ?? [];
+      const empty = cases.filter(
+        (c) => !c.includes("<failure") && !c.includes("<system-out") && !c.includes("<skipped"),
+      );
+      assert.equal(
+        empty.length,
+        tests - skipped - failures - (xml.match(/<system-out>/g) ?? []).length,
+        "only genuine passes may be empty testcases",
+      );
+      // And the reason survives into the report.
+      assert.match(xml, /<skipped message="[^"]+"/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli-checks-shared.ts
+++ b/src/cli-checks-shared.ts
@@ -82,10 +82,13 @@ export function emitGithubAnnotations(checks: JsonCheck[]): void {
 export function emitGitlabJunit(checks: JsonCheck[], allOk: boolean): void {
   const failures = checks.filter((c) => c.status === "fail");
   const warnings = checks.filter((c) => c.status === "warn");
+  const skipped = checks.filter(
+    (c) => c.status !== "fail" && c.status !== "warn" && c.status !== "pass",
+  );
   const lines: string[] = [
     `<?xml version="1.0" encoding="UTF-8"?>`,
-    `<testsuites name="kit-ci" tests="${checks.length}" failures="${failures.length}" errors="0">`,
-    `  <testsuite name="kit" tests="${checks.length}" failures="${failures.length}">`,
+    `<testsuites name="kit-ci" tests="${checks.length}" failures="${failures.length}" errors="0" skipped="${skipped.length}">`,
+    `  <testsuite name="kit" tests="${checks.length}" failures="${failures.length}" skipped="${skipped.length}">`,
   ];
   for (const ch of checks) {
     lines.push(`    <testcase name="${xmlEscape(ch.name)}" classname="${xmlEscape(ch.category)}">`);
@@ -93,6 +96,11 @@ export function emitGitlabJunit(checks: JsonCheck[], allOk: boolean): void {
       lines.push(`      <failure message="${xmlEscape(ch.detail)}"/>`);
     } else if (ch.status === "warn") {
       lines.push(`      <system-out>${xmlEscape(ch.detail)}</system-out>`);
+    } else if (ch.status !== "pass") {
+      // JUnit reads an empty testcase as PASSED, so a skipped check used to render green:
+      // 24 of 26 checks in a directory where nothing applied (#517). `<skipped>` is the
+      // element that exists for exactly this, and the reason goes with it.
+      lines.push(`      <skipped message="${xmlEscape(ch.detail)}"/>`);
     }
     lines.push(`    </testcase>`);
   }
@@ -103,7 +111,7 @@ export function emitGitlabJunit(checks: JsonCheck[], allOk: boolean): void {
   writeFileSync("kit-report.xml", xml, "utf8");
   if (!allOk || warnings.length > 0) {
     console.log(
-      `CI report written to kit-report.xml (${failures.length} failures, ${warnings.length} warnings)`,
+      `CI report written to kit-report.xml (${failures.length} failures, ${warnings.length} warnings, ${skipped.length} skipped)`,
     );
   }
 }

--- a/src/commands/ci.ts
+++ b/src/commands/ci.ts
@@ -31,6 +31,34 @@ import {
   maybeEmitCheckAttestation,
 } from "../cli-checks-shared.js";
 
+/** Icon per check status. `skip` is its own state — it is neither a pass nor a failure (#517). */
+export function statusIcon(status: string): string {
+  switch (status) {
+    case "pass":
+      return "✅";
+    case "warn":
+      return "⚠️";
+    case "fail":
+      return "❌";
+    default:
+      return "➖";
+  }
+}
+
+/** Report order: what must be acted on first, what could not run last. */
+export function statusRank(status: string): number {
+  switch (status) {
+    case "fail":
+      return 0;
+    case "warn":
+      return 1;
+    case "pass":
+      return 2;
+    default:
+      return 3;
+  }
+}
+
 export async function cmdCi(): Promise<boolean> {
   const args = process.argv.slice(2);
 
@@ -207,12 +235,22 @@ export async function cmdCi(): Promise<boolean> {
             "## kit CI Report",
             `| Status | Check | Detail |`,
             `|--------|-------|--------|`,
-            ...checks.map(
-              (c) =>
-                `| ${c.status === "pass" ? "✅" : c.status === "warn" ? "⚠️" : "❌"} | \`${mdCell(`${c.category}/${c.name}`)}\` | ${mdCell(c.detail)} |`,
-            ),
+            // A skip has its own icon. Without one, every not-applicable check rendered ❌ —
+            // a run in a directory that is not a project showed 20+ red rows above a footer
+            // saying "1 failed", and the deliberate exclusions (Socket cloud-only, a
+            // KIT_BUMBLEBEE=0 opt-out, opt-in SAST) read as kit's own design being broken
+            // (#517). Failures first, then warnings, then skips: twenty always-red rows at the
+            // top is how a report becomes unread.
+            ...[...checks]
+              .sort((a, b) => statusRank(a.status) - statusRank(b.status))
+              .map(
+                (c) =>
+                  `| ${statusIcon(c.status)} | \`${mdCell(`${c.category}/${c.name}`)}\` | ${mdCell(c.detail)} |`,
+              ),
             ``,
-            `**${summary.passed} passed, ${summary.failed} failed, ${summary.warnings} warnings**`,
+            // Skipped belongs in the tally: the rows and the count must add up, or the report
+            // contradicts itself in the same output.
+            `**${summary.passed} passed, ${summary.failed} failed, ${summary.warnings} warnings, ${summary.skipped} skipped**`,
           ];
           await import("node:fs/promises").then(({ appendFile }) =>
             appendFile(process.env.GITHUB_STEP_SUMMARY!, lines.join("\n") + "\n"),


### PR DESCRIPTION
Closes #517.

## What the report said, and what had happened

A `kit ci` run in a directory that is not a project:

```
## kit CI Report
❌ secrets/MY_KEY                       Not set in environment
❌ security/dependency/npm audit        no package.json found
❌ security/secrets/secrets scan        not a git repository
❌ security/supply-chain/socket scan    Socket is cloud-only … excluded from kit's local-first check
❌ security/supply-chain/bumblebee      disabled via KIT_BUMBLEBEE
…20 more ❌…

**2 passed, 1 failed, 1 warnings**
```

Twenty-plus red rows above a footer saying **one** failed. The icon was `pass ? ✅ : warn ? ⚠️ : ❌`, with no branch for `skip`, and the footer never printed the skipped count the summary object was already keeping. So the table and the tally contradicted each other in the same output.

Three of the red rows were worse than misleading: `socket scan` is **excluded by design** (cloud-only, stated in its own detail text), `bumblebee` was **switched off by the operator** via `KIT_BUMBLEBEE`, and SAST/guarddog are **opt-in**. kit's own documented design, rendered as broken.

And the mirror image on GitLab — JUnit reads an empty `<testcase>` as PASSED:

```
tests="26" failures="1"
<skipped> tags: 0
empty testcases: 24        ← 24 checks that never ran, reported green
```

## After

```
| ❌ | `secrets/MY_KEY`                          | Not set in environment |
| ⚠️ | `security/secrets/.env gitignored`        | .gitignore not found |
| ✅ | `security/supply-chain/pinned versions`   | all dependencies pinned |
| ➖ | `security/supply-chain/socket scan`       | Socket is cloud-only … |

**6 passed, 1 failed, 1 warnings, 18 skipped**
```

Icon counts: `✅=6 ⚠️=1 ❌=1 ➖=18` — 26, matching `tests=`. JUnit: `tests="26" failures="1" errors="0" skipped="18"` with 18 `<skipped message="…"/>`.

Ordered failures → warnings → passes → skips, because twenty always-red rows at the top is how a report becomes unread — the same failure one level up from the one being fixed.

## What did not change

Skips still do not gate. `allOk` remains `failed === 0 && (!failOnWarning || warnings === 0)`, and `emitGithubAnnotations` still annotates only `fail`/`warn`. The machine-read surface was correct all along, which is the worse way round: the human is the one who concludes "twenty things are broken" (GitHub) or "everything is green" (GitLab), and neither was what kit measured.

## Tests

`src/ci-report-skip.test.ts` — 5:

- `statusIcon` gives `skip` its own icon, and an unknown future status does not silently borrow ❌
- `statusRank` orders fail → warn → pass → skip
- step summary, driven through the compiled CLI in a bare repo: **every icon count equals its footer number**, with the shape that produced the report asserted (many skips, exactly one real failure)
- ordering: the first row is the failure, the last is a skip
- JUnit: one `<skipped>` per skipped check, the `skipped=` attribute matches, the reason survives into the report, and **no testcase is empty** unless it is a genuine pass

## Verification

- `npm test`: **4451 tests, 0 fail, 0 skipped** (macOS, non-root)
- `kit self-audit`: 16 rules, 0 fail, 0 warn · `eslint src`: 0 errors · `prettier --check` clean
- Both formats regenerated from the exact reproduction in the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)