### PR TITLE
chore(release): 6.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [6.10.0] - 2026-08-26
+
 ### Added
 
 - **AISLE nano-analyzer ingestion plugin.** `sandstream-kit-plugin-aisle` reads
@@ -8,6 +10,11 @@
   gate AI-discovered findings through the existing external-findings contract.
   Only `VALID` findings emit by default; rejected triage can be recorded
   deliberately for audit receipts.
+
+### Changed
+
+- **Public provenance cleanup.** Removed internal provenance breadcrumbs from
+  public docs, comments, fixture names, and shared memory.
 
 ## [6.9.0] - 2026-08-23
 

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -1197,7 +1197,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "6.9.0"
+    "version": "6.10.0"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "6.9.0",
+  "version": "6.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "6.9.0",
+      "version": "6.10.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "6.9.0",
+  "version": "6.10.0",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
## Summary
- bumps root package version and lockfile to 6.10.0
- updates OpenCLI contract version to 6.10.0
- cuts CHANGELOG 6.10.0 for AISLE ingestion plus public provenance cleanup
- leaves workspace plugin versions unchanged; AISLE remains its first 0.1.0 package release

## Verification
- npm run build
- npm test
- npm run lint (0 errors; existing warnings only)
- kit check --category security
- node scripts/changelog-section.mjs 6.10.0
- node scripts/gen-opencli.mjs
- node scripts/gen-plugin-registry.mjs
- rg checks for internal breadcrumb terms