### PR TITLE
feat(audit): record where an event happened, and whether it was a test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **Audit entries now say where they happened, and whether they were a test** (#526).
+
+  kit's own log had **7 199 events and not one carried a location**. Every entry named a key and an
+  operation, and no place — so the 4 053 `policy-check` events, almost all of them the test suite
+  exercising the gate, could not be separated from an operator's. `kit usage` had to print *"operator
+  and test activity cannot be told apart in these totals"* instead of a number. The evidence existed
+  and was unusable.
+
+  Two fields, and the choice of fields is the point:
+
+  - **`repo`** — `owner/repo` from the origin remote, or the working tree's directory name when
+    there is no remote. Deliberately **not** the absolute cwd: this log is exportable
+    (`kit audit export`, the Remote push), and an absolute path carries the operator's username and,
+    in a consultancy tree, client names. `owner/repo` is what the repository already publishes in
+    its own remote, so it adds no exposure while still telling two trees apart. A test asserts no
+    home path can appear in a serialised entry.
+  - **`test`** — stamped at write time from `NODE_TEST_CONTEXT` (which node:test sets and spawned
+    CLIs inherit) or `KIT_TEST=1`. After the fact there is nothing left to distinguish a
+    test-generated event by, so it has to be recorded when it happens.
+
+  Resolution is cached per directory: the append path handles thousands of events, and a `git` spawn
+  per event would not be acceptable. A directory whose identity cannot be determined caches that
+  too, so a non-git tree does not re-spawn git on every event. An explicitly supplied `repo` is
+  never overwritten — the broker files evidence on another tree's behalf and knows its own answer.
+
+  `kit audit` shows both, and prints `—` for entries written before the fields existed rather than
+  guessing.
+
 ### Fixed
 
 - **`kit ci` rendered a skipped check as a failure on GitHub and as a pass on GitLab** (#517).

--- a/src/audit.test.ts
+++ b/src/audit.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { readFile, unlink } from "node:fs/promises";
-import { mkdtempSync, rmSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join, basename } from "node:path";
 import { tmpdir } from "node:os";
 import {
   logAuditEvent,
@@ -11,6 +12,8 @@ import {
   appendAuditEventDirect,
   verifyAuditChain,
   verifyAuditSignatures,
+  repoIdentity,
+  isTestRun,
 } from "./audit.js";
 import { loadOrCreateIdentity, localPublicKeys } from "./identity.js";
 import type { GovernanceConfig } from "./config.js";
@@ -801,5 +804,122 @@ describe("formatAuditLog — edges, ordering and agent attribution", () => {
     assert.equal(lines.length, 3);
     assert.equal(lines[1], "  Error: line1");
     assert.equal(lines[2], "line2");
+  });
+});
+
+/**
+ * An audit entry that cannot say WHERE it happened cannot be attributed.
+ *
+ * kit's own log had 7 199 events and not one carried a location. Every entry named a key and an
+ * operation, and no place — so the 4 053 `policy-check` events (almost all of them the test suite
+ * exercising the gate) could not be separated from an operator's, and `kit usage` had to print
+ * "operator and test activity cannot be told apart" instead of a number. The evidence was there and
+ * unusable.
+ *
+ * Two fields fix that, and the choice of fields is the interesting part:
+ *
+ *   - `repo` as `owner/repo`, NOT the absolute cwd. This log is exportable (`kit audit export`, the
+ *     Remote push), and an absolute path carries the operator's username and, in a consultancy
+ *     tree, client names. `owner/repo` is what the repository already publishes in its own remote,
+ *     so it adds no exposure while still telling two trees apart.
+ *   - `test` stamped at write time, because after the fact there is nothing left to distinguish a
+ *     test-generated event by.
+ */
+
+function gitRepo(remote?: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "kit-attr-"));
+  spawnSync("git", ["init", "-q", "-b", "main", dir]);
+  if (remote) spawnSync("git", ["-C", dir, "remote", "add", "origin", remote]);
+  return dir;
+}
+
+describe("repoIdentity", () => {
+  it("reduces every remote form to owner/repo", () => {
+    for (const [remote, expected] of [
+      ["git@github.com:acme/widget.git", "acme/widget"],
+      ["https://github.com/acme/widget.git", "acme/widget"],
+      ["https://github.com/acme/widget", "acme/widget"],
+      ["ssh://git@gitlab.example.com:2222/acme/widget.git", "acme/widget"],
+    ] as const) {
+      const dir = gitRepo(remote);
+      try {
+        assert.equal(repoIdentity(dir), expected, remote);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("falls back to the working tree's name when there is no remote", () => {
+    const dir = gitRepo();
+    try {
+      assert.equal(repoIdentity(dir), basename(dir));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("answers nothing outside a git tree, rather than inventing a name", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kit-attr-plain-"));
+    try {
+      assert.equal(repoIdentity(dir), undefined);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("isTestRun", () => {
+  it("recognises node:test, which spawned CLIs inherit", () => {
+    assert.equal(isTestRun({ NODE_TEST_CONTEXT: "child-v8" }), true);
+    assert.equal(isTestRun({ KIT_TEST: "1" }), true);
+    assert.equal(isTestRun({}), false);
+    // Not every truthy-looking value: an explicit opt-out must stay opted out.
+    assert.equal(isTestRun({ KIT_TEST: "0" }), false);
+  });
+});
+
+describe("appended events carry their attribution", () => {
+  it("stamps repo and test, and never the absolute path", async () => {
+    const dir = gitRepo("git@github.com:acme/widget.git");
+    try {
+      const ok = await appendAuditEventDirect(
+        { operation: "policy-check", environment: "test", success: false },
+        { cwd: dir },
+      );
+      assert.equal(ok, true);
+      const logPath = join(dir, ".kit-audit.jsonl");
+      assert.ok(existsSync(logPath), "the event must land in the governed tree");
+      const entry = JSON.parse(readFileSync(logPath, "utf-8").trim().split("\n")[0]) as Record<
+        string,
+        unknown
+      >;
+
+      assert.equal(entry.repo, "acme/widget");
+      // This suite IS a test run, so the marker must be set — that is the whole point of the field.
+      assert.equal(entry.test, true);
+      // The exposure rule: no absolute path anywhere in the serialised entry.
+      const raw = readFileSync(logPath, "utf-8");
+      assert.doesNotMatch(raw, /\/(Users|home)\//, "an exported log must not carry a home path");
+      assert.doesNotMatch(raw, new RegExp(dir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves an explicitly supplied repo alone — the broker knows its own answer", async () => {
+    const dir = gitRepo("git@github.com:acme/widget.git");
+    try {
+      await appendAuditEventDirect(
+        { operation: "broker-write", environment: "test", success: true, repo: "other/tree" },
+        { cwd: dir },
+      );
+      const entry = JSON.parse(
+        readFileSync(join(dir, ".kit-audit.jsonl"), "utf-8").trim().split("\n")[0],
+      ) as Record<string, unknown>;
+      assert.equal(entry.repo, "other/tree");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -1,5 +1,6 @@
 import { appendFile, readFile, writeFile, rename } from "node:fs/promises";
-import { resolve } from "node:path";
+import { resolve, basename } from "node:path";
+import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import type { GovernanceConfig } from "./config.js";
 import { identityId, verifySignature } from "./identity.js";
@@ -29,6 +30,66 @@ function redactAuditValue(v: unknown): unknown {
     return out;
   }
   return v;
+}
+
+/**
+ * Repo identity per working tree, resolved once.
+ *
+ * The append path is hot — 4 000+ refusals in this repo's own log — so a `git` spawn per event is
+ * not acceptable. Resolved on first use per directory and cached for the process; a tree whose
+ * identity cannot be determined caches `undefined` too, so a non-git directory does not re-spawn
+ * git on every event.
+ */
+const repoIdentityCache = new Map<string, string | undefined>();
+
+export function repoIdentity(cwd: string): string | undefined {
+  if (repoIdentityCache.has(cwd)) return repoIdentityCache.get(cwd);
+  let identity: string | undefined;
+  try {
+    const remote = execFileSync("git", ["-C", cwd, "remote", "get-url", "origin"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2_000,
+    }).trim();
+    // Any remote form reduces to owner/repo: https, ssh, scp-style, with or without .git.
+    const m = /([^/:]+)\/([^/]+?)(?:\.git)?$/.exec(remote);
+    if (m) identity = `${m[1]}/${m[2]}`;
+  } catch {
+    /* no remote, or not a git tree */
+  }
+  if (!identity) {
+    try {
+      const top = execFileSync("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 2_000,
+      }).trim();
+      if (top) identity = basename(top);
+    } catch {
+      /* not a git tree at all */
+    }
+  }
+  repoIdentityCache.set(cwd, identity);
+  return identity;
+}
+
+/** True when this process is a test run — node:test sets NODE_TEST_CONTEXT, and it is inherited by spawned CLIs. */
+export function isTestRun(env: NodeJS.ProcessEnv = process.env): boolean {
+  return typeof env.NODE_TEST_CONTEXT === "string" || env.KIT_TEST === "1";
+}
+
+/**
+ * Stamp the two attribution fields onto an event, without overwriting what a caller set explicitly
+ * (the broker files evidence on another tree's behalf and knows its own answer).
+ */
+function withAttribution(event: AuditEvent, cwd: string): AuditEvent {
+  const stamped: AuditEvent = { ...event };
+  if (stamped.repo === undefined) {
+    const repo = repoIdentity(cwd);
+    if (repo) stamped.repo = repo;
+  }
+  if (stamped.test === undefined && isTestRun()) stamped.test = true;
+  return stamped;
 }
 
 function redactAuditEvent(event: AuditEvent): AuditEvent {
@@ -278,6 +339,32 @@ const RETRY_BACKOFF_MS = [250, 1_000, 4_000];
 
 export interface AuditEvent {
   timestamp: string;
+  /**
+   * The repository the operation ran in, as `owner/repo` from the origin remote, or the working
+   * tree's directory name when there is no remote.
+   *
+   * Deliberately NOT the absolute cwd. This log is exportable (`kit audit export`, the Remote
+   * push), and an absolute path carries the operator's username and, in a consultancy tree, client
+   * names — `/Users/<name>/Development/<client>/…`. `owner/repo` is information the repository
+   * already publishes in its own remote, so recording it adds no new exposure while still telling
+   * two trees apart.
+   *
+   * Why this exists: kit's own log had 7 199 events and not one of them said WHERE. Every entry was
+   * attributable to a key and to an operation, and to no place — so operator activity could not be
+   * separated from the test suite's, and no per-actor or per-repo number could be built on top. A
+   * verdict about "how much did the floor refuse" was unanswerable in the one repo that had the
+   * most evidence.
+   */
+  repo?: string;
+  /**
+   * True when the process was a test run.
+   *
+   * kit's own 4 053 `policy-check` events are almost entirely the suite exercising the gate. Left
+   * unmarked they inflate every count that reads the log, which is why `kit usage` had to print
+   * "operator and test activity cannot be told apart" instead of a number. Marked at write time,
+   * because after the fact there is nothing to distinguish them by.
+   */
+  test?: true;
   agent_id?: string;
   agent_name?: string;
   operation: string;
@@ -305,12 +392,12 @@ export async function appendAuditEventDirect(
 ): Promise<boolean> {
   // Redact at construction so EVERY sink — chain write, remote push, pending queue —
   // sees the redacted event, not just the on-disk chain.
-  const auditEvent: AuditEvent = redactAuditEvent({
-    timestamp: new Date().toISOString(),
-    ...event,
-  });
+  const auditEvent: AuditEvent = redactAuditEvent(
+    withAttribution({ timestamp: new Date().toISOString(), ...event }, opts.cwd ?? process.cwd()),
+  );
   const logFile = opts.logFile ?? ".kit-audit.jsonl";
-  const logPath = resolve(opts.cwd ?? process.cwd(), logFile);
+  const dir = opts.cwd ?? process.cwd();
+  const logPath = resolve(dir, logFile);
   try {
     const wroteHash = await appendChained(logPath, auditEvent);
     // Best-effort external HMAC anchor advance. Fail-soft by contract: never
@@ -467,12 +554,17 @@ export async function logAuditEvent(
     return true;
   }
 
-  const auditEvent: AuditEvent = {
-    timestamp: new Date().toISOString(),
-    agent_id: config.agent.id,
-    agent_name: config.agent.name,
-    ...event,
-  };
+  const auditEvent: AuditEvent = withAttribution(
+    {
+      timestamp: new Date().toISOString(),
+      agent_id: config.agent.id,
+      agent_name: config.agent.name,
+      ...event,
+    },
+    // The GOVERNED tree, matching where the log itself lands a few lines below: an event filed in
+    // B's chain must say B, not the host process's directory.
+    cwd ?? process.cwd(),
+  );
 
   // When include_secrets is false (the default), strip secrets two ways: by KEY NAME
   // (sanitizeMetadata drops keys like `password`) AND by VALUE — redact known credential

--- a/src/output.ts
+++ b/src/output.ts
@@ -374,6 +374,7 @@ export function printAuditTable(events: import("./audit.js").AuditEvent[]): void
   const envWidth = Math.max(6, ...events.map((e) => e.environment.length)) + 2;
   const actorWidth =
     Math.max(8, ...events.map((e) => (e.agent_name ?? e.agent_id ?? "unknown").length)) + 2;
+  const repoWidth = Math.max(4, ...events.map((e) => (e.repo ?? "—").length)) + 2;
 
   for (const event of events) {
     const icon = event.success ? CHECK : CROSS;
@@ -382,9 +383,14 @@ export function printAuditTable(events: import("./audit.js").AuditEvent[]): void
     const env = pad(`[${event.environment}]`, envWidth + 2);
     const actor = pad(event.agent_name ?? event.agent_id ?? "unknown", actorWidth);
     const duration = event.duration_ms != null ? `${c.dim}${event.duration_ms}ms${c.reset}` : "";
+    // Where it happened, and whether it was a test. Both were missing for every one of the 7 199
+    // entries in kit's own log, which is why nobody could tell operator activity from the suite's.
+    // Entries written before those fields existed print an em dash rather than a guess.
+    const repo = pad(event.repo ?? "—", repoWidth);
+    const marker = event.test ? `${c.dim}test${c.reset}` : "    ";
 
     console.log(
-      `  ${icon} ${c.dim}${ts}${c.reset}  ${op}  ${c.gray}${env}${c.reset}  ${actor}  ${duration}`,
+      `  ${icon} ${c.dim}${ts}${c.reset}  ${op}  ${c.gray}${env}${c.reset}  ${actor}  ${c.dim}${repo}${c.reset}  ${marker}  ${duration}`,
     );
 
     if (event.error) {


### PR DESCRIPTION
Item 2 of the three. The measurement that motivates it, from kit's own repo:

```
poster: 7199 | signerade: 3333 (46.3 %) | unika kid: 139
med cwd: 0
policy-check 4053 · read-only-mode-refusal 1177 · read-only-mode-activated 928 · elevation-check 449
```

Every entry was attributable to a **key** and to an **operation**, and to no **place**. So the 4 053 `policy-check` events — almost all of them the test suite exercising the gate — could not be separated from an operator's, and `kit usage` had to print *"operator and test activity cannot be told apart in these totals"* rather than a number. The evidence existed and was unusable, which is the same defect shape as the rest of this week: a record that cannot answer the question it was kept for.

## Two fields, and the choice matters more than the addition

**`repo`** — `owner/repo` from the origin remote; the working tree's directory name when there is no remote; nothing at all outside a git tree.

Deliberately **not** the absolute cwd, which is what I originally proposed. This log is exportable (`kit audit export`, the Remote push), and an absolute path carries the operator's username and, in a consultancy tree, client names:

```
/Users/<name>/Development/<client>/…
```

`owner/repo` is information the repository already publishes in its own remote, so recording it adds no new exposure while still telling two trees apart. There is a test asserting that no home path can appear in a serialised entry — the rule is enforced, not just intended.

**`test`** — stamped from `NODE_TEST_CONTEXT` (node:test sets it, and spawned CLIs inherit it, which is exactly how kit's suite drives the gate) or `KIT_TEST=1`. It must be recorded **at write time**: afterwards there is nothing left to distinguish a test-generated event by, which is why kit's existing 7 199 entries can never be sorted retroactively.

## Cost, and the negative cache

The append path handles thousands of events — 4 000+ refusals in this repo alone — so a `git` spawn per event is not acceptable. Identity resolves once per directory and is cached **including the negative answer**, so a non-git directory does not re-spawn git on every event.

An explicitly supplied `repo` is never overwritten: `exec-broker` files evidence on another tree's behalf and knows its own answer.

## Visible where a human looks

```
✓ 8/22/2026, 8:43:33 PM  read-only-mode-activated  [unknown]  unknown  sandstream/kit
✓ 8/22/2026, 8:43:41 PM  read-only-mode-activated  [unknown]  unknown  sandstream/kit  test
✓ 8/22/2026, 7:58:12 PM  read-only-mode-activated  [unknown]  unknown  —
```

The em dash is entries written before the fields existed. Not a guess, and not blank — the same rule as everywhere else: unknown is reported as unknown.

Verified against four real trees: an ssh remote (`git@github.com:acme/widget.git` → `acme/widget`), an https remote, a git repo with no remote (falls back to the directory name), and a plain directory (no identity claimed). Every remote form reduces through one regex, tested against scp-style and `ssh://host:port/` forms too.

## Follow-up, once #519 lands

`kit usage`'s floor tab currently reports `actorUnknown` from the absence of `cwd`. It should read `test` instead, and can then show operator and test counts separately rather than declining to answer. Deliberately not done here — #519 is unmerged, and coupling the two branches to save one commit is how a rebase becomes a merge conflict.

4 457 tests pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)