### PR TITLE
fix(flags): make regeneration byte-identical, and say where a table ends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,46 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **Regenerating `flag-surface.ts` produced a 512-line diff over identical content** (#525).
+
+  `scripts/derive-command-flags.mjs --emit` wrote one verb per line; Prettier reformats that to one
+  flag per line. So running the documented regeneration command reflowed the whole file without
+  changing a single fact — and I read that diff as the generator having narrowed the accepted flags
+  of 70+ verbs, reported it as a defect, and repeated it in two PR bodies and a shared-memory entry
+  before comparing either side's content. Measured properly: **0 of 72 verbs differ.**
+
+  `emit()` now produces Prettier's shape (width-based, same `printWidth` of 100), so regeneration is
+  byte-identical, and a test compares the generated string against the committed file and names the
+  first differing line. A generated file nobody dares regenerate is a hardcoded table wearing a
+  generator's hat.
+
+### Changed
+
+- **A scanner that finds nothing now says what it looked for** (#525).
+
+  Some tables have to be hardcoded — nothing in a repository can tell you what a Stripe key looks
+  like. What must never be hidden is where such a table ends. "No credential patterns found" reads
+  as "there are no credentials"; the true statement is "none of the shapes kit knows". So the
+  denominator is part of the claim:
+
+  ```
+  ✓ scan-build: no matches for 25 known credential shapes — a shape outside that set is not detected
+  ✓ scan-artifact: file.js — no matches for 25 known credential shapes
+  ```
+
+  The count is `SECRET_SHAPE_COUNT`, derived from the pattern list rather than written down: a
+  hardcoded count is a claim that rots the first time someone adds a pattern. While adding it, a
+  grep for `label:` said 29 and the derived count said 25 — the grep had counted the interface field
+  and a doc line, which is the argument for deriving it in one datum.
+
+  `secrets scan`'s clean line now names its detector too — *"no committed secrets (trufflehog
+  detector set, full history)"* — because that path's bound is trufflehog's set over history, a much
+  larger one than kit's own pattern list used by `scan-staged` and `scan-build`, and a reader cannot
+  size the claim without knowing which applied. The fallback path already stated its bound
+  explicitly and is unchanged.
+
+### Fixed
+
 - **`kit ci` rendered a skipped check as a failure on GitHub and as a pass on GitLab** (#517).
   Two surfaces, two opposite lies, one missing case.
 

--- a/scripts/derive-command-flags.mjs
+++ b/scripts/derive-command-flags.mjs
@@ -263,12 +263,30 @@ const GENERATED_HEADER = `/**
 
 `;
 
-function emit(surface) {
-  const lines = [GENERATED_HEADER, "export const COMMAND_FLAGS: Record<string, readonly string[]> = {"];
+export function emit(surface) {
+  // The header already ends in a newline; `join("\n")` would add a second one, and Prettier
+  // collapses it — one more way a no-op regeneration produced a diff.
+  const lines = [
+    GENERATED_HEADER.replace(/\n+$/, ""),
+    "",
+    "export const COMMAND_FLAGS: Record<string, readonly string[]> = {",
+  ];
   for (const verb of Object.keys(surface).sort()) {
     const flags = surface[verb];
     const key = /^[a-z][a-z0-9]*$/.test(verb) ? verb : JSON.stringify(verb);
-    lines.push(`  ${key}: [${flags.map((f) => JSON.stringify(f)).join(", ")}],`);
+    const inline = `  ${key}: [${flags.map((f) => JSON.stringify(f)).join(", ")}],`;
+    // Emit what Prettier would emit. This file is generated AND committed, so a regeneration that
+    // is content-identical must also be diff-identical. The single-line form gets reflowed to one
+    // flag per line, turning a no-op regeneration into a 512-line diff — which was misread as
+    // catastrophic data loss, and reported as such. Prettier's rule is width-based (printWidth
+    // 100), so the same threshold is applied here rather than guessed at.
+    if (inline.length <= 100) {
+      lines.push(inline);
+    } else {
+      lines.push(`  ${key}: [`);
+      for (const f of flags) lines.push(`    ${JSON.stringify(f)},`);
+      lines.push(`  ],`);
+    }
   }
   lines.push("};", "");
   lines.push(`/**

--- a/src/check-security.ts
+++ b/src/check-security.ts
@@ -1517,7 +1517,10 @@ async function checkSecretsInCode(root: string): Promise<SecurityCheckResult> {
         category: "secrets",
         name: "secrets scan",
         status: "pass",
-        detail: `no committed secrets (trufflehog git)${pbdNote}${exampleNote}${ignoredNote}`,
+        // Name the detector, not just the outcome: this path's coverage is trufflehog's set over
+        // full history, which is a different (much larger) bound than kit's own pattern list used
+        // by scan-staged and scan-build. A reader cannot size "no committed secrets" without it.
+        detail: `no committed secrets (trufflehog detector set, full history)${pbdNote}${exampleNote}${ignoredNote}`,
       };
     } catch {
       return {

--- a/src/commands/security.ts
+++ b/src/commands/security.ts
@@ -27,6 +27,7 @@ import { clearBumblebeeCache } from "../bumblebee.js";
 import { scanStagedFiles } from "../scan-staged.js";
 import { existsSync } from "node:fs";
 import { scanBuildArtifacts } from "../scan-build.js";
+import { SECRET_SHAPE_COUNT } from "../utils/redactSecrets.js";
 import { scanTranscripts } from "../scan-transcripts.js";
 import { sampleCosts } from "../cost-monitor.js";
 import { checkGitignore, patchGitignore, findCommittedSensitive } from "../check-gitignore.js";
@@ -486,7 +487,9 @@ async function cmdSecurityScanArtifact(): Promise<boolean> {
 
   const engine = r.engine ? ` ${c.dim}(via ${r.engine})${c.reset}` : "";
   if (r.verdict === "clean") {
-    console.log(`${c.green}✓ scan-artifact: ${target} — clean${c.reset}${engine}`);
+    console.log(
+      `${c.green}✓ scan-artifact: ${target} — no matches for ${SECRET_SHAPE_COUNT} known credential shapes${c.reset}${engine}`,
+    );
     console.log(`  ${c.dim}${r.detail}${c.reset}`);
     return true;
   }
@@ -507,7 +510,11 @@ async function cmdSecurityScanBuild(): Promise<boolean> {
   const extras = process.argv.slice(4).filter((a) => !a.startsWith("--"));
   const hits = await scanBuildArtifacts(process.cwd(), extras.length > 0 ? extras : undefined);
   if (hits.length === 0) {
-    console.log(`${c.green}✓ scan-build: no credential patterns in build artifacts.${c.reset}`);
+    // The denominator belongs in the claim: "no patterns found" reads as "no secrets there", and
+    // the honest statement is "none of the shapes kit knows".
+    console.log(
+      `${c.green}✓ scan-build: no matches for ${SECRET_SHAPE_COUNT} known credential shapes${c.reset}${c.dim} — a shape outside that set is not detected${c.reset}`,
+    );
     return true;
   }
   const total = hits.reduce((sum, h) => sum + h.findings.length, 0);

--- a/src/flag-surface.test.ts
+++ b/src/flag-surface.test.ts
@@ -279,3 +279,43 @@ describe("flag floor — kit never prints an invocation it would reject", () => 
     assert.match(r.stdout, /Available services:/);
   });
 });
+
+/**
+ * Regenerating must be a no-op — byte for byte, not just fact for fact.
+ *
+ * The drift test above compares FACTS: every flag the source reads must appear in the table. It
+ * passed while `--emit` wrote the same data in a different shape, one verb per line where Prettier
+ * wants one flag per line. Running the documented regeneration command therefore produced a
+ * 512-line diff over identical content — and I read that diff as the generator having narrowed the
+ * accepted flags of 70+ verbs, reported it as a defect, and wrote it into two PR bodies and a
+ * shared-memory entry before measuring the content. It was formatting.
+ *
+ * So the property is stronger than "the facts agree": the generator's output must be exactly what
+ * is committed. A regeneration that cannot be run without producing noise is a regeneration nobody
+ * runs, and a generated file nobody dares regenerate is a hardcoded table wearing a generator's
+ * hat.
+ */
+describe("regeneration is byte-identical", () => {
+  it("emits exactly the committed file", async () => {
+    const mod = (await import(
+      pathToFileURL(join(REPO_ROOT, "scripts", "derive-command-flags.mjs")).href
+    )) as {
+      deriveFlagSurface: (depth?: number) => { surface: Record<string, string[]> };
+      emit: (surface: Record<string, string[]>) => string;
+    };
+    const { surface } = mod.deriveFlagSurface();
+    const generated = mod.emit(surface);
+    const committed = readFileSync(join(REPO_ROOT, "src", "flag-surface.ts"), "utf-8");
+
+    if (generated !== committed) {
+      // Point at the first divergence: a whole-file diff in an assertion message is unreadable.
+      const g = generated.split("\n");
+      const c = committed.split("\n");
+      const i = g.findIndex((line, idx) => line !== c[idx]);
+      assert.fail(
+        `line ${i + 1} differs — run \`node scripts/derive-command-flags.mjs --emit\`\n` +
+          `  generated: ${JSON.stringify(g[i])}\n  committed: ${JSON.stringify(c[i])}`,
+      );
+    }
+  });
+});

