### PR TITLE
fix(hooks): a rebase is not a bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,34 @@
   download count, every repository link must be the one real repository, each plugin must be findable
   by the name a person would type, and regeneration must be byte-identical.
 
+- **A rebase is not a bypass** (#522).
+
+  Every `git rebase` produced one "commit(s) bypassed pre-commit hook — (sentinel-missing)" entry
+  per replayed commit. Four false positives came out of a single day of rebasing branches, on
+  commits whose pre-commit hook HAD run — on the original. A false positive in a security banner is
+  worse than no banner: it teaches the operator to skip the line, and then the real `--no-verify`
+  scrolls past unread.
+
+  Git replays commits without running pre-commit, but it *does* run post-commit for each replayed
+  commit, so the sentinel is absent and the commit looked bypassed. Measured while fixing it: during
+  a replay the post-commit hook sees `rebase-merge/` and `CHERRY_PICK_HEAD` present, an ordinary
+  commit sees neither, and `GIT_REFLOG_ACTION` is not exported to post-commit at all — so the state
+  is unambiguous exactly where the decision is made. The event is now recorded as `replayed` and
+  prints nothing. It is still recorded: the log is an audit trail, and "this commit was replayed" is
+  a fact worth keeping — it just is not a finding.
+
+  **Entries written before this fix are re-classified too**, so the four already in a log stop being
+  counted without anyone editing an append-only file. The witness is the reflog, which records the
+  operation that created each sha. Only messages that *create* a commit count — `rebase (pick)`,
+  `(squash)`, `(fixup)`, `(reword)`, `cherry-pick`, `am` — and deliberately not `rebase (finish)`,
+  which names the branch tip afterwards and would therefore excuse a genuine `--no-verify` commit
+  that happened to be that tip. That would turn a false positive into a false negative, which is the
+  one direction this must never take. A reflog that has expired answers "unknown", and an unknown
+  entry stays counted.
+
+  The banner now says `N entries came from a rebase/cherry-pick replay — not counted.` rather than
+  silently reporting a smaller number than the log is long.
+
 - **`kit ci` rendered a skipped check as a failure on GitHub and as a pass on GitLab** (#517).
   Two surfaces, two opposite lies, one missing case.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -251,17 +251,26 @@ async function showSkippedCommitBanner(): Promise<void> {
       await import("./skipped-commits.js");
     const entries = parseSkippedCommits(content);
     if (entries.length === 0) return;
-    const { live, orphaned } = partitionSkippedCommits(
+    const { live, orphaned, replayed } = partitionSkippedCommits(
       entries,
       gitReachabilityProbe(process.cwd()),
     );
-    // Nothing the repo still contains — the log is history, not a finding.
+    // Nothing the repo still contains, or nothing but replays — the log is history, not a finding.
+    // A rebase replays commits without pre-commit (git runs post-commit for each), so a day of
+    // rebasing used to produce a red banner about commits whose hook had run on the original.
     if (live.length === 0) return;
     process.stderr.write(
       `${c.red}[kit] ${live.length} commit(s) bypassed pre-commit hook — most recent:${c.reset}\n`,
     );
     for (const entry of live.slice(-3)) {
       process.stderr.write(`  ${entry.timestamp}  ${entry.sha.slice(0, 8)}  (${entry.reason})\n`);
+    }
+    if (replayed.length > 0) {
+      // Named, not hidden: the operator should be able to see why the number is smaller than the
+      // log is long, without opening the file.
+      process.stderr.write(
+        `  ${replayed.length} entr${replayed.length === 1 ? "y" : "ies"} came from a rebase/cherry-pick replay — not counted.\n`,
+      );
     }
     if (orphaned.length > 0) {
       process.stderr.write(

--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -5,9 +5,15 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { installHooks, uninstallHooks, resolveHooksDir } from "./hooks.js";
+import { installHooks, uninstallHooks, resolveHooksDir, SKIPPED_COMMITS_LOG } from "./hooks.js";
 import { checkHooks, isGitRepository } from "./check-hooks.js";
 import type { HooksConfig } from "./config.js";
+import { spawnSync } from "node:child_process";
+import {
+  parseSkippedCommits,
+  partitionSkippedCommits,
+  gitReachabilityProbe,
+} from "./skipped-commits.js";
 
 describe("installHooks", () => {
   const testGitDir = join(tmpdir(), `.test-git-${process.pid}`);
@@ -503,6 +509,126 @@ describe("uninstallHooks — result contract and destructive edges", () => {
       if (prior === undefined) delete process.env.KIT_READ_ONLY;
       else process.env.KIT_READ_ONLY = prior;
       await rm(base, { recursive: true, force: true });
+    }
+  });
+});
+
+/**
+ * The bypass detector must tell a rebase apart from a `--no-verify`.
+ *
+ * Git replays commits during a rebase without running pre-commit, but it DOES run post-commit for
+ * each replayed commit — so the sentinel is absent and the detector recorded "sentinel-missing" on
+ * a commit whose hook had already run, on the original. Four false positives came out of one day of
+ * rebasing branches. A false positive in a security banner is worse than no banner: it teaches the
+ * operator to skip the line, and the real bypass scrolls past unread.
+ *
+ * Driven through real git rather than by inspecting the script text, because the property is about
+ * what git does to the hook, not about what the hook says. Measured while writing this: during a
+ * replay the post-commit hook sees `rebase-merge/` and `CHERRY_PICK_HEAD` present, while an
+ * ordinary commit sees neither, and `GIT_REFLOG_ACTION` is not exported to post-commit at all.
+ */
+describe("bypass detector vs rebase", () => {
+  const git = (cwd: string, ...args: string[]): string => {
+    const r = spawnSync("git", args, { cwd, encoding: "utf-8", timeout: 60_000 });
+    return (r.stdout ?? "") + (r.stderr ?? "");
+  };
+
+  async function repoWithDetector(): Promise<string | null> {
+    const dir = await mkdtemp(join(tmpdir(), "kit-rebase-detect-"));
+    if (spawnSync("git", ["init", "-q", "-b", "main", dir]).status !== 0) return null;
+    git(dir, "config", "user.email", "t@kit.local");
+    git(dir, "config", "user.name", "t");
+    await writeFile(join(dir, ".kit.toml"), '[tools]\nnode = "22"\n', "utf-8");
+    // installHooks writes the sentinel pair regardless of what the config declares, which is the
+    // point: the bypass detector is not opt-in.
+    await installHooks({} as HooksConfig, join(dir, ".git"), dir);
+    return dir;
+  }
+
+  it("records a replayed commit as a replay, and a real --no-verify as a bypass", async () => {
+    const dir = await repoWithDetector();
+    if (!dir) return; // no git here: nothing to assert, and nothing claimed
+    try {
+      await writeFile(join(dir, "a.txt"), "x\n", "utf-8");
+      git(dir, "add", "-A");
+      git(dir, "commit", "-q", "-m", "base");
+      git(dir, "checkout", "-q", "-b", "feature");
+      await writeFile(join(dir, "b.txt"), "y\n", "utf-8");
+      git(dir, "add", "-A");
+      git(dir, "commit", "-q", "-m", "feature work");
+      git(dir, "checkout", "-q", "main");
+      await writeFile(join(dir, "c.txt"), "z\n", "utf-8");
+      git(dir, "add", "-A");
+      git(dir, "commit", "-q", "-m", "main work");
+      git(dir, "checkout", "-q", "feature");
+
+      const rebaseOut = git(dir, "rebase", "main");
+      assert.doesNotMatch(
+        rebaseOut,
+        /pre-commit hook was skipped/,
+        `a rebase must not warn about a bypass:\n${rebaseOut}`,
+      );
+
+      const logPath = join(dir, SKIPPED_COMMITS_LOG);
+      const afterRebase = parseSkippedCommits(await readFile(logPath, "utf-8").catch(() => ""));
+      assert.ok(afterRebase.length > 0, "the replay is still recorded — the log is an audit trail");
+      assert.ok(
+        afterRebase.every((e) => e.reason === "replayed"),
+        `every rebase entry must be labelled a replay: ${JSON.stringify(afterRebase)}`,
+      );
+
+      // And the thing the detector exists for still works.
+      await writeFile(join(dir, "d.txt"), "w\n", "utf-8");
+      git(dir, "add", "-A");
+      const bypassOut = git(dir, "commit", "-q", "--no-verify", "-m", "bypassed");
+      assert.match(bypassOut, /pre-commit hook was skipped/, "a real --no-verify must still warn");
+
+      const all = parseSkippedCommits(await readFile(logPath, "utf-8"));
+      const genuine = all.filter((e) => e.reason !== "replayed");
+      assert.equal(genuine.length, 1, `exactly one genuine bypass: ${JSON.stringify(all)}`);
+
+      // The report must count the one and excuse the other.
+      const { live, replayed } = partitionSkippedCommits(all, gitReachabilityProbe(dir));
+      assert.equal(live.length, 1, "one bypass counted");
+      assert.equal(replayed.length, all.length - 1, "the replays set aside");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("excuses an entry written before the fix, using the reflog as the witness", async () => {
+    const dir = await repoWithDetector();
+    if (!dir) return;
+    try {
+      await writeFile(join(dir, "a.txt"), "x\n", "utf-8");
+      git(dir, "add", "-A");
+      git(dir, "commit", "-q", "-m", "base");
+      git(dir, "checkout", "-q", "-b", "feature");
+      await writeFile(join(dir, "b.txt"), "y\n", "utf-8");
+      git(dir, "add", "-A");
+      git(dir, "commit", "-q", "-m", "feature work");
+      git(dir, "checkout", "-q", "main");
+      await writeFile(join(dir, "c.txt"), "z\n", "utf-8");
+      git(dir, "add", "-A");
+      git(dir, "commit", "-q", "-m", "main work");
+      git(dir, "checkout", "-q", "feature");
+      git(dir, "rebase", "main");
+
+      // Rewrite the log the way the old hook would have written it: no replay label at all.
+      const sha = git(dir, "rev-parse", "HEAD").trim();
+      await writeFile(
+        join(dir, SKIPPED_COMMITS_LOG),
+        JSON.stringify({ timestamp: "2026-08-20T09:00:00Z", sha, reason: "sentinel-missing" }) +
+          "\n",
+        "utf-8",
+      );
+
+      const entries = parseSkippedCommits(await readFile(join(dir, SKIPPED_COMMITS_LOG), "utf-8"));
+      const { live, replayed } = partitionSkippedCommits(entries, gitReachabilityProbe(dir));
+      assert.equal(live.length, 0, "the reflog proves this sha was created by a rebase pick");
+      assert.equal(replayed.length, 1);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
     }
   });
 });

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -214,13 +214,27 @@ if [ -n "$__kit_git_dir" ] && [ -n "$__kit_repo_root" ]; then
       fi
     fi
   fi
+  # A rebase, cherry-pick or am REPLAYS a commit whose pre-commit hook already ran on the
+  # original. Git runs post-commit for each replayed commit but not pre-commit, so the sentinel is
+  # missing and the commit looks bypassed. Measured: four false positives in one day of rebasing
+  # branches. A false positive in a security banner is worse than no banner — it teaches the
+  # operator to ignore the line. During a replay the post-commit hook can see the state
+  # unambiguously (rebase-merge/ and CHERRY_PICK_HEAD both present; GIT_REFLOG_ACTION is NOT
+  # exported here, so it cannot be used), so the event is recorded as a replay and stays silent.
+  if [ -d "$__kit_git_dir/rebase-merge" ] || [ -d "$__kit_git_dir/rebase-apply" ] ||
+     [ -f "$__kit_git_dir/CHERRY_PICK_HEAD" ] || [ -f "$__kit_git_dir/MERGE_HEAD" ]; then
+    if [ -n "$__kit_reason" ]; then __kit_reason="replayed"; fi
+    __kit_quiet=1
+  fi
   if [ -n "$__kit_reason" ]; then
     __kit_log="$__kit_repo_root/${SKIPPED_COMMITS_LOG}"
     __kit_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
     printf '{"timestamp":"%s","sha":"%s","reason":"%s","user":"%s"}\\n' \\
       "$__kit_ts" "$__kit_head" "$__kit_reason" "\${USER:-unknown}" \\
       >> "$__kit_log" 2>/dev/null || true
-    echo "[kit] WARNING: pre-commit hook was skipped ($__kit_reason). Logged to ${SKIPPED_COMMITS_LOG}." >&2
+    if [ -z "$__kit_quiet" ]; then
+      echo "[kit] WARNING: pre-commit hook was skipped ($__kit_reason). Logged to ${SKIPPED_COMMITS_LOG}." >&2
+    fi
   fi
   # Clean up sentinel so the next commit starts fresh.
   rm -f "$__kit_sentinel" 2>/dev/null || true

--- a/src/skipped-commits.test.ts
+++ b/src/skipped-commits.test.ts
@@ -23,6 +23,7 @@ import {
   partitionSkippedCommits,
   gitReachabilityProbe,
   type ReachabilityProbe,
+  CREATING_REPLAY_MESSAGE as CREATING_REPLAY_MESSAGE_FOR_TEST,
 } from "./skipped-commits.js";
 import { SKIPPED_COMMITS_LOG } from "./hooks.js";
 
@@ -36,11 +37,16 @@ function entry(sha: string, reason = "sentinel-missing") {
   return { timestamp: "2026-08-04T10:00:00Z", sha, reason };
 }
 
-/** A probe answering from two explicit sets — no git, so the rule is what is tested. */
-function probeFrom(resolvable: string[], contained: string[]): ReachabilityProbe {
+/** A probe answering from explicit sets — no git, so the rule is what is tested. */
+function probeFrom(
+  resolvable: string[],
+  contained: string[],
+  replayed: string[] = [],
+): ReachabilityProbe {
   return {
     resolves: (sha) => resolvable.includes(sha),
     containedByAnyRef: (sha) => contained.includes(sha),
+    createdByReplay: (sha) => replayed.includes(sha),
   };
 }
 
@@ -239,5 +245,96 @@ describe("the CLI banner reflects the partition", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+});
+
+/**
+ * A rebase is not a bypass.
+ *
+ * Every `git rebase` replays commits without running pre-commit — git runs post-commit for each
+ * one, the sentinel is absent, and the detector recorded "sentinel-missing". Measured: four false
+ * positives from one day of rebasing branches, on commits whose pre-commit hook HAD run, on the
+ * original. A false positive in a security banner is worse than no banner: it teaches the operator
+ * to skip the line, and then the real `--no-verify` scrolls past unread.
+ *
+ * The classification has two sources, and the second one is what fixes a log that already has
+ * false entries in it: the hook now writes `replayed` when it can see the rebase state, and the
+ * reflog can still prove it for lines written before that fix.
+ *
+ * The negative case below is the one that must never regress: `rebase (finish)` names the branch
+ * tip AFTER a rebase, so matching it would excuse a genuine `--no-verify` commit that happened to
+ * be that tip — turning a false positive into a false negative, in the wrong direction.
+ */
+describe("a replayed commit is not a bypass", () => {
+  const C = "c".repeat(40);
+
+  it("sets aside an entry the hook already recorded as a replay", () => {
+    const { live, replayed } = partitionSkippedCommits(
+      [entry(A, "replayed"), entry(B)],
+      probeFrom([A, B], [A, B]),
+    );
+    assert.deepEqual(
+      live.map((e) => e.sha),
+      [B],
+      "only the genuine bypass may be counted",
+    );
+    assert.deepEqual(
+      replayed.map((e) => e.sha),
+      [A],
+    );
+  });
+
+  it("sets aside an older entry the reflog can still prove was replayed", () => {
+    // Written before the hook knew about rebases: reason is the old one, and only the reflog
+    // distinguishes it.
+    const { live, replayed } = partitionSkippedCommits(
+      [entry(A), entry(B)],
+      probeFrom([A, B], [A, B], [A]),
+    );
+    assert.deepEqual(
+      live.map((e) => e.sha),
+      [B],
+    );
+    assert.deepEqual(
+      replayed.map((e) => e.sha),
+      [A],
+    );
+  });
+
+  it("keeps counting a bypass the reflog cannot excuse", () => {
+    const { live, replayed, orphaned } = partitionSkippedCommits(
+      [entry(C)],
+      probeFrom([C], [C], []),
+    );
+    assert.deepEqual(
+      live.map((e) => e.sha),
+      [C],
+    );
+    assert.equal(replayed.length, 0);
+    assert.equal(orphaned.length, 0);
+  });
+
+  it("only messages that CREATE a commit count as a replay", () => {
+    // The regex lives in the module; this asserts the property through the git-backed probe's
+    // contract by way of the documented list. `rebase (finish)` and `revert` must not qualify.
+    const creating = [
+      "rebase (pick): add thing",
+      "rebase -i (squash): fold",
+      "rebase (fixup): tidy",
+      "rebase (reword): message",
+      "cherry-pick: port fix",
+      "am: apply patch",
+    ];
+    const notCreating = [
+      "rebase (finish): returning to refs/heads/feature",
+      "rebase (start): checkout main",
+      "checkout: moving from main to feature",
+      "commit: ordinary work",
+      "commit (amend): fixed",
+      "revert: undo a thing",
+      "merge main: Fast-forward",
+    ];
+    for (const m of creating) assert.match(m, CREATING_REPLAY_MESSAGE_FOR_TEST, m);
+    for (const m of notCreating) assert.doesNotMatch(m, CREATING_REPLAY_MESSAGE_FOR_TEST, m);
   });
 });

--- a/src/skipped-commits.ts
+++ b/src/skipped-commits.ts
@@ -15,6 +15,19 @@
  */
 import { execFileSync } from "node:child_process";
 
+/**
+ * Reflog messages that mean "this sha was created by replaying an existing commit".
+ *
+ * Deliberately NOT `rebase (finish)` or `rebase (start)`: those name where the branch ended up, so
+ * matching them would excuse a genuine `--no-verify` commit that happened to be the tip when
+ * someone rebased. `revert` is absent too — a revert is an ordinary commit and runs the hooks.
+ */
+export const CREATING_REPLAY_MESSAGE =
+  // The word boundary sits inside each alternative on purpose: `\b` after `\)` never matches,
+  // since both `)` and the `:` that follows are non-word characters — the first version of this
+  // regex silently matched nothing at all, and the test caught it.
+  /^(rebase(\s+-i)?\s+\((pick|squash|fixup|reword|edit)\)|cherry-pick\b|am\b)/;
+
 export interface SkippedCommitEntry {
   timestamp: string;
   sha: string;
@@ -31,6 +44,18 @@ export interface ReachabilityProbe {
   resolves(sha: string): boolean;
   /** Does at least one ref reach it? */
   containedByAnyRef(sha: string): boolean;
+  /**
+   * Was this commit CREATED by a replay (rebase pick/squash/fixup/reword, cherry-pick, am)?
+   *
+   * Answered from the reflog, which records the operation that produced each sha. Only the
+   * messages that create a commit count: `rebase (finish)` names the branch tip afterwards, so a
+   * genuine `--no-verify` commit at the tip of a branch someone then rebased would be excused by
+   * it — downgrading a real bypass, which is the one error this must not make.
+   *
+   * Unknown answers `false`: a reflog expires (30–90 days), and an entry we cannot classify stays
+   * counted, the same direction the rest of this module takes.
+   */
+  createdByReplay(sha: string): boolean;
 }
 
 /**
@@ -38,6 +63,13 @@ export interface ReachabilityProbe {
  * shell hook appending under `|| true`, so a truncated line must not blind the banner
  * to the entries around it.
  */
+/**
+ * Reasons the post-commit detector writes for a replay rather than a bypass. Recorded rather than
+ * dropped: the log is an audit trail, and "this commit was replayed" is a fact worth keeping — it
+ * just is not a finding.
+ */
+export const REPLAY_REASONS = new Set(["replayed"]);
+
 export function parseSkippedCommits(content: string): SkippedCommitEntry[] {
   const entries: SkippedCommitEntry[] = [];
   for (const line of content.split("\n")) {
@@ -67,15 +99,26 @@ export function parseSkippedCommits(content: string): SkippedCommitEntry[] {
 export function partitionSkippedCommits(
   entries: SkippedCommitEntry[],
   probe: ReachabilityProbe,
-): { live: SkippedCommitEntry[]; orphaned: SkippedCommitEntry[] } {
+): {
+  live: SkippedCommitEntry[];
+  orphaned: SkippedCommitEntry[];
+  replayed: SkippedCommitEntry[];
+} {
   const live: SkippedCommitEntry[] = [];
   const orphaned: SkippedCommitEntry[] = [];
+  const replayed: SkippedCommitEntry[] = [];
   for (const entry of entries) {
+    // A replay is not a bypass, whether the hook already knew that when it wrote the line (newer
+    // installs) or the reflog can still prove it (entries written before the hook was fixed).
+    if (REPLAY_REASONS.has(entry.reason) || probe.createdByReplay(entry.sha)) {
+      replayed.push(entry);
+      continue;
+    }
     if (probe.containedByAnyRef(entry.sha)) live.push(entry);
     else if (probe.resolves(entry.sha)) orphaned.push(entry);
     else live.push(entry);
   }
-  return { live, orphaned };
+  return { live, orphaned, replayed };
 }
 
 /**
@@ -124,11 +167,33 @@ export function gitReachabilityProbe(cwd: string): ReachabilityProbe {
     return value;
   };
 
+  // Shas the reflog says were CREATED by a replay. One walk, cached: `git reflog --all` is a
+  // single call, and the alternative is one call per logged entry.
+  let replayed: Set<string> | null = null;
+  const replayedSet = (): Set<string> => {
+    if (replayed) return replayed;
+    const out = git(["reflog", "--all", "--format=%H %gs"]) ?? "";
+    const set = new Set<string>();
+    for (const line of out.split("\n")) {
+      const space = line.indexOf(" ");
+      if (space <= 0) continue;
+      const sha = line.slice(0, space);
+      const message = line.slice(space + 1);
+      if (CREATING_REPLAY_MESSAGE.test(message)) set.add(sha);
+    }
+    replayed = set;
+    return replayed;
+  };
+
   return {
     resolves: (sha) => fullSha(sha) !== null,
     containedByAnyRef: (sha) => {
       const full = fullSha(sha);
       return full !== null && reachableSet().has(full);
+    },
+    createdByReplay: (sha) => {
+      const full = fullSha(sha);
+      return full !== null && replayedSet().has(full);
     },
   };
 }


### PR DESCRIPTION
> Jag samlade fyra falska positiva på en dag genom att ombasa grenar. Pre-commit KÖRDE på originalcommiten; rebasen spelade bara om den utan hooks.

Reproduced, and the mechanism is worth stating precisely: git replays commits **without** running `pre-commit`, but it **does** run `post-commit` for each replayed commit. So the sentinel is absent, and the detector recorded `sentinel-missing` on a commit whose hook had already run.

```
$ git rebase main
[kit] WARNING: pre-commit hook was skipped (sentinel-missing). Logged to .kit-skipped-commits.jsonl.
```

## What the hook can actually see

Measured with a probe hook during a real rebase, rather than assumed:

| Signal | ordinary commit | during replay |
| --- | --- | --- |
| `$GIT_DIR/rebase-merge/` | no | **YES** |
| `$GIT_DIR/CHERRY_PICK_HEAD` | no | **YES** |
| `GIT_REFLOG_ACTION` | empty | **empty** — not exported to post-commit |

So the state is unambiguous exactly where the decision is made. The reflog-action variable that would have been the obvious signal is not available there at all, which is worth recording so nobody reaches for it later.

The event is now written as `reason: "replayed"` and prints nothing. It is still written — the log is an audit trail, and "this commit was replayed" is a fact worth keeping. It is just not a finding.

## The four you already have

They are in the log with the old reason, and the log is append-only. So the report side gained a second witness: the **reflog**, which records the operation that created each sha. Only messages that *create* a commit count:

```
rebase (pick) · rebase -i (squash) · (fixup) · (reword) · cherry-pick · am
```

Deliberately **not** `rebase (finish)`. That message names the branch tip *after* a rebase — including a rebase that replayed nothing — so matching it would excuse a genuine `--no-verify` commit that happened to be that tip. Trading a false positive for a false negative is the one direction this must not take, and it has its own test.

An expired reflog (30–90 days) answers "unknown", and an unknown entry stays counted — the same direction the rest of `skipped-commits.ts` already takes.

The banner now names what it set aside instead of just printing a smaller number:

```
[kit] 1 commit(s) bypassed pre-commit hook — most recent:
  2026-08-21T14:52:03Z  b2d4b7e7  (sentinel-missing)
  1 entry came from a rebase/cherry-pick replay — not counted.
```

## Verified end to end

In a real repo, with the built CLI:

- `git rebase` → silent, logged as `replayed`;
- `git commit --no-verify` → still warns, still counted;
- an old-style `sentinel-missing` entry created by a rebase → excused by the reflog, banner drops to zero.

Two git-driven integration tests pin both directions (`src/hooks.test.ts`), and the regex has its own test — which is how I caught that `\b` after `\)` never matches, since `)` and `:` are both non-word characters. The first version of that regex matched nothing at all.

4 457 tests pass, 0 fail.

## Not done here

`kit usage`'s floor tab (#519) counts every line in the log as a bypass; it should use this classification once both land. Items 2 and 3 from the same report — the "no NEW vulnerabilities" policy gate and the client-bundle exposure check — are separate features, not fixes, and come next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)