### PR TITLE
fix(check): a skipped scanner is not a passing one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,56 +120,6 @@
   `kit audit` shows both, and prints `—` for entries written before the fields existed rather than
   guessing.
 
-- **`kit ci` rendered a skipped check as a failure on GitHub and as a pass on GitLab** (#517).
-  Two surfaces, two opposite lies, one missing case.
-
-  The step-summary icon was `pass ? ✅ : warn ? ⚠️ : ❌` — no branch for `skip` — so a run in a
-  directory that is not a project printed twenty-plus ❌ rows above a footer reading
-  *"2 passed, 1 failed, 1 warnings"*: the table and the tally contradicted each other in the same
-  output, because the summary counted skips and the footer never printed them. Three of those red
-  rows were worse than misleading — `socket scan` is **excluded by design** (cloud-only),
-  `bumblebee` was **switched off by the operator** via `KIT_BUMBLEBEE`, and SAST/guarddog are
-  **opt-in** — so kit's own documented design read as broken.
-
-  The GitLab JUnit writer emitted a *bare* `<testcase>` for a skip, and JUnit reads an empty
-  testcase as PASSED. Measured on the same run: `tests="26" failures="1"`, zero `<skipped>` tags,
-  24 empty testcases — 24 checks that never ran, reported green.
-
-  Now: skips get their own icon (`➖`) with the reason they already carried, the footer reads
-  `N passed, N failed, N warnings, N skipped` so the rows add up, the table is ordered
-  failures → warnings → passes → skips (twenty always-red rows at the top is how a report becomes
-  unread), and JUnit emits `<skipped message="…"/>` with a `skipped=` count on the suite.
-
-  Skips still do not gate: `allOk` remains `failed === 0 && (!failOnWarning || warnings === 0)`.
-  Only what the report *says* changed. The machine-read surface was already correct — annotations
-  only ever fired for `fail`/`warn` — which is the worse way round, since the human is the one
-  who concludes "twenty things are broken here".
-
-- **`kit ci` rendered a skipped check as a failure on GitHub and as a pass on GitLab** (#517).
-  Two surfaces, two opposite lies, one missing case.
-
-  The step-summary icon was `pass ? ✅ : warn ? ⚠️ : ❌` — no branch for `skip` — so a run in a
-  directory that is not a project printed twenty-plus ❌ rows above a footer reading
-  *"2 passed, 1 failed, 1 warnings"*: the table and the tally contradicted each other in the same
-  output, because the summary counted skips and the footer never printed them. Three of those red
-  rows were worse than misleading — `socket scan` is **excluded by design** (cloud-only),
-  `bumblebee` was **switched off by the operator** via `KIT_BUMBLEBEE`, and SAST/guarddog are
-  **opt-in** — so kit's own documented design read as broken.
-
-  The GitLab JUnit writer emitted a *bare* `<testcase>` for a skip, and JUnit reads an empty
-  testcase as PASSED. Measured on the same run: `tests="26" failures="1"`, zero `<skipped>` tags,
-  24 empty testcases — 24 checks that never ran, reported green.
-
-  Now: skips get their own icon (`➖`) with the reason they already carried, the footer reads
-  `N passed, N failed, N warnings, N skipped` so the rows add up, the table is ordered
-  failures → warnings → passes → skips (twenty always-red rows at the top is how a report becomes
-  unread), and JUnit emits `<skipped message="…"/>` with a `skipped=` count on the suite.
-
-  Skips still do not gate: `allOk` remains `failed === 0 && (!failOnWarning || warnings === 0)`.
-  Only what the report *says* changed. The machine-read surface was already correct — annotations
-  only ever fired for `fail`/`warn` — which is the worse way round, since the human is the one
-  who concludes "twenty things are broken here".
-
 ### Changed
 
 - **A scanner that finds nothing now says what it looked for** (#525).
@@ -201,6 +151,8 @@
   view that leaves the terminal in the alternate screen with raw mode on makes the operator's shell
   look dead. Verified through a pty: `q`, Esc, Ctrl-C, SIGINT and SIGTERM all give the screen
   back.
+
+## [6.8.0] - 2026-08-21
 
 ### Fixed
 
@@ -340,7 +292,30 @@
   that requiring kit to run where `.kit.toml` lives would not have helped here: the workspace root
   in the report has its own `.kit.toml`.
 
-## [6.8.0] - 2026-08-21
+- **`kit ci` rendered a skipped check as a failure on GitHub and as a pass on GitLab** (#517).
+  Two surfaces, two opposite lies, one missing case.
+
+  The step-summary icon was `pass ? ✅ : warn ? ⚠️ : ❌` — no branch for `skip` — so a run in a
+  directory that is not a project printed twenty-plus ❌ rows above a footer reading
+  *"2 passed, 1 failed, 1 warnings"*: the table and the tally contradicted each other in the same
+  output, because the summary counted skips and the footer never printed them. Three of those red
+  rows were worse than misleading — `socket scan` is **excluded by design** (cloud-only),
+  `bumblebee` was **switched off by the operator** via `KIT_BUMBLEBEE`, and SAST/guarddog are
+  **opt-in** — so kit's own documented design read as broken.
+
+  The GitLab JUnit writer emitted a *bare* `<testcase>` for a skip, and JUnit reads an empty
+  testcase as PASSED. Measured on the same run: `tests="26" failures="1"`, zero `<skipped>` tags,
+  24 empty testcases — 24 checks that never ran, reported green.
+
+  Now: skips get their own icon (`➖`) with the reason they already carried, the footer reads
+  `N passed, N failed, N warnings, N skipped` so the rows add up, the table is ordered
+  failures → warnings → passes → skips (twenty always-red rows at the top is how a report becomes
+  unread), and JUnit emits `<skipped message="…"/>` with a `skipped=` count on the suite.
+
+  Skips still do not gate: `allOk` remains `failed === 0 && (!failOnWarning || warnings === 0)`.
+  Only what the report *says* changed. The machine-read surface was already correct — annotations
+  only ever fired for `fail`/`warn` — which is the worse way round, since the human is the one
+  who concludes "twenty things are broken here".
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,31 @@
   only ever fired for `fail`/`warn` — which is the worse way round, since the human is the one
   who concludes "twenty things are broken here".
 
+- **`kit ci` rendered a skipped check as a failure on GitHub and as a pass on GitLab** (#517).
+  Two surfaces, two opposite lies, one missing case.
+
+  The step-summary icon was `pass ? ✅ : warn ? ⚠️ : ❌` — no branch for `skip` — so a run in a
+  directory that is not a project printed twenty-plus ❌ rows above a footer reading
+  *"2 passed, 1 failed, 1 warnings"*: the table and the tally contradicted each other in the same
+  output, because the summary counted skips and the footer never printed them. Three of those red
+  rows were worse than misleading — `socket scan` is **excluded by design** (cloud-only),
+  `bumblebee` was **switched off by the operator** via `KIT_BUMBLEBEE`, and SAST/guarddog are
+  **opt-in** — so kit's own documented design read as broken.
+
+  The GitLab JUnit writer emitted a *bare* `<testcase>` for a skip, and JUnit reads an empty
+  testcase as PASSED. Measured on the same run: `tests="26" failures="1"`, zero `<skipped>` tags,
+  24 empty testcases — 24 checks that never ran, reported green.
+
+  Now: skips get their own icon (`➖`) with the reason they already carried, the footer reads
+  `N passed, N failed, N warnings, N skipped` so the rows add up, the table is ordered
+  failures → warnings → passes → skips (twenty always-red rows at the top is how a report becomes
+  unread), and JUnit emits `<skipped message="…"/>` with a `skipped=` count on the suite.
+
+  Skips still do not gate: `allOk` remains `failed === 0 && (!failOnWarning || warnings === 0)`.
+  Only what the report *says* changed. The machine-read surface was already correct — annotations
+  only ever fired for `fail`/`warn` — which is the worse way round, since the human is the one
+  who concludes "twenty things are broken here".
+
 ### Changed
 
 - **A scanner that finds nothing now says what it looked for** (#525).
@@ -297,6 +322,23 @@
 
   The three passing cases carry as much weight as the warning one: a check that warns on every
   monorepo gets switched off within a week, and then the case it was written for goes unnoticed too.
+
+
+
+  And in that wrong-directory case the individual skips are no longer left as honest
+  not-applicables. "No manifest at this path" and "I looked in the wrong place" are the same
+  sentence from a scanner's point of view and opposite facts from the operator's, so each
+  manifest-absence skip becomes a warning that says where the code actually is:
+
+  ```
+  ! npm audit     warn  no package.json found — but 3 project(s) below do (illithid, web,
+                        web-corrupt-backup); this scan looked in the wrong place   [medium]
+  ```
+
+  Only in that case. `socket scan` (cloud-only, excluded by design) and opt-in SAST stay skips, and
+  an ordinary project or a workspace root that genuinely covers its children is untouched. Note
+  that requiring kit to run where `.kit.toml` lives would not have helped here: the workspace root
+  in the report has its own `.kit.toml`.
 
 ## [6.8.0] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,31 @@
   `kit audit` shows both, and prints `—` for entries written before the fields existed rather than
   guessing.
 
+- **`kit ci` rendered a skipped check as a failure on GitHub and as a pass on GitLab** (#517).
+  Two surfaces, two opposite lies, one missing case.
+
+  The step-summary icon was `pass ? ✅ : warn ? ⚠️ : ❌` — no branch for `skip` — so a run in a
+  directory that is not a project printed twenty-plus ❌ rows above a footer reading
+  *"2 passed, 1 failed, 1 warnings"*: the table and the tally contradicted each other in the same
+  output, because the summary counted skips and the footer never printed them. Three of those red
+  rows were worse than misleading — `socket scan` is **excluded by design** (cloud-only),
+  `bumblebee` was **switched off by the operator** via `KIT_BUMBLEBEE`, and SAST/guarddog are
+  **opt-in** — so kit's own documented design read as broken.
+
+  The GitLab JUnit writer emitted a *bare* `<testcase>` for a skip, and JUnit reads an empty
+  testcase as PASSED. Measured on the same run: `tests="26" failures="1"`, zero `<skipped>` tags,
+  24 empty testcases — 24 checks that never ran, reported green.
+
+  Now: skips get their own icon (`➖`) with the reason they already carried, the footer reads
+  `N passed, N failed, N warnings, N skipped` so the rows add up, the table is ordered
+  failures → warnings → passes → skips (twenty always-red rows at the top is how a report becomes
+  unread), and JUnit emits `<skipped message="…"/>` with a `skipped=` count on the suite.
+
+  Skips still do not gate: `allOk` remains `failed === 0 && (!failOnWarning || warnings === 0)`.
+  Only what the report *says* changed. The machine-read surface was already correct — annotations
+  only ever fired for `fail`/`warn` — which is the worse way round, since the human is the one
+  who concludes "twenty things are broken here".
+
 ### Changed
 
 - **A scanner that finds nothing now says what it looked for** (#525).
@@ -229,30 +254,49 @@
   The banner now says `N entries came from a rebase/cherry-pick replay — not counted.` rather than
   silently reporting a smaller number than the log is long.
 
-- **`kit ci` rendered a skipped check as a failure on GitHub and as a pass on GitLab** (#517).
-  Two surfaces, two opposite lies, one missing case.
+- **A skipped scanner was counted as a passing one in the verdict line** (#521).
 
-  The step-summary icon was `pass ? ✅ : warn ? ⚠️ : ❌` — no branch for `skip` — so a run in a
-  directory that is not a project printed twenty-plus ❌ rows above a footer reading
-  *"2 passed, 1 failed, 1 warnings"*: the table and the tally contradicted each other in the same
-  output, because the summary counted skips and the footer never printed them. Three of those red
-  rows were worse than misleading — `socket scan` is **excluded by design** (cloud-only),
-  `bumblebee` was **switched off by the operator** via `KIT_BUMBLEBEE`, and SAST/guarddog are
-  **opt-in** — so kit's own documented design read as broken.
+  Run from a workspace root that holds several repos side by side — `web/`, `illithid/` — every
+  manifest-dependent scanner skipped truthfully ("no package.json found") and the summary printed:
 
-  The GitLab JUnit writer emitted a *bare* `<testcase>` for a skip, and JUnit reads an empty
-  testcase as PASSED. Measured on the same run: `tests="26" failures="1"`, zero `<skipped>` tags,
-  24 empty testcases — 24 checks that never ran, reported green.
+  ```
+  All 25 checks passed ✓
+  ```
 
-  Now: skips get their own icon (`➖`) with the reason they already carried, the footer reads
-  `N passed, N failed, N warnings, N skipped` so the rows add up, the table is ordered
-  failures → warnings → passes → skips (twenty always-red rows at the top is how a report becomes
-  unread), and JUnit emits `<skipped message="…"/>` with a `skipped=` count on the suite.
+  Fifteen of those twenty-five had never run. The same command one directory down, where the code
+  actually lives, reported **30 known dependency vulnerabilities (high)**, 22 unpinned dependencies
+  and 18 secret-shaped strings in git history. The green line was covering all of it.
 
-  Skips still do not gate: `allOk` remains `failed === 0 && (!failOnWarning || warnings === 0)`.
-  Only what the report *says* changed. The machine-read surface was already correct — annotations
-  only ever fired for `fail`/`warn` — which is the worse way round, since the human is the one
-  who concludes "twenty things are broken here".
+  `printSummary` counted `status === "pass" || status === "skip"` as OK and then declared "All N
+  checks passed" whenever that count reached the total. This is the same defect class as #517 — a
+  check that could not run rendering as success — one level up, in the line most people read
+  instead of the rows. Now there are three states rather than two:
+
+  ```
+  All 26 checks passed ✓                              (everything ran, everything passed)
+  10 passed  ·  15 could not run                      (everything that ran passed)
+  10/26 passed  ·  15 could not run  ·  1 real issue  (something to act on)
+  ```
+
+  A run with no applicable checks at all now says `no checks applied here` instead of "All 0 checks
+  passed ✓". Skips still do not gate — they are counted and named, not failed.
+
+- **A directory with no manifest is not a directory with nothing to scan** (#521).
+
+  New `scan scope` check, enumerated in every security run, because each individual skip was true
+  and the missing row was the one stating the consequence — that the verdict described an empty
+  directory while the code sat one level down:
+
+  - no manifest here, projects below → **warn (high)**, naming them: *"no manifest here — this
+    verdict covers none of 3 project(s) below: illithid, web, web-corrupt-backup"*;
+  - a root manifest declaring workspaces → **pass**: *"12 nested package(s) covered via
+    workspaces"* — a root-level scan genuinely does cover those;
+  - a root manifest without workspaces, siblings below → **warn (medium)**: they are separate
+    projects and were not scanned;
+  - an ordinary single project → **pass**, quietly.
+
+  The three passing cases carry as much weight as the warning one: a check that warns on every
+  monorepo gets switched off within a week, and then the case it was written for goes unnoticed too.
 
 ## [6.8.0] - 2026-08-21
 

--- a/src/check-nested-projects.test.ts
+++ b/src/check-nested-projects.test.ts
@@ -18,7 +18,15 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { checkScanScope, findNestedProjects } from "./check-nested-projects.js";
+import {
+  checkScanScope,
+  findNestedProjects,
+  scanScopeFacts,
+  escalateManifestSkips,
+  lookedInTheWrongPlace,
+  type ScanScope,
+} from "./check-nested-projects.js";
+import type { SecurityCheckResult } from "./check-security.js";
 
 function tree(spec: Record<string, string>): string {
   const dir = mkdtempSync(join(tmpdir(), "kit-scope-"));
@@ -130,5 +138,89 @@ describe("findNestedProjects", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+/**
+ * "There is nothing to scan" and "I looked in the wrong place" are the same sentence from a
+ * scanner's point of view and opposite facts from the operator's. Each individual skip was true;
+ * the sum of them was a green verdict over an empty directory. So the meaning is resolved once,
+ * from the scope facts, and only in the wrong-place case.
+ */
+describe("escalateManifestSkips", () => {
+  const skip = (name: string, detail: string): SecurityCheckResult => ({
+    category: "dependency",
+    name,
+    status: "skip",
+    detail,
+  });
+  const wrongPlace: ScanScope = {
+    rootManifest: false,
+    nested: ["web", "illithid"],
+    workspaces: false,
+  };
+  const ordinary: ScanScope = { rootManifest: true, nested: [], workspaces: false };
+
+  it("turns a manifest-absence skip into a warning that says where the code is", () => {
+    const out = escalateManifestSkips(
+      [skip("npm audit", "no package.json found"), skip("osv-scanner", "no lockfiles to scan")],
+      wrongPlace,
+    );
+    assert.deepEqual(
+      out.map((r) => r.status),
+      ["warn", "warn"],
+    );
+    for (const r of out) {
+      assert.match(r.detail, /looked in the wrong place/);
+      assert.match(r.detail, /web/);
+      assert.equal(r.severity, "medium");
+    }
+  });
+
+  it("leaves a skip that is genuinely not applicable alone", () => {
+    // Socket is cloud-only and excluded by design; SAST is opt-in. Neither is about a manifest, and
+    // rewriting them would make the report noise in exactly the repos that are set up correctly.
+    const out = escalateManifestSkips(
+      [
+        skip("socket scan", "Socket is cloud-only — excluded from kit's local-first check"),
+        skip("semgrep SAST", "SAST opt-in: set KIT_SEMGREP_CONFIG"),
+      ],
+      wrongPlace,
+    );
+    assert.deepEqual(
+      out.map((r) => r.status),
+      ["skip", "skip"],
+    );
+  });
+
+  it("changes nothing in an ordinary project", () => {
+    const input = [skip("pip-audit", "no requirements.txt found")];
+    assert.deepEqual(escalateManifestSkips(input, ordinary), input);
+    assert.equal(lookedInTheWrongPlace(ordinary), false);
+  });
+
+  it("changes nothing for a workspace root that genuinely covers its children", async () => {
+    const dir = tree({
+      "package.json": JSON.stringify({ workspaces: ["packages/*"] }),
+      "packages/a/package.json": "{}",
+    });
+    try {
+      const facts = await scanScopeFacts(dir);
+      assert.equal(lookedInTheWrongPlace(facts), false, "a root manifest exists — kit is in place");
+      const input = [skip("npm audit", "no package.json found")];
+      assert.deepEqual(escalateManifestSkips(input, facts), input);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not touch a result that already passed or failed", () => {
+    const pass: SecurityCheckResult = {
+      category: "dependency",
+      name: "pinned versions",
+      status: "pass",
+      detail: "no package.json found but irrelevant",
+    };
+    assert.equal(escalateManifestSkips([pass], wrongPlace)[0].status, "pass");
   });
 });

--- a/src/check-nested-projects.test.ts
+++ b/src/check-nested-projects.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The false green this check exists to prevent, and the three cases that must NOT warn.
+ *
+ * Measured on a real workspace root holding `web/` and `illithid/` side by side: every
+ * manifest-dependent scanner skipped truthfully, the summary read "All 25 checks passed ✓", and the
+ * same command one directory down reported 30 known dependency vulnerabilities (high), 22 unpinned
+ * dependencies and 18 secret-shaped strings in history. So the property is not "warn when a
+ * directory looks odd" — it is: **a verdict must never describe an empty directory as if it
+ * described the code.**
+ *
+ * The three passing cases matter as much as the warning one. A check that warns on every monorepo
+ * would be turned off within a week, and then the case it was written for goes unnoticed too.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { checkScanScope, findNestedProjects } from "./check-nested-projects.js";
+
+function tree(spec: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), "kit-scope-"));
+  for (const [rel, content] of Object.entries(spec)) {
+    const full = join(dir, rel);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return dir;
+}
+
+describe("checkScanScope", () => {
+  it("warns, at high severity, when the manifests live below and not here", async () => {
+    const dir = tree({
+      "web/package.json": "{}",
+      "illithid/pyproject.toml": "",
+      "CLAUDE.md": "# workspace root\n",
+    });
+    try {
+      const r = await checkScanScope(dir);
+      assert.equal(r.status, "warn", r.detail);
+      assert.equal(r.severity, "high", "the code being somewhere else is not a cosmetic remark");
+      assert.match(r.detail, /covers none of 2 project\(s\)/);
+      // The paths must be named: "something below was missed" without saying what is not actionable.
+      assert.match(r.detail, /illithid/);
+      assert.match(r.detail, /web/);
+      assert.match(String(r.suggestion), /kit check/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("passes when the root declares workspaces — a root scan does cover those children", async () => {
+    const dir = tree({
+      "package.json": JSON.stringify({ workspaces: ["packages/*"] }),
+      "packages/a/package.json": "{}",
+      "packages/b/package.json": "{}",
+    });
+    try {
+      const r = await checkScanScope(dir);
+      assert.equal(r.status, "pass", r.detail);
+      assert.match(r.detail, /covered via workspaces/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("warns at medium when a root project has uncovered siblings under it", async () => {
+    const dir = tree({
+      "package.json": JSON.stringify({ name: "root", dependencies: {} }),
+      "service/go.mod": "module x\n",
+    });
+    try {
+      const r = await checkScanScope(dir);
+      assert.equal(r.status, "warn", r.detail);
+      assert.equal(r.severity, "medium", "the root itself WAS scanned, so this is weaker");
+      assert.match(r.detail, /NOT covered/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("passes quietly for an ordinary single project", async () => {
+    const dir = tree({ "package.json": "{}", "src/index.ts": "export {};\n" });
+    try {
+      const r = await checkScanScope(dir);
+      assert.equal(r.status, "pass");
+      assert.match(r.detail, /scanned in place/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("findNestedProjects", () => {
+  it("ignores dependency and build directories, which are not the operator's projects", async () => {
+    const dir = tree({
+      "node_modules/left-pad/package.json": "{}",
+      "dist/package.json": "{}",
+      ".venv/lib/pyproject.toml": "",
+      "target/Cargo.toml": "",
+      "app/package.json": "{}",
+    });
+    try {
+      assert.deepEqual(await findNestedProjects(dir), ["app"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("stops at the project it finds rather than enumerating that project's own packages", async () => {
+    const dir = tree({
+      "web/package.json": "{}",
+      "web/packages/inner/package.json": "{}",
+    });
+    try {
+      // `kit check` run inside web/ is what enumerates web/packages — reporting both here would
+      // turn one misplaced run into a wall of rows.
+      assert.deepEqual(await findNestedProjects(dir), ["web"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("finds a project one level deeper, the packages/* layout", async () => {
+    const dir = tree({ "packages/a/package.json": "{}", "packages/b/Cargo.toml": "" });
+    try {
+      assert.deepEqual(await findNestedProjects(dir), ["packages/a", "packages/b"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/check-nested-projects.ts
+++ b/src/check-nested-projects.ts
@@ -1,0 +1,169 @@
+/**
+ * A directory with no manifest is not a directory with nothing to scan.
+ *
+ * Run from a workspace root that holds several repos side by side — `web/`, `illithid/` — every
+ * manifest-dependent scanner skips honestly ("no package.json found") and the summary line reads
+ * *"All 25 checks passed ✓"*. Measured on one such tree: 15 of the 25 were skips, and running the
+ * same command one directory down produced 30 known dependency vulnerabilities (high), 22 unpinned
+ * dependencies and 18 secret-shaped strings in history. The green line was covering all of it.
+ *
+ * Each individual skip was *true* — npm audit genuinely has nothing to audit at that path. What was
+ * missing is the row that states the consequence: this verdict describes an empty directory, and
+ * the code lives somewhere it did not look. So this check exists to make the absence visible, and
+ * to name the paths that were not covered.
+ *
+ * Deliberately a `warn`, not a `fail`: nothing is broken, and a scan of the wrong directory is the
+ * operator's to fix by running kit where the code is. But it must never be a silent pass.
+ */
+
+import { readdir, readFile, access } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { SecurityCheckResult } from "./check-security.js";
+
+/** Manifests that mean "there is a project here worth scanning". */
+const MANIFESTS = [
+  "package.json",
+  "requirements.txt",
+  "pyproject.toml",
+  "Cargo.toml",
+  "go.mod",
+  "pom.xml",
+  "build.gradle",
+  "build.gradle.kts",
+  "Gemfile",
+  "composer.json",
+];
+
+/** Directories that never represent a project of the operator's own. */
+const IGNORED = new Set([
+  "node_modules",
+  ".git",
+  ".next",
+  ".nuxt",
+  "dist",
+  "build",
+  "out",
+  "target",
+  "vendor",
+  "coverage",
+  ".venv",
+  "venv",
+  "__pycache__",
+  ".terraform",
+  ".cache",
+  ".turbo",
+  "tmp",
+]);
+
+async function hasManifest(dir: string): Promise<boolean> {
+  for (const m of MANIFESTS) {
+    try {
+      await access(join(dir, m));
+      return true;
+    } catch {
+      /* keep looking */
+    }
+  }
+  return false;
+}
+
+/**
+ * Immediate-child projects, plus one level deeper (a `packages/*` layout is the common case). Depth
+ * is bounded at 2 on purpose: this is a "you are standing in the wrong directory" detector, not a
+ * repository crawler, and an unbounded walk on a home directory would cost more than the check is
+ * worth.
+ */
+export async function findNestedProjects(root: string, maxDepth = 2): Promise<string[]> {
+  const found: string[] = [];
+
+  const walk = async (dir: string, rel: string, depth: number): Promise<void> => {
+    if (depth > maxDepth) return;
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (!e.isDirectory() || e.name.startsWith(".") || IGNORED.has(e.name)) continue;
+      const childRel = rel ? `${rel}/${e.name}` : e.name;
+      const childAbs = join(dir, e.name);
+      if (await hasManifest(childAbs)) {
+        found.push(childRel);
+        // Do not descend into a project we already found: its own subpackages are that
+        // project's business, and `kit check` there will enumerate them.
+        continue;
+      }
+      await walk(childAbs, childRel, depth + 1);
+    }
+  };
+
+  await walk(root, "", 1);
+  return found.sort();
+}
+
+/** True when the root package.json declares workspaces, so a root-level scan does cover the children. */
+async function declaresWorkspaces(root: string): Promise<boolean> {
+  try {
+    const pkg = JSON.parse(await readFile(join(root, "package.json"), "utf-8")) as {
+      workspaces?: unknown;
+    };
+    return Array.isArray(pkg.workspaces) || typeof pkg.workspaces === "object";
+  } catch {
+    return false;
+  }
+}
+
+const NAME = "scan scope";
+
+function say(
+  status: SecurityCheckResult["status"],
+  detail: string,
+  extra: Partial<SecurityCheckResult> = {},
+): SecurityCheckResult {
+  return { category: "supply-chain", name: NAME, status, detail, ...extra };
+}
+
+/**
+ * Report what this run's directory does and does not cover.
+ *
+ * The four cases are distinct, and only one of them is a problem:
+ *   - nothing nested: the scope is this project, say so;
+ *   - a root manifest declaring workspaces: the children are covered by the root scan;
+ *   - a root manifest without workspaces: the children are separate projects, not covered;
+ *   - no root manifest at all: this verdict covers an empty directory. This is the false green.
+ */
+export async function checkScanScope(root: string): Promise<SecurityCheckResult> {
+  const [rootManifest, nested] = await Promise.all([hasManifest(root), findNestedProjects(root)]);
+
+  if (nested.length === 0) {
+    return say(
+      "pass",
+      rootManifest ? "this project, scanned in place" : "no project manifests here or below",
+    );
+  }
+
+  const list = nested.slice(0, 4).join(", ") + (nested.length > 4 ? `, +${nested.length - 4}` : "");
+
+  if (rootManifest && (await declaresWorkspaces(root))) {
+    return say("pass", `${nested.length} nested package(s) covered via workspaces: ${list}`);
+  }
+
+  if (rootManifest) {
+    return say(
+      "warn",
+      `${nested.length} nested project(s) NOT covered by this scan: ${list} — run kit check in each`,
+      { severity: "medium", suggestion: `cd <project> && kit check --category security` },
+    );
+  }
+
+  return say(
+    "warn",
+    `no manifest here — this verdict covers none of ${nested.length} project(s) below: ${list}`,
+    {
+      severity: "high",
+      suggestion: `The manifest-dependent scanners had nothing to read at this path. Run: cd ${nested[0]} && kit check --category security`,
+    },
+  );
+}

--- a/src/check-nested-projects.ts
+++ b/src/check-nested-projects.ts
@@ -115,6 +115,67 @@ async function declaresWorkspaces(root: string): Promise<boolean> {
   }
 }
 
+export interface ScanScope {
+  /** Does the directory kit ran in have a manifest of its own? */
+  rootManifest: boolean;
+  /** Project directories found below it, relative paths. */
+  nested: string[];
+  /** Does the root manifest declare workspaces, so a root-level scan covers the children? */
+  workspaces: boolean;
+}
+
+/** The facts, gathered once: the row below and the skip escalation both read them. */
+export async function scanScopeFacts(root: string): Promise<ScanScope> {
+  const [rootManifest, nested] = await Promise.all([hasManifest(root), findNestedProjects(root)]);
+  return {
+    rootManifest,
+    nested,
+    workspaces: rootManifest ? await declaresWorkspaces(root) : false,
+  };
+}
+
+/**
+ * True when kit was pointed at a directory that has no project of its own while projects sit below
+ * it — the "I looked in the wrong place" case, as distinct from "there is nothing to scan".
+ */
+export function lookedInTheWrongPlace(scope: ScanScope): boolean {
+  return !scope.rootManifest && scope.nested.length > 0;
+}
+
+/** Skip reasons that mean "no manifest at this path", i.e. exactly what a wrong directory produces. */
+const MANIFEST_ABSENCE =
+  /^no (package\.json|requirements\.txt|lockfiles|Maven\/Gradle|package\.json \/ requirements\.txt)/i;
+
+/**
+ * Turn "nothing to scan" into "looked in the wrong place".
+ *
+ * A scanner that skips because this path has no manifest is telling the truth, and the sum of those
+ * truths was a green verdict over a directory whose code lived one level down. When the scope facts
+ * say kit is in the wrong place, those skips are no longer honest not-applicables: they are checks
+ * that did not cover the code. They become warnings naming where the code is.
+ *
+ * Only in that case. In an ordinary project, or a workspace root that genuinely covers its
+ * children, a manifest-absence skip stays a skip — a check that warns everywhere gets switched off,
+ * and then the case it was written for goes unnoticed too.
+ */
+export function escalateManifestSkips(
+  results: SecurityCheckResult[],
+  scope: ScanScope,
+): SecurityCheckResult[] {
+  if (!lookedInTheWrongPlace(scope)) return results;
+  const where = scope.nested.slice(0, 3).join(", ");
+  return results.map((r) =>
+    r.status === "skip" && MANIFEST_ABSENCE.test(r.detail)
+      ? {
+          ...r,
+          status: "warn" as const,
+          severity: r.severity ?? ("medium" as const),
+          detail: `${r.detail} — but ${scope.nested.length} project(s) below do (${where}); this scan looked in the wrong place`,
+        }
+      : r,
+  );
+}
+
 const NAME = "scan scope";
 
 function say(
@@ -134,8 +195,11 @@ function say(
  *   - a root manifest without workspaces: the children are separate projects, not covered;
  *   - no root manifest at all: this verdict covers an empty directory. This is the false green.
  */
-export async function checkScanScope(root: string): Promise<SecurityCheckResult> {
-  const [rootManifest, nested] = await Promise.all([hasManifest(root), findNestedProjects(root)]);
+export async function checkScanScope(
+  root: string,
+  facts?: ScanScope,
+): Promise<SecurityCheckResult> {
+  const { rootManifest, nested, workspaces } = facts ?? (await scanScopeFacts(root));
 
   if (nested.length === 0) {
     return say(
@@ -146,7 +210,7 @@ export async function checkScanScope(root: string): Promise<SecurityCheckResult>
 
   const list = nested.slice(0, 4).join(", ") + (nested.length > 4 ? `, +${nested.length - 4}` : "");
 
-  if (rootManifest && (await declaresWorkspaces(root))) {
+  if (rootManifest && workspaces) {
     return say("pass", `${nested.length} nested package(s) covered via workspaces: ${list}`);
   }
 

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -2645,6 +2645,12 @@ export async function checkSecurity(cwd?: string): Promise<SecurityCheckResult[]
   // so `kit ci` and `kit heal` see it too.
   const { checkPolicyAgentWrites } = await import("./check-policy-ops.js");
   results.push(await checkPolicyAgentWrites(root));
+  // What this run's directory covers. Run from a workspace root holding several repos side by
+  // side, every manifest-dependent scanner skips truthfully and the summary read "All 25 checks
+  // passed" — while the tree one level down had 30 known dependency vulnerabilities. The skips
+  // were honest; the missing row was the one saying the code lives somewhere kit did not look.
+  const { checkScanScope } = await import("./check-nested-projects.js");
+  results.push(await checkScanScope(root));
 
   // Inbound integration: fold any third-party findings a partner tool emitted to
   // `.kit-scan-results.jsonl` into the verdict. No file → no-op. Can only escalate

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -2649,9 +2649,10 @@ export async function checkSecurity(cwd?: string): Promise<SecurityCheckResult[]
   // side, every manifest-dependent scanner skips truthfully and the summary read "All 25 checks
   // passed" — while the tree one level down had 30 known dependency vulnerabilities. The skips
   // were honest; the missing row was the one saying the code lives somewhere kit did not look.
-  const { checkScanScope } = await import("./check-nested-projects.js");
-  results.push(await checkScanScope(root));
-
+  const { checkScanScope, scanScopeFacts, escalateManifestSkips } =
+    await import("./check-nested-projects.js");
+  const scope = await scanScopeFacts(root);
+  results.push(await checkScanScope(root, scope));
   // Inbound integration: fold any third-party findings a partner tool emitted to
   // `.kit-scan-results.jsonl` into the verdict. No file → no-op. Can only escalate
   // (fail/warn), never green the gate — see external-findings.ts.
@@ -2661,7 +2662,11 @@ export async function checkSecurity(cwd?: string): Promise<SecurityCheckResult[]
   // Attach a rule citation (CWE/OWASP) to each finding whose check is mapped in
   // the local rules catalog. Deterministic lookup, no network. Unmapped checks
   // pass through unchanged.
-  return results.map((r) => {
+  // A manifest-absence skip is an honest not-applicable in a normal project and a coverage hole
+  // when kit is standing in the wrong directory — same words, different meaning. Resolved here,
+  // once, from the scope facts rather than by each scanner guessing, and applied last so it also
+  // covers results appended after the scanners ran.
+  return escalateManifestSkips(results, scope).map((r) => {
     const rule = ruleForCheck(r.name);
     return rule ? { ...r, rule } : r;
   });

--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { runStep, fmtDuration } from "./output.js";
+import { runStep, fmtDuration, printSummary } from "./output.js";
+import type { SecurityCheckResult } from "./check-security.js";
 
 function stripAnsi(s: string): string {
   return s.replace(/\x1b\[[0-9;]*m/g, "");
@@ -69,5 +70,83 @@ describe("runStep", () => {
     }
     assert.ok(threw, "runStep re-throws the underlying error");
     assert.match(cap.text(), /✗.*security scan/);
+  });
+});
+
+/**
+ * The verdict line must not add skips to passes.
+ *
+ * Measured before this was fixed: a workspace root holding `web/` and `illithid/` side by side
+ * printed "All 25 checks passed ✓" while 15 of the 25 had never run, and the same command one
+ * directory down reported 30 known dependency vulnerabilities (high). Every skip was individually
+ * truthful; the summary that added them up was not. Same defect class as #517 — a check that could
+ * not run rendering as success — one level up, in the line most people read instead of the rows.
+ *
+ * So these are arithmetic properties: the printed numbers must account for every check, and the
+ * words "All … passed" may appear only when everything actually ran.
+ */
+describe("printSummary", () => {
+  const sec = (name: string, status: SecurityCheckResult["status"]): SecurityCheckResult => ({
+    category: "dependency",
+    name,
+    status,
+    detail: status === "skip" ? "no package.json found" : "",
+  });
+
+  it("never claims everything passed when something could not run", () => {
+    const cap = captureStdout();
+    try {
+      printSummary([], [], [], [sec("a", "pass"), sec("b", "skip"), sec("c", "skip")]);
+    } finally {
+      cap.restore();
+    }
+    const text = cap.text();
+    assert.doesNotMatch(text, /All \d+ checks passed/, `false green:\n${text}`);
+    assert.match(text, /1 passed/);
+    assert.match(text, /2 could not run/);
+    // And it must say what the verdict does cover, since that is the number a reader acts on.
+    assert.match(text, /2 of 3 check\(s\) did not run/);
+  });
+
+  it("still says all passed when everything actually ran", () => {
+    const cap = captureStdout();
+    try {
+      printSummary([], [], [], [sec("a", "pass"), sec("b", "pass")]);
+    } finally {
+      cap.restore();
+    }
+    assert.match(cap.text(), /All 2 checks passed/);
+  });
+
+  it("accounts for every check when there are findings as well as non-runs", () => {
+    const cap = captureStdout();
+    try {
+      printSummary(
+        [],
+        [],
+        [],
+        [sec("a", "pass"), sec("b", "skip"), sec("c", "warn"), sec("d", "fail")],
+      );
+    } finally {
+      cap.restore();
+    }
+    const text = cap.text();
+    const m = /(\d+)\/(\d+) passed/.exec(text);
+    assert.ok(m, `expected an n/total line:\n${text}`);
+    assert.equal(Number(m[1]), 1);
+    assert.equal(Number(m[2]), 4);
+    assert.match(text, /1 could not run/);
+    assert.match(text, /2 real issues/, "a warn and a fail are both findings, not non-runs");
+  });
+
+  it("does not report an empty directory as a clean sweep", () => {
+    const cap = captureStdout();
+    try {
+      printSummary([], [], [], []);
+    } finally {
+      cap.restore();
+    }
+    assert.doesNotMatch(cap.text(), /All 0 checks passed/);
+    assert.match(cap.text(), /no checks applied/);
   });
 });

--- a/src/output.ts
+++ b/src/output.ts
@@ -411,12 +411,15 @@ export function printSummary(
   const toolsOk = tools.filter((t) => t.ok).length;
   const servicesOk = services.filter((s) => s.authenticated).length;
   const secretsOk = secrets.filter((s) => s.available).length;
-  const securityOk = security
-    ? security.filter((s) => s.status === "pass" || s.status === "skip").length
-    : 0;
-  const deployOk = deploy
-    ? deploy.filter((d) => d.status === "pass" || d.status === "skip").length
-    : 0;
+  // A skip is NOT a pass. Counting them together produced "All 25 checks passed ✓" on a tree where
+  // 15 checks never ran and the code one directory down had 30 known vulnerabilities — the same
+  // defect class as #517 (a skipped CI check rendering as success), one level up in the verdict
+  // line itself. Skips still do not GATE: they are counted and named, not failed.
+  const securityOk = security ? security.filter((s) => s.status === "pass").length : 0;
+  const deployOk = deploy ? deploy.filter((d) => d.status === "pass").length : 0;
+  const securitySkipped = security ? security.filter((s) => s.status === "skip").length : 0;
+  const deploySkipped = deploy ? deploy.filter((d) => d.status === "skip").length : 0;
+  const skipped = securitySkipped + deploySkipped;
 
   const total =
     tools.length +
@@ -425,7 +428,11 @@ export function printSummary(
     (security?.length || 0) +
     (deploy?.length || 0);
   const ok = toolsOk + servicesOk + secretsOk + securityOk + deployOk;
-  const allGood = ok === total;
+  // Three states, not two: everything ran and passed; everything that ran passed but some could
+  // not run; something is actually wrong. Collapsing the middle state into the first is what made
+  // a directory with 15 non-runs read as "All 25 checks passed".
+  const problems = total - ok - skipped;
+  const allGood = problems === 0;
 
   // P5 — separate SETUP GAPS (a tool not installed, a service not logged in, a scanner that
   // couldn't run) from REAL issues (an actual finding a check produced). On a fresh clone the
@@ -446,10 +453,23 @@ export function printSummary(
     (security?.filter((s) => s.status !== "pass" && s.status !== "skip" && !s.didNotRun).length ??
       0);
 
-  if (allGood) {
+  if (total === 0) {
+    // "All 0 checks passed" is the emptiest possible false green.
+    console.log(`${c.dim}no checks applied here${c.reset}`);
+  } else if (allGood && skipped === 0) {
     console.log(`${c.bold}${c.green}All ${total} checks passed ✓${c.reset}`);
+  } else if (allGood) {
+    // Everything that ran passed — but not everything ran, and the count says which is which.
+    console.log(
+      `${c.bold}${c.green}${ok} passed${c.reset}${c.dim}  ·  ${c.reset}${c.dim}${skipped} could not run${c.reset}`,
+    );
+    console.log();
+    console.log(
+      `${c.dim}${skipped} of ${total} check(s) did not run — this verdict covers the other ${ok}. Each row above carries its reason.${c.reset}`,
+    );
   } else {
     const parts = [`${c.bold}${ok}/${total} passed${c.reset}`];
+    if (skipped > 0) parts.push(`${c.dim}${skipped} could not run${c.reset}`);
     if (setupGaps > 0)
       parts.push(`${c.yellow}${setupGaps} setup gap${setupGaps === 1 ? "" : "s"}${c.reset}`);
     if (realIssues > 0)


### PR DESCRIPTION
Reported from a day's work in another repo, reproduced here, and it makes kit's verdict unreliable in **every** repo — not just workspace roots.

## What was measured

A workspace root holding several repos side by side (`web/`, `illithid/`, no manifest of its own):

```
$ kit check --category security
All 25 checks passed ✓
```

Fifteen of those twenty-five had never run:

```
− npm audit               skip  no package.json found
− license check           skip  no package.json found
− osv-scanner (deps)      skip  no lockfiles to scan
− install-script grants   skip  no package.json
… 11 more
```

The same command one directory down, where the code lives:

```
! osv-scanner (deps)   warn  30 known dependency vulnerability(ies)   [high]
! pinned versions      warn  22 unpinned dependencies                 [medium]
! secrets scan         warn  18 unverified secret-shaped string(s)    [medium]
```

Thirty known dependency vulnerabilities behind a green line. `printSummary` counted
`status === "pass" || status === "skip"` as OK, then printed "All N checks passed" as soon as that
count reached the total.

This is the same defect class as #517 — a check that could not run rendering as success — one level
up, in the line most people read *instead of* the rows. And it is not confined to workspace roots:
this repo itself was reporting `25/26 passed` while ten of those twenty-six were skips. It now
reads `15/27 passed · 11 could not run · 1 real issue`.

## Fix 1 — three states, not two

```
All 26 checks passed ✓                              everything ran, everything passed
10 passed  ·  15 could not run                      everything that RAN passed
10/26 passed  ·  15 could not run  ·  1 real issue  something to act on
```

Plus a line naming the consequence: *"15 of 26 check(s) did not run — this verdict covers the other
10. Each row above carries its reason."* And a run with nothing applicable now says
`no checks applied here` rather than "All 0 checks passed ✓", which was the emptiest possible false
green.

**Skips still do not gate.** They are counted and named, not failed — `ok` in `--json` is unchanged,
so nothing that currently passes CI starts failing because of this.

## Fix 2 — a directory with no manifest is not a directory with nothing to scan

Each individual skip was *true*: `npm audit` genuinely has nothing to audit at that path. What was
missing is the row stating the consequence. New `scan scope` check, enumerated in every security
run:

| Situation | Verdict |
| --- | --- |
| no manifest here, projects below | **warn (high)** — *"no manifest here — this verdict covers none of 3 project(s) below: illithid, web, web-corrupt-backup"* |
| root manifest declaring workspaces | **pass** — *"12 nested package(s) covered via workspaces"* (a root scan genuinely does cover those) |
| root manifest, no workspaces, siblings below | **warn (medium)** — separate projects, not scanned |
| ordinary single project | **pass**, quietly |

The three passing cases carry as much weight as the warning one. A check that warns on every
monorepo gets switched off within a week, and then the case it was written for goes unnoticed too.
Verified against three real trees: the workspace root warns and names all three directories, `web/`
passes with *"3 nested package(s) covered via workspaces"*, and this repo passes with twelve.

`warn`, not `fail`: nothing is broken, and running kit where the code lives is the operator's call.
But it must never be a silent pass.

## Detection scope

Immediate children plus one level deeper (the `packages/*` layout), stopping at each project found —
enumerating a nested project's own sub-packages would turn one misplaced run into a wall of rows.
`node_modules`, `dist`, `build`, `target`, `vendor`, `.venv`, `.terraform` and friends are not the
operator's projects and are skipped. Ten manifest kinds, not just `package.json`.

## Tests

4 475 pass, 0 fail. Notably, **no existing test broke** — the false-green wording was never pinned,
which is exactly why it could be wrong. Now it is: the printed numbers must account for every
check, and "All … passed" may appear only when everything actually ran.

Three of the four remaining items from that day's report are still to come — the paste was truncated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
