### PR TITLE
feat(check): check what reaches the browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,56 @@
 
 ## [6.8.0] - 2026-08-21
 
+- **What reaches the browser is now checked** (#523).
+
+  kit covered credentials that were *committed* (trufflehog over history, the staged-file scan) and
+  `.env` hygiene. Neither sees the leak that costs the most: a `VITE_*` or `NEXT_PUBLIC_*` variable
+  holding a real secret is inlined into the bundle at build time and shipped to every visitor —
+  without ever being committed. `.gitignore` does not protect against it and history scanning cannot
+  see it.
+
+  Two checks, both deterministic:
+
+  **`client-exposed env names`** — a client-exposed prefix plus a secret-shaped name is a leak by
+  construction, because the framework will inline it. Nine prefixes (`VITE_`, `NEXT_PUBLIC_`,
+  `PUBLIC_`, `REACT_APP_`, `EXPO_PUBLIC_`, `NUXT_PUBLIC_`, `GATSBY_`, `VUE_APP_`, `STORYBOOK_`)
+  against `SECRET|TOKEN|PASSWORD|CREDENTIAL|PRIVATE|_KEY|API_KEY`. Names that are secret-shaped and
+  public by design are excused — `..._ANON_KEY`, `..._PUBLISHABLE_KEY`, `..._SITE_KEY`, a Sentry
+  DSN, a client id, a measurement id, a VAPID public key. That list is what makes the check keepable:
+  `KEY` alone matches `NEXT_PUBLIC_SUPABASE_ANON_KEY` and `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`, the
+  two most common client env vars there are, both meant to be published.
+
+  Anything else fails, with the escape hatch spelled out in the suggestion:
+
+  ```toml
+  [scan.client_exposed_allow]
+  VITE_DEMO_SECRET_KEY = "demo tenant, rotated nightly"
+  ```
+
+  The reason is required — an entry without one is reported, because "somebody allowed this once" is
+  not something anyone can audit later. Only names are read from `.env*` files; the values are
+  dropped at the parse, since the prefix decides exposure and nothing downstream needs the content.
+
+  **`built bundle secrets`** — the built output is scanned for real credential shapes, which catches
+  the case the name check cannot: a key hardcoded in source that never went through env at all. The
+  scanner for this already existed (`scanBuildArtifacts`) and was reachable only from
+  `kit security scan-build`, so no automatic verdict had ever looked at build output — where the
+  leak actually lands.
+
+  Scoped so it stays usable, both limits measured rather than guessed: it requires a client framework
+  (kit's own `dist/` is a Node CLI, and scanning it produced 73 "credential shapes" — every one a
+  test fixture or one of kit's own detection patterns), and it looks in workspace packages, not just
+  the root (a real repo declares `workspaces` at the root and ships from `apps/web`, so a root-only
+  check called it "nothing builds for a browser"). Compiled tests, mocks and fixtures are excluded
+  and the count of what was set aside is printed. An unbuilt project reports *"present but not built
+  — run the build, then re-check"* rather than passing.
+
+  Verified against a real Vite workspace (`apps/web/dist` — pass) and against a planted leak: the
+  name check fails on `VITE_STRIPE_SECRET_KEY` while leaving `VITE_API_URL` and
+  `NEXT_PUBLIC_SUPABASE_ANON_KEY` alone, and the bundle check finds an `sk_live_…` inlined into
+  `dist/assets/index-abc.js` at critical severity, telling the operator to rotate first — removing
+  it from the build does not un-publish what already shipped.
+
 ### Fixed
 
 - **Regenerating `flag-surface.ts` produced a 512-line diff over identical content** (#525).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 ### Added
 
+- **What reaches the browser is now checked** (#523).
+
+  kit covered credentials that were *committed* (trufflehog over history, the staged-file scan) and
+  `.env` hygiene. Neither sees the leak that costs the most: a `VITE_*` or `NEXT_PUBLIC_*` variable
+  holding a real secret is inlined into the bundle at build time and shipped to every visitor —
+  without ever being committed. `.gitignore` does not protect against it and history scanning cannot
+  see it.
+
+  Two checks, both deterministic:
+
+  **`client-exposed env names`** — a client-exposed prefix plus a secret-shaped name is a leak by
+  construction, because the framework will inline it. Nine prefixes (`VITE_`, `NEXT_PUBLIC_`,
+  `PUBLIC_`, `REACT_APP_`, `EXPO_PUBLIC_`, `NUXT_PUBLIC_`, `GATSBY_`, `VUE_APP_`, `STORYBOOK_`)
+  against `SECRET|TOKEN|PASSWORD|CREDENTIAL|PRIVATE|_KEY|API_KEY`. Names that are secret-shaped and
+  public by design are excused — `..._ANON_KEY`, `..._PUBLISHABLE_KEY`, `..._SITE_KEY`, a Sentry
+  DSN, a client id, a measurement id, a VAPID public key. That list is what makes the check keepable:
+  `KEY` alone matches `NEXT_PUBLIC_SUPABASE_ANON_KEY` and `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`, the
+  two most common client env vars there are, both meant to be published.
+
+  Anything else fails, with the escape hatch spelled out in the suggestion:
+
+  ```toml
+  [scan.client_exposed_allow]
+  VITE_DEMO_SECRET_KEY = "demo tenant, rotated nightly"
+  ```
+
+  The reason is required — an entry without one is reported, because "somebody allowed this once" is
+  not something anyone can audit later. Only names are read from `.env*` files; the values are
+  dropped at the parse, since the prefix decides exposure and nothing downstream needs the content.
+
+  **`built bundle secrets`** — the built output is scanned for real credential shapes, which catches
+  the case the name check cannot: a key hardcoded in source that never went through env at all. The
+  scanner for this already existed (`scanBuildArtifacts`) and was reachable only from
+  `kit security scan-build`, so no automatic verdict had ever looked at build output — where the
+  leak actually lands.
+
+  Scoped so it stays usable, both limits measured rather than guessed: it requires a client framework
+  (kit's own `dist/` is a Node CLI, and scanning it produced 73 "credential shapes" — every one a
+  test fixture or one of kit's own detection patterns), and it looks in workspace packages, not just
+  the root (a real repo declares `workspaces` at the root and ships from `apps/web`, so a root-only
+  check called it "nothing builds for a browser"). Compiled tests, mocks and fixtures are excluded
+  and the count of what was set aside is printed. An unbuilt project reports *"present but not built
+  — run the build, then re-check"* rather than passing.
+
+  Verified against a real Vite workspace (`apps/web/dist` — pass) and against a planted leak: the
+  name check fails on `VITE_STRIPE_SECRET_KEY` while leaving `VITE_API_URL` and
+  `NEXT_PUBLIC_SUPABASE_ANON_KEY` alone, and the bundle check finds an `sk_live_…` inlined into
+  `dist/assets/index-abc.js` at critical severity, telling the operator to rotate first — removing
+  it from the build does not un-publish what already shipped.
+
 - **`kit usage` — what kit knows, and proof that the floor still works** (#519).
 
   Six tabs, switchable in the terminal with the number keys: **Floor** (audited operations and
@@ -151,58 +201,6 @@
   view that leaves the terminal in the alternate screen with raw mode on makes the operator's shell
   look dead. Verified through a pty: `q`, Esc, Ctrl-C, SIGINT and SIGTERM all give the screen
   back.
-
-## [6.8.0] - 2026-08-21
-
-- **What reaches the browser is now checked** (#523).
-
-  kit covered credentials that were *committed* (trufflehog over history, the staged-file scan) and
-  `.env` hygiene. Neither sees the leak that costs the most: a `VITE_*` or `NEXT_PUBLIC_*` variable
-  holding a real secret is inlined into the bundle at build time and shipped to every visitor —
-  without ever being committed. `.gitignore` does not protect against it and history scanning cannot
-  see it.
-
-  Two checks, both deterministic:
-
-  **`client-exposed env names`** — a client-exposed prefix plus a secret-shaped name is a leak by
-  construction, because the framework will inline it. Nine prefixes (`VITE_`, `NEXT_PUBLIC_`,
-  `PUBLIC_`, `REACT_APP_`, `EXPO_PUBLIC_`, `NUXT_PUBLIC_`, `GATSBY_`, `VUE_APP_`, `STORYBOOK_`)
-  against `SECRET|TOKEN|PASSWORD|CREDENTIAL|PRIVATE|_KEY|API_KEY`. Names that are secret-shaped and
-  public by design are excused — `..._ANON_KEY`, `..._PUBLISHABLE_KEY`, `..._SITE_KEY`, a Sentry
-  DSN, a client id, a measurement id, a VAPID public key. That list is what makes the check keepable:
-  `KEY` alone matches `NEXT_PUBLIC_SUPABASE_ANON_KEY` and `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`, the
-  two most common client env vars there are, both meant to be published.
-
-  Anything else fails, with the escape hatch spelled out in the suggestion:
-
-  ```toml
-  [scan.client_exposed_allow]
-  VITE_DEMO_SECRET_KEY = "demo tenant, rotated nightly"
-  ```
-
-  The reason is required — an entry without one is reported, because "somebody allowed this once" is
-  not something anyone can audit later. Only names are read from `.env*` files; the values are
-  dropped at the parse, since the prefix decides exposure and nothing downstream needs the content.
-
-  **`built bundle secrets`** — the built output is scanned for real credential shapes, which catches
-  the case the name check cannot: a key hardcoded in source that never went through env at all. The
-  scanner for this already existed (`scanBuildArtifacts`) and was reachable only from
-  `kit security scan-build`, so no automatic verdict had ever looked at build output — where the
-  leak actually lands.
-
-  Scoped so it stays usable, both limits measured rather than guessed: it requires a client framework
-  (kit's own `dist/` is a Node CLI, and scanning it produced 73 "credential shapes" — every one a
-  test fixture or one of kit's own detection patterns), and it looks in workspace packages, not just
-  the root (a real repo declares `workspaces` at the root and ships from `apps/web`, so a root-only
-  check called it "nothing builds for a browser"). Compiled tests, mocks and fixtures are excluded
-  and the count of what was set aside is printed. An unbuilt project reports *"present but not built
-  — run the build, then re-check"* rather than passing.
-
-  Verified against a real Vite workspace (`apps/web/dist` — pass) and against a planted leak: the
-  name check fails on `VITE_STRIPE_SECRET_KEY` while leaving `VITE_API_URL` and
-  `NEXT_PUBLIC_SUPABASE_ANON_KEY` alone, and the bundle check finds an `sk_live_…` inlined into
-  `dist/assets/index-abc.js` at critical severity, telling the operator to rotate first — removing
-  it from the build does not un-publish what already shipped.
 
 ### Fixed
 
@@ -367,24 +365,7 @@
   only ever fired for `fail`/`warn` — which is the worse way round, since the human is the one
   who concludes "twenty things are broken here".
 
-### Fixed
-
-- **`kit config migrate` deleted every comment in `.kit.toml`, and the dry run did not say so**
-  (#513). It re-serialised from the parsed object, so on the v0 → v1 step — whose entire job is to
-  stamp `version = 1` — kit's own config went from 8 comment lines to 0, and a one-line change
-  produced a 36-line diff. The parsed data was identical, so the backup-and-re-validate safety
-  path passed and flagged nothing. What was lost was policy reasoning: why those scanners are
-  declared, why the refs are `aqua:`-scheme-qualified, which values `environment` accepts.
-
-  An add-only migration is now applied as a **text edit** — the added key is inserted above the
-  first table (top-level keys must precede it or TOML scopes them into it) and the rest of the
-  file is untouched. Anything more structural returns null from the patcher rather than being
-  forced through an edit that cannot express it, and then the run is **refused** while comments
-  exist unless `--allow-comment-loss` is passed, naming how many lines are at stake.
-
-  `--dry-run` now says which path would be taken — *"Applied as a text edit: comments and
-  formatting are preserved"* or the count that would be deleted. A preview that omits the
-  destructive half of a change is worse than no preview.
+## [6.8.0] - 2026-08-21
 
 ### Added
 
@@ -415,7 +396,75 @@
   Auto-migrating on load is also out — a config that changes shape underneath a session is worse
   than one that is behind, and the schema version exists so the change is explicit and reviewable.
 
+- **`[context]` can declare the IDENTITY a repo must use, and kit asserts it** (#503). `kit check`
+  printed `✓ vercel authenticated <account>` and compared it to nothing, while `kit context check`
+  asserted only ids read from repo-local files — so a CLI answering as the wrong account was
+  green. New fields: `vercel.user`, `github.user` (distinct from `github.org`, which is the
+  remote's owner) and `convex.account`. They behave exactly like `git.email`: declared → asserted,
+  mismatch → red and non-zero, unreadable → `unknown` rather than a mismatch, since "cannot tell"
+  and "wrong account" are different findings.
+
+  What the gap cost, measured: a session whose CLI was logged in as a personal account with
+  read-only rights on the production environment read a FILTERED variable list as a complete one.
+  `env ls` showed four variables and looked whole (the ones that also existed in preview), the
+  production-only ones were invisible, and `env pull --environment=production` failed as though
+  the variable did not exist. Two contradictory conclusions were drawn before a web UI settled it.
+
+  A mismatch now also names the mechanism that scopes an identity to a repo, because a global
+  login is what produces a wrong one: `vercel -Q <dir>` / `VERCEL_TOKEN`, `gh auth switch`,
+  `gcloud config configurations activate`, `AWS_PROFILE`, stripe project profiles — and for
+  convex, that it has **no** profiles (`~/.convex/config.json` is global and `convex login`
+  overwrites it), so the isolation is `CONVEX_DEPLOY_KEY` / `CONVEX_DEPLOYMENT` per repo.
+
+  And it says the part that turns a wrong identity into wrong conclusions out loud: *anything you
+  already read as this identity may have been a PARTIAL view — permissions filter listings
+  silently.*
+
+  `kit context check`'s ready-to-paste block offers the detected identities, hedged (`⚠ the gh
+  account logged in NOW — VERIFY it is right for THIS repo`), since the live identity is exactly
+  what the lock exists to question. A value kit could not resolve to a real identity is reported
+  but never offered as something to declare.
+
+- **`kit tools list` — the inventory that did not exist**, and the measurement three surfaces
+  were missing (#500). Per tool: the resolved path, the installer that owns it (classified from
+  the path, never assumed), the installed version, and with `--latest` how far behind it is.
+  Covers the declared `[tools]` **and** the undeclared CLIs an agent decides from — `gh`, `op`,
+  `jq`, `mise`, `docker`, `gcloud`, `kubectl`, `supabase`, `stripe`, `psql`, … — which were
+  invisible precisely because nothing declared them.
+
+  Measured on the machine that filed the report, first run: `trivy 0.72.0 → 0.74.0`,
+  `trufflehog 3.95.9 → 3.97.0`, `gh 2.96.0 → 2.97.0`, `mise 2026.6.11 → 2026.8.9`,
+  `npm 10.9.8 → 12.0.2`, `op 2.34.0 → 2.39.0`. Cold 12s, warm 4s.
+
+- **`latest` is now checked against the installer that would satisfy it.** `versionSatisfies`
+  answered `if (required === "latest") return true;`, so `✓ vercel 53.1.1 (need latest)` printed
+  while the registry had 59.1.4 — six majors. The tools table now shows the installer in brackets
+  and, for a `latest` pin, `!` with `53.1.1 → 59.1.4 available`. A pin of `any` / `present` / `*`
+  asserts presence only, and says so, for repos that genuinely mean "whatever is installed".
+
+  Lookups are per-installer (`npm view`, `mise latest`, `brew info --json=v2`, `pip index`),
+  cached per machine in `~/.kit/tool-latest.json` with a TTL (`KIT_TOOL_LATEST_TTL_H`, default
+  24h), so the gate makes no network call once warm. A failed lookup is **not** cached — a flaky
+  network must not become a day-long policy.
+
 ### Fixed
+
+- **`kit config migrate` deleted every comment in `.kit.toml`, and the dry run did not say so**
+  (#513). It re-serialised from the parsed object, so on the v0 → v1 step — whose entire job is to
+  stamp `version = 1` — kit's own config went from 8 comment lines to 0, and a one-line change
+  produced a 36-line diff. The parsed data was identical, so the backup-and-re-validate safety
+  path passed and flagged nothing. What was lost was policy reasoning: why those scanners are
+  declared, why the refs are `aqua:`-scheme-qualified, which values `environment` accepts.
+
+  An add-only migration is now applied as a **text edit** — the added key is inserted above the
+  first table (top-level keys must precede it or TOML scopes them into it) and the rest of the
+  file is untouched. Anything more structural returns null from the patcher rather than being
+  forced through an edit that cannot express it, and then the run is **refused** while comments
+  exist unless `--allow-comment-loss` is passed, naming how many lines are at stake.
+
+  `--dry-run` now says which path would be taken — *"Applied as a text edit: comments and
+  formatting are preserved"* or the count that would be deleted. A preview that omits the
+  destructive half of a change is worse than no preview.
 
 - **The machine-wide wrapper pointed at whichever kit wrote it** (#509). `~/.kit/bin/kit` is what
   every kit hook in every repo execs, and `ensureKitWrapper()` baked in `process.argv[1]` — so one
@@ -440,8 +489,6 @@
 
   Both new env knobs are registered in `kit config knobs`: `KIT_WRAPPER_ALLOW_DEV` (marked
   dangerous) and `KIT_TOOL_LATEST_TTL_H`, which had been missing since it was introduced.
-
-### Fixed
 
 - **The install-gate recognised one repo-argument form; the tool publishes two** (#507).
   `ownerRepoArg` matched `^[\w.-]+/[\w.-]+$` — one slash, no scheme — so the payload of a
@@ -480,63 +527,6 @@
   note to `88/100` with a single-maintainer warning — the same reason npm's packages scored 88.
   Counting is bracket-aware, so `"Cordasco, Ian <one@example>"` is one maintainer, not two.
 
-### Added
-
-- **`[context]` can declare the IDENTITY a repo must use, and kit asserts it** (#503). `kit check`
-  printed `✓ vercel authenticated <account>` and compared it to nothing, while `kit context check`
-  asserted only ids read from repo-local files — so a CLI answering as the wrong account was
-  green. New fields: `vercel.user`, `github.user` (distinct from `github.org`, which is the
-  remote's owner) and `convex.account`. They behave exactly like `git.email`: declared → asserted,
-  mismatch → red and non-zero, unreadable → `unknown` rather than a mismatch, since "cannot tell"
-  and "wrong account" are different findings.
-
-  What the gap cost, measured: a session whose CLI was logged in as a personal account with
-  read-only rights on the production environment read a FILTERED variable list as a complete one.
-  `env ls` showed four variables and looked whole (the ones that also existed in preview), the
-  production-only ones were invisible, and `env pull --environment=production` failed as though
-  the variable did not exist. Two contradictory conclusions were drawn before a web UI settled it.
-
-  A mismatch now also names the mechanism that scopes an identity to a repo, because a global
-  login is what produces a wrong one: `vercel -Q <dir>` / `VERCEL_TOKEN`, `gh auth switch`,
-  `gcloud config configurations activate`, `AWS_PROFILE`, stripe project profiles — and for
-  convex, that it has **no** profiles (`~/.convex/config.json` is global and `convex login`
-  overwrites it), so the isolation is `CONVEX_DEPLOY_KEY` / `CONVEX_DEPLOYMENT` per repo.
-
-  And it says the part that turns a wrong identity into wrong conclusions out loud: *anything you
-  already read as this identity may have been a PARTIAL view — permissions filter listings
-  silently.*
-
-  `kit context check`'s ready-to-paste block offers the detected identities, hedged (`⚠ the gh
-  account logged in NOW — VERIFY it is right for THIS repo`), since the live identity is exactly
-  what the lock exists to question. A value kit could not resolve to a real identity is reported
-  but never offered as something to declare.
-
-### Added
-
-- **`kit tools list` — the inventory that did not exist**, and the measurement three surfaces
-  were missing (#500). Per tool: the resolved path, the installer that owns it (classified from
-  the path, never assumed), the installed version, and with `--latest` how far behind it is.
-  Covers the declared `[tools]` **and** the undeclared CLIs an agent decides from — `gh`, `op`,
-  `jq`, `mise`, `docker`, `gcloud`, `kubectl`, `supabase`, `stripe`, `psql`, … — which were
-  invisible precisely because nothing declared them.
-
-  Measured on the machine that filed the report, first run: `trivy 0.72.0 → 0.74.0`,
-  `trufflehog 3.95.9 → 3.97.0`, `gh 2.96.0 → 2.97.0`, `mise 2026.6.11 → 2026.8.9`,
-  `npm 10.9.8 → 12.0.2`, `op 2.34.0 → 2.39.0`. Cold 12s, warm 4s.
-
-- **`latest` is now checked against the installer that would satisfy it.** `versionSatisfies`
-  answered `if (required === "latest") return true;`, so `✓ vercel 53.1.1 (need latest)` printed
-  while the registry had 59.1.4 — six majors. The tools table now shows the installer in brackets
-  and, for a `latest` pin, `!` with `53.1.1 → 59.1.4 available`. A pin of `any` / `present` / `*`
-  asserts presence only, and says so, for repos that genuinely mean "whatever is installed".
-
-  Lookups are per-installer (`npm view`, `mise latest`, `brew info --json=v2`, `pip index`),
-  cached per machine in `~/.kit/tool-latest.json` with a TTL (`KIT_TOOL_LATEST_TTL_H`, default
-  24h), so the gate makes no network call once warm. A failed lookup is **not** cached — a flaky
-  network must not become a day-long policy.
-
-### Fixed
-
 - **`cli-lock.json` recorded a provenance it never measured, and the check called it `in sync`.**
   Both writers did the same thing:
 
@@ -560,8 +550,6 @@
   (`aqua:aquasecurity/trivy`, `npm:@socketsecurity/cli`), and the probe used the raw declaration
   rather than the executable name — the same false statement as the one above, pointed the other
   way.
-
-### Fixed
 
 - **The install-gate's refusal described its own machinery instead of the hazard it caught.**
   A blocked `git commit -m "… \`deployment:env:view\` …"` was reported as a false positive; the

--- a/src/check-client-exposure.test.ts
+++ b/src/check-client-exposure.test.ts
@@ -1,0 +1,279 @@
+/**
+ * The leak this covers never touches git.
+ *
+ * A `VITE_*` or `NEXT_PUBLIC_*` variable holding a real secret is inlined into the bundle at build
+ * time and shipped to every visitor. Trufflehog over history cannot see it, `.gitignore` does not
+ * protect against it, and the value is public the moment the site deploys. So the properties below
+ * are about the two ways to catch it — the name, before the build; the bytes, after it.
+ *
+ * The false-positive cases carry as much weight as the true ones, and are the reason this check is
+ * usable at all:
+ *
+ *   - `NEXT_PUBLIC_SUPABASE_ANON_KEY` and `..._STRIPE_PUBLISHABLE_KEY` are the two most common
+ *     client env vars in existence and are meant to be public. A check that flags them on day one
+ *     is switched off before it ever catches a real leak.
+ *   - kit's own `dist/` is a compiled Node CLI. Scanning it produced 73 "credential shapes", every
+ *     one a test fixture or one of kit's own detection patterns — measured, which is why the bundle
+ *     check requires a client framework and ignores compiled tests.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  classifyClientName,
+  collectEnvNames,
+  checkClientExposedNames,
+  checkBuiltBundleSecrets,
+  detectClientBuilds,
+  isTestArtifact,
+} from "./check-client-exposure.js";
+
+function tree(spec: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), "kit-client-exp-"));
+  for (const [rel, content] of Object.entries(spec)) {
+    const full = join(dir, rel);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return dir;
+}
+
+describe("classifyClientName", () => {
+  it("calls a client-exposed secret name what it is", () => {
+    for (const name of [
+      "VITE_STRIPE_SECRET_KEY",
+      "NEXT_PUBLIC_DATABASE_PASSWORD",
+      "PUBLIC_ADMIN_TOKEN",
+      "REACT_APP_PRIVATE_SIGNING_KEY",
+      "EXPO_PUBLIC_SERVICE_CREDENTIAL",
+      "GATSBY_API_KEY",
+    ]) {
+      assert.equal(classifyClientName(name), "leak", name);
+    }
+  });
+
+  it("excuses the secret-shaped names that are public by design", () => {
+    // These read as credentials and are meant to be published. Getting this group wrong is how the
+    // check ends up disabled: they are the most common client env vars there are.
+    for (const name of [
+      "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+      "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY",
+      "VITE_RECAPTCHA_SITE_KEY",
+      "VITE_VAPID_PUBLIC_KEY",
+    ]) {
+      assert.equal(classifyClientName(name), "public-by-convention", name);
+    }
+  });
+
+  it("never flags a name that a build would inline harmlessly", () => {
+    // The property that matters is "not a leak"; whether a name is excused by the public-by-design
+    // list or never looked secret-shaped at all is an internal distinction.
+    for (const name of [
+      "NEXT_PUBLIC_SENTRY_DSN",
+      "VITE_AUTH0_CLIENT_ID",
+      "NEXT_PUBLIC_GA_MEASUREMENT_ID",
+      "VITE_API_URL",
+      "NEXT_PUBLIC_APP_URL",
+    ]) {
+      assert.notEqual(classifyClientName(name), "leak", name);
+    }
+  });
+
+  it("ignores names the browser never sees, however secret they sound", () => {
+    for (const name of [
+      "STRIPE_SECRET_KEY",
+      "DATABASE_URL",
+      "CRON_SECRET",
+      "AZURE_CLIENT_SECRET",
+    ]) {
+      assert.equal(classifyClientName(name), "not-client-exposed", name);
+    }
+  });
+
+  it("ignores a client-exposed name that says nothing about secrets", () => {
+    for (const name of ["VITE_API_URL", "NEXT_PUBLIC_APP_URL", "PUBLIC_SITE_NAME"]) {
+      assert.equal(classifyClientName(name), "not-client-exposed", name);
+    }
+  });
+});
+
+describe("collectEnvNames", () => {
+  it("reads names from every .env file, and never a value", async () => {
+    const dir = tree({
+      ".env": "VITE_A=super-secret-value\n# comment\n\nexport VITE_B=other\n",
+      ".env.example": "VITE_A=changeme\nVITE_C=\n",
+      ".envrc": "should not be read as env\n",
+      "not-env.txt": "VITE_D=x\n",
+    });
+    try {
+      const names = await collectEnvNames(dir);
+      assert.deepEqual([...names.keys()].sort(), ["VITE_A", "VITE_B", "VITE_C"]);
+      assert.deepEqual(names.get("VITE_A"), [".env", ".env.example"], "both sources are named");
+      // The values are dropped at the parse — nothing downstream can leak what it never received.
+      assert.equal(JSON.stringify([...names.values()]).includes("super-secret-value"), false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("checkClientExposedNames", () => {
+  it("fails on a secret-shaped client name and says how to resolve it", async () => {
+    const dir = tree({ ".env": "VITE_STRIPE_SECRET_KEY=x\nVITE_API_URL=y\n" });
+    try {
+      const r = await checkClientExposedNames(dir);
+      assert.equal(r.status, "fail");
+      assert.equal(r.severity, "high");
+      assert.match(r.detail, /VITE_STRIPE_SECRET_KEY/);
+      assert.match(String(r.suggestion), /client_exposed_allow/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts an allowlisted name that carries a reason", async () => {
+    const dir = tree({ ".env": "VITE_DEMO_SECRET_KEY=x\n" });
+    try {
+      const r = await checkClientExposedNames(dir, {
+        VITE_DEMO_SECRET_KEY: "demo tenant, rotated nightly",
+      });
+      assert.equal(r.status, "pass");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports an allowlist entry with no reason — nobody can audit 'someone allowed it once'", async () => {
+    const dir = tree({ ".env": "VITE_DEMO_SECRET_KEY=x\n" });
+    try {
+      const r = await checkClientExposedNames(dir, { VITE_DEMO_SECRET_KEY: "  " });
+      assert.equal(r.status, "warn");
+      assert.match(r.detail, /carry no reason/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips, with the reason, when there are no names to read", async () => {
+    const dir = tree({ "package.json": "{}" });
+    try {
+      const r = await checkClientExposedNames(dir);
+      assert.equal(r.status, "skip");
+      assert.match(r.detail, /no \.env\* files/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("also judges names declared only in .kit.toml", async () => {
+    const dir = tree({ "package.json": "{}" });
+    try {
+      const r = await checkClientExposedNames(dir, {}, ["NEXT_PUBLIC_ADMIN_TOKEN"]);
+      assert.equal(r.status, "fail");
+      assert.match(r.detail, /\.kit\.toml/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("detectClientBuilds", () => {
+  it("finds the framework in a workspace package, not just the root", async () => {
+    // The shape measured on a real repo: the root declares workspaces and no framework, and the
+    // app that ships lives one level in. A root-only check called that "nothing builds for a
+    // browser".
+    const dir = tree({
+      "package.json": JSON.stringify({ workspaces: ["apps/*", "packages/*"] }),
+      "apps/web/package.json": JSON.stringify({ devDependencies: { vite: "^5" } }),
+      "packages/ui/package.json": JSON.stringify({ dependencies: { react: "^18" } }),
+    });
+    try {
+      const builds = await detectClientBuilds(dir);
+      assert.deepEqual(builds, [{ framework: "vite", dir: "apps/web" }]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("finds nothing in a project that does not build for a browser", async () => {
+    const dir = tree({
+      "package.json": JSON.stringify({ dependencies: { express: "^4" } }),
+    });
+    try {
+      assert.deepEqual(await detectClientBuilds(dir), []);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("checkBuiltBundleSecrets", () => {
+  it("finds a credential that was inlined into the bundle", async () => {
+    const dir = tree({
+      "package.json": JSON.stringify({ devDependencies: { vite: "^5" } }),
+      "dist/assets/index-abc.js": `const k="sk_live_${"A".repeat(24)}";export default k;\n`,
+    });
+    try {
+      const r = await checkBuiltBundleSecrets(dir);
+      assert.equal(r.status, "fail");
+      assert.equal(r.severity, "critical");
+      assert.match(r.detail, /dist\/assets\/index-abc\.js/);
+      // Rotation first: removing it from the build does not un-publish what already shipped.
+      assert.match(String(r.suggestion), /Rotate/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not scan a Node CLI's dist — that is not a browser bundle", async () => {
+    const dir = tree({
+      "package.json": JSON.stringify({ dependencies: { commander: "^12" } }),
+      "dist/cli.js": `const k="sk_live_${"A".repeat(24)}";\n`,
+    });
+    try {
+      const r = await checkBuiltBundleSecrets(dir);
+      assert.equal(r.status, "skip");
+      assert.match(r.detail, /nothing builds for a browser/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("says the build has not run rather than calling an unbuilt project clean", async () => {
+    const dir = tree({ "package.json": JSON.stringify({ devDependencies: { next: "^14" } }) });
+    try {
+      const r = await checkBuiltBundleSecrets(dir);
+      assert.equal(r.status, "skip");
+      assert.match(r.detail, /not built/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not count a compiled test fixture as a shipped credential", async () => {
+    const dir = tree({
+      "package.json": JSON.stringify({ devDependencies: { vite: "^5" } }),
+      "dist/thing.test.js": `const k="sk_live_${"A".repeat(24)}";\n`,
+    });
+    try {
+      const r = await checkBuiltBundleSecrets(dir);
+      assert.equal(r.status, "pass");
+      assert.match(r.detail, /test fixture\(s\) not counted/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("classifies test artifacts by path, including mocks and fixtures", () => {
+    assert.equal(isTestArtifact("dist/a.test.js"), true);
+    assert.equal(isTestArtifact("dist/a.spec.mjs"), true);
+    assert.equal(isTestArtifact("dist/__tests__/a.js"), true);
+    assert.equal(isTestArtifact("dist/fixtures/a.js"), true);
+    assert.equal(isTestArtifact("dist/assets/index-abc.js"), false);
+    assert.equal(isTestArtifact("dist/latest.js"), false, "a name containing 'test' is not a test");
+  });
+});

--- a/src/check-client-exposure.ts
+++ b/src/check-client-exposure.ts
@@ -1,0 +1,432 @@
+/**
+ * What reaches the browser, checked deterministically.
+ *
+ * kit covers credentials that were **committed** (trufflehog over history, the staged-file scan)
+ * and `.env` hygiene. Neither sees the failure mode that costs the most: a `VITE_*` or
+ * `NEXT_PUBLIC_*` variable holding a real secret is inlined into `dist/` at build time and then
+ * sits in every visitor's browser — without ever being committed. `.gitignore` does not protect
+ * against it, history scanning cannot see it, and the value is public the moment the site deploys.
+ *
+ * Two checks, deliberately deterministic rather than clever:
+ *
+ *   1. **By name.** A client-exposed prefix plus a secret-shaped name is a leak by construction:
+ *      the framework will inline it, so the only question is whether the value was meant to be
+ *      public. Conventionally-public names are known and excluded (a Stripe publishable key, a
+ *      Supabase anon key, a reCAPTCHA site key, a Sentry DSN); anything else needs an explicit
+ *      allowlist entry in `.kit.toml` carrying the reason.
+ *
+ *   2. **By content.** The built output is scanned for real credential shapes. This catches the
+ *      case the name check cannot: a key hardcoded in source, which never went through env at all.
+ *      The scanner for this already existed (`scanBuildArtifacts`, reachable from
+ *      `kit security scan-build`) and was not part of any automatic verdict — so `kit check` never
+ *      looked at build output, which is where the leak actually lands.
+ *
+ * Only names are read from `.env*` files. A check that reports on secrets must not handle their
+ * values, and it does not need them: the prefix decides exposure, not the content.
+ */
+
+import { readFile, readdir, access } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { SecurityCheckResult } from "./check-security.js";
+
+/**
+ * Prefixes whose variables the framework inlines into the client bundle. Each is a documented
+ * build-time convention, not a guess: Vite (`VITE_`), Next.js (`NEXT_PUBLIC_`), Astro/SvelteKit
+ * (`PUBLIC_`), Create React App (`REACT_APP_`), Expo (`EXPO_PUBLIC_`), Nuxt (`NUXT_PUBLIC_`),
+ * Gatsby (`GATSBY_`), Vue CLI (`VUE_APP_`), Storybook (`STORYBOOK_`).
+ */
+export const CLIENT_PREFIXES = [
+  "VITE_",
+  "NEXT_PUBLIC_",
+  "PUBLIC_",
+  "REACT_APP_",
+  "EXPO_PUBLIC_",
+  "NUXT_PUBLIC_",
+  "GATSBY_",
+  "VUE_APP_",
+  "STORYBOOK_",
+] as const;
+
+/** Words that make a name secret-shaped. `_KEY` is included; see CONVENTIONALLY_PUBLIC for why that alone is not enough. */
+const SENSITIVE_WORD = /(SECRET|TOKEN|PASSWORD|PASSWD|CREDENTIAL|PRIVATE|_KEY\b|APIKEY|API_KEY)/;
+
+/**
+ * Names that are secret-shaped and genuinely public by design.
+ *
+ * This list is the difference between a check people keep and a check people disable. `KEY` alone
+ * matches `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` — the two most
+ * common client env vars in existence, both meant to be public. Flagging those on day one is how a
+ * security check gets switched off before it ever catches the real leak.
+ */
+const CONVENTIONALLY_PUBLIC =
+  /(PUBLISHABLE|ANON_KEY|SITE_KEY|_DSN\b|CLIENT_ID|MEASUREMENT_ID|PUBLIC_KEY|VAPID_PUBLIC|APP_ID)/;
+
+export type NameVerdict = "leak" | "public-by-convention" | "not-client-exposed";
+
+/** Classify one env var NAME. No value is read, and none is needed. */
+export function classifyClientName(name: string): NameVerdict {
+  const upper = name.toUpperCase();
+  if (!CLIENT_PREFIXES.some((p) => upper.startsWith(p))) return "not-client-exposed";
+  if (!SENSITIVE_WORD.test(upper)) return "not-client-exposed";
+  if (CONVENTIONALLY_PUBLIC.test(upper)) return "public-by-convention";
+  return "leak";
+}
+
+/**
+ * Env var names declared anywhere in the repo's `.env*` files.
+ *
+ * `.env.example` counts: a placeholder named `VITE_STRIPE_SECRET_KEY` is a template telling the
+ * next developer to put a secret somewhere the browser will read it. The name is the defect.
+ */
+export async function collectEnvNames(root: string): Promise<Map<string, string[]>> {
+  const byName = new Map<string, string[]>();
+  let entries: string[];
+  try {
+    entries = await readdir(root);
+  } catch {
+    return byName;
+  }
+  for (const file of entries.filter((f) => f === ".env" || f.startsWith(".env."))) {
+    let text: string;
+    try {
+      text = await readFile(join(root, file), "utf-8");
+    } catch {
+      continue;
+    }
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq <= 0) continue;
+      // The name only. Everything right of `=` is deliberately dropped, here, at the parse.
+      const name = trimmed
+        .slice(0, eq)
+        .replace(/^export\s+/, "")
+        .trim();
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) continue;
+      byName.set(name, [...(byName.get(name) ?? []), file]);
+    }
+  }
+  return byName;
+}
+
+const NAME_CHECK = "client-exposed env names";
+
+/**
+ * A client-exposed variable whose name says "secret" fails.
+ *
+ * `fail`, not `warn`: the framework will inline it, so this is not a posture question. The escape
+ * hatch is an allowlist entry that must carry a reason — an allowlist without one is itself
+ * reported, because "someone allowed this once" is not a reason anybody can audit later.
+ */
+export async function checkClientExposedNames(
+  root: string,
+  allow: Record<string, string> = {},
+  extraNames: string[] = [],
+): Promise<SecurityCheckResult> {
+  const base: Omit<SecurityCheckResult, "status" | "detail"> = {
+    category: "exposure",
+    name: NAME_CHECK,
+  };
+
+  const declared = await collectEnvNames(root);
+  for (const name of extraNames)
+    if (!declared.has(name)) declared.set(name, ["[secrets] in .kit.toml"]);
+
+  if (declared.size === 0) {
+    return {
+      ...base,
+      status: "skip",
+      detail: "no .env* files or declared keys to read names from",
+    };
+  }
+
+  const leaks: string[] = [];
+  const allowedWithoutReason: string[] = [];
+  for (const [name, sources] of declared) {
+    if (classifyClientName(name) !== "leak") continue;
+    const reason = allow[name];
+    if (reason === undefined) {
+      leaks.push(`${name} (${sources.join(", ")})`);
+    } else if (reason.trim().length === 0) {
+      allowedWithoutReason.push(name);
+    }
+  }
+
+  if (leaks.length > 0) {
+    return {
+      ...base,
+      status: "fail",
+      severity: "high",
+      detail: `${leaks.length} client-exposed name(s) declare a secret: ${leaks.slice(0, 3).join("; ")}${leaks.length > 3 ? `; +${leaks.length - 3}` : ""} — a build inlines these into the bundle`,
+      suggestion:
+        "Rename to drop the client prefix and read it server-side, or — if the value really is public — allow it with the reason:\n" +
+        "  [scan.client_exposed_allow]\n" +
+        `  ${leaks[0].split(" ")[0]} = "why this is safe to publish"`,
+    };
+  }
+
+  if (allowedWithoutReason.length > 0) {
+    return {
+      ...base,
+      status: "warn",
+      severity: "low",
+      detail: `${allowedWithoutReason.length} allowlisted name(s) carry no reason: ${allowedWithoutReason.join(", ")}`,
+      suggestion: "Give each entry a sentence saying why the value is safe to publish.",
+    };
+  }
+
+  const exposed = [...declared.keys()].filter(
+    (n) => classifyClientName(n) === "public-by-convention",
+  );
+  return {
+    ...base,
+    status: "pass",
+    detail:
+      exposed.length > 0
+        ? `${declared.size} declared name(s); ${exposed.length} client-exposed and public by convention`
+        : `${declared.size} declared name(s), none client-exposed with a secret-shaped name`,
+  };
+}
+
+const BUNDLE_CHECK = "built bundle secrets";
+
+/**
+ * Packages whose presence means this project builds something a browser downloads.
+ *
+ * The gate matters: kit's own `dist/` is a compiled Node CLI, and scanning it produced 73
+ * "credential shapes" — every one a test fixture or one of kit's own detection patterns. A check
+ * that fails on the repo that ships it is a check nobody keeps. `webpack` is deliberately absent:
+ * plenty of server bundles use it, and the frameworks below are unambiguous.
+ */
+const CLIENT_FRAMEWORKS = [
+  "next",
+  "vite",
+  "react-scripts",
+  "@sveltejs/kit",
+  "nuxt",
+  "astro",
+  "expo",
+  "gatsby",
+  "@vue/cli-service",
+  "@angular/core",
+  "@remix-run/react",
+  "parcel",
+];
+
+async function frameworkIn(dir: string): Promise<string | null> {
+  try {
+    const pkg = JSON.parse(await readFile(join(dir, "package.json"), "utf-8")) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const declared = new Set([
+      ...Object.keys(pkg.dependencies ?? {}),
+      ...Object.keys(pkg.devDependencies ?? {}),
+    ]);
+    return CLIENT_FRAMEWORKS.find((f) => declared.has(f)) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** A place in this repo that builds something a browser downloads. `dir` is relative to the root. */
+export interface ClientBuild {
+  framework: string;
+  dir: string;
+}
+
+/**
+ * Every client build in the repo, including the ones in workspace packages.
+ *
+ * The root manifest is not where the framework lives in a monorepo. Measured on a real repo: the
+ * root declares workspaces and no framework, `apps/web` declares vite and holds the `dist/` that
+ * ships — so a root-only check reported "nothing here builds for a browser" about a repo that
+ * builds for a browser. That is the same false green as scanning the wrong directory, one level in.
+ */
+export async function detectClientBuilds(root: string): Promise<ClientBuild[]> {
+  const builds: ClientBuild[] = [];
+  const atRoot = await frameworkIn(root);
+  if (atRoot) builds.push({ framework: atRoot, dir: "" });
+
+  for (const rel of await candidatePackageDirs(root)) {
+    const framework = await frameworkIn(join(root, rel));
+    if (framework) builds.push({ framework, dir: rel });
+  }
+  return builds;
+}
+
+/** Directories that never hold a package of the operator's own. */
+const IGNORED_DIRS = new Set([
+  "node_modules",
+  ".git",
+  "dist",
+  "build",
+  "out",
+  ".next",
+  ".nuxt",
+  "coverage",
+  ".venv",
+  "target",
+  "vendor",
+]);
+
+/**
+ * Where a workspace package might live: the `workspaces` globs first, since they are the repo's own
+ * declaration, then immediate child directories as a fallback for repos that lay packages out
+ * without declaring them. Only `dir/*` globs are expanded — that is the shape npm/yarn/pnpm
+ * workspaces actually use, and a full glob engine here would be more machinery than the question
+ * deserves.
+ */
+async function candidatePackageDirs(root: string): Promise<string[]> {
+  const dirs = new Set<string>();
+
+  let globs: string[] = [];
+  try {
+    const pkg = JSON.parse(await readFile(join(root, "package.json"), "utf-8")) as {
+      workspaces?: string[] | { packages?: string[] };
+    };
+    globs = Array.isArray(pkg.workspaces) ? pkg.workspaces : (pkg.workspaces?.packages ?? []);
+  } catch {
+    /* no manifest, or not JSON */
+  }
+
+  for (const glob of globs) {
+    if (!glob.includes("*")) {
+      dirs.add(glob.replace(/\/+$/, ""));
+      continue;
+    }
+    const parent = glob.slice(0, glob.indexOf("*")).replace(/\/+$/, "");
+    try {
+      for (const e of await readdir(join(root, parent), { withFileTypes: true })) {
+        if (e.isDirectory() && !IGNORED_DIRS.has(e.name)) {
+          dirs.add(parent ? `${parent}/${e.name}` : e.name);
+        }
+      }
+    } catch {
+      /* declared but absent */
+    }
+  }
+
+  try {
+    for (const e of await readdir(root, { withFileTypes: true })) {
+      if (e.isDirectory() && !e.name.startsWith(".") && !IGNORED_DIRS.has(e.name)) dirs.add(e.name);
+    }
+  } catch {
+    /* unreadable root */
+  }
+
+  return [...dirs].sort();
+}
+
+/**
+ * Compiled tests and mocks are not shipped credentials.
+ *
+ * A fixture that contains `ghp_1234…` exists precisely so a scanner can be tested against it, and
+ * flagging it teaches the operator that the check cries wolf.
+ */
+export function isTestArtifact(file: string): boolean {
+  return (
+    /(^|[\\/])(__tests__|__mocks__|fixtures)[\\/]/.test(file) ||
+    /\.(test|spec)\.[cm]?[jt]sx?$/.test(file)
+  );
+}
+
+/** Build-output directories worth scanning, matching what the bundlers actually emit. */
+const BUILD_DIRS = [
+  ".next",
+  "dist",
+  "build",
+  "out",
+  ".vercel/output",
+  ".svelte-kit",
+  ".nuxt",
+  ".output",
+];
+
+/**
+ * Scan the built output for credential shapes.
+ *
+ * When there is no build output, this is a `skip` that says so — a build that has not run is not a
+ * clean bundle, and reporting it as a pass would be the false green this whole area keeps producing.
+ */
+export async function checkBuiltBundleSecrets(root: string): Promise<SecurityCheckResult> {
+  const base: Omit<SecurityCheckResult, "status" | "detail"> = {
+    category: "exposure",
+    name: BUNDLE_CHECK,
+  };
+
+  const builds = await detectClientBuilds(root);
+  if (builds.length === 0) {
+    return {
+      ...base,
+      status: "skip",
+      detail:
+        "no client framework in package.json (or its workspaces) — nothing builds for a browser",
+    };
+  }
+  const framework = [...new Set(builds.map((b) => b.framework))].join("+");
+
+  const present: string[] = [];
+  for (const build of builds) {
+    for (const dir of BUILD_DIRS) {
+      const rel = build.dir ? `${build.dir}/${dir}` : dir;
+      try {
+        await access(join(root, rel));
+        present.push(rel);
+      } catch {
+        /* not built here */
+      }
+    }
+  }
+  if (present.length === 0) {
+    return {
+      ...base,
+      status: "skip",
+      detail: `${framework} project(s) present but not built (no dist/, .next/, …) — run the build, then re-check`,
+    };
+  }
+
+  const { scanBuildArtifacts } = await import("./scan-build.js");
+  let hits: Awaited<ReturnType<typeof scanBuildArtifacts>>;
+  try {
+    hits = await scanBuildArtifacts(root, present);
+  } catch (e) {
+    // A scan that crashed is not a clean scan: didNotRun makes the CI gate treat it as such.
+    return {
+      ...base,
+      status: "fail",
+      severity: "medium",
+      didNotRun: true,
+      detail: `bundle scan could not run: ${(e as Error).message.slice(0, 80)}`,
+    };
+  }
+
+  const shipped = hits.filter((h) => !isTestArtifact(h.file));
+  const excluded = hits.length - shipped.length;
+  const aside = excluded > 0 ? ` (${excluded} test fixture(s) not counted)` : "";
+
+  if (shipped.length === 0) {
+    return {
+      ...base,
+      status: "pass",
+      detail: `no credential shapes in ${present.join(", ")} [${framework}]${aside}`,
+    };
+  }
+
+  hits = shipped;
+  const total = hits.reduce((n, h) => n + h.findings.length, 0);
+  return {
+    ...base,
+    status: "fail",
+    severity: "critical",
+    detail: `${total} credential shape(s) in built output [${framework}]${aside}: ${hits
+      .slice(0, 3)
+      .map((h) => h.file)
+      .join(", ")}${hits.length > 3 ? `; +${hits.length - 3} file(s)` : ""}`,
+    files: hits.map((h) => h.file),
+    suggestion:
+      "Anything in the bundle is public. Rotate the credential, then move the read server-side — removing it from the build is not enough once it has shipped.",
+  };
+}

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -2653,6 +2653,27 @@ export async function checkSecurity(cwd?: string): Promise<SecurityCheckResult[]
     await import("./check-nested-projects.js");
   const scope = await scanScopeFacts(root);
   results.push(await checkScanScope(root, scope));
+
+  // What reaches the browser. Committed-secret scanning cannot see this: a VITE_/NEXT_PUBLIC_
+  // variable with a secret value is inlined into the bundle at build time and shipped to every
+  // visitor without ever being committed. The bundle scanner already existed and was reachable
+  // only from `kit security scan-build`, so no automatic verdict ever looked at build output.
+  const { checkClientExposedNames, checkBuiltBundleSecrets } = await import(
+    "./check-client-exposure.js"
+  );
+  // The GOVERNED project's config, from the threaded root — not the calling process's.
+  let clientAllow: Record<string, string> = {};
+  let declaredKeyNames: string[] = [];
+  try {
+    const { loadConfig } = await import("./config.js");
+    const cfg = await loadConfig(resolve(root, ".kit.toml"));
+    clientAllow = cfg?.scan?.client_exposed_allow ?? {};
+    declaredKeyNames = Object.keys(cfg?.secrets?.keys ?? {});
+  } catch {
+    /* no config here — the check still reads .env* names */
+  }
+  results.push(await checkClientExposedNames(root, clientAllow, declaredKeyNames));
+  results.push(await checkBuiltBundleSecrets(root));
   // Inbound integration: fold any third-party findings a partner tool emitted to
   // `.kit-scan-results.jsonl` into the verdict. No file → no-op. Can only escalate
   // (fail/warn), never green the gate — see external-findings.ts.

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -2658,9 +2658,8 @@ export async function checkSecurity(cwd?: string): Promise<SecurityCheckResult[]
   // variable with a secret value is inlined into the bundle at build time and shipped to every
   // visitor without ever being committed. The bundle scanner already existed and was reachable
   // only from `kit security scan-build`, so no automatic verdict ever looked at build output.
-  const { checkClientExposedNames, checkBuiltBundleSecrets } = await import(
-    "./check-client-exposure.js"
-  );
+  const { checkClientExposedNames, checkBuiltBundleSecrets } =
+    await import("./check-client-exposure.js");
   // The GOVERNED project's config, from the threaded root — not the calling process's.
   let clientAllow: Record<string, string> = {};
   let declaredKeyNames: string[] = [];

--- a/src/config.ts
+++ b/src/config.ts
@@ -469,6 +469,12 @@ export interface kitConfig {
      *  registered scanners on (backwards-compatible); `kit scan --list-delegates`
      *  shows on/off. kit delegates DETECTION here, never its verdict. */
     delegates?: string[];
+    /**
+     * Client-exposed env names (VITE_*, NEXT_PUBLIC_*, …) that are secret-shaped by name but
+     * genuinely safe to publish, each mapped to the REASON. The reason is required: an allowlist
+     * entry without one records that somebody allowed it, which nobody can audit later.
+     */
+    client_exposed_allow?: Record<string, string>;
   };
   /**
    * No-egress / air-gapped posture (declarative; see docs/AIR_GAP.md). Equivalent


### PR DESCRIPTION
> kit täcker committade hemligheter (trufflehog) och .env-hygien. Vad ingen kollar deterministiskt är vad som hamnar i browsern.

Correct, and the gap is worse than a missing check: the mechanism for half of it already existed and was wired only to a manual command, so no automatic verdict had ever looked at build output — which is exactly where this leak lands.

## `client-exposed env names` (new)

A client-exposed prefix plus a secret-shaped name is a leak **by construction**: the framework will inline it, so the only open question is whether the value was meant to be public.

Nine prefixes — `VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`, `REACT_APP_`, `EXPO_PUBLIC_`, `NUXT_PUBLIC_`, `GATSBY_`, `VUE_APP_`, `STORYBOOK_` — against `SECRET|TOKEN|PASSWORD|CREDENTIAL|PRIVATE|_KEY|API_KEY`.

**The exclusion list is the part that decides whether anyone keeps this check.** `KEY` alone matches `NEXT_PUBLIC_SUPABASE_ANON_KEY` and `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` — the two most common client env vars in existence, both designed to be published. So names that are secret-shaped and public by design are excused: `..._ANON_KEY`, `..._PUBLISHABLE_KEY`, `..._SITE_KEY`, a Sentry DSN, a client id, a measurement id, a VAPID public key. Flagging those on day one is how a check gets switched off before it ever catches the real leak.

Everything else **fails** (high), with the escape hatch in the suggestion text:

```toml
[scan.client_exposed_allow]
VITE_DEMO_SECRET_KEY = "demo tenant, rotated nightly"
```

The reason is **required** — an entry with an empty one is reported at low severity, because "somebody allowed this once" is not a thing anyone can audit six months later.

Only **names** are read from `.env*` files. The values are dropped at the parse, not filtered later: a check that reports on secrets should not be holding them. `.env.example` counts too — a placeholder named `VITE_STRIPE_SECRET_KEY` is a template telling the next developer to put a secret where the browser can read it.

## `built bundle secrets` (mechanism existed, verdict did not)

`scanBuildArtifacts` has been in the tree, doing exactly the right thing, reachable only from `kit security scan-build`. Now it runs as part of `kit check --category security`, and it catches what the name check cannot: a key hardcoded in source that never went through env at all.

Both scope limits below were measured, not guessed — and without them this check would be unusable:

| Limit | Why, measured |
| --- | --- |
| requires a client framework | kit's own `dist/` is a compiled Node CLI. Scanning it reported **73 credential shapes** — every one a test fixture or one of kit's own detection patterns. A check that fails on the repo that ships it is a check nobody keeps. |
| looks in workspace packages | A real repo declares `workspaces` at the root with no framework, and ships from `apps/web`. A root-only check said *"nothing here builds for a browser"* about a repo that builds for a browser — the same false green as scanning the wrong directory, one level in. |
| excludes compiled tests/mocks/fixtures | A fixture containing `ghp_1234…` exists so a scanner can be tested against it. The count set aside is printed, so the exclusion is visible rather than silent. |

An unbuilt project reports *"vite project(s) present but not built (no dist/, .next/, …) — run the build, then re-check"*. Not a pass: a build that has not run is not a clean bundle.

## Verified

Against a real Vite workspace:

```
✓ client-exposed env names   pass  43 declared name(s); 2 client-exposed and public by convention
✓ built bundle secrets       pass  no credential shapes in apps/web/dist [vite]
```

And against a planted leak, because a check that only ever passes has not been tested:

```
✗ client-exposed env names   fail  1 client-exposed name(s) declare a secret:
                                   VITE_STRIPE_SECRET_KEY (.env) — a build inlines these   [high]
✗ built bundle secrets       fail  1 credential shape(s) in built output [vite]:
                                   dist/assets/index-abc.js                            [critical]
```

`VITE_API_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` in the same `.env` are correctly left alone. The bundle finding says **rotate first** — removing a credential from the build does not un-publish what already shipped.

18 tests on the new module, 4 469 in the suite, 0 fail. The four false-positive cases have tests of their own, including `dist/latest.js` (a filename containing "test" is not a test).

## Not in scope here

Entropy-based detection over bundle content, beyond the known credential shapes `findSecrets` already recognises. Minified client bundles are full of high-entropy strings — hashes, base64 assets, source-map fragments — and an entropy threshold there is a false-positive generator. The known-prefix list is the deterministic half, which is what was asked for; entropy would need its own evidence before it earns a verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)