### PR TITLE
chore(release): 6.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [6.9.0] - 2026-08-23
+
 ### Added
 
 - **Fail on NEW dependency debt, not on the debt you already have** (#524).

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -1189,7 +1189,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "6.8.0"
+    "version": "6.9.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "6.6.3",
+  "version": "6.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "6.6.3",
+      "version": "6.9.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -2781,7 +2781,7 @@
     },
     "packages/kit-plugin-cloudflare": {
       "name": "sandstream-kit-plugin-cloudflare",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "devDependencies": {
         "@types/node": "22.19.15",
         "typescript": "5.9.3"
@@ -2789,7 +2789,7 @@
     },
     "packages/kit-plugin-fly": {
       "name": "sandstream-kit-plugin-fly",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "devDependencies": {
         "@types/node": "22.19.15",
         "typescript": "5.9.3"
@@ -2797,7 +2797,7 @@
     },
     "packages/kit-plugin-github": {
       "name": "sandstream-kit-plugin-github",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "devDependencies": {
         "sandstream-kit-adapter-sdk": "*",
         "typescript": "5.9.3"
@@ -2808,7 +2808,7 @@
     },
     "packages/kit-plugin-railway": {
       "name": "sandstream-kit-plugin-railway",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "sandstream-kit-adapter-sdk": "*",
         "typescript": "5.9.3"
@@ -2819,7 +2819,7 @@
     },
     "packages/kit-plugin-sentrux": {
       "name": "sandstream-kit-plugin-sentrux",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@types/node": "22.19.15",
         "typescript": "5.9.3"
@@ -2827,7 +2827,7 @@
     },
     "packages/kit-plugin-sentry": {
       "name": "sandstream-kit-plugin-sentry",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "devDependencies": {
         "@types/node": "22.19.15",
         "typescript": "5.9.3"
@@ -2835,7 +2835,7 @@
     },
     "packages/kit-plugin-snyk": {
       "name": "sandstream-kit-plugin-snyk",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@types/node": "22.19.15",
         "typescript": "5.9.3"
@@ -2843,7 +2843,7 @@
     },
     "packages/kit-plugin-stripe": {
       "name": "sandstream-kit-plugin-stripe",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "devDependencies": {
         "@types/node": "22.19.15",
         "typescript": "5.9.3"
@@ -2851,7 +2851,7 @@
     },
     "packages/kit-plugin-supabase": {
       "name": "sandstream-kit-plugin-supabase",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "devDependencies": {
         "sandstream-kit-adapter-sdk": "*",
         "typescript": "5.9.3"
@@ -2862,7 +2862,7 @@
     },
     "packages/kit-plugin-vercel": {
       "name": "sandstream-kit-plugin-vercel",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "devDependencies": {
         "sandstream-kit-adapter-sdk": "*",
         "typescript": "5.9.3"
@@ -2873,7 +2873,7 @@
     },
     "packages/kit-plugin-wiz": {
       "name": "sandstream-kit-plugin-wiz",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@types/node": "22.19.15",
         "typescript": "5.9.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "6.8.0",
+  "version": "6.9.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",

--- a/packages/kit-plugin-cloudflare/package.json
+++ b/packages/kit-plugin-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit-plugin-cloudflare",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Cloudflare Workers secret + API token surface for kit",
   "keywords": [
     "kit-plugin",

--- a/packages/kit-plugin-fly/package.json
+++ b/packages/kit-plugin-fly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit-plugin-fly",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Fly.io app-secret rotation via flyctl GraphQL API",
   "keywords": [
     "kit-plugin",

--- a/packages/kit-plugin-github/package.json
+++ b/packages/kit-plugin-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit-plugin-github",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "kit plugin: GitHub REST API (repo + org secrets, deploy keys, workflow runs).",
   "keywords": [
     "kit-plugin",

--- a/packages/kit-plugin-railway/package.json
+++ b/packages/kit-plugin-railway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit-plugin-railway",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "kit adapter plugin for Railway deployment platform",
   "keywords": [
     "kit-plugin",

--- a/packages/kit-plugin-sentrux/package.json
+++ b/packages/kit-plugin-sentrux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit-plugin-sentrux",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Sentrux architecture-scan ingestion for kit (read-only).",
   "keywords": [
     "kit-plugin",

--- a/packages/kit-plugin-sentry/package.json
+++ b/packages/kit-plugin-sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit-plugin-sentry",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Sentry REST API client for kit \u2014 issue triage, release tagging, project introspection.",
   "keywords": [
     "kit-plugin",

--- a/packages/kit-plugin-snyk/package.json
+++ b/packages/kit-plugin-snyk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit-plugin-snyk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Snyk scan-result ingestion for kit (read-only).",
   "keywords": [
     "kit-plugin",

--- a/packages/kit-plugin-stripe/package.json
+++ b/packages/kit-plugin-stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit-plugin-stripe",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Stripe Management API surface for kit (webhook endpoint rotation + account introspection)",
   "keywords": [
     "kit-plugin",

--- a/packages/kit-plugin-supabase/package.json
+++ b/packages/kit-plugin-supabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit-plugin-supabase",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "kit plugin: Supabase Management API integration (service-role key rotation, project introspection).",
   "keywords": [
     "kit-plugin",

--- a/packages/kit-plugin-vercel/package.json
+++ b/packages/kit-plugin-vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit-plugin-vercel",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "kit plugin: Vercel Management API (env management, project metadata, redeploy triggers).",
   "keywords": [
     "kit-plugin",

--- a/packages/kit-plugin-wiz/package.json
+++ b/packages/kit-plugin-wiz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit-plugin-wiz",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Wiz issue-graph ingestion for kit (read-only).",
   "keywords": [
     "kit-plugin",

--- a/src/plugin-registry.generated.ts
+++ b/src/plugin-registry.generated.ts
@@ -24,7 +24,7 @@ export const OFFICIAL_PLUGINS: PluginMetadata[] = [
   {
     name: "cloudflare",
     description: "Cloudflare Workers secret + API token surface for kit",
-    version: "0.2.0",
+    version: "0.2.1",
     author: "Sandstream",
     license: "MIT",
     repository: "https://github.com/sandstream/kit",
@@ -36,7 +36,7 @@ export const OFFICIAL_PLUGINS: PluginMetadata[] = [
   {
     name: "fly",
     description: "Fly.io app-secret rotation via flyctl GraphQL API",
-    version: "0.2.0",
+    version: "0.2.1",
     author: "Sandstream",
     license: "MIT",
     repository: "https://github.com/sandstream/kit",
@@ -48,7 +48,7 @@ export const OFFICIAL_PLUGINS: PluginMetadata[] = [
   {
     name: "github",
     description: "kit plugin: GitHub REST API (repo + org secrets, deploy keys, workflow runs).",
-    version: "0.2.0",
+    version: "0.2.1",
     author: "Sandstream",
     license: "MIT",
     repository: "https://github.com/sandstream/kit",
@@ -60,7 +60,7 @@ export const OFFICIAL_PLUGINS: PluginMetadata[] = [
   {
     name: "railway",
     description: "kit adapter plugin for Railway deployment platform",
-    version: "0.1.0",
+    version: "0.1.1",
     author: "Sandstream",
     license: "MIT",
     repository: "https://github.com/sandstream/kit",
@@ -72,7 +72,7 @@ export const OFFICIAL_PLUGINS: PluginMetadata[] = [
   {
     name: "sentrux",
     description: "Sentrux architecture-scan ingestion for kit (read-only).",
-    version: "0.1.0",
+    version: "0.1.1",
     author: "Sandstream",
     license: "MIT",
     repository: "https://github.com/sandstream/kit",
@@ -85,7 +85,7 @@ export const OFFICIAL_PLUGINS: PluginMetadata[] = [
     name: "sentry",
     description:
       "Sentry REST API client for kit — issue triage, release tagging, project introspection.",
-    version: "0.2.0",
+    version: "0.2.1",
     author: "Sandstream",
     license: "MIT",
     repository: "https://github.com/sandstream/kit",
@@ -97,7 +97,7 @@ export const OFFICIAL_PLUGINS: PluginMetadata[] = [
   {
     name: "snyk",
     description: "Snyk scan-result ingestion for kit (read-only).",
-    version: "0.1.0",
+    version: "0.1.1",
     author: "Sandstream",
     license: "MIT",
     repository: "https://github.com/sandstream/kit",
@@ -110,7 +110,7 @@ export const OFFICIAL_PLUGINS: PluginMetadata[] = [
     name: "stripe",
     description:
       "Stripe Management API surface for kit (webhook endpoint rotation + account introspection)",
-    version: "0.2.0",
+    version: "0.2.1",
     author: "Sandstream",
     license: "MIT",
     repository: "https://github.com/sandstream/kit",
@@ -123,7 +123,7 @@ export const OFFICIAL_PLUGINS: PluginMetadata[] = [
     name: "supabase",
     description:
       "kit plugin: Supabase Management API integration (service-role key rotation, project introspection).",
-    version: "0.2.0",
+    version: "0.2.1",
     author: "Sandstream",
     license: "MIT",
     repository: "https://github.com/sandstream/kit",
@@ -136,7 +136,7 @@ export const OFFICIAL_PLUGINS: PluginMetadata[] = [
     name: "vercel",
     description:
       "kit plugin: Vercel Management API (env management, project metadata, redeploy triggers).",
-    version: "0.2.0",
+    version: "0.2.1",
     author: "Sandstream",
     license: "MIT",
     repository: "https://github.com/sandstream/kit",
@@ -148,7 +148,7 @@ export const OFFICIAL_PLUGINS: PluginMetadata[] = [
   {
     name: "wiz",
     description: "Wiz issue-graph ingestion for kit (read-only).",
-    version: "0.1.0",
+    version: "0.1.1",
     author: "Sandstream",
     license: "MIT",
     repository: "https://github.com/sandstream/kit",


### PR DESCRIPTION
Ten merged changes since 6.8.0. **Minor, not major**: nothing documented was removed or downgraded and exit codes stay `[0, 1]`, but this adds commands, adds declarable config fields, and changes what a green verdict means — the same shape as the last two releases.

## What ships

| | |
| --- | --- |
| #519 | `kit usage` — what kit has recorded across eight tabs, and `--prove`, which runs the floor against inputs it must refuse |
| #521 | a skipped scanner is no longer counted as a passing one; a manifest-absence skip in the wrong directory is a coverage hole, not a shrug |
| #522 | a rebase is no longer reported as a bypass — retroactively, for entries already in the log |
| #523 | what reaches the browser is checked: by name before the build, by content after |
| #524 | dependency debt gates on what is **new**, against a baseline that may only shrink |
| #525 | regenerating `flag-surface.ts` is byte-identical; a scanner that finds nothing says what it looked for |
| #526 | audit entries record where they happened and whether they were a test |
| #527 | `kit config sections` + a generated `docs/CONFIGURATION.md` |
| #528 | the plugin registry stops advertising packages nobody published |

Several of these change a verdict a repo already relies on. On this repo the security run now reads:

```
16/30 passed  ·  13 could not run  ·  1 real issue
```

where before it would have said **"All 30 checks passed ✓"**. Nothing regressed — the same 13 checks were already not running, and the line now says so. Worth knowing before upgrading a CI that treats the summary as a pass/fail signal, though `ok` in `--json` is unchanged and no gate got stricter.

## Why the plugin packages get a patch bump

#528 gave each of the eleven plugin packages the `keywords` it never had — they are all published with none, which is half of why `kit plugin search cloudflare` found nothing. The publish job skips any workspace version already on the registry (idempotent by design), so without a bump that half of the fix would never reach npm.

`sandstream-kit-adapter-sdk` stays at `1.0.0`: unchanged, and frozen on its own `1.x` track.

## Verified before tagging

- `npm ci && npm run build && npm test` — **4 547 pass, 0 fail, 0 skipped**
- `node scripts/changelog-section.mjs 6.9.0` resolves, so the publish job's pre-publish documentation gate will not abort
- self-audit: 16 rules, 0 fail, 0 warn
- prettier clean; the generated plugin registry regenerates byte-identically at the new versions

Date is today's, the day it ships — not written ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)