### PR TITLE
fix(plugins): a registry that advertises packages nobody published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **The plugin registry advertised packages that do not exist, and ratings nobody measured** (#528).
+
+  `kit plugin list` printed this:
+
+  ```
+  stripe/payments 1.0.0 ★★★★◆ 4.8
+    Install: npm install @kit/plugins/stripe
+  ```
+
+  Checked against npm and GitHub, every claim on that line was false:
+
+  | Claimed | Actual |
+  | --- | --- |
+  | `@kit/plugins/stripe` | no such package — the real one is `sandstream-kit-plugin-stripe`, so the install command could not work |
+  | version `1.0.0` | the published packages are `0.1.0` / `0.2.0` |
+  | `github.com/sandstream/kit-stripe` | HTTP 404 |
+  | `★★★★◆ 4.8`, `1250 downloads` | invented — no source exists for either |
+  | `updated: <now>` | `new Date().toISOString()` at import, so the registry always claimed to be current |
+
+  And it listed **five of eleven** shipped plugins, so `kit plugin search cloudflare` answered *"No
+  plugins found matching: cloudflare"* about a package published on npm at that moment. Six plugins
+  — cloudflare, github, sentrux, sentry, snyk, wiz — were undiscoverable through kit's own discovery
+  surface.
+
+  The registry is now **generated** from each plugin package's own manifest: real npm name, real
+  version, real description, one real repository URL. `rating`, `downloads` and `published` are
+  omitted, and their fields made optional — the display code already treats them as optional, so
+  absent means unshown rather than estimated. `updated` is gone for the same reason.
+
+  Six tests hold it there: every shipped package must be listed, every entry must match the manifest
+  it names (package, version, and a runnable install command), no entry may carry a rating or
+  download count, every repository link must be the one real repository, each plugin must be findable
+  by the name a person would type, and regeneration must be byte-identical.
+
+### Fixed
+
 - **`kit ci` rendered a skipped check as a failure on GitHub and as a pass on GitLab** (#517).
   Two surfaces, two opposite lies, one missing case.
 

--- a/packages/kit-plugin-cloudflare/package.json
+++ b/packages/kit-plugin-cloudflare/package.json
@@ -2,6 +2,13 @@
   "name": "sandstream-kit-plugin-cloudflare",
   "version": "0.2.0",
   "description": "Cloudflare Workers secret + API token surface for kit",
+  "keywords": [
+    "kit-plugin",
+    "secrets",
+    "hosting",
+    "cloudflare",
+    "workers"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/kit-plugin-fly/package.json
+++ b/packages/kit-plugin-fly/package.json
@@ -2,6 +2,13 @@
   "name": "sandstream-kit-plugin-fly",
   "version": "0.2.0",
   "description": "Fly.io app-secret rotation via flyctl GraphQL API",
+  "keywords": [
+    "kit-plugin",
+    "secrets",
+    "hosting",
+    "fly.io",
+    "deployment"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/kit-plugin-github/package.json
+++ b/packages/kit-plugin-github/package.json
@@ -2,6 +2,13 @@
   "name": "sandstream-kit-plugin-github",
   "version": "0.2.0",
   "description": "kit plugin: GitHub REST API (repo + org secrets, deploy keys, workflow runs).",
+  "keywords": [
+    "kit-plugin",
+    "secrets",
+    "vcs",
+    "github",
+    "ci"
+  ],
   "type": "module",
   "exports": {
     ".": {

--- a/packages/kit-plugin-railway/package.json
+++ b/packages/kit-plugin-railway/package.json
@@ -2,6 +2,12 @@
   "name": "sandstream-kit-plugin-railway",
   "version": "0.1.0",
   "description": "kit adapter plugin for Railway deployment platform",
+  "keywords": [
+    "kit-plugin",
+    "hosting",
+    "deployment",
+    "railway"
+  ],
   "type": "module",
   "exports": {
     ".": {

--- a/packages/kit-plugin-sentrux/package.json
+++ b/packages/kit-plugin-sentrux/package.json
@@ -2,6 +2,13 @@
   "name": "sandstream-kit-plugin-sentrux",
   "version": "0.1.0",
   "description": "Sentrux architecture-scan ingestion for kit (read-only).",
+  "keywords": [
+    "kit-plugin",
+    "security",
+    "scanning",
+    "ingestion",
+    "read-only"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/kit-plugin-sentry/package.json
+++ b/packages/kit-plugin-sentry/package.json
@@ -1,7 +1,13 @@
 {
   "name": "sandstream-kit-plugin-sentry",
   "version": "0.2.0",
-  "description": "Sentry REST API client for kit — issue triage, release tagging, project introspection.",
+  "description": "Sentry REST API client for kit \u2014 issue triage, release tagging, project introspection.",
+  "keywords": [
+    "kit-plugin",
+    "monitoring",
+    "observability",
+    "sentry"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/kit-plugin-snyk/package.json
+++ b/packages/kit-plugin-snyk/package.json
@@ -2,6 +2,13 @@
   "name": "sandstream-kit-plugin-snyk",
   "version": "0.1.0",
   "description": "Snyk scan-result ingestion for kit (read-only).",
+  "keywords": [
+    "kit-plugin",
+    "security",
+    "scanning",
+    "ingestion",
+    "read-only"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/kit-plugin-stripe/package.json
+++ b/packages/kit-plugin-stripe/package.json
@@ -2,6 +2,12 @@
   "name": "sandstream-kit-plugin-stripe",
   "version": "0.2.0",
   "description": "Stripe Management API surface for kit (webhook endpoint rotation + account introspection)",
+  "keywords": [
+    "kit-plugin",
+    "payments",
+    "stripe",
+    "webhooks"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/kit-plugin-supabase/package.json
+++ b/packages/kit-plugin-supabase/package.json
@@ -2,6 +2,12 @@
   "name": "sandstream-kit-plugin-supabase",
   "version": "0.2.0",
   "description": "kit plugin: Supabase Management API integration (service-role key rotation, project introspection).",
+  "keywords": [
+    "kit-plugin",
+    "database",
+    "supabase",
+    "secrets"
+  ],
   "type": "module",
   "exports": {
     ".": {

--- a/packages/kit-plugin-vercel/package.json
+++ b/packages/kit-plugin-vercel/package.json
@@ -2,6 +2,13 @@
   "name": "sandstream-kit-plugin-vercel",
   "version": "0.2.0",
   "description": "kit plugin: Vercel Management API (env management, project metadata, redeploy triggers).",
+  "keywords": [
+    "kit-plugin",
+    "hosting",
+    "deployment",
+    "vercel",
+    "env"
+  ],
   "type": "module",
   "exports": {
     ".": {

--- a/packages/kit-plugin-wiz/package.json
+++ b/packages/kit-plugin-wiz/package.json
@@ -2,6 +2,13 @@
   "name": "sandstream-kit-plugin-wiz",
   "version": "0.1.0",
   "description": "Wiz issue-graph ingestion for kit (read-only).",
+  "keywords": [
+    "kit-plugin",
+    "security",
+    "scanning",
+    "ingestion",
+    "read-only"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/scripts/gen-plugin-registry.mjs
+++ b/scripts/gen-plugin-registry.mjs
@@ -1,0 +1,149 @@
+/**
+ * Generate the plugin registry from the plugin packages that actually exist.
+ *
+ * WHY. The hand-written registry claimed things that were not true, and `kit plugin list` rendered
+ * them as fact. Measured against npm and GitHub:
+ *
+ *   - `package: "@kit/plugins/stripe"` — no such package on npm; the real one is
+ *     `sandstream-kit-plugin-stripe`, so the printed `install` command could not work;
+ *   - `version: "1.0.0"` — the published packages are 0.1.0 / 0.2.0;
+ *   - `repository: "https://github.com/sandstream/kit-stripe"` — HTTP 404;
+ *   - `rating: 4.8`, `downloads: 1250` — invented, with no source anywhere, and printed as
+ *     `★★★★◆ 4.8`;
+ *   - `updated: new Date().toISOString()` — evaluated at import, so the registry always claimed to
+ *     be current;
+ *   - five entries for eleven shipped plugins, so `kit plugin search cloudflare` answered
+ *     "No plugins found" about a package published on npm.
+ *
+ * Everything here is read from the packages' own `package.json`. Fields kit has no local source for
+ * — rating, downloads, publish date — are OMITTED rather than estimated; the display code already
+ * treats them as optional, so absent means unshown instead of invented.
+ *
+ * Byte-idempotent: no timestamps, sorted output, Prettier's shape.
+ */
+
+import { readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const OUT = join(ROOT, "src", "plugin-registry.generated.ts");
+
+/** The monorepo these plugins live in — one real URL rather than eleven invented ones. */
+function repositoryUrl() {
+  try {
+    const root = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf-8"));
+    const raw = typeof root.repository === "string" ? root.repository : root.repository?.url;
+    return (raw ?? "https://github.com/sandstream/kit").replace(/^git\+/, "").replace(/\.git$/, "");
+  } catch {
+    return "https://github.com/sandstream/kit";
+  }
+}
+
+export function collect() {
+  const packagesDir = join(ROOT, "packages");
+  const dirs = readdirSync(packagesDir).filter((d) => d.startsWith("kit-plugin-")).sort();
+  const repository = repositoryUrl();
+  const plugins = [];
+
+  for (const dir of dirs) {
+    let pkg;
+    try {
+      pkg = JSON.parse(readFileSync(join(packagesDir, dir, "package.json"), "utf-8"));
+    } catch {
+      continue;
+    }
+    if (pkg.private === true) continue; // not published: nothing to advertise
+    const id = dir.replace(/^kit-plugin-/, "");
+    plugins.push({
+      name: id,
+      description: pkg.description ?? `kit plugin: ${id}`,
+      version: pkg.version ?? "0.0.0",
+      author: typeof pkg.author === "string" ? pkg.author : (pkg.author?.name ?? "Sandstream"),
+      license: pkg.license ?? "MIT",
+      repository,
+      package: pkg.name,
+      kitVersion: pkg.peerDependencies?.["sandstream-kit"] ?? ">=6.0.0",
+      tags: [...new Set([id, ...(pkg.keywords ?? []), "official"])].sort(),
+      install: `npm install ${pkg.name}`,
+    });
+  }
+  return plugins;
+}
+
+export function render() {
+  const plugins = collect();
+  const body = plugins
+    .map((p) => {
+      const lines = [
+        "  {",
+        `    name: ${JSON.stringify(p.name)},`,
+        // Prettier breaks a property whose line exceeds printWidth (100) onto the next line,
+        // indented. Emitting that shape here keeps regeneration byte-identical instead of fighting
+        // `format:check` — the same trap as scripts/derive-command-flags.mjs, met a second time and
+        // handled while writing the generator rather than after misreading its diff.
+        ...(() => {
+          const inline = `    description: ${JSON.stringify(p.description)},`;
+          return inline.length <= 100
+            ? [inline]
+            : ["    description:", `      ${JSON.stringify(p.description)},`];
+        })(),
+        `    version: ${JSON.stringify(p.version)},`,
+        `    author: ${JSON.stringify(p.author)},`,
+        `    license: ${JSON.stringify(p.license)},`,
+        `    repository: ${JSON.stringify(p.repository)},`,
+        `    package: ${JSON.stringify(p.package)},`,
+        `    kitVersion: ${JSON.stringify(p.kitVersion)},`,
+        `    tags: [${p.tags.map((t) => JSON.stringify(t)).join(", ")}],`,
+        `    install: ${JSON.stringify(p.install)},`,
+        "  },",
+      ];
+      return lines.join("\n");
+    })
+    .join("\n");
+
+  return `/**
+ * kit's OFFICIAL PLUGINS — generated from each plugin package manifest under packages.
+ *
+ * (The path is spelled out rather than globbed: a literal star-slash inside a block comment ends
+ * the comment early, and the first version of this generator emitted a file TypeScript could not
+ * parse. Writing it with a backtick broke the generator's own template literal instead.)
+ *
+ * GENERATED. Regenerate with:  node scripts/gen-plugin-registry.mjs
+ * \`plugins-registry.test.ts\` fails when this file drifts from the packages on disk, so a shipped
+ * plugin cannot stay invisible and an entry cannot describe a package that does not exist.
+ *
+ * The hand-written table this replaces advertised npm packages that were never published
+ * (\`@kit/plugins/stripe\`), a 404 repository per plugin, versions that did not match the published
+ * ones, and invented ratings and download counts that \`kit plugin list\` printed as \`★★★★◆ 4.8\`.
+ * Five of eleven shipped plugins were listed at all.
+ *
+ * Fields with no local source — rating, downloads, publish date — are absent by design. The display
+ * code treats them as optional, so absent means unshown rather than estimated.
+ */
+
+import type { PluginMetadata } from "./plugins.js";
+
+export const OFFICIAL_PLUGINS: PluginMetadata[] = [
+${body}
+];
+`;
+}
+
+function main() {
+  const text = render();
+  let previous = null;
+  try {
+    previous = readFileSync(OUT, "utf-8");
+  } catch {
+    /* first run */
+  }
+  if (previous === text) {
+    console.log("src/plugin-registry.generated.ts already current");
+    return;
+  }
+  writeFileSync(OUT, text, "utf-8");
+  console.log(`wrote src/plugin-registry.generated.ts — ${collect().length} plugins`);
+}
+
+if (process.argv[1] && process.argv[1].endsWith("gen-plugin-registry.mjs")) main();

--- a/src/plugin-registry.generated.test.ts
+++ b/src/plugin-registry.generated.test.ts
@@ -1,0 +1,115 @@
+/**
+ * The registry must describe plugins that exist, with the versions they were published at.
+ *
+ * The hand-written table this replaces was not merely stale, it was fabricated — measured against
+ * npm and GitHub:
+ *
+ *   - `package: "@kit/plugins/stripe"` — no such package; the real one is
+ *     `sandstream-kit-plugin-stripe`, so the printed install command could not work;
+ *   - `version: "1.0.0"` — the published packages are 0.1.0 / 0.2.0;
+ *   - `repository: "https://github.com/sandstream/kit-stripe"` — HTTP 404;
+ *   - `rating: 4.8` and `downloads: 1250` — no source anywhere, printed as `★★★★◆ 4.8`;
+ *   - `updated: new Date().toISOString()` — evaluated at import, so it always claimed to be current;
+ *   - five entries for eleven shipped plugins, so `kit plugin search cloudflare` answered "No
+ *     plugins found" about a package that is on npm.
+ *
+ * These tests are the reason it cannot happen again: the registry is generated, the generation is
+ * byte-idempotent, and every entry is checked against the package it names.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { DEFAULT_REGISTRY, searchPlugins } from "./plugins.js";
+import { OFFICIAL_PLUGINS } from "./plugin-registry.generated.js";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function shippedPluginDirs(): string[] {
+  return readdirSync(join(REPO_ROOT, "packages"))
+    .filter((d) => d.startsWith("kit-plugin-"))
+    .sort();
+}
+
+describe("the plugin registry", () => {
+  it("lists every plugin package that ships", () => {
+    const listed = new Set(OFFICIAL_PLUGINS.map((p) => p.name));
+    const missing = shippedPluginDirs()
+      .map((d) => d.replace(/^kit-plugin-/, ""))
+      .filter((id) => !listed.has(id));
+    assert.deepEqual(
+      missing,
+      [],
+      `shipped but undiscoverable — \`kit plugin search\` cannot find these: ${missing.join(", ")}`,
+    );
+  });
+
+  it("names the package each plugin is actually published as, at its real version", () => {
+    for (const plugin of OFFICIAL_PLUGINS) {
+      const manifest = JSON.parse(
+        readFileSync(
+          join(REPO_ROOT, "packages", `kit-plugin-${plugin.name}`, "package.json"),
+          "utf-8",
+        ),
+      ) as { name: string; version: string };
+      assert.equal(plugin.package, manifest.name, `${plugin.name}: package name`);
+      assert.equal(plugin.version, manifest.version, `${plugin.name}: version`);
+      assert.equal(
+        plugin.install,
+        `npm install ${manifest.name}`,
+        `${plugin.name}: the printed install command must be runnable`,
+      );
+    }
+  });
+
+  it("claims no rating, download count or publish date — kit has no source for any of them", () => {
+    for (const plugin of OFFICIAL_PLUGINS) {
+      assert.equal(plugin.rating, undefined, `${plugin.name}: a rating with no source is invented`);
+      assert.equal(plugin.downloads, undefined, `${plugin.name}: same for downloads`);
+      assert.equal(plugin.published, undefined, `${plugin.name}: same for the publish date`);
+    }
+    // And the registry itself must not claim freshness it cannot know.
+    assert.equal(DEFAULT_REGISTRY.updated, undefined);
+  });
+
+  it("points every repository link at one real repository", () => {
+    const root = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf-8")) as {
+      repository?: string | { url?: string };
+    };
+    const expected = (
+      typeof root.repository === "string" ? root.repository : (root.repository?.url ?? "")
+    )
+      .replace(/^git\+/, "")
+      .replace(/\.git$/, "");
+    for (const plugin of OFFICIAL_PLUGINS) {
+      assert.equal(plugin.repository, expected || "https://github.com/sandstream/kit", plugin.name);
+    }
+  });
+
+  it("is findable by the name a person would type", () => {
+    for (const id of ["cloudflare", "stripe", "wiz"]) {
+      const hits = searchPlugins(id);
+      assert.ok(hits.length > 0, `\`kit plugin search ${id}\` must find the shipped plugin`);
+    }
+  });
+
+  it("is byte-identical to what the generator emits", async () => {
+    const mod = (await import(
+      pathToFileURL(join(REPO_ROOT, "scripts", "gen-plugin-registry.mjs")).href
+    )) as { render: () => string };
+    const generated = mod.render();
+    const committed = readFileSync(join(REPO_ROOT, "src", "plugin-registry.generated.ts"), "utf-8");
+    if (generated !== committed) {
+      const g = generated.split("\n");
+      const c = committed.split("\n");
+      const i = g.findIndex((line, idx) => line !== c[idx]);
+      assert.fail(
+        `line ${i + 1} differs — run \`node scripts/gen-plugin-registry.mjs\`\n` +
+          `  generated: ${JSON.stringify(g[i])}\n  committed: ${JSON.stringify(c[i])}`,
+      );
+    }
+  });
+});

--- a/src/plugin-registry.generated.ts
+++ b/src/plugin-registry.generated.ts
@@ -1,0 +1,160 @@
+/**
+ * kit's OFFICIAL PLUGINS — generated from each plugin package manifest under packages.
+ *
+ * (The path is spelled out rather than globbed: a literal star-slash inside a block comment ends
+ * the comment early, and the first version of this generator emitted a file TypeScript could not
+ * parse. Writing it with a backtick broke the generator's own template literal instead.)
+ *
+ * GENERATED. Regenerate with:  node scripts/gen-plugin-registry.mjs
+ * `plugins-registry.test.ts` fails when this file drifts from the packages on disk, so a shipped
+ * plugin cannot stay invisible and an entry cannot describe a package that does not exist.
+ *
+ * The hand-written table this replaces advertised npm packages that were never published
+ * (`@kit/plugins/stripe`), a 404 repository per plugin, versions that did not match the published
+ * ones, and invented ratings and download counts that `kit plugin list` printed as `★★★★◆ 4.8`.
+ * Five of eleven shipped plugins were listed at all.
+ *
+ * Fields with no local source — rating, downloads, publish date — are absent by design. The display
+ * code treats them as optional, so absent means unshown rather than estimated.
+ */
+
+import type { PluginMetadata } from "./plugins.js";
+
+export const OFFICIAL_PLUGINS: PluginMetadata[] = [
+  {
+    name: "cloudflare",
+    description: "Cloudflare Workers secret + API token surface for kit",
+    version: "0.2.0",
+    author: "Sandstream",
+    license: "MIT",
+    repository: "https://github.com/sandstream/kit",
+    package: "sandstream-kit-plugin-cloudflare",
+    kitVersion: ">=6.0.0",
+    tags: ["cloudflare", "hosting", "kit-plugin", "official", "secrets", "workers"],
+    install: "npm install sandstream-kit-plugin-cloudflare",
+  },
+  {
+    name: "fly",
+    description: "Fly.io app-secret rotation via flyctl GraphQL API",
+    version: "0.2.0",
+    author: "Sandstream",
+    license: "MIT",
+    repository: "https://github.com/sandstream/kit",
+    package: "sandstream-kit-plugin-fly",
+    kitVersion: ">=6.0.0",
+    tags: ["deployment", "fly", "fly.io", "hosting", "kit-plugin", "official", "secrets"],
+    install: "npm install sandstream-kit-plugin-fly",
+  },
+  {
+    name: "github",
+    description: "kit plugin: GitHub REST API (repo + org secrets, deploy keys, workflow runs).",
+    version: "0.2.0",
+    author: "Sandstream",
+    license: "MIT",
+    repository: "https://github.com/sandstream/kit",
+    package: "sandstream-kit-plugin-github",
+    kitVersion: ">=6.0.0",
+    tags: ["ci", "github", "kit-plugin", "official", "secrets", "vcs"],
+    install: "npm install sandstream-kit-plugin-github",
+  },
+  {
+    name: "railway",
+    description: "kit adapter plugin for Railway deployment platform",
+    version: "0.1.0",
+    author: "Sandstream",
+    license: "MIT",
+    repository: "https://github.com/sandstream/kit",
+    package: "sandstream-kit-plugin-railway",
+    kitVersion: ">=6.0.0",
+    tags: ["deployment", "hosting", "kit-plugin", "official", "railway"],
+    install: "npm install sandstream-kit-plugin-railway",
+  },
+  {
+    name: "sentrux",
+    description: "Sentrux architecture-scan ingestion for kit (read-only).",
+    version: "0.1.0",
+    author: "Sandstream",
+    license: "MIT",
+    repository: "https://github.com/sandstream/kit",
+    package: "sandstream-kit-plugin-sentrux",
+    kitVersion: ">=6.0.0",
+    tags: ["ingestion", "kit-plugin", "official", "read-only", "scanning", "security", "sentrux"],
+    install: "npm install sandstream-kit-plugin-sentrux",
+  },
+  {
+    name: "sentry",
+    description:
+      "Sentry REST API client for kit — issue triage, release tagging, project introspection.",
+    version: "0.2.0",
+    author: "Sandstream",
+    license: "MIT",
+    repository: "https://github.com/sandstream/kit",
+    package: "sandstream-kit-plugin-sentry",
+    kitVersion: ">=6.0.0",
+    tags: ["kit-plugin", "monitoring", "observability", "official", "sentry"],
+    install: "npm install sandstream-kit-plugin-sentry",
+  },
+  {
+    name: "snyk",
+    description: "Snyk scan-result ingestion for kit (read-only).",
+    version: "0.1.0",
+    author: "Sandstream",
+    license: "MIT",
+    repository: "https://github.com/sandstream/kit",
+    package: "sandstream-kit-plugin-snyk",
+    kitVersion: ">=6.0.0",
+    tags: ["ingestion", "kit-plugin", "official", "read-only", "scanning", "security", "snyk"],
+    install: "npm install sandstream-kit-plugin-snyk",
+  },
+  {
+    name: "stripe",
+    description:
+      "Stripe Management API surface for kit (webhook endpoint rotation + account introspection)",
+    version: "0.2.0",
+    author: "Sandstream",
+    license: "MIT",
+    repository: "https://github.com/sandstream/kit",
+    package: "sandstream-kit-plugin-stripe",
+    kitVersion: ">=6.0.0",
+    tags: ["kit-plugin", "official", "payments", "stripe", "webhooks"],
+    install: "npm install sandstream-kit-plugin-stripe",
+  },
+  {
+    name: "supabase",
+    description:
+      "kit plugin: Supabase Management API integration (service-role key rotation, project introspection).",
+    version: "0.2.0",
+    author: "Sandstream",
+    license: "MIT",
+    repository: "https://github.com/sandstream/kit",
+    package: "sandstream-kit-plugin-supabase",
+    kitVersion: ">=6.0.0",
+    tags: ["database", "kit-plugin", "official", "secrets", "supabase"],
+    install: "npm install sandstream-kit-plugin-supabase",
+  },
+  {
+    name: "vercel",
+    description:
+      "kit plugin: Vercel Management API (env management, project metadata, redeploy triggers).",
+    version: "0.2.0",
+    author: "Sandstream",
+    license: "MIT",
+    repository: "https://github.com/sandstream/kit",
+    package: "sandstream-kit-plugin-vercel",
+    kitVersion: ">=6.0.0",
+    tags: ["deployment", "env", "hosting", "kit-plugin", "official", "vercel"],
+    install: "npm install sandstream-kit-plugin-vercel",
+  },
+  {
+    name: "wiz",
+    description: "Wiz issue-graph ingestion for kit (read-only).",
+    version: "0.1.0",
+    author: "Sandstream",
+    license: "MIT",
+    repository: "https://github.com/sandstream/kit",
+    package: "sandstream-kit-plugin-wiz",
+    kitVersion: ">=6.0.0",
+    tags: ["ingestion", "kit-plugin", "official", "read-only", "scanning", "security", "wiz"],
+    install: "npm install sandstream-kit-plugin-wiz",
+  },
+];

--- a/src/plugins.test.ts
+++ b/src/plugins.test.ts
@@ -18,10 +18,21 @@ describe("Plugin Registry", () => {
       assert(results[0].name.includes("stripe"));
     });
 
-    it("should find plugins by description", () => {
+    it("should find plugins by description or tag", () => {
       const results = searchPlugins("payment");
       assert(results.length > 0);
-      assert(results.some((p) => p.description.toLowerCase().includes("payment")));
+      // The stripe plugin's own description says "Stripe Management API surface", so the hit comes
+      // from its `payments` tag. Both are legitimate routes to a plugin, and asserting the
+      // description alone encoded the old registry's invented copy ("payment processing and
+      // billing adapter") rather than what the package says about itself.
+      assert(
+        results.some(
+          (p) =>
+            p.description.toLowerCase().includes("payment") ||
+            p.tags.some((t) => t.includes("payment")) ||
+            p.name.includes("stripe"),
+        ),
+      );
     });
 
     it("should find plugins by tag", () => {
@@ -38,7 +49,7 @@ describe("Plugin Registry", () => {
     it("should rank results by relevance", () => {
       const results = searchPlugins("stripe");
       // Exact name match should come first
-      assert(results[0].name === "stripe/payments" || results[0].name.includes("stripe"));
+      assert(results[0].name.includes("stripe"));
     });
 
     it("should be case-insensitive", () => {
@@ -67,13 +78,14 @@ describe("Plugin Registry", () => {
       assert.equal(results.length, 0);
     });
 
-    it("should sort by download count", () => {
-      const sorted = listPlugins();
-      for (let i = 0; i < sorted.length - 1; i++) {
-        const current = sorted[i].downloads ?? 0;
-        const next = sorted[i + 1].downloads ?? 0;
-        assert(current >= next, "should be sorted by downloads descending");
-      }
+    it("lists in a stable order, since there is no popularity to sort by", () => {
+      // The old order was "downloads descending" over invented download counts. With those gone,
+      // the only honest ordering is a deterministic one — the same list every run, so a diff of the
+      // output means something changed.
+      const first = listPlugins().map((p) => p.name);
+      const second = listPlugins().map((p) => p.name);
+      assert.deepEqual(first, second);
+      assert.ok(first.length >= 11, `every shipped plugin must be listed: ${first.length}`);
     });
 
     it("should be case-insensitive for tags", () => {
@@ -85,14 +97,14 @@ describe("Plugin Registry", () => {
 
   describe("getPluginInfo", () => {
     it("should find plugin by exact name", () => {
-      const plugin = getPluginInfo("stripe/payments");
+      const plugin = getPluginInfo("stripe");
       assert(plugin !== null);
-      assert.equal(plugin?.name, "stripe/payments");
+      assert.equal(plugin?.name, "stripe");
     });
 
     it("should be case-insensitive", () => {
-      const lower = getPluginInfo("stripe/payments");
-      const upper = getPluginInfo("STRIPE/PAYMENTS");
+      const lower = getPluginInfo("stripe");
+      const upper = getPluginInfo("STRIPE");
       assert.equal(lower?.name, upper?.name);
     });
 
@@ -102,7 +114,7 @@ describe("Plugin Registry", () => {
     });
 
     it("should return complete metadata", () => {
-      const plugin = getPluginInfo("stripe/payments");
+      const plugin = getPluginInfo("stripe");
       assert(plugin);
       assert(plugin.name);
       assert(plugin.description);
@@ -112,8 +124,13 @@ describe("Plugin Registry", () => {
       assert(plugin.repository);
       assert(plugin.kitVersion);
       assert(Array.isArray(plugin.tags));
-      assert(plugin.published);
       assert(plugin.install);
+      // NOT `published`, `rating` or `downloads`: the registry is generated from each package's own
+      // manifest, and kit has no local source for any of those three. The table this replaced filled
+      // them in — a made-up date, `rating: 4.8`, `downloads: 1250` — and `kit plugin list` printed
+      // the stars as fact.
+      assert.equal(plugin.published, undefined);
+      assert.equal(plugin.rating, undefined);
     });
   });
 
@@ -121,8 +138,12 @@ describe("Plugin Registry", () => {
     it("should return all unique tags", () => {
       const tags = getAllTags();
       assert(tags.length > 0);
-      assert(tags.includes("adapter"));
+      // Not "adapter": the old registry put that tag on all five entries regardless of what the
+      // plugin did — half of these are read-only ingestion or management-API surfaces. Tags now
+      // come from each package's own keywords, so the assertion is about tags that are true.
       assert(tags.includes("official"));
+      assert(tags.includes("hosting"));
+      assert(tags.includes("security"));
     });
 
     it("should return sorted tags", () => {
@@ -203,7 +224,10 @@ describe("Plugin Registry", () => {
     it("should have valid plugin metadata", () => {
       for (const plugin of DEFAULT_REGISTRY.plugins) {
         assert(plugin.name, "plugin must have name");
-        assert(plugin.name.includes("/"), "plugin name must be provider/service");
+        // The id is the plugin's real id (`stripe`), not an invented provider/service pair. There
+        // was no source for the second half: the entry called `stripe/payments` describes a
+        // package whose own description is "Stripe Management API surface".
+        assert.match(plugin.name, /^[a-z0-9-]+$/, "plugin id must match its package suffix");
         assert(plugin.description, "plugin must have description");
         assert(plugin.version, "plugin must have version");
         assert(plugin.author, "plugin must have author");
@@ -212,13 +236,27 @@ describe("Plugin Registry", () => {
         assert(plugin.kitVersion, "plugin must have kitVersion");
         assert(Array.isArray(plugin.tags), "tags must be array");
         assert(plugin.tags.length > 0, "plugin must have at least one tag");
-        assert(plugin.published, "plugin must have published date");
+        // NOT a publish date: kit has no offline source for one, and the table this replaced
+        // filled it in with a made-up 2026-04-15 for every entry. What must hold instead is that
+        // the install command names the package the plugin is actually published as.
+        assert.equal(plugin.published, undefined, "no publish date kit cannot source");
         assert(plugin.install, "plugin must have install command");
+        assert.equal(
+          plugin.install,
+          `npm install ${plugin.package}`,
+          `${plugin.name}: the printed install command must be runnable`,
+        );
       }
     });
 
-    it("should have at least 5 plugins", () => {
-      assert(DEFAULT_REGISTRY.plugins.length >= 5, "registry should have at least 5 plugins");
+    it("lists every plugin that ships, not a subset", () => {
+      // The old registry had five entries for eleven shipped packages, so `kit plugin search
+      // cloudflare` answered "No plugins found" about a package published on npm. "At least 5" is
+      // what let that pass; the count now follows the packages.
+      assert(
+        DEFAULT_REGISTRY.plugins.length >= 11,
+        `expected every shipped plugin: ${DEFAULT_REGISTRY.plugins.length}`,
+      );
     });
 
     it("should have 'official' tag for all built-in plugins", () => {
@@ -250,9 +288,11 @@ describe("Plugin Registry", () => {
       assert(payments.length > 0);
     });
 
-    it("should have adapter tag", () => {
-      const adapters = listPlugins("adapter");
-      assert(adapters.length > 0);
+    it("should have a security category", () => {
+      // snyk, wiz and sentrux are read-only scan-ingestion plugins — a category the old
+      // five-entry registry had no room for.
+      const security = listPlugins("security");
+      assert(security.length >= 3, `expected the ingestion plugins: ${security.length}`);
     });
   });
 
@@ -276,11 +316,11 @@ describe("Plugin Registry", () => {
 
     it("should allow filtering by category then searching", () => {
       const hosting = listPlugins("hosting");
-      const railwayInHosting = hosting.find((p) => p.name === "railway/hosting");
+      const railwayInHosting = hosting.find((p) => p.name === "railway");
       assert(railwayInHosting);
 
       const railwayBySearch = searchPlugins("railway");
-      assert(railwayBySearch.some((p) => p.name === "railway/hosting"));
+      assert(railwayBySearch.some((p) => p.name === "railway"));
     });
   });
 });

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -9,6 +9,7 @@
  */
 
 import { exec } from "./utils/exec.js";
+import { OFFICIAL_PLUGINS } from "./plugin-registry.generated.js";
 
 /**
  * Plugin metadata as it appears in the registry
@@ -32,8 +33,14 @@ export interface PluginMetadata {
   kitVersion: string;
   /** Array of tags for categorization */
   tags: string[];
-  /** Date published (ISO 8601) */
-  published: string;
+  /**
+   * Date published (ISO 8601), when a source for it exists.
+   *
+   * Optional because kit has no offline source for it: the previous hand-written registry filled
+   * this in with a made-up date, alongside made-up ratings and download counts. A field kit cannot
+   * substantiate is absent, not estimated.
+   */
+  published?: string;
   /** Download count in last 30 days */
   downloads?: number;
   /** Average rating (0-5 stars) */
@@ -47,94 +54,28 @@ export interface PluginMetadata {
  */
 export interface PluginRegistry {
   version: string;
-  updated: string;
+  /**
+   * When the registry was last updated, when that is knowable.
+   *
+   * Optional because the previous value was `new Date().toISOString()` evaluated at import — the
+   * registry claimed to be current every time it was read, which is the same thing as claiming
+   * nothing.
+   */
+  updated?: string;
   plugins: PluginMetadata[];
 }
 
 /**
- * Local default registry embedded in kit
- * This provides a foundation registry of official plugins
+ * kit's default plugin registry.
+ *
+ * Generated from the plugin packages that actually exist (see plugin-registry.generated.ts). The
+ * hand-written table this replaces listed five of eleven shipped plugins, named npm packages that
+ * were never published, pointed every repository link at a 404, and carried invented ratings and
+ * download counts that `kit plugin list` rendered as `★★★★◆ 4.8`.
  */
 export const DEFAULT_REGISTRY: PluginRegistry = {
-  version: "1.0.0",
-  updated: new Date().toISOString(),
-  plugins: [
-    {
-      name: "stripe/payments",
-      description: "Stripe payment processing and billing adapter",
-      version: "1.0.0",
-      author: "Sandstream",
-      license: "MIT",
-      repository: "https://github.com/sandstream/kit-stripe",
-      package: "@kit/plugins/stripe",
-      kitVersion: ">=0.1.0",
-      tags: ["payments", "adapter", "official"],
-      published: "2026-04-15T00:00:00Z",
-      downloads: 1250,
-      rating: 4.8,
-      install: "npm install @kit/plugins/stripe",
-    },
-    {
-      name: "supabase/database",
-      description: "PostgreSQL database via Supabase with real-time APIs",
-      version: "1.0.0",
-      author: "Sandstream",
-      license: "MIT",
-      repository: "https://github.com/sandstream/kit-supabase",
-      package: "@kit/plugins/supabase",
-      kitVersion: ">=0.1.0",
-      tags: ["database", "adapter", "official"],
-      published: "2026-04-15T00:00:00Z",
-      downloads: 1890,
-      rating: 4.9,
-      install: "npm install @kit/plugins/supabase",
-    },
-    {
-      name: "vercel/hosting",
-      description: "Vercel serverless deployment platform",
-      version: "1.0.0",
-      author: "Sandstream",
-      license: "MIT",
-      repository: "https://github.com/sandstream/kit-vercel",
-      package: "@kit/plugins/vercel",
-      kitVersion: ">=0.1.0",
-      tags: ["hosting", "adapter", "official"],
-      published: "2026-04-15T00:00:00Z",
-      downloads: 2340,
-      rating: 4.7,
-      install: "npm install @kit/plugins/vercel",
-    },
-    {
-      name: "railway/hosting",
-      description: "Railway infrastructure platform deployment",
-      version: "1.0.0",
-      author: "Sandstream",
-      license: "MIT",
-      repository: "https://github.com/sandstream/kit-railway",
-      package: "@kit/plugins/railway",
-      kitVersion: ">=0.1.0",
-      tags: ["hosting", "adapter", "official"],
-      published: "2026-04-15T00:00:00Z",
-      downloads: 890,
-      rating: 4.6,
-      install: "npm install @kit/plugins/railway",
-    },
-    {
-      name: "flyio/hosting",
-      description: "Fly.io container deployment platform",
-      version: "1.0.0",
-      author: "Sandstream",
-      license: "MIT",
-      repository: "https://github.com/sandstream/kit-flyio",
-      package: "@kit/plugins/flyio",
-      kitVersion: ">=0.1.0",
-      tags: ["hosting", "adapter", "official"],
-      published: "2026-04-15T00:00:00Z",
-      downloads: 650,
-      rating: 4.5,
-      install: "npm install @kit/plugins/flyio",
-    },
-  ],
+  version: "2.0.0",
+  plugins: OFFICIAL_PLUGINS,
 };
 
 /**


### PR DESCRIPTION
Second half of the settings arc — *koll även integrationer och så är ok*. It was not ok.

## What `kit plugin list` was printing

```
stripe/payments 1.0.0 ★★★★◆ 4.8
  Stripe payment processing and billing adapter
  Install: npm install @kit/plugins/stripe
```

Every claim on that line, checked against npm and GitHub:

| Claimed | Actual |
| --- | --- |
| `@kit/plugins/stripe` | **does not exist** — the real package is `sandstream-kit-plugin-stripe`, so the printed install command could not work |
| `1.0.0` | the published packages are **0.1.0 / 0.2.0** |
| `github.com/sandstream/kit-stripe` | **HTTP 404** |
| `★★★★◆ 4.8` · `1250 downloads` | **invented** — no source exists for either, and the stars were rendered as fact |
| `updated: <now>` | `new Date().toISOString()` evaluated at import, so the registry always claimed to be current |
| 5 plugins | **11 ship**, all published to npm |

That last row has a user-visible consequence: `kit plugin search cloudflare` answered *"No plugins found matching: cloudflare"* about a package that was on npm at that moment. **cloudflare, github, sentrux, sentry, snyk and wiz** were undiscoverable through kit's own discovery surface.

This is the same class as everything else this week — mechanism shipped, reader missing — with an added twist: the reader that did exist was reporting numbers nobody measured. That is the one thing kit is supposed to make impossible.

## Now

Generated from each plugin package's own manifest — real name, real version, real description, one real repository:

```
Available Plugins — 11 found

  cloudflare 0.2.0
    Cloudflare Workers secret + API token surface for kit
  ...

$ kit plugin info stripe
  stripe 0.2.0
    Stripe Management API surface for kit (webhook endpoint rotation + account introspection)
    Install: npm install sandstream-kit-plugin-stripe   ← npm says 0.2.0
```

`rating`, `downloads` and `published` are **omitted**, and their fields made optional. The display code already treated them as optional, so absent means unshown rather than estimated — no stars appear because there is nothing to base stars on. `updated` is gone for the same reason.

**Categories were real information**, so they moved to where they belong: each package now declares its own `keywords` — payments, database, hosting, security, monitoring, secrets, vcs, observability — and the registry derives tags from them. `kit plugin list --tag hosting` returns cloudflare, fly, railway, vercel; `--tag security` returns the three read-only scan-ingestion plugins (snyk, wiz, sentrux) that the five-entry registry had no room for. It also fixes discoverability on npm itself, where all eleven packages had **no keywords at all**.

The blanket `adapter` tag is gone: it was on all five entries regardless of what the plugin did, and half of these are ingestion or management-API surfaces, not adapters.

## Tests

Six new ones, each pinning a way this went wrong: every shipped package must be listed; every entry must match the manifest it names (package, version, and a **runnable** install command); no entry may carry a rating, download count or publish date; every repository link must be the one real repository; each plugin must be findable by the name a person would type; and regeneration must be byte-identical.

The generator emits Prettier's shape for over-long descriptions, so regenerating cannot fight `format:check` — #525's lesson applied while writing the generator rather than after misreading its diff. It also spells out the package glob in its own header, because a literal `*/` closed the block comment and the first generated file would not parse (and writing it with backticks broke the generator's own template literal).

Nine existing assertions encoded the fabricated data and were updated **with the reason recorded** in each: the `provider/service` id (`stripe/payments` described a package whose own description is "Stripe Management API surface"), sorting by invented download counts, `"should have at least 5 plugins"` — which is exactly what let 5-of-11 pass — and a required publish date.

4 457 tests pass, 0 fail.

## Companion

#527 is the other half: `kit config sections` and a generated `docs/CONFIGURATION.md`, because 23 config sections had no reference and two appeared in no document at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)