### PR TITLE
fix(ci): make publish reruns and container scan stable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # Protected environment gate. There is no npm token here any more: all 13 packages
-    # have a GitHub Actions trusted publisher naming this repo, THIS workflow file, and
+    # Protected environment gate. There is no npm token here any more: every published package
+    # has a GitHub Actions trusted publisher naming this repo, THIS workflow file, and
     # THIS environment, so npm mints a short-lived credential from the job's OIDC identity
     # and only for runs that reach this environment. That makes the environment part of the
     # credential rather than merely the guard around a secret — configure required reviewers
@@ -51,7 +51,7 @@ jobs:
         # with NO long-lived secret — and it exists only in npm >= 11.5.1 (node >= 22.14.0).
         # setup-node ships npm 10.9.x for node 22, so the client in this job would have no
         # OIDC exchange to make. Installed here so the prerequisite is already true when the
-        # registry-side switch lands (13 per-package configs on npmjs.com — docs/RELEASING.md).
+        # registry-side switch lands (one per published package on npmjs.com — docs/RELEASING.md).
         #
         # Measured on npm 11.19.0 against this repo before wiring: `npm ci` and
         # `npm publish --dry-run` both behave identically, and npm >= 11's skip-install-scripts
@@ -265,7 +265,22 @@ jobs:
         #   npm view sandstream-kit --json | jq '.dist'
         # --tag routes prereleases to `next` (see the resolve step) so they never
         # clobber `latest`.
-        run: npm publish --provenance --access public --tag ${{ steps.disttag.outputs.tag }}
+        #
+        # IDEMPOTENT: the root package is skipped when that exact version is
+        # already on the registry. That lets a partial release rerun continue to
+        # the workspace / GitHub-release recovery steps instead of dying on
+        # EPUBLISHCONFLICT after npm already burned the version.
+        env:
+          DIST_TAG: ${{ steps.disttag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          name="$(node -p "require('./package.json').name")"
+          version="$(node -p "require('./package.json').version")"
+          if npm view "$name@$version" version >/dev/null 2>&1; then
+            echo "· $name@$version already on npm — skipping root publish"
+            exit 0
+          fi
+          npm publish --provenance --access public --tag "$DIST_TAG"
 
       - name: Publish the adapter SDK and first-party plugins
         # WHY THIS EXISTS: `packages/` is not in the root tarball (files: ["dist","README.md",

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -159,7 +159,7 @@ jobs:
         run: docker build -t kit:${{ github.sha }} .
       - name: Trivy scan (HIGH+CRITICAL — gating)
         # scanners: vuln — only CVE scan. Secret scanning handled by gitleaks.
-        # Image is clean of HIGH/CRITICAL after npm removal + picomatch bump.
+        # Image is clean of HIGH/CRITICAL after runtime apk upgrades + npm removal.
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: kit:${{ github.sha }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   failure can continue to GitHub release/SBOM recovery instead of stopping on
   `EPUBLISHCONFLICT`.
 
+- **Container CVE drift.** Runtime Docker image now upgrades Alpine OpenSSL packages
+  before removing npm, so the Trivy gate does not stay red while the floating
+  `node:22-alpine` image lags fixed Alpine patch packages.
+
 ## [6.10.0] - 2026-08-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+### Fixed
+
+- **Publish workflow partial reruns.** Root npm publish now skips an already-published
+  exact version, matching workspace publish behavior, so a rerun after a later-step
+  failure can continue to GitHub release/SBOM recovery instead of stopping on
+  `EPUBLISHCONFLICT`.
+
 ## [6.10.0] - 2026-08-26
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,11 @@ FROM node:22-alpine
 
 WORKDIR /app
 
-# Install dumb-init for proper signal handling.
+# Install dumb-init for proper signal handling, and pull fixed OpenSSL patch
+# levels from Alpine repositories when the floating Node image lags them.
 # Remove bundled npm (ships with a vulnerable picomatch and isn't needed at
 # runtime — kit CLI shells out to `node`, never `npm`). Saves ~30MB.
-RUN apk add --no-cache dumb-init \
+RUN apk add --no-cache --upgrade dumb-init libcrypto3 libssl3 \
  && rm -rf /usr/local/lib/node_modules/npm \
  && rm -f /usr/local/bin/npm /usr/local/bin/npx
 

--- a/src/publish-workflow.test.ts
+++ b/src/publish-workflow.test.ts
@@ -131,3 +131,20 @@ describe("publish.yml — trusted-publishing prerequisites", () => {
     );
   });
 });
+
+describe("publish.yml — publish steps are rerunnable after partial failures", () => {
+  it("skips the root package when the exact version already exists on npm", () => {
+    const start = EXECUTED.indexOf("Publish to npm with provenance");
+    const end = EXECUTED.indexOf("Publish the adapter SDK and first-party plugins");
+    assert.ok(start >= 0, "publish.yml no longer has the root npm publish step");
+    assert.ok(end > start, "publish.yml root publish step is no longer before workspace publish");
+
+    const step = EXECUTED.slice(start, end);
+    const lookup = step.indexOf('npm view "$name@$version" version');
+    const publish = step.indexOf('npm publish --provenance --access public --tag "$DIST_TAG"');
+
+    assert.ok(lookup >= 0, "root publish must check whether name@version already exists");
+    assert.ok(publish > lookup, "root publish must check npm before publishing");
+    assert.match(step, /already on npm/);
+  });
+});


### PR DESCRIPTION
## Summary
- skip root npm publish when the exact root version already exists on npm
- keep workspace publish behavior unchanged
- upgrade Alpine OpenSSL runtime packages in the Docker image before removing npm
- add a workflow regression test for partial-release reruns

## Verification
- npm run build
- node --test dist/publish-workflow.test.js
- npm run lint (0 errors, existing warnings)
- git diff --check
- kit check --category security