### PR TITLE
chore(release): 6.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 ## [Unreleased]
 
+## [6.10.1] - 2026-08-28
+
 ### Fixed
+
+- **Open issue regression batch.** Closed the local regressions behind #529, #531, #533,
+  #535, #536, #537, #538, #549, and #550 without pulling #349 into scope.
+
+  - Memory tombstones now participate in merge/sync, so `memory forget-message` cannot be
+    undone by a later pull.
+  - Shared-memory entries written by `kit memory share` now carry explicit operator
+    provenance by default, and touched shared areas can surface aging notices.
+  - Fetch-to-shell installers that resolve to GitHub repositories now flow through the same
+    install triage path as package-manager repo forms.
+  - `kit guard status` reports displaced shims on `PATH`, and `git clone` is observed as a
+    repo-intake event without pretending it is blocked.
+  - The OpenCLI contract now publishes accepted flag names via the generated flag surface,
+    and the docs audit checks `kit <command> --flag` references against that per-command
+    oracle.
+  - The CI self-audit now has the inverse script check: scripts must either be referenced or
+    explicitly declared as operator-run.
 
 - **Publish workflow partial reruns.** Root npm publish now skips an already-published
   exact version, matching workspace publish behavior, so a rerun after a later-step

--- a/contracts/kit.opencli.json
+++ b/contracts/kit.opencli.json
@@ -4378,7 +4378,7 @@
     "binary": "kit",
     "summary": "Deterministic, local-first developer-environment manager and fail-closed governance layer for AI agents and humans.",
     "title": "kit",
-    "version": "6.10.0"
+    "version": "6.10.1"
   },
   "opencliVersion": "1.0.0-alpha.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandstream-kit",
-  "version": "6.10.0",
+  "version": "6.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandstream-kit",
-      "version": "6.10.0",
+      "version": "6.10.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandstream-kit",
-  "version": "6.10.0",
+  "version": "6.10.1",
   "description": "developer kit. zero LLM, local-first, multi-vault. one command from git clone to working dev environment.",
   "license": "MIT",
   "funding": "https://buymeacoffee.com/sandstream",


### PR DESCRIPTION
Release prep for v6.10.1.

Summary:
- bump root package and lockfile from 6.10.0 to 6.10.1
- add CHANGELOG.md section for 6.10.1
- regenerate contracts/kit.opencli.json with 6.10.1 metadata

Verification:
- npm run build
- npm run lint
- npm test
- node --test dist/changelog-section.test.js dist/opencli.test.js
- node dist/cli.js --version
- node dist/cli.js self-audit --format json
- node dist/cli.js check --category security --json
- node dist/cli.js adr check
- git diff --check