--- a/src/utils/redactSecrets.test.ts
+++ b/src/utils/redactSecrets.test.ts
@@ -1,6 +1,14 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { redactSecrets, safeStatusLine, findSecrets, shannonEntropy } from "./redactSecrets.js";
+import {
+  redactSecrets,
+  safeStatusLine,
+  findSecrets,
+  shannonEntropy,
+  SECRET_PATTERNS,
+  SECRET_SHAPE_COUNT,
+  secretShapeLabels,
+} from "./redactSecrets.js";
 
 describe("findSecrets — entropy backstop (fail-closed shared-memory gate)", () => {
   const has = (text: string, opts?: { entropyBackstop?: boolean }) =>
@@ -264,5 +272,33 @@ describe("findSecrets — Swedish personnummer (PII parity, Luhn-validated)", ()
     assert.equal(pnr("ts 1234567890 log").length, 0); // MM=34 → not a date
     assert.equal(pnr("call 0701234567 now").length, 0); // phone-shaped, fails validation
     assert.equal(pnr("no pii in this line").length, 0);
+  });
+});
+
+/**
+ * The bound has to be derived, and it has to be sayable.
+ *
+ * Some tables must be hardcoded: nothing in a repository can tell you what a Stripe key looks
+ * like. What must never be hidden is where such a table ends — "no secrets found" and "no secrets
+ * of the kinds I know" are different statements, and only the second is true. So the count is
+ * derived from the list rather than written down, because a written count is a claim that rots the
+ * first time someone adds a pattern.
+ *
+ * Measured while adding this: a grep for `label:` said 29 shapes, the derived count says 25. The
+ * grep counted the interface field and a doc line. That is the whole argument in one datum.
+ */
+
+describe("the detector's declared bound", () => {
+  it("is derived from the pattern list, not written down", () => {
+    assert.equal(SECRET_SHAPE_COUNT, SECRET_PATTERNS.length);
+    assert.ok(SECRET_SHAPE_COUNT > 10, "a plausible detector, not an empty list");
+  });
+
+  it("names every shape exactly once, so a count and a list cannot disagree", () => {
+    const labels = secretShapeLabels();
+    assert.equal(new Set(labels).size, labels.length, "no duplicate labels");
+    assert.deepEqual(labels, [...labels].sort(), "stable order for stable output");
+    // Every pattern contributes a label: a nameless pattern could never be reported.
+    for (const p of SECRET_PATTERNS) assert.ok(p.label.length > 0);
   });
 });

