### PR TITLE
feat(ci): run the ADR gate, and pin it so it cannot go quiet again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,20 @@ jobs:
       # workflows. --category tests narrows the run to that one dimension.
       - name: Test-coverage gate (net-new untested files)
         run: node dist/cli.js check --category tests --enforce-tests
+
+      # kit's own ADR gate, enforced. Measured before wiring it: three accepted ADRs
+      # carry four deterministic `kit-enforce` rules, they catch real violations (an
+      # `openai` import, a `lodash` import, a coverage-registry import from the check
+      # path each exit 1), and nothing in this repo ran them. Not pre-commit, not
+      # pre-push, not CI — `kit check` does not include the ADR stage, only
+      # `kit review` does, and no workflow called either. The rules were armed and
+      # never fired for a month: enforcement that happens only when a human remembers
+      # to type the command is documentation with a CLI.
+      #
+      # Hard fail, not a warning: the gate is clean today (0 violations), so failing
+      # closed costs nothing now and means something the first time it does not. Only
+      # `status: accepted` ADRs gate, prose is never interpreted, and an accepted ADR
+      # with no enforce block is reported as "documented, not enforced", never green.
+      # `ci-adr-gate.test.ts` pins this step's existence — deleting it fails the suite.
+      - name: ADR gate (accepted ADRs' kit-enforce rules)
+        run: node dist/cli.js adr check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,20 @@ This repo is managed by [kit](https://github.com/sandstream/kit) (env, secrets, 
 - Everything else: `kit --help` — the commands are self-documenting.
 
 <!-- END kit -->
+
+## Architecture decisions are a gate, and `kit check` does not run it
+
+`docs/adr` holds five ADRs. The three accepted ones carry a `kit-enforce` block, which
+makes them four deterministic rules — not prose:
+
+- **ADR-0001** no model-client import anywhere in `src/**` (the zero-LLM core).
+- **ADR-0002** no new runtime dependency from the forbidden list — stdlib otherwise.
+- **ADR-0003** the check path imports no coverage-framework mappings.
+
+`node dist/cli.js adr check` runs them and **fails CI hard** on a violation. `kit check`
+does **not** include the ADR stage — only `kit review` (check + design + standards + adr)
+does. So before opening a PR that adds a dependency, moves an import, or touches
+`src/check*.ts`, run `kit review`, not `kit check` alone.
+
+Adding one of those imports is an ADR-level decision, not a code change: amend or supersede
+the ADR in the same PR, or the gate will refuse the code and cite the ADR that refused it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,3 +27,20 @@ This repo is managed by [kit](https://github.com/sandstream/kit) (env, secrets, 
   another customer's project in public bodies.
 - Findings that could be a real security leak in a named third-party repo go to
   the private `sandstream/kit-research` repo, never a public kit issue.
+
+## Architecture decisions are a gate, and `kit check` does not run it
+
+`docs/adr` holds five ADRs. The three accepted ones carry a `kit-enforce` block, which
+makes them four deterministic rules — not prose:
+
+- **ADR-0001** no model-client import anywhere in `src/**` (the zero-LLM core).
+- **ADR-0002** no new runtime dependency from the forbidden list — stdlib otherwise.
+- **ADR-0003** the check path imports no coverage-framework mappings.
+
+`node dist/cli.js adr check` runs them and **fails CI hard** on a violation. `kit check`
+does **not** include the ADR stage — only `kit review` (check + design + standards + adr)
+does. So before opening a PR that adds a dependency, moves an import, or touches
+`src/check*.ts`, run `kit review`, not `kit check` alone.
+
+Adding one of those imports is an ADR-level decision, not a code change: amend or supersede
+the ADR in the same PR, or the gate will refuse the code and cite the ADR that refused it.

--- a/src/ci-adr-gate.test.ts
+++ b/src/ci-adr-gate.test.ts
@@ -1,0 +1,75 @@
+/**
+ * The ADR gate must be INVOKED by a workflow, not merely exist.
+ *
+ * Measured on 6.9.0: `docs/adr` held three accepted ADRs carrying four deterministic
+ * `kit-enforce` rules; `kit adr check` caught real violations and exited 1; and nothing in the
+ * repo ever ran it. Not pre-commit (scan-staged, build, test), not pre-push (npm audit), not
+ * `ci.yml`, not `security.yml`. `kit check` does not include the ADR stage — only `kit review`
+ * does — and no workflow called either. The rules were armed and unfired for a month.
+ *
+ * That failure is invisible by construction: a gate nobody runs produces no output, and no output
+ * reads exactly like a clean run. The repo already has the mirror of this rule — `self-audit-ci`
+ * proves every script a workflow points AT exists — but not its inverse, that a gate which exists
+ * is pointed at by something. This is that inverse, for the one gate it has already bitten on.
+ *
+ * Deliberately asserts on the COMMAND, not on a step name: a renamed step is fine, a deleted
+ * invocation is not.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const WORKFLOW_DIR = join(REPO_ROOT, ".github", "workflows");
+
+/** Every workflow's text, keyed by filename, with comment lines stripped — a gate named only in
+ *  a comment is not a gate that runs. */
+function workflowBodies(): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const file of readdirSync(WORKFLOW_DIR)) {
+    if (!file.endsWith(".yml") && !file.endsWith(".yaml")) continue;
+    out[file] = readFileSync(join(WORKFLOW_DIR, file), "utf-8")
+      .split("\n")
+      .filter((line) => !/^\s*#/.test(line))
+      .join("\n");
+  }
+  return out;
+}
+
+/** `kit adr check` and `kit review` both run the ADR rules; either satisfies the requirement. */
+const INVOKES_ADR = /\b(adr\s+check|kit_review\b|cli\.js\s+review\b|kit\s+review\b)/;
+
+describe("the ADR gate is wired into CI", () => {
+  it("is invoked by at least one workflow, outside a comment", () => {
+    const hits = Object.entries(workflowBodies())
+      .filter(([, body]) => INVOKES_ADR.test(body))
+      .map(([file]) => file);
+    assert.ok(
+      hits.length > 0,
+      "no workflow runs `adr check` (or `kit review`, which includes it). " +
+        "docs/adr's accepted ADRs carry deterministic rules that then gate nothing — " +
+        "which is indistinguishable, in a green build, from having no violations.",
+    );
+  });
+
+  it("runs it as a hard failure, not a reported-and-ignored step", () => {
+    for (const [file, body] of Object.entries(workflowBodies())) {
+      if (!INVOKES_ADR.test(body)) continue;
+      const step = body
+        .split(/\n(?=\s*- name:)/)
+        .find((block) => INVOKES_ADR.test(block) && /run:/.test(block));
+      if (!step) continue;
+      assert.ok(
+        !/continue-on-error:\s*true/.test(step),
+        `${file} runs the ADR gate with continue-on-error — a gate that cannot fail the build is a report`,
+      );
+      assert.ok(
+        !/\|\|\s*true/.test(step),
+        `${file} swallows the ADR gate's exit code with \`|| true\``,
+      );
+    }
+  });
+});


### PR DESCRIPTION
`docs/adr` holds five ADRs. Three are accepted and carry a `kit-enforce` block — four deterministic rules. **They work, and nothing ran them.**

## Measured first

The rules are not vacuous. A probe repo with the same ADR files:

```
import OpenAI from "openai"                    → ✗ ADR-0001, exit 1
import _ from "lodash"                          → ✗ ADR-0002
src/commands/check.ts → coverage/registry.js    → ✗ ADR-0003
```

And the invocation surface:

| where | what it runs |
| --- | --- |
| pre-commit | `security scan-staged` · `npm run build` · `npm test` |
| pre-push | `npm audit --audit-level=high` |
| `ci.yml` | format · lint · build · test · `check --category tests` |
| `security.yml` | scanners · `check-security` · `self-audit` · dogfood |

Zero hits for `kit adr` or `kit review` in `.github/` or `scripts/`. `kit check` does **not** include the ADR stage — only `kit review` does. So the gate fired only when a human typed the command, and it had been armed and unfired since #403 adopted it on **2026-07-26**. `.kit-baseline.json` holds only the `tests` category, so nothing was masked; the rules simply never ran.

A gate nobody runs emits nothing, and nothing reads exactly like a clean run.

## What lands

- **`ci.yml` runs `node dist/cli.js adr check`** as a hard failure, beside the test-coverage gate. Hard rather than warn-first because the gate is clean today (0 violations) — failing closed costs nothing now and means something the first time it does not.
- **`ci-adr-gate.test.ts` pins the invocation.** It asserts a workflow actually *runs* the gate (comment lines stripped — a gate named in a comment is not a gate), and that it does so without `continue-on-error: true` or `|| true`, because a gate that cannot fail the build is a report. Both assertions were driven to RED before the step existed.
- **`CLAUDE.md` + `AGENTS.md`** say what `kit check` does not cover, placed *outside* the kit-managed block so `kit agent-config` cannot overwrite it: run `kit review` before a PR that adds a dependency, moves an import, or touches `src/check*.ts`.

This is the inverse of a rule the repo already had: `self-audit-ci` proves every script a workflow points **at** exists; nothing proved a gate that exists is pointed at. Now one of them is — see #533 for the general case.

## Verified

4549 tests pass on a clean build, lint and format clean, and `node dist/cli.js adr check` — the exact command CI runs — exits 0 here.

**Not proved in CI:** the red path. `ci.yml` triggers only on push to `main` and PRs to `main`, so demonstrating the failure would mean opening a PR that deliberately violates an ADR. The failure path is proved locally (exit 1 on each of the three probes above), and the guard test forbids the two ways a step gets silently defanged.

## Not built

The two unenforced ADRs (0004 skills-above-kit, 0005 browser-owned-by-kit) stay documented-only. Both are statements about ownership boundaries rather than import-level facts, and `kit adr list` already reports them as *documented, not enforced* rather than green — inventing a regex to make them look enforced would be worse than the honest label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)