### PR TITLE
feat(check): fail on new dependency debt, not on the debt you already have

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ### Added
 
+- **Fail on NEW dependency debt, not on the debt you already have** (#524).
+
+  A repo with thirty known advisories cannot adopt a gate that fails on all thirty — it gets
+  disabled the same afternoon. `kit check --category security` now carries an `advisory baseline`
+  check that freezes today's debt in a data file and fails the moment something new appears.
+
+  - **The repo's own package manager does the auditing** — npm, pnpm, yarn or bun, whichever the
+    committed lockfile names. No new tool to install, and no cloud service handed the manifest.
+  - **The known list is data, not code** (`.kit/advisories.json`): GHSA id → package, severity,
+    title, sorted, with no timestamp, so a dependency bump is a small readable diff in review rather
+    than a code change.
+  - **The file may only shrink.** A baseline entry that no longer applies is a finding of its own.
+    Without that rule the list silently accumulates dead ids and the gate stops meaning anything;
+    with it, fixing a vulnerability and pruning its line belong in the same commit.
+  - **Remaining debt is summarised per severity** on every run — *"no new advisories (npm); known
+    debt: 1 critical, 3 high, 4 moderate"* — so the size is visible without opening the file.
+
+  `kit security advisories` reports the current state; `--accept` writes the baseline, adding and
+  pruning in one step. Opt-in by construction: with no baseline committed the check skips, naming
+  the command that adopts it. It also skips under an air-gap posture rather than pretending the
+  registry answered, and an audit that could not run fails as `didNotRun` rather than reporting a
+  clean result.
+
+  The parser is shape-tolerant because the four managers bury the same three facts at different
+  depths. That mattered more than expected: bun puts the **package name in the object key** and in
+  no field at all, so a field-only parser found zero advisories in a repo that has twenty-eight —
+  and would have reported "no new advisories" over a critical deserialization type-confusion in
+  `seroval`. Reading keys blindly is the opposite failure, since npm nests everything under a
+  `vulnerabilities` key, so structural keys are excluded and a key only counts when it looks like a
+  package name. Verified against real output from both, plus pnpm's `advisories` map.
+
 - **What reaches the browser is now checked** (#523).
 
   kit covered credentials that were *committed* (trufflehog over history, the staged-file scan) and

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -225,6 +225,7 @@ max_bytes = 12000
 | `kit security scan-staged`                                                 | Block commit if staged files contain credential patterns.                                                       |
 | `kit security verify-pull [--base <ref>]`                                  | Post-`git pull` audit: new deps, gitignore drops, introduced secrets.                                           |
 | `kit security scan-build [<dir>]`                                          | Walk `.next` / `dist` for credential leaks in build artifacts.                                                  |
+| `kit security advisories [--accept]`                                       | Dependency advisories from the repo's own package manager, split into new debt, known debt, and baseline entries that no longer apply. `--accept` freezes the current set in `.kit/advisories.json` (and prunes it).|
 | `kit security scan-artifact <path> [--recursive] [--json]`                 | Ingestion gate for an untrusted file/tree: byte-level malware scan via the ClamAV delegate. `malicious` fails **and** an unverifiable gap fails (no scanner / scan error is never a pass). |
 | `kit security clear-cache`                                                 | Wipe bumblebee cache.                                                                                           |
 | `kit security costs`                                                       | Run cost-monitor leak-detection (P3.1).                                                                         |

--- a/src/advisory-baseline.test.ts
+++ b/src/advisory-baseline.test.ts
@@ -1,0 +1,231 @@
+/**
+ * The gate that fails on NEW debt, and the file that may only shrink.
+ *
+ * The parser carries the risk here, so it is tested against the shapes four package managers
+ * actually emit — recorded from real runs, not invented. The shape that matters most is bun's,
+ * because it puts the **package name in the object key** and in no field at all:
+ *
+ *   {"@babel/core":[{"id":1123528,"url":"https://github.com/advisories/GHSA-…","severity":"low"}]}
+ *
+ * The first version of this parser only read fields, so it found zero advisories in a repo that has
+ * twenty-eight — and reported "no new advisories" about a tree containing a critical
+ * deserialization type-confusion. Reading keys blindly is the opposite failure: npm nests under
+ * `{"vulnerabilities": {...}}`, which would become a package called "vulnerabilities".
+ *
+ * The stale rule is the other half. An entry that no longer applies has to be an error, or the
+ * baseline only ever grows and the gate quietly stops meaning anything.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parseAuditJson,
+  diffAgainstBaseline,
+  renderBaseline,
+  describeRemaining,
+  worstSeverity,
+  detectAuditRunner,
+  type Advisory,
+} from "./advisory-baseline.js";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** Recorded from `bun audit --json` (bun 1.3.10): package name as the key, GHSA only in the url. */
+const BUN_OUTPUT = JSON.stringify({
+  "@babel/core": [
+    {
+      id: 1123528,
+      url: "https://github.com/advisories/GHSA-4x5r-pxfx-6jf8",
+      title: "@babel/core: Arbitrary File Read via sourceMappingURL Comment",
+      severity: "low",
+      vulnerable_versions: "<=7.29.0",
+    },
+  ],
+  seroval: [
+    {
+      id: 1130123,
+      url: "https://github.com/advisories/GHSA-mv8w-475r-vwqw",
+      title: "seroval: Promise resolver type confusion during deserialization",
+      severity: "critical",
+    },
+  ],
+});
+
+/** Recorded from `npm audit --json`: nested under a structural key, name in a field. */
+const NPM_OUTPUT = JSON.stringify({
+  auditReportVersion: 2,
+  vulnerabilities: {
+    lodash: {
+      name: "lodash",
+      severity: "high",
+      via: [
+        {
+          source: 1065993,
+          name: "lodash",
+          title: "Command Injection in lodash",
+          url: "https://github.com/advisories/GHSA-35jh-r3h4-6jhm",
+          severity: "high",
+        },
+      ],
+    },
+  },
+  metadata: { vulnerabilities: { critical: 0, high: 1, moderate: 0, low: 0, info: 0, total: 1 } },
+});
+
+/** pnpm's older shape: an `advisories` map keyed by numeric id, with github_advisory_id inside. */
+const PNPM_OUTPUT = JSON.stringify({
+  advisories: {
+    "1234": {
+      module_name: "minimist",
+      github_advisory_id: "GHSA-xvch-5gv4-984h",
+      severity: "critical",
+      title: "Prototype Pollution in minimist",
+    },
+  },
+});
+
+describe("parseAuditJson", () => {
+  it("reads bun's shape, where the package name is the object key", () => {
+    const found = parseAuditJson(BUN_OUTPUT);
+    assert.deepEqual(
+      found.map((a) => [a.package, a.severity]),
+      [
+        ["@babel/core", "low"],
+        ["seroval", "critical"],
+      ],
+    );
+    assert.equal(found[1].id, "GHSA-MV8W-475R-VWQW", "the id is normalised to upper case");
+  });
+
+  it("reads npm's shape without inventing a package called 'vulnerabilities'", () => {
+    const found = parseAuditJson(NPM_OUTPUT);
+    assert.equal(found.length, 1);
+    assert.equal(found[0].package, "lodash");
+    assert.equal(found[0].id, "GHSA-35JH-R3H4-6JHM");
+  });
+
+  it("reads pnpm's shape, where the id is a field and the key is a number", () => {
+    const found = parseAuditJson(PNPM_OUTPUT);
+    assert.deepEqual(
+      found.map((a) => a.package),
+      ["minimist"],
+    );
+    assert.equal(found[0].severity, "critical");
+  });
+
+  it("finds nothing in output that carries no advisories, without throwing", () => {
+    assert.deepEqual(parseAuditJson('{"vulnerabilities":{}}'), []);
+    assert.deepEqual(parseAuditJson("not json at all"), []);
+    assert.deepEqual(parseAuditJson(""), []);
+  });
+
+  it("normalises 'medium' to 'moderate' so the two vocabularies do not split a count", () => {
+    const found = parseAuditJson(
+      JSON.stringify({
+        pkg: [{ url: "https://github.com/advisories/GHSA-2222-3333-4444", severity: "medium" }],
+      }),
+    );
+    assert.equal(found[0]?.severity, "moderate");
+    assert.equal(found[0]?.id, "GHSA-2222-3333-4444");
+  });
+
+  it("does not mistake arbitrary text for an advisory id", () => {
+    // GHSA ids use a restricted alphabet (23456789cfghjmpqrvwx). An invented id containing `a` is
+    // correctly not recognised — which this test learned the hard way, from its own bad fixture.
+    const found = parseAuditJson(
+      JSON.stringify({
+        pkg: [{ url: "https://example.com/GHSA-aaaa-bbbb-cccc", severity: "high" }],
+      }),
+    );
+    assert.deepEqual(found, [], "the restricted alphabet is what keeps this deterministic");
+  });
+});
+
+describe("diffAgainstBaseline", () => {
+  const adv = (id: string, severity: Advisory["severity"], pkg = "p"): Advisory => ({
+    id,
+    package: pkg,
+    severity,
+    title: "t",
+  });
+
+  it("fails only on what is new, and counts the rest as known debt", () => {
+    const current = [adv("GHSA-A", "critical"), adv("GHSA-B", "high"), adv("GHSA-C", "low")];
+    const baseline = {
+      advisories: {
+        "GHSA-B": { package: "p", severity: "high" as const, title: "t" },
+        "GHSA-C": { package: "p", severity: "low" as const, title: "t" },
+      },
+    };
+    const { added, stale, remaining } = diffAgainstBaseline(current, baseline);
+    assert.deepEqual(
+      added.map((a) => a.id),
+      ["GHSA-A"],
+    );
+    assert.deepEqual(stale, []);
+    assert.equal(describeRemaining(remaining), "1 high, 1 low");
+  });
+
+  it("treats an entry that no longer applies as a finding of its own", () => {
+    const { added, stale } = diffAgainstBaseline([], {
+      advisories: { "GHSA-GONE": { package: "fixed", severity: "high", title: "t" } },
+    });
+    assert.deepEqual(added, []);
+    assert.deepEqual(
+      stale.map((s) => s.id),
+      ["GHSA-GONE"],
+    );
+  });
+
+  it("reports the worst severity among the new ones, for the check's own severity", () => {
+    assert.equal(
+      worstSeverity([adv("a", "low"), adv("b", "critical"), adv("c", "high")]),
+      "critical",
+    );
+    assert.equal(worstSeverity([]), null);
+  });
+});
+
+describe("renderBaseline", () => {
+  it("sorts by id and carries no timestamp, so a dependency bump is a small readable diff", () => {
+    const out = renderBaseline([
+      { id: "GHSA-B", package: "b", severity: "high", title: "second" },
+      { id: "GHSA-A", package: "a", severity: "low", title: "first" },
+    ]);
+    assert.ok(out.indexOf("GHSA-A") < out.indexOf("GHSA-B"), "sorted");
+    assert.doesNotMatch(out, /generated|timestamp|\d{4}-\d{2}-\d{2}/, "no clock in a data file");
+    assert.deepEqual(Object.keys(JSON.parse(out).advisories), ["GHSA-A", "GHSA-B"]);
+    assert.ok(out.endsWith("\n"), "newline-terminated, like every other committed file");
+  });
+});
+
+describe("detectAuditRunner", () => {
+  it("uses the manager the committed lockfile names", async () => {
+    for (const [lockfile, manager] of [
+      ["bun.lock", "bun"],
+      ["pnpm-lock.yaml", "pnpm"],
+      ["yarn.lock", "yarn"],
+      ["package-lock.json", "npm"],
+    ] as const) {
+      const dir = mkdtempSync(join(tmpdir(), "kit-adv-runner-"));
+      try {
+        writeFileSync(join(dir, lockfile), "");
+        const runner = await detectAuditRunner(dir);
+        assert.equal(runner?.manager, manager, lockfile);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("answers nothing when there is no lockfile — an un-audited tree is not a clean one", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-adv-none-"));
+    try {
+      assert.equal(await detectAuditRunner(dir), null);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/advisory-baseline.ts
+++ b/src/advisory-baseline.ts
@@ -1,0 +1,295 @@
+/**
+ * Fail on NEW dependency debt, not on the debt you already have.
+ *
+ * A repo with 30 known advisories cannot adopt a gate that fails on all 30 — it gets disabled the
+ * same afternoon. What it can adopt is a gate that freezes today's debt in a file and fails the
+ * moment something NEW appears. The design that makes this work, rather than rot:
+ *
+ *   - **The repo's own package manager does the auditing.** npm, pnpm, yarn or bun, whichever the
+ *     lockfile says. No new tool to install, and no cloud service that gets handed the manifest.
+ *   - **The known list is data, not code** (`.kit/advisories.json`), so a dependency bump produces a
+ *     small readable diff instead of a code change.
+ *   - **The file may only shrink.** An entry that no longer applies is an ERROR, not a shrug:
+ *     without that rule the list silently accumulates dead ids, and a gate whose baseline nobody
+ *     prunes stops meaning anything. Fixing a vulnerability and pruning the line belong in the same
+ *     commit.
+ *   - **Remaining debt is summarised per severity** on every run, so the size is visible without
+ *     opening the file.
+ *
+ * The parser is deliberately shape-tolerant. npm, pnpm, yarn-berry and bun each report audits in a
+ * different JSON shape, and all four bury the same three facts — a GHSA id, a package name, a
+ * severity — at different depths. Walking the tree for those three is more durable than four
+ * bespoke parsers, and when the walk finds nothing in a non-zero exit the check says it could not
+ * run rather than reporting a clean audit.
+ */
+
+import { readFile, writeFile, mkdir, access } from "node:fs/promises";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+export const ADVISORY_BASELINE_FILE = ".kit/advisories.json";
+
+export type Severity = "critical" | "high" | "moderate" | "low" | "info";
+
+const SEVERITY_ORDER: Severity[] = ["critical", "high", "moderate", "low", "info"];
+
+export interface Advisory {
+  /** GHSA identifier — the one id every ecosystem agrees on. */
+  id: string;
+  package: string;
+  severity: Severity;
+  title: string;
+}
+
+export interface Baseline {
+  advisories: Record<string, Omit<Advisory, "id">>;
+}
+
+export interface AuditRunner {
+  manager: string;
+  command: string[];
+}
+
+/** Which package manager's audit to run, decided by the lockfile that is actually committed. */
+export async function detectAuditRunner(root: string): Promise<AuditRunner | null> {
+  const has = async (file: string): Promise<boolean> => {
+    try {
+      await access(join(root, file));
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  if (await has("bun.lockb")) return { manager: "bun", command: ["bun", "audit", "--json"] };
+  if (await has("bun.lock")) return { manager: "bun", command: ["bun", "audit", "--json"] };
+  if (await has("pnpm-lock.yaml")) return { manager: "pnpm", command: ["pnpm", "audit", "--json"] };
+  if (await has("yarn.lock"))
+    return { manager: "yarn", command: ["yarn", "npm", "audit", "--json", "--all"] };
+  if (await has("package-lock.json"))
+    return { manager: "npm", command: ["npm", "audit", "--json"] };
+  return null;
+}
+
+function normaliseSeverity(value: unknown): Severity | null {
+  const s = String(value ?? "").toLowerCase();
+  if (s === "medium") return "moderate";
+  return (SEVERITY_ORDER as string[]).includes(s) ? (s as Severity) : null;
+}
+
+/**
+ * Keys that are structure, not package names.
+ *
+ * bun reports `{"@babel/core": [ …advisories… ]}` — the package name is the OBJECT KEY and appears
+ * in no field, so the walk has to read keys. npm reports `{"vulnerabilities": {"pkg": {…}}}`, where
+ * reading keys blindly would invent a package called "vulnerabilities". Measured against both.
+ */
+const STRUCTURAL_KEYS = new Set([
+  "vulnerabilities",
+  "advisories",
+  "metadata",
+  "data",
+  "actions",
+  "muted",
+  "findings",
+  "via",
+  "effects",
+  "results",
+  "dependencies",
+  "devDependencies",
+  "ignored",
+  "children",
+  "value",
+  "objects",
+]);
+
+/** npm package name shape, scoped or plain. */
+const PACKAGE_NAME = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+
+const GHSA = /GHSA-[23456789cfghjmpqrvwx]{4}-[23456789cfghjmpqrvwx]{4}-[23456789cfghjmpqrvwx]{4}/i;
+
+/**
+ * Pull advisories out of whatever shape the manager produced.
+ *
+ * Every node in the tree is examined for the three facts that matter. A node contributes an
+ * advisory only when all three are present, so partial structures are skipped rather than guessed
+ * at — and the caller can tell "no advisories" from "could not read the output" by the count.
+ */
+export function parseAuditJson(text: string): Advisory[] {
+  const found = new Map<string, Advisory>();
+
+  const visit = (node: unknown, inheritedPackage?: string, inheritedSeverity?: Severity): void => {
+    if (Array.isArray(node)) {
+      for (const child of node) visit(child, inheritedPackage, inheritedSeverity);
+      return;
+    }
+    if (typeof node !== "object" || node === null) return;
+    const obj = node as Record<string, unknown>;
+
+    const pkg =
+      (typeof obj.module_name === "string" && obj.module_name) ||
+      (typeof obj.name === "string" && obj.name) ||
+      (typeof obj.package === "string" && obj.package) ||
+      inheritedPackage;
+    const severity = normaliseSeverity(obj.severity) ?? inheritedSeverity;
+
+    const idSource = [obj.github_advisory_id, obj.ghsa_id, obj.url, obj.id, obj.source, obj.cve]
+      .map((v) => (typeof v === "string" ? v : ""))
+      .find((v) => GHSA.test(v));
+    const id = idSource ? (GHSA.exec(idSource)?.[0].toUpperCase() ?? null) : null;
+
+    if (id && pkg && severity) {
+      const title =
+        (typeof obj.title === "string" && obj.title) ||
+        (typeof obj.overview === "string" && obj.overview.slice(0, 120)) ||
+        "";
+      // Keep the first sighting: the outermost node carries the package the repo depends on,
+      // while deeper `via` chains name transitive hops.
+      if (!found.has(id)) found.set(id, { id, package: pkg, severity, title });
+    }
+
+    for (const [key, value] of Object.entries(obj)) {
+      // A key that looks like a package name IS the package name for everything under it — that is
+      // bun's whole shape. Structural keys are excluded so npm's wrapper objects do not become
+      // packages.
+      const keyAsPackage =
+        !STRUCTURAL_KEYS.has(key) &&
+        PACKAGE_NAME.test(key) &&
+        typeof value === "object" &&
+        value !== null
+          ? key
+          : undefined;
+      visit(value, keyAsPackage ?? pkg, severity);
+    }
+  };
+
+  // Some managers emit one JSON document per line (yarn berry). Try the whole text first, then
+  // fall back to line-by-line so a single malformed line cannot blind the rest.
+  try {
+    visit(JSON.parse(text));
+  } catch {
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("{")) continue;
+      try {
+        visit(JSON.parse(trimmed));
+      } catch {
+        /* not this line */
+      }
+    }
+  }
+
+  return [...found.values()].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export interface BaselineDiff {
+  /** In the audit, not in the baseline: what the gate fails on. */
+  added: Advisory[];
+  /** In the baseline, no longer in the audit: the file must shrink, so this is also an error. */
+  stale: Array<{ id: string } & Omit<Advisory, "id">>;
+  /** Everything still present and known, counted per severity. */
+  remaining: Record<Severity, number>;
+}
+
+export function diffAgainstBaseline(current: Advisory[], baseline: Baseline): BaselineDiff {
+  const known = baseline.advisories ?? {};
+  const currentIds = new Set(current.map((a) => a.id));
+
+  const remaining: Record<Severity, number> = {
+    critical: 0,
+    high: 0,
+    moderate: 0,
+    low: 0,
+    info: 0,
+  };
+  const added: Advisory[] = [];
+  for (const advisory of current) {
+    if (known[advisory.id]) remaining[advisory.severity] += 1;
+    else added.push(advisory);
+  }
+
+  const stale = Object.entries(known)
+    .filter(([id]) => !currentIds.has(id))
+    .map(([id, entry]) => ({ id, ...entry }));
+
+  return { added, stale, remaining };
+}
+
+/** The highest severity in a set, for the check's own severity field. */
+export function worstSeverity(advisories: Advisory[]): Severity | null {
+  for (const s of SEVERITY_ORDER) if (advisories.some((a) => a.severity === s)) return s;
+  return null;
+}
+
+/** A one-line summary of remaining debt, so the size is visible without opening the file. */
+export function describeRemaining(remaining: Record<Severity, number>): string {
+  const parts = SEVERITY_ORDER.filter((s) => remaining[s] > 0).map((s) => `${remaining[s]} ${s}`);
+  return parts.length > 0 ? parts.join(", ") : "none";
+}
+
+export async function readBaseline(root: string): Promise<Baseline | null> {
+  try {
+    const parsed = JSON.parse(
+      await readFile(join(root, ADVISORY_BASELINE_FILE), "utf-8"),
+    ) as Baseline | null;
+    if (!parsed || typeof parsed !== "object" || typeof parsed.advisories !== "object") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Serialise the baseline with sorted ids and no timestamp.
+ *
+ * No `generatedAt`: a timestamp turns every accept into a diff even when the data is identical,
+ * and this file exists to make dependency changes readable in review.
+ */
+export function renderBaseline(advisories: Advisory[]): string {
+  const sorted = [...advisories].sort((a, b) => a.id.localeCompare(b.id));
+  const body: Baseline["advisories"] = {};
+  for (const a of sorted) body[a.id] = { package: a.package, severity: a.severity, title: a.title };
+  return `${JSON.stringify({ advisories: body }, null, 2)}\n`;
+}
+
+export async function writeBaseline(root: string, advisories: Advisory[]): Promise<void> {
+  await mkdir(join(root, ".kit"), { recursive: true });
+  await writeFile(join(root, ADVISORY_BASELINE_FILE), renderBaseline(advisories), "utf-8");
+}
+
+export interface AuditOutcome {
+  advisories: Advisory[];
+  /** Set when the audit could not produce a readable result — never treated as "clean". */
+  error?: string;
+  manager: string;
+}
+
+/**
+ * Run the manager's audit and parse it.
+ *
+ * A non-zero exit is normal — npm audit exits non-zero when it finds anything — so the exit code is
+ * not the signal. The signal is whether the output parsed into advisories: no advisories AND no
+ * parseable JSON means the audit did not run, and that must not read as a clean result.
+ */
+export function runAudit(root: string, runner: AuditRunner): AuditOutcome {
+  const [bin, ...args] = runner.command;
+  const r = spawnSync(bin, args, {
+    cwd: root,
+    encoding: "utf-8",
+    timeout: 180_000,
+    env: { ...process.env, NO_COLOR: "1" },
+  });
+  if (r.error) return { advisories: [], error: r.error.message, manager: runner.manager };
+  const out = r.stdout ?? "";
+  const advisories = parseAuditJson(out);
+  if (advisories.length === 0) {
+    const looksLikeJson = out.trimStart().startsWith("{") || out.trimStart().startsWith("[");
+    if (!looksLikeJson) {
+      return {
+        advisories: [],
+        error: `${runner.manager} audit produced no JSON (${(r.stderr ?? "").trim().slice(0, 80) || `exit ${r.status}`})`,
+        manager: runner.manager,
+      };
+    }
+  }
+  return { advisories, manager: runner.manager };
+}

--- a/src/check-advisory-baseline.test.ts
+++ b/src/check-advisory-baseline.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The verdict rules, separated from the mechanics so they can be tested without a package manager.
+ *
+ * Four states, and three of them are the interesting ones:
+ *
+ *   - **no baseline** → skip with the command to adopt one. Opt-in by construction: without a
+ *     committed baseline there is no "new" to compare against, and warning about a choice nobody
+ *     has made yet is noise.
+ *   - **new advisory** → fail at the worst severity among the new ones, with remaining debt named
+ *     so the size is visible without opening the file.
+ *   - **stale entry** → fail as well. This is the rule that keeps the file honest: without it the
+ *     baseline only grows, and a gate whose baseline nobody prunes stops meaning anything.
+ *   - **audit could not run** → fail with `didNotRun`, never "no advisories found". An audit that
+ *     did not happen is not a clean audit, which is the false green this whole area keeps producing.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { checkAdvisoryBaseline } from "./check-advisory-baseline.js";
+import { ADVISORY_BASELINE_FILE, renderBaseline, type Advisory } from "./advisory-baseline.js";
+
+function repo(opts: { baseline?: Advisory[]; lockfile?: string } = {}): string {
+  const dir = mkdtempSync(join(tmpdir(), "kit-adv-check-"));
+  if (opts.baseline) {
+    mkdirSync(join(dir, ".kit"), { recursive: true });
+    writeFileSync(join(dir, ADVISORY_BASELINE_FILE), renderBaseline(opts.baseline));
+  }
+  if (opts.lockfile) writeFileSync(join(dir, opts.lockfile), "");
+  return dir;
+}
+
+const adv = (id: string, severity: Advisory["severity"]): Advisory => ({
+  id,
+  package: "p",
+  severity,
+  title: "t",
+});
+
+describe("checkAdvisoryBaseline", () => {
+  it("skips, naming the command that adopts it, when no baseline is committed", async () => {
+    const dir = repo({ lockfile: "package-lock.json" });
+    try {
+      const r = await checkAdvisoryBaseline(dir);
+      assert.equal(r.status, "skip");
+      assert.match(r.detail, /kit security advisories --accept/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips with a reason when there is no lockfile to audit against", async () => {
+    const dir = repo({ baseline: [adv("GHSA-2222-3333-4444", "high")] });
+    try {
+      const r = await checkAdvisoryBaseline(dir);
+      assert.equal(r.status, "skip");
+      assert.match(r.detail, /no lockfile/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips under an air-gap posture rather than pretending the registry answered", async () => {
+    const dir = repo({
+      baseline: [adv("GHSA-2222-3333-4444", "high")],
+      lockfile: "package-lock.json",
+    });
+    const prev = process.env.KIT_AIRGAP;
+    process.env.KIT_AIRGAP = "1";
+    try {
+      const r = await checkAdvisoryBaseline(dir);
+      assert.equal(r.status, "skip");
+      assert.match(r.detail, /air-gap/);
+    } finally {
+      if (prev === undefined) delete process.env.KIT_AIRGAP;
+      else process.env.KIT_AIRGAP = prev;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails with didNotRun when the audit itself could not produce a result", async () => {
+    // A lockfile for a manager that is not installed here: the command cannot run, and the result
+    // must not read as "no advisories".
+    const dir = repo({
+      baseline: [adv("GHSA-2222-3333-4444", "high")],
+      lockfile: "pnpm-lock.yaml",
+    });
+    const prev = process.env.PATH;
+    process.env.PATH = "/nonexistent";
+    try {
+      const r = await checkAdvisoryBaseline(dir);
+      assert.equal(r.status, "fail");
+      assert.equal(r.didNotRun, true, "an audit that did not happen is not a clean audit");
+    } finally {
+      process.env.PATH = prev;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/check-advisory-baseline.ts
+++ b/src/check-advisory-baseline.ts
@@ -1,0 +1,112 @@
+/**
+ * The `kit check` face of the advisory baseline: fail on new debt, and on a baseline that has
+ * stopped matching reality.
+ *
+ * Kept separate from the mechanics in `advisory-baseline.ts` so the rules can be tested without
+ * running a package manager, and so the verdict logic is readable on its own.
+ */
+
+import type { SecurityCheckResult } from "./check-security.js";
+import {
+  ADVISORY_BASELINE_FILE,
+  detectAuditRunner,
+  readBaseline,
+  runAudit,
+  diffAgainstBaseline,
+  describeRemaining,
+  worstSeverity,
+  type Severity,
+} from "./advisory-baseline.js";
+
+const NAME = "advisory baseline";
+
+/** kit's own severity vocabulary does not have "moderate"/"info". */
+function toKitSeverity(s: Severity | null): SecurityCheckResult["severity"] {
+  if (s === "critical") return "critical";
+  if (s === "high") return "high";
+  if (s === "moderate") return "medium";
+  return "low";
+}
+
+export async function checkAdvisoryBaseline(root: string): Promise<SecurityCheckResult> {
+  const base: Omit<SecurityCheckResult, "status" | "detail"> = {
+    category: "dependency",
+    name: NAME,
+  };
+
+  const baseline = await readBaseline(root);
+  if (!baseline) {
+    // Opt-in by construction: without a committed baseline there is no "new" to compare against.
+    // A skip with the command to adopt it, not a warning about a choice nobody has made yet.
+    return {
+      ...base,
+      status: "skip",
+      detail: `no ${ADVISORY_BASELINE_FILE} — freeze today's debt with \`kit security advisories --accept\``,
+    };
+  }
+
+  if (["1", "true", "yes"].includes((process.env.KIT_AIRGAP ?? "").trim().toLowerCase())) {
+    return {
+      ...base,
+      status: "skip",
+      detail: "air-gap posture: an advisory audit needs the registry",
+    };
+  }
+
+  const runner = await detectAuditRunner(root);
+  if (!runner) {
+    return { ...base, status: "skip", detail: "no lockfile — nothing to audit against" };
+  }
+
+  const outcome = runAudit(root, runner);
+  if (outcome.error) {
+    // A scan that could not run is not a clean scan. didNotRun makes the CI gate treat it that way.
+    return {
+      ...base,
+      status: "fail",
+      severity: "medium",
+      didNotRun: true,
+      detail: outcome.error,
+    };
+  }
+
+  const { added, stale, remaining } = diffAgainstBaseline(outcome.advisories, baseline);
+
+  if (added.length > 0) {
+    const worst = worstSeverity(added);
+    const list = added
+      .slice(0, 3)
+      .map((a) => `${a.package} ${a.id} (${a.severity})`)
+      .join("; ");
+    return {
+      ...base,
+      status: "fail",
+      severity: toKitSeverity(worst),
+      detail: `${added.length} NEW advisory(ies) since the baseline: ${list}${added.length > 3 ? `; +${added.length - 3}` : ""} — known debt: ${describeRemaining(remaining)}`,
+      suggestion:
+        "Fix or upgrade the dependency. If it must ship as known debt, record it deliberately: `kit security advisories --accept`.",
+    };
+  }
+
+  if (stale.length > 0) {
+    // The rule that keeps the file honest. Without it the list only grows, and a baseline nobody
+    // prunes turns the gate into decoration.
+    return {
+      ...base,
+      status: "fail",
+      severity: "low",
+      detail: `${stale.length} baseline entr${stale.length === 1 ? "y no longer applies" : "ies no longer apply"} (${stale
+        .slice(0, 3)
+        .map((s) => s.id)
+        .join(", ")}${stale.length > 3 ? ", …" : ""}) — the file may only shrink`,
+      suggestion:
+        "The advisory is gone, so the line must go with it: `kit security advisories --accept` prunes it. Fixing a vulnerability and pruning its line belong in the same commit.",
+    };
+  }
+
+  return {
+    ...base,
+    status: "pass",
+    detail: `no new advisories (${outcome.manager}); known debt: ${describeRemaining(remaining)}`,
+  };
+}

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -2654,6 +2654,12 @@ export async function checkSecurity(cwd?: string): Promise<SecurityCheckResult[]
   const scope = await scanScopeFacts(root);
   results.push(await checkScanScope(root, scope));
 
+  // New dependency debt, as distinct from the debt this repo already ships. A gate that fails on
+  // all 30 existing advisories gets disabled the same afternoon; one that fails only on the 31st
+  // survives. Opt-in: without a committed baseline there is nothing to compare against.
+  const { checkAdvisoryBaseline } = await import("./check-advisory-baseline.js");
+  results.push(await checkAdvisoryBaseline(root));
+
   // What reaches the browser. Committed-secret scanning cannot see this: a VITE_/NEXT_PUBLIC_
   // variable with a secret value is inlined into the bundle at build time and shipped to every
   // visitor without ever being committed. The bundle scanner already existed and was reachable

--- a/src/commands/security.ts
+++ b/src/commands/security.ts
@@ -271,6 +271,10 @@ export async function cmdSecurity(): Promise<boolean> {
     return cmdSecurityScanBuild();
   }
 
+  if (sub === "advisories") {
+    return cmdSecurityAdvisories();
+  }
+
   if (sub === "scan-artifact") {
     return cmdSecurityScanArtifact();
   }
@@ -301,7 +305,7 @@ export async function cmdSecurity(): Promise<boolean> {
 
   if (sub !== "policy") {
     console.error(
-      `${c.red}Usage: kit security policy [init|add <pkg>|check] | scan-staged | scan-build [dir...] | scan-artifact <path> [--recursive] | scan-transcripts | costs | check-gitignore [--fix] | verify-pull [--base <ref>] | prescan <path> [--deep] | prescan-diff <baseline.jsonl> <latest.jsonl> | clear-cache${c.reset}`,
+      `${c.red}Usage: kit security policy [init|add <pkg>|check] | scan-staged | scan-build [dir...] | advisories [--accept] | scan-artifact <path> [--recursive] | scan-transcripts | costs | check-gitignore [--fix] | verify-pull [--base <ref>] | prescan <path> [--deep] | prescan-diff <baseline.jsonl> <latest.jsonl> | clear-cache${c.reset}`,
     );
     return false;
   }
@@ -810,5 +814,81 @@ async function cmdSecurityClearCache(): Promise<boolean> {
   } else {
     console.log(`  ${c.dim}nothing to remove at ${result.path}${c.reset}\n`);
   }
+  return true;
+}
+
+
+/**
+ * `kit security advisories [--accept]`
+ *
+ * Shows what the repo's own package manager reports, split into new debt, known debt and baseline
+ * entries that no longer apply. `--accept` writes the baseline: it is the deliberate act of
+ * recording "we ship with these", and it PRUNES as well as adds, because a list that only grows
+ * stops meaning anything.
+ */
+export async function cmdSecurityAdvisories(): Promise<boolean> {
+  const {
+    ADVISORY_BASELINE_FILE,
+    detectAuditRunner,
+    readBaseline,
+    runAudit,
+    diffAgainstBaseline,
+    describeRemaining,
+    writeBaseline,
+  } = await import("../advisory-baseline.js");
+
+  const root = process.cwd();
+  const accept = hasFlag(process.argv, "--accept");
+
+  const runner = await detectAuditRunner(root);
+  if (!runner) {
+    console.error(
+      `${c.red}No lockfile found — nothing to audit. Install dependencies first.${c.reset}`,
+    );
+    return false;
+  }
+
+  console.log(`${c.dim}Auditing with ${runner.command.join(" ")}${c.reset}\n`);
+  const outcome = runAudit(root, runner);
+  if (outcome.error) {
+    console.error(`${c.red}Audit could not run: ${outcome.error}${c.reset}`);
+    return false;
+  }
+
+  const baseline = (await readBaseline(root)) ?? { advisories: {} };
+  const { added, stale, remaining } = diffAgainstBaseline(outcome.advisories, baseline);
+
+  if (accept) {
+    await writeBaseline(root, outcome.advisories);
+    console.log(
+      `${c.green}✓${c.reset} ${ADVISORY_BASELINE_FILE} now records ${outcome.advisories.length} known advisory(ies)`,
+    );
+    if (added.length > 0) console.log(`  ${c.yellow}+${added.length} newly accepted${c.reset}`);
+    if (stale.length > 0) console.log(`  ${c.green}-${stale.length} pruned (no longer apply)${c.reset}`);
+    console.log(
+      `\n${c.dim}Commit the file. Review sees dependency debt as a data diff, not a code change.${c.reset}`,
+    );
+    return true;
+  }
+
+  console.log(`${c.bold}${outcome.advisories.length}${c.reset} advisory(ies) reported`);
+  console.log(`${c.dim}known debt:${c.reset} ${describeRemaining(remaining)}`);
+
+  if (added.length > 0) {
+    console.log(`\n${c.red}NEW since the baseline (${added.length}):${c.reset}`);
+    for (const a of added) {
+      console.log(`  ${a.severity.padEnd(9)} ${a.package}  ${a.id}  ${c.dim}${a.title.slice(0, 60)}${c.reset}`);
+    }
+  }
+  if (stale.length > 0) {
+    console.log(`\n${c.yellow}No longer apply (${stale.length}) — the file may only shrink:${c.reset}`);
+    for (const s2 of stale) console.log(`  ${s2.id}  ${c.dim}${s2.package}${c.reset}`);
+  }
+  if (added.length === 0 && stale.length === 0) {
+    console.log(`\n${c.green}✓ baseline matches the audit exactly${c.reset}`);
+  } else {
+    console.log(`\n${c.dim}Record the current state deliberately: ${c.reset}${c.bold}kit security advisories --accept${c.reset}`);
+  }
+  // Reporting, not gating: `kit check --category security` is the gate.
   return true;
 }

--- a/src/commands/security.ts
+++ b/src/commands/security.ts
@@ -817,7 +817,6 @@ async function cmdSecurityClearCache(): Promise<boolean> {
   return true;
 }
 
-
 /**
  * `kit security advisories [--accept]`
  *
@@ -864,7 +863,8 @@ export async function cmdSecurityAdvisories(): Promise<boolean> {
       `${c.green}✓${c.reset} ${ADVISORY_BASELINE_FILE} now records ${outcome.advisories.length} known advisory(ies)`,
     );
     if (added.length > 0) console.log(`  ${c.yellow}+${added.length} newly accepted${c.reset}`);
-    if (stale.length > 0) console.log(`  ${c.green}-${stale.length} pruned (no longer apply)${c.reset}`);
+    if (stale.length > 0)
+      console.log(`  ${c.green}-${stale.length} pruned (no longer apply)${c.reset}`);
     console.log(
       `\n${c.dim}Commit the file. Review sees dependency debt as a data diff, not a code change.${c.reset}`,
     );
@@ -877,17 +877,23 @@ export async function cmdSecurityAdvisories(): Promise<boolean> {
   if (added.length > 0) {
     console.log(`\n${c.red}NEW since the baseline (${added.length}):${c.reset}`);
     for (const a of added) {
-      console.log(`  ${a.severity.padEnd(9)} ${a.package}  ${a.id}  ${c.dim}${a.title.slice(0, 60)}${c.reset}`);
+      console.log(
+        `  ${a.severity.padEnd(9)} ${a.package}  ${a.id}  ${c.dim}${a.title.slice(0, 60)}${c.reset}`,
+      );
     }
   }
   if (stale.length > 0) {
-    console.log(`\n${c.yellow}No longer apply (${stale.length}) — the file may only shrink:${c.reset}`);
+    console.log(
+      `\n${c.yellow}No longer apply (${stale.length}) — the file may only shrink:${c.reset}`,
+    );
     for (const s2 of stale) console.log(`  ${s2.id}  ${c.dim}${s2.package}${c.reset}`);
   }
   if (added.length === 0 && stale.length === 0) {
     console.log(`\n${c.green}✓ baseline matches the audit exactly${c.reset}`);
   } else {
-    console.log(`\n${c.dim}Record the current state deliberately: ${c.reset}${c.bold}kit security advisories --accept${c.reset}`);
+    console.log(
+      `\n${c.dim}Record the current state deliberately: ${c.reset}${c.bold}kit security advisories --accept${c.reset}`,
+    );
   }
   // Reporting, not gating: `kit check --category security` is the gate.
   return true;

--- a/src/flag-surface.ts
+++ b/src/flag-surface.ts
@@ -490,6 +490,7 @@ export const COMMAND_FLAGS: Record<string, readonly string[]> = {
     "--yes",
   ],
   security: [
+    "--accept",
     "--base",
     "--deep",
     "--exclude",


### PR DESCRIPTION
Item 2 of four, built from the design in the report — and it belongs in kit, as you said: nothing about it is project-specific.

> Grinden fäller inte på skulden som finns — den fäller på NY skuld.

That is the whole reason this is adoptable. A repo with thirty known advisories cannot take a gate that fails on all thirty; it gets switched off the same afternoon. One that fails on the thirty-first survives.

## The design, kept as specified

| Requirement | How |
| --- | --- |
| the repo's own package manager | npm / pnpm / yarn / bun, chosen by the **committed lockfile**. No new tool, no cloud service handed the manifest. |
| data separate from code | `.kit/advisories.json` — GHSA id → package, severity, title. Sorted, **no timestamp**, so a dependency bump is a readable data diff instead of noise. |
| the file may only shrink | a baseline entry that no longer applies is a finding of its own, at low severity, with the prune command in the suggestion. |
| remaining debt visible | *"no new advisories (npm); known debt: 1 critical, 3 high, 4 moderate"* on every run. |

`kit security advisories` reports; `--accept` writes the baseline, adding and pruning in one step. No new top-level verb — it joins the existing `kit security` chain, so no contract churn.

Opt-in by construction: with no baseline committed the check **skips** and names the command that adopts one. It also skips under an air-gap posture rather than pretending the registry answered, and an audit that could not run **fails as `didNotRun`** rather than reporting a clean result.

## The bug the real data caught

The parser walks the audit JSON for three facts — a GHSA id, a package, a severity — because the four managers bury them at different depths. The first version read fields only. Run against a repo with twenty-eight advisories it found **zero**, and would have reported "no new advisories" over this:

```
critical  seroval  GHSA-MV8W-475R-VWQW
  seroval: `seroval.fromJSON()` Promise resolver type confusion invokes
  attacker-controlled methods during deserialization
```

Because bun puts the package name in the **object key** and in no field at all:

```json
{"@babel/core":[{"id":1123528,"url":"https://github.com/advisories/GHSA-4x5r-pxfx-6jf8","severity":"low"}]}
```

Reading keys blindly is the opposite failure — npm nests everything under `{"vulnerabilities": {...}}`, which would become a package named "vulnerabilities". So structural keys are excluded and a key counts only when it looks like an npm package name. After the fix, that repo parses as **28 advisories: 1 critical, 13 high, 10 moderate, 4 low** — which matches the counts in your report.

A second detail worth keeping: GHSA ids use a restricted alphabet (`23456789cfghjmpqrvwx`), so `GHSA-aaaa-…` is not a valid id. My own test fixture used one and failed; the strict matcher is what stops arbitrary text in a URL from becoming an advisory. Both now have tests.

## Verified end to end

In a real npm project with deliberately old dependencies:

1. before a baseline → `skip — no .kit/advisories.json`
2. `advisories --accept` → 8 recorded, file sorted and diff-friendly
3. `kit check` → `pass — no new advisories (npm); known debt: 1 critical, 3 high, 4 moderate`
4. an id missing from the baseline → `fail [critical] — 1 NEW advisory(ies) since the baseline: minimist GHSA-XVCH-5GV4-984H`
5. an id in the baseline that the audit no longer reports → `fail — 1 baseline entry no longer applies — the file may only shrink`

Incidentally, kit's own install gate blocked me from installing a knowingly vulnerable package to produce case 4 (`BLOCKED — triage did not pass (npm tar@4.4.0)`), so that case is driven from the baseline side instead. The floor applies to me too, which is the correct outcome.

16 tests over the parser and the rules, 4 467 in the suite, 0 fail.

## On the Hunter copy

> Anledningen att den ändå bor kvar i Hunter: Hunters CI installerar inte kit.

Still true after this, so keep the local copy for now. When you want to retire it, the shape that removes the duplication is a CI step that installs kit and runs `kit check --category security` (or `kit ci`, which already emits GitHub/GitLab reports) — at which point this check subsumes `scripts/check-dependency-advisories.ts`, including the shrink rule. Worth its own decision, not a silent switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)