--- a/src/utils/redactSecrets.ts
+++ b/src/utils/redactSecrets.ts
@@ -186,6 +186,22 @@ export const SECRET_PATTERNS: RedactPattern[] = [
   // Skipped intentionally: too many false-positives against commit hashes.
 ];
 
+/**
+ * How many credential shapes kit itself can recognise.
+ *
+ * Derived from the list, never written down: a hardcoded count is a claim that rots the first time
+ * someone adds a pattern. This number exists so a scanner that finds nothing can say what it looked
+ * for — "no secrets found" and "no secrets of the 29 kinds I know" are different statements, and
+ * only the second one is true. Some tables must be hardcoded (nothing in a repo can tell you what a
+ * Stripe key looks like); what must never be hidden is where the table ends.
+ */
+export const SECRET_SHAPE_COUNT = SECRET_PATTERNS.length;
+
+/** The shape labels, for a caller that wants to name them rather than count them. */
+export function secretShapeLabels(): string[] {
+  return [...new Set(SECRET_PATTERNS.map((p) => p.label))].sort();
+}
+
 export function redactSecrets(input: string): string {
   if (!input) return input;
   let out = input;


### PR DESCRIPTION
Two halves of one lesson, and the first half is a correction of my own reporting.

## 1. The 512-line diff was formatting, not content

I told you that `scripts/derive-command-flags.mjs --emit` narrows the accepted-flag sets of 70+ verbs, and that the drift test lets it pass silently. **That was wrong.** Measured properly — comparing the derived surface against the built table verb by verb instead of reading `git diff --stat`:

```
verb totalt: 72 | med innehållsskillnad: 0
```

What actually happened: `emit()` wrote one verb per line, Prettier reformats that to one flag per line, so a no-op regeneration reflowed the whole file. 512 deletions, zero facts changed. I reported a defect from a line count without parsing either side, and the claim propagated into #519's body, #521's, and a shared-memory entry.

The record is straightened in all four places: comments on #519 and #521, and the memory entry **reversed** rather than edited (`--reverses 0ef8d4`), since that tier is append-only.

**The real defect** is still worth fixing, and it is the reason the misread was possible: regeneration was not idempotent. A generated file that cannot be regenerated without producing 512 lines of noise is a file nobody regenerates — which makes it a hardcoded table wearing a generator's hat, and `kit` is meant to be deterministic, not static.

`emit()` now produces Prettier's shape, using the same width rule (`printWidth: 100`) rather than a guess. Regeneration is byte-identical, and CI's `format:check` no longer disagrees with the generator.

The test that would have caught it compares the generated string against the committed file:

```
line 36 differs — run `node scripts/derive-command-flags.mjs --emit`
  generated: "  add: [\"--auto\", \"--aws-region\", …"
  committed: "  add: ["
```

Verified by reintroducing the old single-line form: 17 pass, 1 fail, pointing at line 36. Restored: 18 pass.

## 2. Where a table ends must be visible

You put it exactly right: *ibland måste vi avgränsa, men då ska det vara synligt.*

Some tables **must** be hardcoded. Nothing in a repository can tell you that `sk_live_` is a Stripe key, that `VITE_` gets inlined into a bundle, or that GHSA ids use the alphabet `23456789cfghjmpqrvwx`. That is knowledge about the world, not about your code.

What must never be hidden is where the table ends — because "no credential patterns found" reads as "there are no credentials", while the true statement is "none of the shapes kit knows". Same defect class as everything else this week: **a verdict without a denominator.**

```
✓ scan-build: no matches for 25 known credential shapes — a shape outside that set is not detected
✓ scan-artifact: file.js — no matches for 25 known credential shapes
```

The count is `SECRET_SHAPE_COUNT`, **derived** from `SECRET_PATTERNS`, never written down. A written count is a claim that rots the first time someone adds a pattern — and the proof arrived while I was adding it: a grep for `label:` said 29 shapes, the derived count says 25. The grep had counted the interface field and a doc line. That is the whole argument in one datum, and it has a test.

`secrets scan`'s clean line now names its detector too — *"no committed secrets (trufflehog detector set, full history)"* — because that path's bound is trufflehog's set over history, which is a much larger bound than kit's own pattern list used by `scan-staged` and `scan-build`. A reader cannot size the claim without knowing which one applied. The fallback path was already explicit (*"basic scan … HEAD/working-tree only, NOT git history"*) and is unchanged; my initial claim that "the bound is invisible" was too broad, and that path is the counter-example.

## What is deliberately not in here

The inventory found **95 literal tables of 8+ entries** in `src/`. They are not one problem, they are three:

| Kind | Failure direction | Verdict |
| --- | --- | --- |
| derivable from kit's own source (`COMMAND_FLAGS`, public surface, opencli) | drifts silently | must be generated + drift-tested — all three verified content-correct and now idempotent |
| irreducible world knowledge (credential shapes, client prefixes, package managers, frameworks) | missing entry → **false green** | must be hardcoded; the bound must be stated |
| judgment lists (conventionally-public names, ignored dirs, test-artifact paths) | missing entry → false positive, visible and self-correcting | fine as they are |

Only the middle row is dangerous, and this PR covers the credential-shape case. Walking the remaining tables in that row belongs in an issue, not in a PR that started as a formatting fix — otherwise this grows without end.

4 454 tests pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)